### PR TITLE
allow-future-dates-inconsistency: remove plural singular inconsistency

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramEndpointCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramEndpointCallMockIntegrationShould.java
@@ -222,7 +222,7 @@ public class ProgramEndpointCallMockIntegrationShould extends AbsStoreTestCase {
                 ProgramTrackedEntityAttributeModel.Columns.DISPLAY_DESCRIPTION,
                 ProgramTrackedEntityAttributeModel.Columns.MANDATORY,
                 ProgramTrackedEntityAttributeModel.Columns.TRACKED_ENTITY_ATTRIBUTE,
-                ProgramTrackedEntityAttributeModel.Columns.ALLOW_FUTURE_DATES,
+                ProgramTrackedEntityAttributeModel.Columns.ALLOW_FUTURE_DATE,
                 ProgramTrackedEntityAttributeModel.Columns.DISPLAY_IN_LIST,
                 ProgramTrackedEntityAttributeModel.Columns.PROGRAM,
                 ProgramTrackedEntityAttributeModel.Columns.SORT_ORDER

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeModelShould.java
@@ -55,7 +55,7 @@ public class ProgramTrackedEntityAttributeModelShould {
     private static final String DISPLAY_DESCRIPTION = "test_display_description";
     private static final Boolean MANDATORY = true;
     private static final String TRACKED_ENTITY_ATTRIBUTE = "test_tracked_entity_attribute";
-    private static final Boolean ALLOW_FUTURE_DATES = false;
+    private static final Boolean ALLOW_FUTURE_DATE = false;
     private static final Boolean DISPLAY_IN_LIST = true;
     private static final Integer SORT_ORDER = 99;
 
@@ -83,7 +83,7 @@ public class ProgramTrackedEntityAttributeModelShould {
                 Columns.DISPLAY_DESCRIPTION,
                 Columns.MANDATORY,
                 Columns.TRACKED_ENTITY_ATTRIBUTE,
-                Columns.ALLOW_FUTURE_DATES,
+                Columns.ALLOW_FUTURE_DATE,
                 Columns.DISPLAY_IN_LIST,
                 Columns.SORT_ORDER
         });
@@ -91,7 +91,7 @@ public class ProgramTrackedEntityAttributeModelShould {
                 ID, UID, CODE, NAME, DISPLAY_NAME, dateString, dateString,
                 SHORT_NAME, DISPLAY_SHORT_NAME, DESCRIPTION, DISPLAY_DESCRIPTION,
                 toInteger(MANDATORY), TRACKED_ENTITY_ATTRIBUTE,
-                toInteger(ALLOW_FUTURE_DATES), toInteger(DISPLAY_IN_LIST), SORT_ORDER
+                toInteger(ALLOW_FUTURE_DATE), toInteger(DISPLAY_IN_LIST), SORT_ORDER
         });
         cursor.moveToFirst();
 
@@ -111,7 +111,7 @@ public class ProgramTrackedEntityAttributeModelShould {
         assertThat(model.displayDescription()).isEqualTo(DISPLAY_DESCRIPTION);
         assertThat(model.mandatory()).isEqualTo(MANDATORY);
         assertThat(model.trackedEntityAttribute()).isEqualTo(TRACKED_ENTITY_ATTRIBUTE);
-        assertThat(model.allowFutureDates()).isEqualTo(ALLOW_FUTURE_DATES);
+        assertThat(model.allowFutureDate()).isEqualTo(ALLOW_FUTURE_DATE);
         assertThat(model.displayInList()).isEqualTo(DISPLAY_IN_LIST);
         assertThat(model.sortOrder()).isEqualTo(SORT_ORDER);
     }
