### PR TITLE
metadata-call-not-null: make MetadataCall return unit

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/D2.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.java
@@ -114,13 +114,13 @@ public final class D2 {
     }
 
     @NonNull
-    public Callable<Void> logout() {
+    public Callable<Unit> logout() {
         return LogOutUserCallable.createToLogOut(databaseAdapter);
 
     }
 
     @NonNull
-    public Callable<Void> wipeDB() {
+    public Callable<Unit> wipeDB() {
         return LogOutUserCallable.createToWipe(databaseAdapter);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/D2.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.android.core.user.IsUserLoggedInCallable;
 import org.hisp.dhis.android.core.user.LogOutUserCallable;
 import org.hisp.dhis.android.core.user.User;
 import org.hisp.dhis.android.core.user.UserAuthenticateCall;
+import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.utils.services.ProgramIndicatorEngine;
 
 import java.util.Collection;
@@ -124,7 +125,7 @@ public final class D2 {
     }
 
     @NonNull
-    public Callable<Void> syncMetaData() {
+    public Callable<Unit> syncMetaData() {
         return MetadataCall.create(databaseAdapter, retrofit);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/D2.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.android.core.calls.TrackerDataCall;
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.common.D2CallException;
 import org.hisp.dhis.android.core.common.SSLContextInitializer;
+import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.configuration.ConfigurationModel;
 import org.hisp.dhis.android.core.data.api.FieldsConverterFactory;
 import org.hisp.dhis.android.core.data.api.FilterConverterFactory;
@@ -60,7 +61,6 @@ import org.hisp.dhis.android.core.user.IsUserLoggedInCallable;
 import org.hisp.dhis.android.core.user.LogOutUserCallable;
 import org.hisp.dhis.android.core.user.User;
 import org.hisp.dhis.android.core.user.UserAuthenticateCall;
-import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.utils.services.ProgramIndicatorEngine;
 
 import java.util.Collection;

--- a/core/src/main/java/org/hisp/dhis/android/core/calls/MetadataCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/calls/MetadataCall.java
@@ -53,13 +53,14 @@ import org.hisp.dhis.android.core.systeminfo.SystemInfo;
 import org.hisp.dhis.android.core.systeminfo.SystemInfoCall;
 import org.hisp.dhis.android.core.user.User;
 import org.hisp.dhis.android.core.user.UserCall;
+import org.hisp.dhis.android.core.common.Unit;
 
 import java.util.List;
 import java.util.concurrent.Callable;
 
 import retrofit2.Retrofit;
 
-public class MetadataCall extends SyncCall<Void> {
+public class MetadataCall extends SyncCall<Unit> {
 
     private final DatabaseAdapter databaseAdapter;
     private final Retrofit retrofit;
@@ -100,14 +101,14 @@ public class MetadataCall extends SyncCall<Void> {
     }
 
     @Override
-    public Void call() throws Exception {
+    public Unit call() throws Exception {
         setExecuted();
 
         final D2CallExecutor executor = new D2CallExecutor();
 
-        return executor.executeD2CallTransactionally(databaseAdapter, new Callable<Void>() {
+        return executor.executeD2CallTransactionally(databaseAdapter, new Callable<Unit>() {
             @Override
-            public Void call() throws D2CallException {
+            public Unit call() throws D2CallException {
                 SystemInfo systemInfo = executor.executeD2Call(
                         systemInfoCallFactory.create(databaseAdapter, retrofit));
 
@@ -130,7 +131,7 @@ public class MetadataCall extends SyncCall<Void> {
 
                 foreignKeyCleaner.cleanForeignKeyErrors();
 
-                return null;
+                return new Unit();
             }
         });
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/common/Unit.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/Unit.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.common;
+
+public final class Unit {
+
+    public Unit() {
+        // This constructor is intentionally empty. Nothing special is needed here.
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/user/LogOutUserCallable.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/LogOutUserCallable.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.android.core.category.CategoryOptionStore;
 import org.hisp.dhis.android.core.category.CategoryStoreImpl;
 import org.hisp.dhis.android.core.common.DeletableStore;
 import org.hisp.dhis.android.core.common.ObjectStyleStore;
+import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.common.ValueTypeDeviceRenderingStore;
 import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 import org.hisp.dhis.android.core.dataelement.DataElementStore;
@@ -87,7 +88,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 @SuppressWarnings("PMD.ExcessiveImports")
-public class LogOutUserCallable implements Callable<Void> {
+public class LogOutUserCallable implements Callable<Unit> {
 
     @NonNull
     private final List<DeletableStore> deletableStores;
@@ -97,12 +98,12 @@ public class LogOutUserCallable implements Callable<Void> {
     }
 
     @Override
-    public Void call() throws Exception {
+    public Unit call() throws Exception {
         // clear out all tables
         for (DeletableStore deletableStore : deletableStores) {
             deletableStore.delete();
         }
-        return null;
+        return new Unit();
     }
 
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserAuthenticateCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserAuthenticateCall.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.android.core.common.GenericHandler;
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.common.ObjectWithoutUidStore;
 import org.hisp.dhis.android.core.common.SyncCall;
+import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 import org.hisp.dhis.android.core.data.database.Transaction;
 import org.hisp.dhis.android.core.resource.ResourceHandler;
@@ -73,7 +74,7 @@ public final class UserAuthenticateCall extends SyncCall<User> {
     private final AuthenticatedUserStore authenticatedUserStore;
     private final ObjectWithoutUidStore<SystemInfoModel> systemInfoStore;
     private final IdentifiableObjectStore<UserModel> userStore;
-    private final Callable<Void> dbWipe;
+    private final Callable<Unit> dbWipe;
 
     // username and password of candidate
     private final String username;
@@ -90,7 +91,7 @@ public final class UserAuthenticateCall extends SyncCall<User> {
             @NonNull AuthenticatedUserStore authenticatedUserStore,
             @NonNull ObjectWithoutUidStore<SystemInfoModel> systemInfoStore,
             @NonNull IdentifiableObjectStore<UserModel> userStore,
-            @NonNull Callable<Void> dbWipe,
+            @NonNull Callable<Unit> dbWipe,
             @NonNull String username,
             @NonNull String password,
             @NonNull String apiURL) {

--- a/core/src/test/java/org/hisp/dhis/android/core/user/LogOutUserCallableShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/LogOutUserCallableShould.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.core.user;
 import org.hisp.dhis.android.core.common.DeletableStore;
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.common.ObjectStore;
+import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitModel;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +64,7 @@ public class LogOutUserCallableShould {
     @Mock
     private IdentifiableObjectStore<OrganisationUnitModel> organisationUnitStore;
 
-    private Callable<Void> logOutUserCallable;
+    private Callable<Unit> logOutUserCallable;
 
     @Before
     public void setUp() throws Exception {

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserAuthenticateCallUnitShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserAuthenticateCallUnitShould.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.android.core.common.D2CallException;
 import org.hisp.dhis.android.core.common.GenericHandler;
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.common.ObjectWithoutUidStore;
+import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.data.api.Fields;
 import org.hisp.dhis.android.core.data.database.Transaction;
 import org.hisp.dhis.android.core.resource.ResourceHandler;
@@ -126,7 +127,7 @@ public class UserAuthenticateCallUnitShould extends BaseCallShould {
     private Call<SystemInfo> systemInfoEndpointCall;
 
     @Mock
-    private Callable<Void> dbWipeCall;
+    private Callable<Unit> dbWipeCall;
 
     private String baseEndpoint;
 


### PR DESCRIPTION
Solves [ANDROSDK-235](https://jira.dhis2.org/browse/ANDROSDK-235). Only applied to MetadataSync, so it can be tested in the app. Other D2 calls, like wipeDb or syncAggregatedData must be reviewed as well. 