### PR TITLE
Changed UserCall to download paths for OrganisationUnits + version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ ext {
             buildToolsVersion: "25.0.2",
             minSdkVersion    : 15,
             targetSdkVersion : 25,
-            versionCode      : 11,
-            versionName      : "0.1.1-SNAPSHOT"
+            versionCode      : 12,
+            versionName      : "0.1.2-SNAPSHOT"
     ]
 
     libraries = [

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserCall.java
@@ -137,6 +137,7 @@ public final class UserCall implements Call<Response<User>> {
                 ),
                 User.organisationUnits.with(
                         OrganisationUnit.uid,
+                        OrganisationUnit.path,
                         OrganisationUnit.programs.with(
                                 Program.uid
                         )

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserCallTests.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserCallTests.java
@@ -237,6 +237,7 @@ public class UserCallTests {
                         ),
                         User.organisationUnits.with(
                                 OrganisationUnit.uid,
+                                OrganisationUnit.path,
                                 OrganisationUnit.programs.with(
                                         Program.uid
                                 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,8 +38,8 @@ org.gradle.jvmargs=-Xmx1536m
 
 # Properties which are consumed by plugins/gradle-mvn-push.gradle plugin.
 # They are used for publishing artifact to snapshot repository.
-VERSION_NAME=0.1.1-SNAPSHOT
-VERSION_CODE=11
+VERSION_NAME=0.1.2-SNAPSHOT
+VERSION_CODE=12
 GROUP=org.hisp.dhis
 
 POM_DESCRIPTION=Android SDK for DHIS 2.


### PR DESCRIPTION
This fixes an issue that occurs after, when feeding the retrieved User with assigned OrganisationUnits (with null paths) to OrganisationUnitCall, causing an exception.
Bumped the sdk version.