### PR TITLE
Migration from deprecated android-apt to annotationProcessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,7 +30,6 @@
 def libs = rootProject.ext.libraries
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.neenbedankt.android-apt'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -79,7 +78,7 @@ dependencies {
     compile 'com.squareup:otto:1.3.6'
 
     // Raizlabs libraries.
-    apt 'com.raizlabs.android:DBFlow-Compiler:2.2.1'
+    annotationProcessor 'com.raizlabs.android:DBFlow-Compiler:2.2.1'
     compile 'com.raizlabs.android:DBFlow-Core:2.2.1'
     compile 'com.raizlabs.android:DBFlow:2.2.1'
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -42,6 +42,7 @@ android {
         versionCode cfg.versionCode
         versionName cfg.versionName
         buildConfigField "String", "main_app", '"'+cfg.package+'"'
+        vectorDrawables.useSupportLibrary = true
     }
 
     compileOptions {


### PR DESCRIPTION
These changes would allow updating the Android Gradle plugin to version 3.0.1 and Gradle to version 4.1