### PR TITLE
optionset-limit-null: set null as uid limit in optionSetCall

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionSetCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionSetCall.java
@@ -82,7 +82,7 @@ public class OptionSetCall extends EndpointPayloadCall<OptionSet, UidsQuery> {
             return new OptionSetCall(
                     data,
                     data.retrofit().create(OptionSetService.class),
-                    UidsQuery.create(uids, 64),
+                    UidsQuery.create(uids, null),
                     new TransactionalResourceListPersistor<>(
                             data,
                             OptionSetHandler.create(data.databaseAdapter()),


### PR DESCRIPTION
Workaround to avoid uid query limit error on optionsetcall