### PR TITLE
Tei search

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
@@ -78,6 +78,18 @@ public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStor
         assertThat(queryResponse).isNotEmpty();
     }
 
+    //@Test
+    public void use_filter_to_show_less_attributes() throws Exception {
+        login();
+
+        List<String> attributeList = new ArrayList<>(1);
+        attributeList.add("w75KJ2mc4zz");
+
+        TrackedEntityInstanceQuery query = queryBuilder.attribute(attributeList).build();
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+
     private void login() throws Exception {
         d2.logout().call();
         Response<User> loginResponse = d2.logIn("android", "Android123").call();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
@@ -65,6 +65,19 @@ public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStor
         assertThat(queryResponse).isNotEmpty();
     }
 
+    //@Test
+    public void query_tracked_entity_instances_two_attributes() throws Exception {
+        login();
+
+        List<String> attributeList = new ArrayList<>(2);
+        attributeList.add("w75KJ2mc4zz:like:Filona");
+        attributeList.add("zDhUuAYrxNC:like:Ryder");
+
+        TrackedEntityInstanceQuery query = queryBuilder.attribute(attributeList).build();
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+
     private void login() throws Exception {
         d2.logout().call();
         Response<User> loginResponse = d2.logIn("android", "Android123").call();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
@@ -1,0 +1,48 @@
+package org.hisp.dhis.android.core;
+
+import org.hisp.dhis.android.core.common.D2Factory;
+import org.hisp.dhis.android.core.data.api.OuMode;
+import org.hisp.dhis.android.core.data.database.AbsStoreTestCase;
+import org.hisp.dhis.android.core.data.server.RealServerMother;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQuery;
+import org.hisp.dhis.android.core.user.User;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Response;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStoreTestCase {
+    private D2 d2;
+
+    @Before
+    @Override
+    public void setUp() throws IOException {
+        super.setUp();
+
+        d2 = D2Factory.create(RealServerMother.url, databaseAdapter());
+    }
+
+    //@Test
+    public void query_tracked_entity_instances() throws Exception {
+        d2.logout().call();
+        Response<User> loginResponse = d2.logIn("android", "Android123").call();
+        assertThat(loginResponse.isSuccessful()).isTrue();
+
+        List<String> orgUnits = new ArrayList<>();
+        orgUnits.add("O6uvpzGd5pu");
+
+        TrackedEntityInstanceQuery query = TrackedEntityInstanceQuery.builder()
+                .paging(true).page(1).pageSize(50)
+                .orgUnits(orgUnits).orgUnitMode(OuMode.ACCESSIBLE).program("IpHINAT79UW").build();
+
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+}

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
@@ -8,7 +8,6 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQuery;
 import org.hisp.dhis.android.core.user.User;
 import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -20,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStoreTestCase {
     private D2 d2;
+    private TrackedEntityInstanceQuery.Builder queryBuilder;
 
     @Before
     @Override
@@ -27,22 +27,35 @@ public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStor
         super.setUp();
 
         d2 = D2Factory.create(RealServerMother.url, databaseAdapter());
-    }
 
-    //@Test
-    public void query_tracked_entity_instances() throws Exception {
-        d2.logout().call();
-        Response<User> loginResponse = d2.logIn("android", "Android123").call();
-        assertThat(loginResponse.isSuccessful()).isTrue();
 
         List<String> orgUnits = new ArrayList<>();
         orgUnits.add("O6uvpzGd5pu");
 
-        TrackedEntityInstanceQuery query = TrackedEntityInstanceQuery.builder()
+        queryBuilder = TrackedEntityInstanceQuery.builder()
                 .paging(true).page(1).pageSize(50)
-                .orgUnits(orgUnits).orgUnitMode(OuMode.ACCESSIBLE).program("IpHINAT79UW").build();
+                .orgUnits(orgUnits).orgUnitMode(OuMode.ACCESSIBLE).program("IpHINAT79UW");
+    }
 
+    //@Test
+    public void query_tracked_entity_instances_no_filter() throws Exception {
+        login();
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(queryBuilder.build()).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+
+    //@Test
+    public void query_tracked_entity_instances_filter_name() throws Exception {
+        login();
+
+        TrackedEntityInstanceQuery query = queryBuilder.query("jorge").build();
         List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
         assertThat(queryResponse).isNotEmpty();
+    }
+
+    private void login() throws Exception {
+        d2.logout().call();
+        Response<User> loginResponse = d2.logIn("android", "Android123").call();
+        assertThat(loginResponse.isSuccessful()).isTrue();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
@@ -53,6 +53,18 @@ public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStor
         assertThat(queryResponse).isNotEmpty();
     }
 
+    //@Test
+    public void query_tracked_entity_instances_one_attribute() throws Exception {
+        login();
+
+        List<String> attributeList = new ArrayList<>(1);
+        attributeList.add("w75KJ2mc4zz:like:jorge");
+
+        TrackedEntityInstanceQuery query = queryBuilder.attribute(attributeList).build();
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+
     private void login() throws Exception {
         d2.logout().call();
         Response<User> loginResponse = d2.logIn("android", "Android123").call();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/TrackedEntityInstanceQueryCallRealIntegrationShould.java
@@ -79,13 +79,38 @@ public class TrackedEntityInstanceQueryCallRealIntegrationShould extends AbsStor
     }
 
     //@Test
-    public void use_filter_to_show_less_attributes() throws Exception {
+    public void use_attribute_to_reduce_attributes_returned() throws Exception {
         login();
 
         List<String> attributeList = new ArrayList<>(1);
         attributeList.add("w75KJ2mc4zz");
 
         TrackedEntityInstanceQuery query = queryBuilder.attribute(attributeList).build();
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+
+    //@Test
+    public void query_tracked_entity_instances_one_filter() throws Exception {
+        login();
+
+        List<String> filterList = new ArrayList<>(1);
+        filterList.add("w75KJ2mc4zz:like:jorge");
+
+        TrackedEntityInstanceQuery query = queryBuilder.filter(filterList).build();
+        List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
+        assertThat(queryResponse).isNotEmpty();
+    }
+
+    //@Test
+    public void query_tracked_entity_instances_two_filters() throws Exception {
+        login();
+
+        List<String> filterList = new ArrayList<>(2);
+        filterList.add("w75KJ2mc4zz:like:Filona");
+        filterList.add("zDhUuAYrxNC:like:Ryder");
+
+        TrackedEntityInstanceQuery query = queryBuilder.filter(filterList).build();
         List<TrackedEntityInstance> queryResponse = d2.queryTrackedEntityInstances(query).call();
         assertThat(queryResponse).isNotEmpty();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/D2.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.java
@@ -51,11 +51,14 @@ import org.hisp.dhis.android.core.imports.WebResponse;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeReservedValueManager;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceEndPointCall;
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQuery;
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryCall;
 import org.hisp.dhis.android.core.user.IsUserLoggedInCallable;
 import org.hisp.dhis.android.core.user.LogOutUserCallable;
 import org.hisp.dhis.android.core.user.User;
 import org.hisp.dhis.android.core.user.UserAuthenticateCall;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import okhttp3.OkHttpClient;
@@ -154,6 +157,11 @@ public final class D2 {
     @NonNull
     public Call<Response<WebResponse>> syncTrackedEntityInstances() {
         return TrackedEntityInstancePostCall.create(databaseAdapter, retrofit);
+    }
+
+    @NonNull
+    public Call<List<TrackedEntityInstance>> queryTrackedEntityInstances(TrackedEntityInstanceQuery query) {
+        return TrackedEntityInstanceQueryCall.create(retrofit, query);
     }
 
     public Call<Response<WebResponse>> syncSingleEvents() {

--- a/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
@@ -48,6 +48,9 @@ public abstract class D2CallException extends Exception {
     @Nullable
     public abstract Integer httpErrorCode();
 
+    @Nullable
+    public abstract Exception originalException();
+
     public static Builder builder() {
         return new AutoValue_D2CallException.Builder();
     }
@@ -61,6 +64,8 @@ public abstract class D2CallException extends Exception {
         public abstract Builder isHttpError(Boolean isHttpError);
 
         public abstract Builder httpErrorCode(Integer httpErrorCode);
+
+        public abstract Builder originalException(Exception originalException);
 
         public abstract D2CallException build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.common;
+
+import com.google.auto.value.AutoValue;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import retrofit2.Response;
+
+@AutoValue
+public abstract class D2CallException extends Exception {
+
+    public abstract String errorCode();
+    public abstract String errorDescription();
+    public abstract Boolean isHttpError();
+    public abstract Integer httpErrorCode();
+
+    public static Builder builder() {
+        return new AutoValue_D2CallException.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder errorCode(String errorCode);
+
+        public abstract Builder errorDescription(String errorDescription);
+
+        public abstract Builder isHttpError(Boolean isHttpError);
+
+        public abstract Builder httpErrorCode(Integer httpErrorCode);
+
+        public abstract D2CallException build();
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
@@ -33,9 +33,6 @@ import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import retrofit2.Response;
-
 @AutoValue
 public abstract class D2CallException extends Exception {
 

--- a/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/D2CallException.java
@@ -28,6 +28,9 @@
 
 package org.hisp.dhis.android.core.common;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.google.auto.value.AutoValue;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -36,9 +39,16 @@ import retrofit2.Response;
 @AutoValue
 public abstract class D2CallException extends Exception {
 
+    @Nullable
     public abstract String errorCode();
+
+    @Nullable
     public abstract String errorDescription();
+
+    @NonNull
     public abstract Boolean isHttpError();
+
+    @Nullable
     public abstract Integer httpErrorCode();
 
     public static Builder builder() {

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueEndpointCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueEndpointCall.java
@@ -37,7 +37,7 @@ import java.util.Set;
 
 import retrofit2.Call;
 
-import static org.hisp.dhis.android.core.utils.Utils.commaSeparatedArrayValuesFromSet;
+import static org.hisp.dhis.android.core.utils.Utils.commaSeparatedCollectionValues;
 
 public final class DataValueEndpointCall extends GenericEndpointCallImpl<DataValue, DataValueModel,
         DataValueQuery> {
@@ -55,9 +55,9 @@ public final class DataValueEndpointCall extends GenericEndpointCallImpl<DataVal
         return dataValueService.getDataValues(
                 DataValue.allFields,
                 DataValue.lastUpdated.gt(lastUpdated),
-                commaSeparatedArrayValuesFromSet(query.dataSetUids()),
-                commaSeparatedArrayValuesFromSet(query.periodIds()),
-                commaSeparatedArrayValuesFromSet(query.orgUnitUids()),
+                commaSeparatedCollectionValues(query.dataSetUids()),
+                commaSeparatedCollectionValues(query.periodIds()),
+                commaSeparatedCollectionValues(query.orgUnitUids()),
                 Boolean.FALSE);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
@@ -8,6 +8,8 @@ import org.hisp.dhis.android.core.data.api.Which;
 import org.hisp.dhis.android.core.imports.WebResponse;
 import org.hisp.dhis.android.core.trackedentity.search.SearchGrid;
 
+import java.util.List;
+
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
@@ -22,6 +24,7 @@ public interface TrackedEntityInstanceService {
     String OU_MODE = "ouMode";
     String FIELDS = "fields";
     String QUERY = "query";
+    String ATTRIBUTE = "attribute";
     String PAGING = "paging";
     String PAGE = "page";
     String PAGE_SIZE = "pageSize";
@@ -44,7 +47,8 @@ public interface TrackedEntityInstanceService {
             @Query(OU) String orgUnit,
             @Query(FILTER) @Where Filter<TrackedEntityInstance, String> lastUpdated,
             @Query(FIELDS) @Which Fields<TrackedEntityInstance> fields,
-            @Query(PAGING) Boolean paging, @Query(PAGE) int page,
+            @Query(PAGING) Boolean paging,
+            @Query(PAGE) int page,
             @Query(PAGE_SIZE) int pageSize);
 
     @GET(TRACKED_ENTITY_INSTANCES + "/query")
@@ -53,6 +57,8 @@ public interface TrackedEntityInstanceService {
             @Query(OU_MODE) String orgUnitMode,
             @Query(PROGRAM) String program,
             @Query(QUERY) String query,
+            @Query(ATTRIBUTE) List<String> attribute,
+            @Query(FILTER) List<String> filter,
             @Query(PAGING) Boolean paging,
             @Query(PAGE) int page,
             @Query(PAGE_SIZE) int pageSize);

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
@@ -6,6 +6,7 @@ import org.hisp.dhis.android.core.data.api.Filter;
 import org.hisp.dhis.android.core.data.api.Where;
 import org.hisp.dhis.android.core.data.api.Which;
 import org.hisp.dhis.android.core.imports.WebResponse;
+import org.hisp.dhis.android.core.trackedentity.search.SearchGrid;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
@@ -46,7 +47,7 @@ public interface TrackedEntityInstanceService {
             @Query(PAGE_SIZE) int pageSize);
 
     @GET(TRACKED_ENTITY_INSTANCES + "/query")
-    Call<Payload<TrackedEntityInstance>> query(
+    Call<SearchGrid> query(
             @Query(OU) String orgUnit,
             @Query(OU_MODE) String orgUnitMode,
             @Query(PROGRAM) String program,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
@@ -21,6 +21,7 @@ public interface TrackedEntityInstanceService {
     String OU = "ou";
     String OU_MODE = "ouMode";
     String FIELDS = "fields";
+    String QUERY = "query";
     String PAGING = "paging";
     String PAGE = "page";
     String PAGE_SIZE = "pageSize";
@@ -51,6 +52,8 @@ public interface TrackedEntityInstanceService {
             @Query(OU) String orgUnit,
             @Query(OU_MODE) String orgUnitMode,
             @Query(PROGRAM) String program,
-            @Query(PAGING) Boolean paging, @Query(PAGE) int page,
+            @Query(QUERY) String query,
+            @Query(PAGING) Boolean paging,
+            @Query(PAGE) int page,
             @Query(PAGE_SIZE) int pageSize);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceService.java
@@ -18,10 +18,12 @@ public interface TrackedEntityInstanceService {
     String TRACKED_ENTITY_INSTANCES = "trackedEntityInstances";
     String TRACKED_ENTITY_INSTANCES_UID = "trackedEntityInstanceUid";
     String OU = "ou";
+    String OU_MODE = "ouMode";
     String FIELDS = "fields";
     String PAGING = "paging";
     String PAGE = "page";
     String PAGE_SIZE = "pageSize";
+    String PROGRAM = "program";
     String INCLUDE_DELETED = "includeDeleted";
     String FILTER = "filter";
 
@@ -40,6 +42,14 @@ public interface TrackedEntityInstanceService {
             @Query(OU) String orgUnit,
             @Query(FILTER) @Where Filter<TrackedEntityInstance, String> lastUpdated,
             @Query(FIELDS) @Which Fields<TrackedEntityInstance> fields,
+            @Query(PAGING) Boolean paging, @Query(PAGE) int page,
+            @Query(PAGE_SIZE) int pageSize);
+
+    @GET(TRACKED_ENTITY_INSTANCES + "/query")
+    Call<Payload<TrackedEntityInstance>> query(
+            @Query(OU) String orgUnit,
+            @Query(OU_MODE) String orgUnitMode,
+            @Query(PROGRAM) String program,
             @Query(PAGING) Boolean paging, @Query(PAGE) int page,
             @Query(PAGE_SIZE) int pageSize);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridMapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridMapper.java
@@ -36,7 +36,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
-final class SearchGridMapper {
+class SearchGridMapper {
     private static final Integer NON_ATTRIBUTE_LENGTH = 7;
 
     public List<TrackedEntityInstance> transform(SearchGrid searchGrid) throws ParseException {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
@@ -7,9 +7,8 @@ import org.hisp.dhis.android.core.data.api.OuMode;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
-import io.reactivex.annotations.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 
 @AutoValue
 public abstract class TrackedEntityInstanceQuery extends BaseQuery {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
@@ -1,0 +1,39 @@
+package org.hisp.dhis.android.core.trackedentity.search;
+
+import com.google.auto.value.AutoValue;
+
+import org.hisp.dhis.android.core.common.BaseQuery;
+import org.hisp.dhis.android.core.data.api.OuMode;
+
+import javax.annotation.Nullable;
+
+import io.reactivex.annotations.NonNull;
+
+@AutoValue
+public abstract class TrackedEntityInstanceQuery extends BaseQuery {
+
+
+    @NonNull
+    public abstract String orgUnit();
+
+    @Nullable
+    public abstract OuMode orgUnitMode();
+
+    @Nullable
+    public abstract String program();
+
+    public static Builder builder() {
+        return new AutoValue_TrackedEntityInstanceQuery.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder extends BaseQuery.Builder<Builder> {
+        public abstract Builder orgUnit(String orgUnit);
+
+        public abstract Builder orgUnitMode(OuMode orgUnitMode);
+
+        public abstract Builder program(String program);
+
+        public abstract TrackedEntityInstanceQuery build();
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
@@ -24,6 +24,15 @@ public abstract class TrackedEntityInstanceQuery extends BaseQuery {
     @Nullable
     public abstract String program();
 
+    @Nullable
+    public abstract String query();
+
+    @Nullable
+    public abstract List<String> attribute();
+
+    @Nullable
+    public abstract List<String> filter();
+
     public static Builder builder() {
         return new AutoValue_TrackedEntityInstanceQuery.Builder();
     }
@@ -35,6 +44,12 @@ public abstract class TrackedEntityInstanceQuery extends BaseQuery {
         public abstract Builder orgUnitMode(OuMode orgUnitMode);
 
         public abstract Builder program(String program);
+
+        public abstract Builder query(String query);
+
+        public abstract Builder attribute(List<String> attribute);
+
+        public abstract Builder filter(List<String> filter);
 
         public abstract TrackedEntityInstanceQuery build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQuery.java
@@ -5,6 +5,8 @@ import com.google.auto.value.AutoValue;
 import org.hisp.dhis.android.core.common.BaseQuery;
 import org.hisp.dhis.android.core.data.api.OuMode;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import io.reactivex.annotations.NonNull;
@@ -14,7 +16,7 @@ public abstract class TrackedEntityInstanceQuery extends BaseQuery {
 
 
     @NonNull
-    public abstract String orgUnit();
+    public abstract List<String> orgUnits();
 
     @Nullable
     public abstract OuMode orgUnitMode();
@@ -28,7 +30,7 @@ public abstract class TrackedEntityInstanceQuery extends BaseQuery {
 
     @AutoValue.Builder
     public abstract static class Builder extends BaseQuery.Builder<Builder> {
-        public abstract Builder orgUnit(String orgUnit);
+        public abstract Builder orgUnits(List<String> orgUnits);
 
         public abstract Builder orgUnitMode(OuMode orgUnitMode);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -22,7 +22,7 @@ public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedE
     private final TrackedEntityInstanceQuery query;
     private final SearchGridMapper mapper;
 
-    private TrackedEntityInstanceQueryCall(
+    TrackedEntityInstanceQueryCall(
             @NonNull TrackedEntityInstanceService service,
             @NonNull TrackedEntityInstanceQuery query,
             @NonNull SearchGridMapper mapper) {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -16,6 +16,7 @@ import java.util.List;
 import retrofit2.Response;
 import retrofit2.Retrofit;
 
+@SuppressWarnings({"PMD.PreserveStackTrace"})
 public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedEntityInstance>> {
 
     private final TrackedEntityInstanceService service;

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -44,8 +44,8 @@ public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedE
         try {
             String orgUnits = Utils.joinCollectionWithSeparator(query.orgUnits(), ";");
             Response<SearchGrid> searchGridResponse = service.query(orgUnits,
-                    orgUnitModeStr, query.program(), query.query(), query.paging(), query.page(),
-                    query.pageSize()).execute();
+                    orgUnitModeStr, query.program(), query.query(), query.attribute(), query.filter(),
+                    query.paging(), query.page(), query.pageSize()).execute();
 
             if (!searchGridResponse.isSuccessful()) {
                 throw httpExceptionBuilder.httpErrorCode(searchGridResponse.code()).build();

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -47,21 +47,21 @@ public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedE
                     orgUnitModeStr, query.program(), query.query(), query.attribute(), query.filter(),
                     query.paging(), query.page(), query.pageSize()).execute();
 
-            if (!searchGridResponse.isSuccessful()) {
-                throw httpExceptionBuilder.httpErrorCode(searchGridResponse.code()).build();
-            } else {
+            if (searchGridResponse.isSuccessful()) {
                 SearchGrid searchGrid = searchGridResponse.body();
-
                 try {
                     return mapper.transform(searchGrid);
                 } catch (ParseException pe) {
                     throw D2CallException.builder()
                             .isHttpError(false).errorDescription("Search Grid mapping exception")
+                            .originalException(pe)
                             .build();
                 }
+            } else {
+                throw httpExceptionBuilder.httpErrorCode(searchGridResponse.code()).build();
             }
         } catch (IOException e) {
-            throw httpExceptionBuilder.build();
+            throw httpExceptionBuilder.originalException(e).build();
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -1,0 +1,72 @@
+package org.hisp.dhis.android.core.trackedentity.search;
+
+import android.support.annotation.NonNull;
+
+import org.hisp.dhis.android.core.common.D2CallException;
+import org.hisp.dhis.android.core.common.SyncCall;
+import org.hisp.dhis.android.core.data.api.OuMode;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceService;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
+import retrofit2.Response;
+import retrofit2.Retrofit;
+
+public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedEntityInstance>> {
+
+    private final TrackedEntityInstanceService service;
+    private final TrackedEntityInstanceQuery query;
+    private final SearchGridMapper mapper;
+
+    private TrackedEntityInstanceQueryCall(
+            @NonNull TrackedEntityInstanceService service,
+            @NonNull TrackedEntityInstanceQuery query,
+            @NonNull SearchGridMapper mapper) {
+        this.service = service;
+        this.query = query;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<TrackedEntityInstance> call() throws D2CallException {
+        super.setExecuted();
+
+
+        OuMode mode = query.orgUnitMode();
+        String orgUnitModeStr = mode == null ? null : mode.toString();
+        D2CallException.Builder httpExceptionBuilder = D2CallException.builder()
+                .isHttpError(true).errorDescription("Search Grid call failed");
+
+        try {
+            Response<SearchGrid> searchGridResponse = service.query(query.orgUnit(),
+                    orgUnitModeStr, query.program(), query.paging(), query.page(), query.pageSize()).execute();
+
+            if (!searchGridResponse.isSuccessful()) {
+                throw httpExceptionBuilder.httpErrorCode(searchGridResponse.code()).build();
+            } else {
+                SearchGrid searchGrid = searchGridResponse.body();
+
+                try {
+                    return mapper.transform(searchGrid);
+                } catch (ParseException pe) {
+                    throw D2CallException.builder()
+                            .isHttpError(false).errorDescription("Search Grid mapping exception")
+                            .build();
+                }
+            }
+        } catch (IOException e) {
+            throw httpExceptionBuilder.build();
+        }
+    }
+
+    public static TrackedEntityInstanceQueryCall create(Retrofit retrofit, TrackedEntityInstanceQuery query) {
+        return new TrackedEntityInstanceQueryCall(
+                retrofit.create(TrackedEntityInstanceService.class),
+                query,
+                new SearchGridMapper()
+        );
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -44,7 +44,8 @@ public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedE
         try {
             String orgUnits = Utils.joinCollectionWithSeparator(query.orgUnits(), ";");
             Response<SearchGrid> searchGridResponse = service.query(orgUnits,
-                    orgUnitModeStr, query.program(), query.paging(), query.page(), query.pageSize()).execute();
+                    orgUnitModeStr, query.program(), query.query(), query.paging(), query.page(),
+                    query.pageSize()).execute();
 
             if (!searchGridResponse.isSuccessful()) {
                 throw httpExceptionBuilder.httpErrorCode(searchGridResponse.code()).build();

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCall.java
@@ -7,6 +7,7 @@ import org.hisp.dhis.android.core.common.SyncCall;
 import org.hisp.dhis.android.core.data.api.OuMode;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.android.core.utils.Utils;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -41,7 +42,8 @@ public final class TrackedEntityInstanceQueryCall extends SyncCall<List<TrackedE
                 .isHttpError(true).errorDescription("Search Grid call failed");
 
         try {
-            Response<SearchGrid> searchGridResponse = service.query(query.orgUnit(),
+            String orgUnits = Utils.joinCollectionWithSeparator(query.orgUnits(), ";");
+            Response<SearchGrid> searchGridResponse = service.query(orgUnits,
                     orgUnitModeStr, query.program(), query.paging(), query.page(), query.pageSize()).execute();
 
             if (!searchGridResponse.isSuccessful()) {

--- a/core/src/main/java/org/hisp/dhis/android/core/utils/Utils.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/utils/Utils.java
@@ -37,9 +37,9 @@ import org.hisp.dhis.android.core.event.Event;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A collection of utility abstractions
@@ -107,10 +107,14 @@ public final class Utils {
     }
 
     private static String commaSeparatedArrayValues(String... values) {
-        return  commaAndSpaceSeparatedArrayValues(values).replace(" ", "");
+        return commaAndSpaceSeparatedArrayValues(values).replace(" ", "");
     }
 
-    public static String commaSeparatedArrayValuesFromSet(Set<String> values) {
-        return  commaSeparatedArrayValues(values.toArray(new String[values.size()]));
+    public static String commaSeparatedCollectionValues(Collection<String> values) {
+        return commaSeparatedArrayValues(values.toArray(new String[values.size()]));
+    }
+
+    public static String joinCollectionWithSeparator(Collection<String> values, String separator) {
+        return commaSeparatedCollectionValues(values).replace(",", ";");
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallShould.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.trackedentity.search;
+
+import org.hisp.dhis.android.core.common.BaseCallShould;
+import org.hisp.dhis.android.core.data.api.OuMode;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Response;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnit4.class)
+public class TrackedEntityInstanceQueryCallShould extends BaseCallShould {
+    @Mock
+    private TrackedEntityInstanceService service;
+
+    @Mock
+    private SearchGridMapper mapper;
+
+    @Mock
+    private SearchGrid searchGrid;
+
+    @Mock
+    private Call<SearchGrid> searchGridCall;
+
+    @Mock
+    private List<TrackedEntityInstance> teis;
+
+    @Mock
+    private List<String> attribute;
+
+    @Mock
+    private List<String> filter;
+
+    private List<String> orgUnits;
+
+    private final String program = "program";
+    private final String queryStr = "queryStr";
+    private final Boolean paging = true;
+    private final Integer page = 2;
+    private final Integer pageSize = 33;
+
+    // object to test
+    private TrackedEntityInstanceQueryCall call;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        orgUnits = new ArrayList<>(2);
+        orgUnits.add("ou1");
+        orgUnits.add("ou2");
+
+        TrackedEntityInstanceQuery query = TrackedEntityInstanceQuery.builder().
+                orgUnits(orgUnits).orgUnitMode(OuMode.ACCESSIBLE).program(program)
+                .query(queryStr).attribute(attribute).filter(filter)
+                .paging(paging).page(page).pageSize(pageSize).build();
+
+        when(service.query(anyString(), anyString(), anyString(), anyString(),
+                anyListOf(String.class), anyListOf(String.class), anyBoolean(), anyInt(), anyInt()))
+        .thenReturn(searchGridCall);
+        when(searchGridCall.execute()).thenReturn(Response.success(searchGrid));
+        when(mapper.transform(any(SearchGrid.class))).thenReturn(teis);
+
+        // Metadata call
+        call = new TrackedEntityInstanceQueryCall(service, query, mapper);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        super.tearDown();
+    }
+
+    @Test
+    public void succeed_when_endpoint_calls_succeed() throws Exception {
+        List<TrackedEntityInstance> teisResponse = call.call();
+        assertThat(teisResponse).isEqualTo(teis);
+    }
+}


### PR DESCRIPTION
Solves TEIs online search. A method is exposed in D2 so that the can perform the query. A builder for the query is provided for maximum flexibility. Attributes and filter are passed as a list of strings, we can provide a new structure in the future.

I will set [ANDROSDK-39](https://jira.dhis2.org/browse/ANDROSDK-39) as "Coding Done". We can create new tickets for smaller issues and for the second step of the online search (persistence of downloaded TEIs). 

TrackedEntityInstanceQueryCallRealIntegrationShould tests functionality using D2 with a real server. 