### PR TITLE
Show event date if no elements to display

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/adapters/rows/events/EventItemRow.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/adapters/rows/events/EventItemRow.java
@@ -103,7 +103,7 @@ public final class EventItemRow implements EventRow {
 
         holder.listener.setEvent(mEvent);
         holder.listener.setStatus(mStatus);
-        if (elementsToShow >= 1) {
+        if (elementsToShow >= 0) {
             holder.firstItem.setText(mFirstItem);
             holder.firstItem.setVisibility(View.VISIBLE);
         } else {


### PR DESCRIPTION
Quick fix to show event date when no element is marked as "display in reports"