### PR TITLE
Model builder tests

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/IdentifiableModelAbstractShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/IdentifiableModelAbstractShould.java
@@ -31,11 +31,11 @@ package org.hisp.dhis.android.core.common;
 import org.hisp.dhis.android.core.utils.ColumnsAsserts;
 import org.junit.Test;
 
-public abstract class IdentifiableModelAbstractShould<P extends BaseIdentifiableObject,
-        M extends BaseIdentifiableObjectModel> extends ModelAbstractShould<P, M> {
+public abstract class IdentifiableModelAbstractShould<M extends BaseIdentifiableObjectModel>
+        extends ModelAbstractShould<M> {
 
-    public IdentifiableModelAbstractShould(String[] columns, int columnsLength, ModelBuilder<P, M> modelBuilder) {
-        super(columns, columnsLength, modelBuilder);
+    public IdentifiableModelAbstractShould(String[] columns, int columnsLength) {
+        super(columns, columnsLength);
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/NameableModelAbstractShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/NameableModelAbstractShould.java
@@ -31,11 +31,11 @@ package org.hisp.dhis.android.core.common;
 import org.hisp.dhis.android.core.utils.ColumnsAsserts;
 import org.junit.Test;
 
-public abstract class NameableModelAbstractShould<P extends BaseNameableObject,
-        M extends BaseNameableObjectModel> extends IdentifiableModelAbstractShould<P, M> {
+public abstract class NameableModelAbstractShould<
+        M extends BaseNameableObjectModel> extends IdentifiableModelAbstractShould<M> {
 
-    public NameableModelAbstractShould(String[] columns, int columnsLength, ModelBuilder<P, M> modelBuilder) {
-        super(columns, columnsLength, modelBuilder);
+    public NameableModelAbstractShould(String[] columns, int columnsLength) {
+        super(columns, columnsLength);
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/DataSetModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/DataSetModelShould.java
@@ -31,11 +31,7 @@ package org.hisp.dhis.android.core.dataset;
 import android.database.Cursor;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.hisp.dhis.android.core.common.Access;
-import org.hisp.dhis.android.core.common.DataAccess;
 import org.hisp.dhis.android.core.common.NameableModelAbstractShould;
-import org.hisp.dhis.android.core.common.ObjectStyle;
-import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.dataset.DataSetModel.Columns;
 import org.hisp.dhis.android.core.period.PeriodType;
 import org.hisp.dhis.android.core.utils.ColumnsArrayUtils;
@@ -43,32 +39,18 @@ import org.hisp.dhis.android.core.utils.Utils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.hisp.dhis.android.core.AndroidTestUtils.toInteger;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.COLOR;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DESCRIPTION;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_DESCRIPTION;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_SHORT_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.ICON;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.SHORT_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillNameableModelProperties;
 
 @RunWith(AndroidJUnit4.class)
-public class DataSetModelShould extends NameableModelAbstractShould<DataSet, DataSetModel> {
+public class DataSetModelShould extends NameableModelAbstractShould<DataSetModel> {
 
     public DataSetModelShould() {
-        super(DataSetModel.Columns.all(), 26, new DataSetModelBuilder());
+        super(DataSetModel.Columns.all(), 26);
     }
 
     @Override
@@ -101,28 +83,23 @@ public class DataSetModelShould extends NameableModelAbstractShould<DataSet, Dat
     }
 
     @Override
-    protected DataSet buildPojo() {
-        return DataSet.create(UID, CODE, NAME, DISPLAY_NAME, CREATED, LAST_UPDATED, SHORT_NAME,
-                DISPLAY_SHORT_NAME, DESCRIPTION, DISPLAY_DESCRIPTION, PeriodType.Monthly,
-                ObjectWithUid.create("cc_uid"),
-                false, 1, 10, 100, false,
-                0, false, false,
-                false, false, false,
-                false, false, new ArrayList<DataElementUids>(),
-                new ArrayList<ObjectWithUid>(), Access.create(true, true, false, true,
-                        true, true, DataAccess.create(true, false)),
-                ObjectStyle.create(COLOR, ICON), DELETED);
-    }
-
-    @Override
     protected Object[] getModelAsObjectArray() {
         return Utils.appendInNewArray(ColumnsArrayUtils.getNameableModelAsObjectArray(model),
-                model.periodType(), model.categoryCombo(), toInteger(model.mobile()), model.version(),
-                model.expiryDays(), model.timelyDays(), toInteger(model.notifyCompletingUser()),
-                model.openFuturePeriods(), toInteger(model.fieldCombinationRequired()),
-                toInteger(model.validCompleteOnly()), toInteger(model.noValueRequiresComment()),
-                toInteger(model.skipOffline()), toInteger(model.dataElementDecoration()),
-                toInteger(model.renderAsTabs()), toInteger(model.renderHorizontally()),
+                model.periodType(),
+                model.categoryCombo(),
+                toInteger(model.mobile()),
+                model.version(),
+                model.expiryDays(),
+                model.timelyDays(),
+                toInteger(model.notifyCompletingUser()),
+                model.openFuturePeriods(),
+                toInteger(model.fieldCombinationRequired()),
+                toInteger(model.validCompleteOnly()),
+                toInteger(model.noValueRequiresComment()),
+                toInteger(model.skipOffline()),
+                toInteger(model.dataElementDecoration()),
+                toInteger(model.renderAsTabs()),
+                toInteger(model.renderHorizontally()),
                 toInteger(model.accessDataWrite()));
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/DataValueModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/DataValueModelShould.java
@@ -44,12 +44,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.hisp.dhis.android.core.AndroidTestUtils.toInteger;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED_STR;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED_STR;
 
 @RunWith(AndroidJUnit4.class)
-public class DataValueModelShould extends ModelAbstractShould<DataValue, DataValueModel> {
+public class DataValueModelShould extends ModelAbstractShould<DataValueModel> {
     private static final String DATA_ELEMENT = "dataElement";
     private static final String PERIOD = "period";
     private static final String ORGANISATION_UNIT = "organisationUnit";
@@ -61,13 +60,7 @@ public class DataValueModelShould extends ModelAbstractShould<DataValue, DataVal
     private static final boolean FOLLOW_UP = false;
 
     public DataValueModelShould() {
-        super(DataValueModel.Columns.all(), 11, new DataValueModelBuilder());
-    }
-
-    @Override
-    protected DataValue buildPojo() {
-        return DataValue.create(DATA_ELEMENT, PERIOD, ORGANISATION_UNIT, CATEGORY_OPTION_COMBO,
-                ATTRIBUTE_OPTION_COMBO, VALUE, STORED_BY, CREATED, LAST_UPDATED, COMMENT, FOLLOW_UP, DELETED);
+        super(DataValueModel.Columns.all(), 11);
     }
 
     @Override
@@ -96,9 +89,16 @@ public class DataValueModelShould extends ModelAbstractShould<DataValue, DataVal
     @Override
     protected Object[] getModelAsObjectArray() {
         return Utils.appendInNewArray(ColumnsArrayUtils.getModelAsObjectArray(model),
-                model.dataElement(), model.period(), model.organisationUnit(),
-                model.categoryOptionCombo(), model.attributeOptionCombo(), model.value(),
-                model.storedBy(), CREATED_STR, LAST_UPDATED_STR, model.comment(),
+                model.dataElement(),
+                model.period(),
+                model.organisationUnit(),
+                model.categoryOptionCombo(),
+                model.attributeOptionCombo(),
+                model.value(),
+                model.storedBy(),
+                CREATED_STR,
+                LAST_UPDATED_STR,
+                model.comment(),
                 toInteger(model.followUp()));
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorModelShould.java
@@ -32,7 +32,6 @@ import android.database.Cursor;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.hisp.dhis.android.core.common.NameableModelAbstractShould;
-import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.indicator.IndicatorModel.Columns;
 import org.hisp.dhis.android.core.utils.ColumnsArrayUtils;
 import org.hisp.dhis.android.core.utils.Utils;
@@ -43,32 +42,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DESCRIPTION;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_DESCRIPTION;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_SHORT_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.SHORT_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillNameableModelProperties;
 
 @RunWith(AndroidJUnit4.class)
-public class IndicatorModelShould extends NameableModelAbstractShould<Indicator, IndicatorModel> {
-
-    private final Boolean annualized = false;
-    private final String indicatorType = "bWuNrMHEoZ0";
-    private final String numerator = "#{a.b}";
-    private final String numeratorDescription = "num descr";
-    private final String denominator = "#{c.d}";
-    private final String denominatorDescription = "den descr";
-    private final String url = "dhis2.org";
+public class IndicatorModelShould extends NameableModelAbstractShould<IndicatorModel> {
 
     public IndicatorModelShould() {
-            super(IndicatorModel.Columns.all(), 17, new IndicatorModelBuilder());
+            super(IndicatorModel.Columns.all(), 17);
     }
 
     @Override
@@ -76,27 +56,19 @@ public class IndicatorModelShould extends NameableModelAbstractShould<Indicator,
         IndicatorModel.Builder indicatorModelBuilder = IndicatorModel.builder();
         fillNameableModelProperties(indicatorModelBuilder);
         indicatorModelBuilder
-                .annualized(annualized)
-                .indicatorType(indicatorType)
-                .numerator(numerator)
-                .numeratorDescription(numeratorDescription)
-                .denominator(denominator)
-                .denominatorDescription(denominatorDescription)
-                .url(url);
+                .annualized(false)
+                .indicatorType("bWuNrMHEoZ0")
+                .numerator("#{a.b}")
+                .numeratorDescription("num descr")
+                .denominator("#{c.d}")
+                .denominatorDescription("den descr")
+                .url("dhis2.org");
         return indicatorModelBuilder.build();
     }
 
     @Override
     protected IndicatorModel cursorToModel(Cursor cursor) {
         return IndicatorModel.create(cursor);
-    }
-
-    @Override
-    protected Indicator buildPojo() {
-        return Indicator.create(UID, CODE, NAME, DISPLAY_NAME, CREATED, LAST_UPDATED, SHORT_NAME,
-                DISPLAY_SHORT_NAME, DESCRIPTION, DISPLAY_DESCRIPTION, annualized,
-                ObjectWithUid.create(indicatorType), numerator, numeratorDescription,
-                denominator, denominatorDescription, url, DELETED);
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorModelShould.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.hisp.dhis.android.core.AndroidTestUtils.toInteger;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillNameableModelProperties;
 
 @RunWith(AndroidJUnit4.class)
@@ -74,8 +75,12 @@ public class IndicatorModelShould extends NameableModelAbstractShould<IndicatorM
     @Override
     protected Object[] getModelAsObjectArray() {
         return Utils.appendInNewArray(ColumnsArrayUtils.getNameableModelAsObjectArray(model),
-                model.annualized(), model.indicatorType(), model.numerator(),
-                model.numeratorDescription(), model.denominator(), model.denominatorDescription(),
+                toInteger(model.annualized()),
+                model.indicatorType(),
+                model.numerator(),
+                model.numeratorDescription(),
+                model.denominator(),
+                model.denominatorDescription(),
                 model.url());
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorTypeModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorTypeModelShould.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.hisp.dhis.android.core.AndroidTestUtils.toInteger;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillIdentifiableModelProperties;
 
 @RunWith(AndroidJUnit4.class)
@@ -69,7 +70,8 @@ public class IndicatorTypeModelShould extends IdentifiableModelAbstractShould<In
     @Override
     protected Object[] getModelAsObjectArray() {
         return Utils.appendInNewArray(ColumnsArrayUtils.getIdentifiableModelAsObjectArray(model),
-                model.number(), model.factor());
+                toInteger(model.number()),
+                model.factor());
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendModelShould.java
@@ -42,27 +42,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillIdentifiableModelProperties;
 
 @RunWith(AndroidJUnit4.class)
-public class LegendModelShould extends IdentifiableModelAbstractShould<Legend, LegendModel> {
-
-    private final Double startValue = 20.0;
-    private final Double endValue = 30.5;
-    private final String color = "#FFFFFF";
-    private final String legendSetUid = "test_legend_set_uid";
+public class LegendModelShould extends IdentifiableModelAbstractShould<LegendModel> {
 
     public LegendModelShould() {
-            super(Columns.all(), 10, new LegendModelBuilder(LegendSet.create(
-                    "test_legend_set_uid", null, null, null,
-                    null, null, null, null, null)));
+            super(Columns.all(), 10);
     }
 
     @Override
@@ -70,10 +56,10 @@ public class LegendModelShould extends IdentifiableModelAbstractShould<Legend, L
         LegendModel.Builder builder = LegendModel.builder();
         fillIdentifiableModelProperties(builder);
         builder
-                .startValue(startValue)
-                .endValue(endValue)
-                .color(color)
-                .legendSet(legendSetUid);
+                .startValue(20.0)
+                .endValue(30.5)
+                .color("#FFFFFF")
+                .legendSet("test_legend_set_uid");
         return builder.build();
     }
 
@@ -83,15 +69,12 @@ public class LegendModelShould extends IdentifiableModelAbstractShould<Legend, L
     }
 
     @Override
-    protected Legend buildPojo() {
-        return Legend.create(UID, CODE, NAME, DISPLAY_NAME, CREATED, LAST_UPDATED, DELETED,
-                startValue, endValue, color);
-    }
-
-    @Override
     protected Object[] getModelAsObjectArray() {
         return Utils.appendInNewArray(ColumnsArrayUtils.getIdentifiableModelAsObjectArray(model),
-                model.startValue(), model.endValue(), model.color(), model.legendSet());
+                model.startValue(),
+                model.endValue(),
+                model.color(),
+                model.legendSet());
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendSetModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendSetModelShould.java
@@ -42,39 +42,25 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillIdentifiableModelProperties;
 
 @RunWith(AndroidJUnit4.class)
-public class LegendSetModelShould extends IdentifiableModelAbstractShould<LegendSet, LegendSetModel> {
-
-    private final String symbolizer = "color";
+public class LegendSetModelShould extends IdentifiableModelAbstractShould<LegendSetModel> {
 
     public LegendSetModelShould() {
-            super(Columns.all(), 7, new LegendSetModelBuilder());
+            super(Columns.all(), 7);
     }
 
     @Override
     protected LegendSetModel buildModel() {
         LegendSetModel.Builder builder = LegendSetModel.builder();
         fillIdentifiableModelProperties(builder);
-        return builder.symbolizer(symbolizer).build();
+        return builder.symbolizer("color").build();
     }
 
     @Override
     protected LegendSetModel cursorToModel(Cursor cursor) {
         return LegendSetModel.create(cursor);
-    }
-
-    @Override
-    protected LegendSet buildPojo() {
-        return LegendSet.create(UID, CODE, NAME, DISPLAY_NAME, CREATED, LAST_UPDATED, DELETED, symbolizer, null);
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueModelShould.java
@@ -32,7 +32,6 @@ import android.database.Cursor;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.hisp.dhis.android.core.common.ModelAbstractShould;
-import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeReservedValueModel.Columns;
 import org.hisp.dhis.android.core.utils.ColumnsArrayUtils;
 import org.hisp.dhis.android.core.utils.Utils;
@@ -48,7 +47,7 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREA
 
 @RunWith(AndroidJUnit4.class)
 public class TrackedEntityAttributeReservedValueModelShould extends
-        ModelAbstractShould<TrackedEntityAttributeReservedValue, TrackedEntityAttributeReservedValueModel> {
+        ModelAbstractShould<TrackedEntityAttributeReservedValueModel> {
     private final static String OWNER_OBJECT = "ownerObject";
     private final static String OWNER_UID = "ownerUid";
     private final static String KEY = "key";
@@ -56,16 +55,7 @@ public class TrackedEntityAttributeReservedValueModelShould extends
     private final static String ORGANISATION_UNI = "orgUnitUid";
 
     public TrackedEntityAttributeReservedValueModelShould() {
-        super(TrackedEntityAttributeReservedValueModel.Columns.all(), 7,
-                new TrackedEntityAttributeReservedValueModelBuilder(OrganisationUnit.create("orgUnitUid", null,
-                        null, null, null, null, null, null,
-                        null, null, null, null, null, null,
-                        null, null, null, null, null)));
-    }
-
-    @Override
-    protected TrackedEntityAttributeReservedValue buildPojo() {
-        return TrackedEntityAttributeReservedValue.create(OWNER_OBJECT, OWNER_UID, KEY, VALUE, CREATED, CREATED);
+        super(TrackedEntityAttributeReservedValueModel.Columns.all(), 7);
     }
 
     @Override

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionModelBuilderShould.java
@@ -28,12 +28,12 @@
 
 package org.hisp.dhis.android.core.category;
 
+import org.hisp.dhis.android.core.common.ModelBuilder;
 import org.hisp.dhis.android.core.common.NameableModelBuilderAbstractShould;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 
@@ -53,16 +53,10 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 public class CategoryOptionModelBuilderShould extends
         NameableModelBuilderAbstractShould<CategoryOption, CategoryOptionModel> {
 
-    private CategoryOption pojo;
-
-    private CategoryOptionModel model;
-
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
-        pojo = buildPojo();
-        model = buildModel();
+        super.setUp();
     }
 
     @Override
@@ -78,14 +72,15 @@ public class CategoryOptionModelBuilderShould extends
                 DISPLAY_SHORT_NAME,
                 DESCRIPTION,
                 DISPLAY_DESCRIPTION,
+
                 CREATED,
                 CREATED
         );
     }
 
     @Override
-    protected CategoryOptionModel buildModel() {
-        return new CategoryOptionModelBuilder().buildModel(pojo);
+    protected ModelBuilder<CategoryOption, CategoryOptionModel> modelBuilder() {
+        return new CategoryOptionModelBuilder();
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/common/IdentifiableModelBuilderAbstractShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/IdentifiableModelBuilderAbstractShould.java
@@ -29,20 +29,19 @@ package org.hisp.dhis.android.core.common;
 
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public abstract class IdentifiableModelBuilderAbstractShould<P extends BaseIdentifiableObject,
-        M extends BaseIdentifiableObjectModel> {
+        M extends BaseIdentifiableObjectModel> extends ModelBuilderAbstractShould<P, M> {
 
-    protected abstract P buildPojo();
-
-    protected abstract M buildModel();
+    public void setUp() throws IOException {
+        super.setUp();
+    }
 
     @Test
     public void copy_pojo_identifiable_properties() {
-        P pojo = buildPojo();
-        M model = buildModel();
-
         assertThat(model.uid()).isEqualTo(pojo.uid());
         assertThat(model.code()).isEqualTo(pojo.code());
         assertThat(model.name()).isEqualTo(pojo.name());

--- a/core/src/test/java/org/hisp/dhis/android/core/common/IdentifiableModelBuilderAbstractShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/IdentifiableModelBuilderAbstractShould.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public abstract class IdentifiableModelBuilderAbstractShould<P extends BaseIdentifiableObject,
         M extends BaseIdentifiableObjectModel> extends ModelBuilderAbstractShould<P, M> {
 
+    @Override
     public void setUp() throws IOException {
         super.setUp();
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/common/ModelBuilderAbstractShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/ModelBuilderAbstractShould.java
@@ -25,15 +25,20 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package org.hisp.dhis.android.core.common;
 
-public abstract class ModelAbstractShould<M extends BaseModel> extends LinkModelAbstractShould<M> {
+import java.io.IOException;
 
-    protected final M model;
+public abstract class ModelBuilderAbstractShould<P, M> {
 
-    public ModelAbstractShould(String[] columns, int columnsLength) {
-        super(columns, columnsLength);
-        this.model = buildModel();
+    protected P pojo;
+    protected M model;
+
+    protected abstract P buildPojo();
+    protected abstract ModelBuilder<P, M> modelBuilder();
+
+    public void setUp() throws IOException {
+        this.pojo = buildPojo();
+        this.model = modelBuilder().buildModel(pojo);
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/common/ModelBuilderAbstractShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/ModelBuilderAbstractShould.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.android.core.common;
 
+import org.mockito.MockitoAnnotations;
+
 import java.io.IOException;
 
 public abstract class ModelBuilderAbstractShould<P, M> {
@@ -38,6 +40,7 @@ public abstract class ModelBuilderAbstractShould<P, M> {
     protected abstract ModelBuilder<P, M> modelBuilder();
 
     public void setUp() throws IOException {
+        MockitoAnnotations.initMocks(this);
         this.pojo = buildPojo();
         this.model = modelBuilder().buildModel(pojo);
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/common/NameableModelBuilderAbstractShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/NameableModelBuilderAbstractShould.java
@@ -29,16 +29,19 @@ package org.hisp.dhis.android.core.common;
 
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public abstract class NameableModelBuilderAbstractShould<P extends BaseNameableObject,
         M extends BaseNameableObjectModel> extends IdentifiableModelBuilderAbstractShould<P, M> {
 
+    public void setUp() throws IOException {
+        super.setUp();
+    }
+
     @Test
     public void copy_pojo_nameable_properties() {
-        P pojo = buildPojo();
-        M model = buildModel();
-
         assertThat(model.shortName()).isEqualTo(pojo.shortName());
         assertThat(model.displayShortName()).isEqualTo(pojo.displayShortName());
         assertThat(model.description()).isEqualTo(pojo.description());

--- a/core/src/test/java/org/hisp/dhis/android/core/common/NameableModelBuilderAbstractShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/NameableModelBuilderAbstractShould.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public abstract class NameableModelBuilderAbstractShould<P extends BaseNameableObject,
         M extends BaseNameableObjectModel> extends IdentifiableModelBuilderAbstractShould<P, M> {
 
+    @Override
     public void setUp() throws IOException {
         super.setUp();
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetModelBuilderShould.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -59,6 +60,9 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 @RunWith(JUnit4.class)
 public class DataSetModelBuilderShould extends NameableModelBuilderAbstractShould<DataSet, DataSetModel> {
 
+    public void setUp() throws IOException {
+        super.setUp();
+    }
     @Override
     protected DataSet buildPojo() {
         return DataSet.create(

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetModelBuilderShould.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.dataset;
+
+import org.hisp.dhis.android.core.common.Access;
+import org.hisp.dhis.android.core.common.DataAccess;
+import org.hisp.dhis.android.core.common.ModelBuilder;
+import org.hisp.dhis.android.core.common.NameableModelBuilderAbstractShould;
+import org.hisp.dhis.android.core.common.ObjectStyle;
+import org.hisp.dhis.android.core.common.ObjectWithUid;
+import org.hisp.dhis.android.core.period.PeriodType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.COLOR;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DESCRIPTION;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_DESCRIPTION;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_SHORT_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.ICON;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.SHORT_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
+
+@RunWith(JUnit4.class)
+public class DataSetModelBuilderShould extends NameableModelBuilderAbstractShould<DataSet, DataSetModel> {
+
+    @Override
+    protected DataSet buildPojo() {
+        return DataSet.create(
+                UID,
+                CODE,
+                NAME,
+                DISPLAY_NAME,
+                CREATED,
+                LAST_UPDATED,
+                SHORT_NAME,
+                DISPLAY_SHORT_NAME,
+                DESCRIPTION,
+                DISPLAY_DESCRIPTION,
+                PeriodType.Monthly,
+                ObjectWithUid.create("cc_uid"),
+                false,
+                1,
+                10,
+                100,
+                false,
+                0,
+                true,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                new ArrayList<DataElementUids>(),
+                new ArrayList<ObjectWithUid>(),
+                Access.create(true, true, false, true,
+                        true, true, DataAccess.create(true, false)),
+                ObjectStyle.create(COLOR, ICON),
+                DELETED);
+    }
+
+    @Override
+    protected ModelBuilder<DataSet, DataSetModel> modelBuilder() {
+        return new DataSetModelBuilder();
+    }
+
+    @Test
+    public void copy_pojo_dataset_properties() {
+        assertThat(model.mobile()).isEqualTo(pojo.mobile());
+        assertThat(model.version()).isEqualTo(pojo.version());
+        assertThat(model.expiryDays()).isEqualTo(pojo.expiryDays());
+        assertThat(model.timelyDays()).isEqualTo(pojo.timelyDays());
+        assertThat(model.notifyCompletingUser()).isEqualTo(pojo.notifyCompletingUser());
+        assertThat(model.openFuturePeriods()).isEqualTo(pojo.openFuturePeriods());
+        assertThat(model.fieldCombinationRequired()).isEqualTo(pojo.fieldCombinationRequired());
+        assertThat(model.validCompleteOnly()).isEqualTo(pojo.validCompleteOnly());
+        assertThat(model.noValueRequiresComment()).isEqualTo(pojo.noValueRequiresComment());
+        assertThat(model.skipOffline()).isEqualTo(pojo.skipOffline());
+        assertThat(model.dataElementDecoration()).isEqualTo(pojo.dataElementDecoration());
+        assertThat(model.renderAsTabs()).isEqualTo(pojo.renderAsTabs());
+        assertThat(model.renderHorizontally()).isEqualTo(pojo.renderHorizontally());
+        assertThat(model.accessDataWrite()).isEqualTo(pojo.access().data().write());
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetModelBuilderShould.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.android.core.common.NameableModelBuilderAbstractShould;
 import org.hisp.dhis.android.core.common.ObjectStyle;
 import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.period.PeriodType;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -60,9 +61,12 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 @RunWith(JUnit4.class)
 public class DataSetModelBuilderShould extends NameableModelBuilderAbstractShould<DataSet, DataSetModel> {
 
+    @Override
+    @Before
     public void setUp() throws IOException {
         super.setUp();
     }
+
     @Override
     protected DataSet buildPojo() {
         return DataSet.create(

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueModelBuilderShould.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.datavalue;
+
+import org.hisp.dhis.android.core.common.ModelBuilder;
+import org.hisp.dhis.android.core.common.ModelBuilderAbstractShould;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
+
+@RunWith(JUnit4.class)
+public class DataValueModelBuilderShould extends ModelBuilderAbstractShould<DataValue,
+        DataValueModel> {
+
+    private static final String DATA_ELEMENT = "dataElement";
+    private static final String PERIOD = "period";
+    private static final String ORGANISATION_UNIT = "organisationUnit";
+    private static final String CATEGORY_OPTION_COMBO = "categoryOptionCombo";
+    private static final String ATTRIBUTE_OPTION_COMBO = "attributeOptionCombo";
+    private static final String VALUE = "value";
+    private static final String STORED_BY = "storedBy";
+    private static final String COMMENT = "comment";
+    private static final boolean FOLLOW_UP = false;
+
+    @Override
+    protected DataValue buildPojo() {
+        return DataValue.create(
+                DATA_ELEMENT,
+                PERIOD,
+                ORGANISATION_UNIT,
+                CATEGORY_OPTION_COMBO,
+                ATTRIBUTE_OPTION_COMBO,
+                VALUE,
+                STORED_BY,
+                CREATED,
+                LAST_UPDATED,
+                COMMENT,
+                FOLLOW_UP,
+                DELETED);
+    }
+
+    @Override
+    protected ModelBuilder<DataValue, DataValueModel> modelBuilder() {
+        return new DataValueModelBuilder();
+    }
+
+    @Test
+    public void copy_pojo_data_value_properties() {
+        assertThat(model.dataElement()).isEqualTo(pojo.dataElement());
+        assertThat(model.period()).isEqualTo(pojo.period());
+        assertThat(model.organisationUnit()).isEqualTo(pojo.organisationUnit());
+        assertThat(model.categoryOptionCombo()).isEqualTo(pojo.categoryOptionCombo());
+        assertThat(model.attributeOptionCombo()).isEqualTo(pojo.attributeOptionCombo());
+        assertThat(model.value()).isEqualTo(pojo.value());
+        assertThat(model.storedBy()).isEqualTo(pojo.storedBy());
+        assertThat(model.created()).isEqualTo(pojo.created());
+        assertThat(model.lastUpdated()).isEqualTo(pojo.lastUpdated());
+        assertThat(model.comment()).isEqualTo(pojo.comment());
+        assertThat(model.followUp()).isEqualTo(pojo.followUp());
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueModelBuilderShould.java
@@ -30,9 +30,12 @@ package org.hisp.dhis.android.core.datavalue;
 
 import org.hisp.dhis.android.core.common.ModelBuilder;
 import org.hisp.dhis.android.core.common.ModelBuilderAbstractShould;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
@@ -52,6 +55,12 @@ public class DataValueModelBuilderShould extends ModelBuilderAbstractShould<Data
     private static final String STORED_BY = "storedBy";
     private static final String COMMENT = "comment";
     private static final boolean FOLLOW_UP = false;
+
+    @Override
+    @Before
+    public void setUp() throws IOException {
+        super.setUp();
+    }
 
     @Override
     protected DataValue buildPojo() {

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorModelBuilderShould.java
@@ -81,7 +81,7 @@ public class IndicatorModelBuilderShould extends IdentifiableModelBuilderAbstrac
 
     @Override
     protected ModelBuilder<Indicator, IndicatorModel> modelBuilder() {
-        return null;
+        return new IndicatorModelBuilder();
     }
 
     @Before

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorModelBuilderShould.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.indicator;
+
+import org.hisp.dhis.android.core.common.IdentifiableModelBuilderAbstractShould;
+import org.hisp.dhis.android.core.common.ModelBuilder;
+import org.hisp.dhis.android.core.common.ObjectWithUid;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DESCRIPTION;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_DESCRIPTION;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_SHORT_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.SHORT_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
+
+@RunWith(JUnit4.class)
+public class IndicatorModelBuilderShould extends IdentifiableModelBuilderAbstractShould<Indicator,
+        IndicatorModel> {
+
+    @Override
+    protected Indicator buildPojo() {
+        return Indicator.create(
+                UID,
+                CODE,
+                NAME,
+                DISPLAY_NAME,
+                CREATED,
+                LAST_UPDATED,
+                SHORT_NAME,
+                DISPLAY_SHORT_NAME,
+                DESCRIPTION,
+                DISPLAY_DESCRIPTION,
+
+                false,
+                ObjectWithUid.create("bWuNrMHEoZ0"),
+                "#{a.b}",
+                "num descr",
+                "#{c.d}",
+                "den descr",
+                "dhis2.org",
+                DELETED);
+    }
+
+    @Override
+    protected ModelBuilder<Indicator, IndicatorModel> modelBuilder() {
+        return null;
+    }
+
+    @Before
+    @Override
+    public void setUp() throws IOException {
+        super.setUp();
+    }
+
+    @Test
+    public void copy_pojo_indicator_properties() {
+        assertThat(model.annualized()).isEqualTo(pojo.annualized());
+        assertThat(model.indicatorType()).isEqualTo(pojo.indicatorType().uid());
+        assertThat(model.numerator()).isEqualTo(pojo.numerator());
+        assertThat(model.numeratorDescription()).isEqualTo(pojo.numeratorDescription());
+        assertThat(model.denominator()).isEqualTo(pojo.denominator());
+        assertThat(model.denominatorDescription()).isEqualTo(pojo.denominatorDescription());
+        assertThat(model.url()).isEqualTo(pojo.url());
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeModelBuilderShould.java
@@ -30,9 +30,12 @@ package org.hisp.dhis.android.core.indicator;
 
 import org.hisp.dhis.android.core.common.IdentifiableModelBuilderAbstractShould;
 import org.hisp.dhis.android.core.common.ModelBuilder;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
@@ -47,6 +50,12 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 public class IndicatorTypeModelBuilderShould extends IdentifiableModelBuilderAbstractShould<IndicatorType,
         IndicatorTypeModel> {
 
+
+    @Before
+    @Override
+    public void setUp() throws IOException {
+        super.setUp();
+    }
 
     @Override
     protected IndicatorType buildPojo() {

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeModelBuilderShould.java
@@ -28,55 +28,40 @@
 
 package org.hisp.dhis.android.core.indicator;
 
-import android.database.Cursor;
-import android.support.test.runner.AndroidJUnit4;
-
-import org.hisp.dhis.android.core.common.IdentifiableModelAbstractShould;
-import org.hisp.dhis.android.core.indicator.IndicatorTypeModel.Columns;
-import org.hisp.dhis.android.core.utils.ColumnsArrayUtils;
-import org.hisp.dhis.android.core.utils.Utils;
+import org.hisp.dhis.android.core.common.IdentifiableModelBuilderAbstractShould;
+import org.hisp.dhis.android.core.common.ModelBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-import java.util.Arrays;
-import java.util.List;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CODE;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DELETED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.DISPLAY_NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.LAST_UPDATED;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.NAME;
+import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillIdentifiableModelProperties;
+@RunWith(JUnit4.class)
+public class IndicatorTypeModelBuilderShould extends IdentifiableModelBuilderAbstractShould<IndicatorType,
+        IndicatorTypeModel> {
 
-@RunWith(AndroidJUnit4.class)
-public class IndicatorTypeModelShould extends IdentifiableModelAbstractShould<IndicatorTypeModel> {
 
-    public IndicatorTypeModelShould() {
-            super(Columns.all(), 8);
+    @Override
+    protected IndicatorType buildPojo() {
+        return IndicatorType.create(UID, CODE, NAME, DISPLAY_NAME, CREATED, LAST_UPDATED,
+                true, 11, DELETED);
     }
 
     @Override
-    protected IndicatorTypeModel buildModel() {
-        IndicatorTypeModel.Builder builder = IndicatorTypeModel.builder();
-        fillIdentifiableModelProperties(builder);
-        builder
-                .number(false)
-                .factor(100);
-        return builder.build();
-    }
-
-    @Override
-    protected IndicatorTypeModel cursorToModel(Cursor cursor) {
-        return IndicatorTypeModel.create(cursor);
-    }
-
-    @Override
-    protected Object[] getModelAsObjectArray() {
-        return Utils.appendInNewArray(ColumnsArrayUtils.getIdentifiableModelAsObjectArray(model),
-                model.number(), model.factor());
+    protected ModelBuilder<IndicatorType, IndicatorTypeModel> modelBuilder() {
+        return new IndicatorTypeModelBuilder();
     }
 
     @Test
-    public void have_extra_indicator_model_columns() {
-        List<String> columnsList = Arrays.asList(columns);
-
-        assertThat(columnsList.contains(Columns.NUMBER)).isEqualTo(true);
-        assertThat(columnsList.contains(Columns.FACTOR)).isEqualTo(true);
+    public void copy_pojo_indicator_type_properties() {
+        assertThat(model.number()).isEqualTo(pojo.number());
+        assertThat(model.factor()).isEqualTo(pojo.factor());
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendModelBuilderShould.java
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.core.legendset;
 
 import org.hisp.dhis.android.core.common.IdentifiableModelBuilderAbstractShould;
+import org.hisp.dhis.android.core.common.ModelBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,22 +51,16 @@ import static org.mockito.Mockito.when;
 @RunWith(JUnit4.class)
 public class LegendModelBuilderShould extends IdentifiableModelBuilderAbstractShould<Legend, LegendModel> {
 
-    private Legend pojo;
-
-    private LegendModel model;
-
     @Mock
     private LegendSet legendSet;
 
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws IOException {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
 
         when(legendSet.uid()).thenReturn("legend_set_uid");
-
-        pojo = buildPojo();
-        model = buildModel();
     }
 
     @Override
@@ -85,8 +80,8 @@ public class LegendModelBuilderShould extends IdentifiableModelBuilderAbstractSh
     }
 
     @Override
-    protected LegendModel buildModel() {
-        return new LegendModelBuilder(legendSet).buildModel(pojo);
+    protected ModelBuilder<Legend, LegendModel> modelBuilder() {
+        return new LegendModelBuilder(legendSet);
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendModelBuilderShould.java
@@ -55,12 +55,11 @@ public class LegendModelBuilderShould extends IdentifiableModelBuilderAbstractSh
     private LegendSet legendSet;
 
     @Before
-    @SuppressWarnings("unchecked")
+    @Override
     public void setUp() throws IOException {
         super.setUp();
-        MockitoAnnotations.initMocks(this);
-
         when(legendSet.uid()).thenReturn("legend_set_uid");
+        MockitoAnnotations.initMocks(this);
     }
 
     @Override

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetModelBuilderShould.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.legendset;
 
 import org.assertj.core.util.Lists;
 import org.hisp.dhis.android.core.common.IdentifiableModelBuilderAbstractShould;
+import org.hisp.dhis.android.core.common.ModelBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,17 +50,9 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 @RunWith(JUnit4.class)
 public class LegendSetModelBuilderShould extends IdentifiableModelBuilderAbstractShould<LegendSet, LegendSetModel> {
 
-    private LegendSet pojo;
-
-    private LegendSetModel model;
-
     @Before
-    @SuppressWarnings("unchecked")
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
-
-        pojo = buildPojo();
-        model = buildModel();
     }
 
     @Override
@@ -78,8 +71,8 @@ public class LegendSetModelBuilderShould extends IdentifiableModelBuilderAbstrac
     }
 
     @Override
-    protected LegendSetModel buildModel() {
-        return new LegendSetModelBuilder().buildModel(pojo);
+    protected ModelBuilder<LegendSet, LegendSetModel> modelBuilder() {
+        return new LegendSetModelBuilder();
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetModelBuilderShould.java
@@ -35,7 +35,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 
@@ -50,9 +49,10 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.UID;
 @RunWith(JUnit4.class)
 public class LegendSetModelBuilderShould extends IdentifiableModelBuilderAbstractShould<LegendSet, LegendSetModel> {
 
+    @Override
     @Before
     public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        super.setUp();
     }
 
     @Override

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitModelBuilderShould.java
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.core.organisationunit;
 
 import org.assertj.core.util.Lists;
+import org.hisp.dhis.android.core.common.ModelBuilder;
 import org.hisp.dhis.android.core.common.NameableModelBuilderAbstractShould;
 import org.hisp.dhis.android.core.dataset.DataSet;
 import org.hisp.dhis.android.core.program.Program;
@@ -55,10 +56,6 @@ import static org.mockito.Mockito.when;
 public class OrganisationUnitModelBuilderShould extends NameableModelBuilderAbstractShould<OrganisationUnit,
         OrganisationUnitModel> {
 
-    private OrganisationUnit pojo;
-
-    private OrganisationUnitModel model;
-
     @Mock
     private OrganisationUnit parent;
 
@@ -68,14 +65,12 @@ public class OrganisationUnitModelBuilderShould extends NameableModelBuilderAbst
     @Before
     @SuppressWarnings("unchecked")
     public void setUp() throws IOException {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
 
         when(parent.uid()).thenReturn("parentUid");
         when(parent.displayName()).thenReturn("parentDisplayName");
         when(grandparent.displayName()).thenReturn("grandparentDisplayName");
-
-        pojo = buildPojo();
-        model = buildModel();
     }
 
     @Override
@@ -104,8 +99,8 @@ public class OrganisationUnitModelBuilderShould extends NameableModelBuilderAbst
     }
 
     @Override
-    protected OrganisationUnitModel buildModel() {
-        return new OrganisationUnitModelBuilder().buildModel(pojo);
+    protected ModelBuilder<OrganisationUnit, OrganisationUnitModel> modelBuilder() {
+        return new OrganisationUnitModelBuilder();
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitModelBuilderShould.java
@@ -63,14 +63,15 @@ public class OrganisationUnitModelBuilderShould extends NameableModelBuilderAbst
     private OrganisationUnit grandparent;
 
     @Before
-    @SuppressWarnings("unchecked")
+    @Override
     public void setUp() throws IOException {
         super.setUp();
-        MockitoAnnotations.initMocks(this);
 
         when(parent.uid()).thenReturn("parentUid");
         when(parent.displayName()).thenReturn("parentDisplayName");
         when(grandparent.displayName()).thenReturn("grandparentDisplayName");
+
+        MockitoAnnotations.initMocks(this);
     }
 
     @Override

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueModelBuilderShould.java
@@ -54,9 +54,8 @@ public class TrackedEntityAttributeReservedValueModelBuilderShould extends Model
     @Before
     public void setUp() throws IOException {
         super.setUp();
-        MockitoAnnotations.initMocks(this);
-
         when(organisationUnit.uid()).thenReturn("orgUnitUid");
+        MockitoAnnotations.initMocks(this);
     }
 
     protected TrackedEntityAttributeReservedValue buildPojo() {

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueModelBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueModelBuilderShould.java
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.android.core.trackedentity;
 
+import org.hisp.dhis.android.core.common.ModelBuilder;
+import org.hisp.dhis.android.core.common.ModelBuilderAbstractShould;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,23 +45,18 @@ import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.CREA
 import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
-public class TrackedEntityAttributeReservedValueModelBuilderShould {
-
-    private TrackedEntityAttributeReservedValue pojo;
-
-    private TrackedEntityAttributeReservedValueModel model;
+public class TrackedEntityAttributeReservedValueModelBuilderShould extends ModelBuilderAbstractShould<
+    TrackedEntityAttributeReservedValue, TrackedEntityAttributeReservedValueModel> {
 
     @Mock
     private OrganisationUnit organisationUnit;
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setUp() throws IOException {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
 
         when(organisationUnit.uid()).thenReturn("orgUnitUid");
-        pojo = buildPojo();
-        model = buildModel();
     }
 
     protected TrackedEntityAttributeReservedValue buildPojo() {
@@ -73,12 +70,13 @@ public class TrackedEntityAttributeReservedValueModelBuilderShould {
         );
     }
 
-    protected TrackedEntityAttributeReservedValueModel buildModel() {
-        return new TrackedEntityAttributeReservedValueModelBuilder(organisationUnit).buildModel(pojo);
+    @Override
+    protected ModelBuilder<TrackedEntityAttributeReservedValue, TrackedEntityAttributeReservedValueModel> modelBuilder() {
+        return new TrackedEntityAttributeReservedValueModelBuilder(organisationUnit);
     }
 
     @Test
-    public void copy_pojo_relationship_properties() {
+    public void copy_pojo_reserved_value_properties() {
         assertThat(model.ownerObject()).isEqualTo(pojo.ownerObject());
         assertThat(model.ownerUid()).isEqualTo(pojo.ownerUid());
         assertThat(model.key()).isEqualTo(pojo.key());


### PR DESCRIPTION
Removes pojos and pojoToModel testing in model tests, since conversion is no longer done in models but in ModelBuilders. In the cases where the conversion was tested there but there was no model builder test yet, it has been created. 