### PR TITLE
android-sdk-28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-25.0.2
-  - android-25
+  - build-tools-28.0.3
+  - android-28
   - android-22
   - extra-android-m2repository
   - extra-google-google_play_services

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ subprojects { project ->
 
 ext {
     configuration = [
-            buildToolsVersion: "25.0.2",
+            buildToolsVersion: "28.0.3",
             minSdkVersion    : 19,
-            targetSdkVersion : 25,
+            targetSdkVersion : 28,
             versionCode      : 112,
             versionName      : "0.11.13-SNAPSHOT"
     ]


### PR DESCRIPTION
Upgrades Android Target SDK to API 27 (Android 8.1). It doesn't affect to the minimum SDK version supported. 