### PR TITLE
object-with-delete: create interface and remove duplication

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/common/BaseIdentifiableObject.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/BaseIdentifiableObject.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.text.ParseException;
 import java.util.Date;
 
-public abstract class BaseIdentifiableObject implements IdentifiableObject {
+public abstract class BaseIdentifiableObject implements IdentifiableObject, ObjectWithDeleteInterface {
     /* date format which should be used for all Date instances
     within models which extend BaseIdentifiableObject */
     public static final SafeDateFormat DATE_FORMAT = new SafeDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");

--- a/core/src/main/java/org/hisp/dhis/android/core/common/ObjectWithDeleteInterface.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/ObjectWithDeleteInterface.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.common;
+
+public interface ObjectWithDeleteInterface {
+    Boolean deleted();
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/Enrollment.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/Enrollment.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.Coordinates;
+import org.hisp.dhis.android.core.common.ObjectWithDeleteInterface;
 import org.hisp.dhis.android.core.data.api.Field;
 import org.hisp.dhis.android.core.data.api.Fields;
 import org.hisp.dhis.android.core.data.api.NestedField;
@@ -47,7 +48,7 @@ import java.util.List;
 import static org.hisp.dhis.android.core.utils.Utils.safeUnmodifiableList;
 
 @AutoValue
-public abstract class Enrollment {
+public abstract class Enrollment implements ObjectWithDeleteInterface {
     private static final String UID = "enrollment";
     private static final String CREATED = "created";
     private static final String LAST_UPDATED = "lastUpdated";

--- a/core/src/main/java/org/hisp/dhis/android/core/event/Event.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/Event.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.Coordinates;
+import org.hisp.dhis.android.core.common.ObjectWithDeleteInterface;
 import org.hisp.dhis.android.core.data.api.Field;
 import org.hisp.dhis.android.core.data.api.Fields;
 import org.hisp.dhis.android.core.data.api.NestedField;
@@ -46,7 +47,7 @@ import java.util.Date;
 import java.util.List;
 
 @AutoValue
-public abstract class Event {
+public abstract class Event implements ObjectWithDeleteInterface {
     private static final String UID = "event";
     private static final String ENROLLMENT_UID = "enrollment";
     private static final String CREATED = "created";

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstance.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstance.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import org.hisp.dhis.android.core.common.ObjectWithDeleteInterface;
 import org.hisp.dhis.android.core.data.api.Field;
 import org.hisp.dhis.android.core.data.api.Fields;
 import org.hisp.dhis.android.core.data.api.NestedField;
@@ -47,7 +48,7 @@ import java.util.List;
 import static org.hisp.dhis.android.core.utils.Utils.safeUnmodifiableList;
 
 @AutoValue
-public abstract class TrackedEntityInstance {
+public abstract class TrackedEntityInstance implements ObjectWithDeleteInterface {
     private static final String UID = "trackedEntityInstance";
     private static final String CREATED_AT_CLIENT = "createdAtClient";
     private static final String LAST_UPDATED_AT_CLIENT = "lastUpdatedAtClient";

--- a/core/src/main/java/org/hisp/dhis/android/core/utils/Utils.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/utils/Utils.java
@@ -32,6 +32,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
+import org.hisp.dhis.android.core.common.ObjectWithDeleteInterface;
 import org.hisp.dhis.android.core.enrollment.Enrollment;
 import org.hisp.dhis.android.core.event.Event;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
@@ -68,23 +69,7 @@ public final class Utils {
         return null;
     }
 
-    public static <T extends BaseIdentifiableObject> boolean isDeleted(@NonNull T object) {
-        return object.deleted() != null && object.deleted();
-    }
-
-    //----------------------------------------------------------------------------------------------------
-    // DUPLICATION OF ISDELETED METHODS BECAUSE TRACKER MODELS DOESN'T INHERIT FROM BASEIDENTIFIABLEOBJECT
-    //----------------------------------------------------------------------------------------------------
-
-    public static boolean isDeleted(@NonNull Event object) {
-        return object.deleted() != null && object.deleted();
-    }
-
-    public static boolean isDeleted(@NonNull Enrollment object) {
-        return object.deleted() != null && object.deleted();
-    }
-
-    public static boolean isDeleted(@NonNull TrackedEntityInstance object) {
+    public static boolean isDeleted(@NonNull ObjectWithDeleteInterface object) {
         return object.deleted() != null && object.deleted();
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/utils/Utils.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/utils/Utils.java
@@ -31,11 +31,7 @@ package org.hisp.dhis.android.core.utils;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.common.ObjectWithDeleteInterface;
-import org.hisp.dhis.android.core.enrollment.Enrollment;
-import org.hisp.dhis.android.core.event.Event;
-import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
Creates an interface for objects with `delete()` method and use it in `Utils`, being able to remove 3 duplicated versions of `isDeleted()`.