### PR TITLE
uid-call-last-updated: remove lastUpdated filter in uidPayloadCall

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElementEndpointCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElementEndpointCall.java
@@ -57,7 +57,7 @@ public final class DataElementEndpointCall extends UidPayloadCall<DataElement> {
     protected retrofit2.Call<Payload<DataElement>> getCall(UidsQuery query, String lastUpdated) {
         return dataElementService.getDataElements(
                 DataElement.allFields,
-                DataElement.lastUpdated.gt(lastUpdated),
+                DataElement.lastUpdated.gt(null),
                 DataElement.uid.in(query.uids()),
                 Boolean.FALSE);
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorEndpointCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorEndpointCall.java
@@ -57,7 +57,7 @@ public final class IndicatorEndpointCall extends UidPayloadCall<Indicator> {
     protected retrofit2.Call<Payload<Indicator>> getCall(UidsQuery query, String lastUpdated) {
         return indicatorService.getIndicators(
                 Indicator.allFields,
-                Indicator.lastUpdated.gt(lastUpdated),
+                Indicator.lastUpdated.gt(null),
                 Indicator.uid.in(query.uids()),
                 Boolean.FALSE);
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorTypeEndpointCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorTypeEndpointCall.java
@@ -57,7 +57,7 @@ public final class IndicatorTypeEndpointCall extends UidPayloadCall<IndicatorTyp
     protected retrofit2.Call<Payload<IndicatorType>> getCall(UidsQuery query, String lastUpdated) {
         return indicatorTypeService.getIndicatorTypes(
                 IndicatorType.allFields,
-                IndicatorType.lastUpdated.gt(lastUpdated),
+                IndicatorType.lastUpdated.gt(null),
                 IndicatorType.uid.in(query.uids()),
                 Boolean.FALSE);
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionSetCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionSetCall.java
@@ -57,8 +57,11 @@ public final class OptionSetCall extends UidPayloadCall<OptionSet> {
 
     @Override
     protected retrofit2.Call<Payload<OptionSet>> getCall(UidsQuery query, String lastUpdated) {
-        return optionSetService.optionSets(false,
-                getFields(), OptionSet.uid.in(query.uids()));
+        return optionSetService.optionSets(
+                false,
+                getFields(),
+                OptionSet.uid.in(query.uids())
+        );
     }
 
     private Fields<OptionSet> getFields() {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageEndpointCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageEndpointCall.java
@@ -55,8 +55,11 @@ public final class ProgramStageEndpointCall extends UidPayloadCall<ProgramStage>
 
     @Override
     protected retrofit2.Call<Payload<ProgramStage>> getCall(UidsQuery query, String lastUpdated) {
-        return programStageService.getProgramStages(ProgramStage.allFields,
-                ProgramStage.uid.in(query.uids()), Boolean.FALSE);
+        return programStageService.getProgramStages(
+                ProgramStage.allFields,
+                ProgramStage.uid.in(query.uids()),
+                Boolean.FALSE
+        );
     }
 
     public static final UidsCallFactory<ProgramStage> FACTORY = new UidsCallFactory<ProgramStage>() {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeCall.java
@@ -57,7 +57,7 @@ public final class TrackedEntityTypeCall extends UidPayloadCall<TrackedEntityTyp
         return trackedEntityTypeService.getTrackedEntityTypes(
                 TrackedEntityType.allFields,
                 TrackedEntityType.uid.in(query.uids()),
-                TrackedEntityType.lastUpdated.gt(lastUpdated),
+                TrackedEntityType.lastUpdated.gt(null),
                 Boolean.FALSE
         );
     }


### PR DESCRIPTION
Do not use "lastUpdated" filter in query by uid (linked to [ANDROSDK-244](https://jira.dhis2.org/browse/ANDROSDK-244))