@@ -132,7 +132,7 @@ public class ProgramTrackedEntityAttributeModelShould {
                 .displayDescription(DISPLAY_DESCRIPTION)
                 .mandatory(MANDATORY)
                 .trackedEntityAttribute(TRACKED_ENTITY_ATTRIBUTE)
-                .allowFutureDates(ALLOW_FUTURE_DATES)
+                .allowFutureDate(ALLOW_FUTURE_DATE)
                 .displayInList(DISPLAY_IN_LIST)
                 .sortOrder(SORT_ORDER)
                 .build();
@@ -151,7 +151,7 @@ public class ProgramTrackedEntityAttributeModelShould {
         assertThat(contentValues.getAsString(Columns.DISPLAY_DESCRIPTION)).isEqualTo(DISPLAY_DESCRIPTION);
         assertThat(contentValues.getAsBoolean(Columns.MANDATORY)).isEqualTo(MANDATORY);
         assertThat(contentValues.getAsString(Columns.TRACKED_ENTITY_ATTRIBUTE)).isEqualTo(TRACKED_ENTITY_ATTRIBUTE);
-        assertThat(contentValues.getAsBoolean(Columns.ALLOW_FUTURE_DATES)).isEqualTo(ALLOW_FUTURE_DATES);
+        assertThat(contentValues.getAsBoolean(Columns.ALLOW_FUTURE_DATE)).isEqualTo(ALLOW_FUTURE_DATE);
         assertThat(contentValues.getAsBoolean(Columns.DISPLAY_IN_LIST)).isEqualTo(DISPLAY_IN_LIST);
         assertThat(contentValues.getAsInteger(Columns.SORT_ORDER)).isEqualTo(SORT_ORDER);
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeModel.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeModel.java
@@ -49,7 +49,7 @@ public abstract class ProgramTrackedEntityAttributeModel extends BaseNameableObj
     public static class Columns extends BaseNameableObjectModel.Columns {
         public static final String MANDATORY = "mandatory";
         public static final String TRACKED_ENTITY_ATTRIBUTE = "trackedEntityAttribute";
-        public static final String ALLOW_FUTURE_DATES = "allowFutureDate";
+        public static final String ALLOW_FUTURE_DATE = "allowFutureDate";
         public static final String DISPLAY_IN_LIST = "displayInList";
         public static final String PROGRAM = "program";
         public static final String SORT_ORDER = "sortOrder";
@@ -57,7 +57,7 @@ public abstract class ProgramTrackedEntityAttributeModel extends BaseNameableObj
 
         @Override
         public String[] all() {
-            return Utils.appendInNewArray(super.all(), MANDATORY, TRACKED_ENTITY_ATTRIBUTE, ALLOW_FUTURE_DATES,
+            return Utils.appendInNewArray(super.all(), MANDATORY, TRACKED_ENTITY_ATTRIBUTE, ALLOW_FUTURE_DATE,
                     DISPLAY_IN_LIST, PROGRAM, SORT_ORDER, SEARCHABLE);
         }
     }
@@ -81,8 +81,8 @@ public abstract class ProgramTrackedEntityAttributeModel extends BaseNameableObj
     public abstract String trackedEntityAttribute();
 
     @Nullable
-    @ColumnName(Columns.ALLOW_FUTURE_DATES)
-    public abstract Boolean allowFutureDates();
+    @ColumnName(Columns.ALLOW_FUTURE_DATE)
+    public abstract Boolean allowFutureDate();
 
     @Nullable
     @ColumnName(Columns.DISPLAY_IN_LIST)
@@ -105,7 +105,7 @@ public abstract class ProgramTrackedEntityAttributeModel extends BaseNameableObj
         super.bindToStatement(sqLiteStatement);
         sqLiteBind(sqLiteStatement, 11, mandatory());
         sqLiteBind(sqLiteStatement, 12, trackedEntityAttribute());
-        sqLiteBind(sqLiteStatement, 13, allowFutureDates());
+        sqLiteBind(sqLiteStatement, 13, allowFutureDate());
         sqLiteBind(sqLiteStatement, 14, displayInList());
         sqLiteBind(sqLiteStatement, 15, program());
         sqLiteBind(sqLiteStatement, 16, sortOrder());
@@ -119,7 +119,7 @@ public abstract class ProgramTrackedEntityAttributeModel extends BaseNameableObj
 
         public abstract Builder trackedEntityAttribute(@NonNull String trackedEntityAttribute);
 
-        public abstract Builder allowFutureDates(@Nullable Boolean allowFutureFate);
+        public abstract Builder allowFutureDate(@Nullable Boolean allowFutureFate);
 
         public abstract Builder displayInList(@Nullable Boolean displayInList);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeModelBuilder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeModelBuilder.java
@@ -48,7 +48,7 @@ public class ProgramTrackedEntityAttributeModelBuilder extends
                 .displayDescription(programTrackedEntityAttribute.displayDescription())
                 .mandatory(programTrackedEntityAttribute.mandatory())
                 .trackedEntityAttribute(programTrackedEntityAttribute.trackedEntityAttribute().uid())
-                .allowFutureDates(programTrackedEntityAttribute.allowFutureDate())
+                .allowFutureDate(programTrackedEntityAttribute.allowFutureDate())
                 .displayInList(programTrackedEntityAttribute.displayInList())
                 .program(programTrackedEntityAttribute.program().uid())
                 .sortOrder(programTrackedEntityAttribute.sortOrder())


### PR DESCRIPTION
Removes allowFutureDates inconsistency (POJO, web API and column were in singular, model field was in plural). 