### PR TITLE
In filter empty values

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/data/api/InFilter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/data/api/InFilter.java
@@ -15,7 +15,7 @@ public abstract class InFilter<T, K> implements Filter<T, K> {
     public static <T, K> Filter<T, K> create(@NonNull Field<T, K> field,
                                              @Nullable Collection<String> values) {
         //If the filter is incomplete, returning null, tells Retrofit that this filter should not be included.
-        if (values == null || values.isEmpty()) {
+        if (values == null) {
             return null;
         }
         return new AutoValue_InFilter<>(field, "in", Collections.unmodifiableCollection(values));

--- a/core/src/test/java/org/hisp/dhis/android/core/data/api/FilterConverterShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/data/api/FilterConverterShould.java
@@ -201,6 +201,31 @@ public class FilterConverterShould {
         server.shutdown();
     }
 
+    @Test
+    public void returns_correct_path_when_create_a_retrofit_request_with_in_filter_and_empty_values() throws IOException, InterruptedException {
+        ArrayList<String> values = new ArrayList(0);
+        MockWebServer server = new MockWebServer();
+        server.start();
+
+        server.enqueue(new MockResponse());
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(server.url("/"))
+                .addConverterFactory(FilterConverterFactory.create())
+                .build();
+
+        TestService service = retrofit.create(TestService.class);
+        service.test(
+                InFilter.create(Field.create("id"), values),
+                GtFilter.create(Field.create("lastUpdated"), "")
+        ).execute();
+
+        RecordedRequest request = server.takeRequest();
+
+        assertThat(request.getPath()).isEqualTo("/api?filter=id:in:[]");
+        server.shutdown();
+    }
+
     //TODO: test Filter for null input and empty string.
 
     @Test


### PR DESCRIPTION
Fixes in filter for empty value set. Previously, when values were empty no filter was being generated, which was producing the download of all entities instead of none of them. 