### PR TITLE
metadata-real-integration-sync-once

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.java
@@ -46,6 +46,23 @@ public class MetadataCallRealIntegrationShould extends AbsStoreTestCase {
     //It depends on a live server to operate and the login is hardcoded here.
     //Uncomment in order to quickly test changes vs a real server, but keep it uncommented after.
     //@Test
+    public void response_successful_on_sync_meta_data_once() throws Exception {
+        retrofit2.Response response = null;
+        d2.logout().call();
+        response = d2.logIn("android", "Android123").call();
+        assertThat(response.isSuccessful()).isTrue();
+
+        response = d2.syncMetaData().call();
+        assertThat(response.isSuccessful()).isTrue();
+
+        //TODO: add aditional sync + break point.
+        //when debugger stops at the new break point manually change metadata online & resume.
+        //This way I can make sure that additive (updates) work as well.
+        //The changes could be to one of the programs, adding stuff to it.
+        // adding a new program..etc.
+    }
+
+    //@Test
     public void response_successful_on_sync_meta_data_two_times() throws Exception {
         retrofit2.Response response = null;
         d2.logout().call();
@@ -59,12 +76,6 @@ public class MetadataCallRealIntegrationShould extends AbsStoreTestCase {
         //second sync:
         response = d2.syncMetaData().call();
         assertThat(response.isSuccessful()).isTrue();
-
-        //TODO: add aditional sync + break point.
-        //when debugger stops at the new break point manually change metadata online & resume.
-        //This way I can make sure that additive (updates) work as well.
-        //The changes could be to one of the programs, adding stuff to it.
-        // adding a new program..etc.
     }
 
     //@Test


### PR DESCRIPTION
Includes a test that performs sync only once in MetadataCallRealIntegrationShould.java, to speed up manual testing with real servers.