### PR TITLE
event-model-enrollment-uid-inconsistency: rename enrollmentUid model field

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/CreateEventUtils.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/CreateEventUtils.java
@@ -53,10 +53,10 @@ public class CreateEventUtils {
         event.put(EventModel.Columns.UID, uid);
 
         if (enrollmentUid == null) {
-            event.putNull(EventModel.Columns.ENROLLMENT_UID);
+            event.putNull(EventModel.Columns.ENROLLMENT);
         }
 
-        event.put(EventModel.Columns.ENROLLMENT_UID, enrollmentUid);
+        event.put(EventModel.Columns.ENROLLMENT, enrollmentUid);
         event.put(EventModel.Columns.CREATED, DATE);
         event.put(EventModel.Columns.LAST_UPDATED, DATE);
         event.put(EventModel.Columns.STATUS, STATUS.name());

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventModelShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventModelShould.java
@@ -66,7 +66,7 @@ public class EventModelShould {
     @Test
     public void create_model_when_created_from_database_cursor() {
         MatrixCursor cursor = new MatrixCursor(new String[]{
-                Columns.ID, Columns.UID, Columns.ENROLLMENT_UID,
+                Columns.ID, Columns.UID, Columns.ENROLLMENT,
                 Columns.CREATED, Columns.LAST_UPDATED,
                 Columns.STATUS, Columns.LATITUDE,
                 Columns.LONGITUDE, Columns.PROGRAM, Columns.PROGRAM_STAGE,
@@ -84,7 +84,7 @@ public class EventModelShould {
 
         assertThat(model.id()).isEqualTo(ID);
         assertThat(model.uid()).isEqualTo(EVENT_UID);
-        assertThat(model.enrollmentUid()).isEqualTo(ENROLLMENT_UID);
+        assertThat(model.enrollment()).isEqualTo(ENROLLMENT_UID);
         assertThat(model.created()).isEqualTo(date);
         assertThat(model.lastUpdated()).isEqualTo(date);
         assertThat(model.status()).isEqualTo(STATUS);
@@ -102,7 +102,7 @@ public class EventModelShould {
         EventModel model = EventModel.builder()
                 .id(ID)
                 .uid(EVENT_UID)
-                .enrollmentUid(ENROLLMENT_UID)
+                .enrollment(ENROLLMENT_UID)
                 .created(date)
                 .lastUpdated(date)
                 .status(STATUS)
@@ -120,7 +120,7 @@ public class EventModelShould {
 
         assertThat(contentValues.getAsLong(Columns.ID)).isEqualTo(ID);
         assertThat(contentValues.getAsString(Columns.UID)).isEqualTo(EVENT_UID);
-        assertThat(contentValues.getAsString(Columns.ENROLLMENT_UID)).isEqualTo(ENROLLMENT_UID);
+        assertThat(contentValues.getAsString(Columns.ENROLLMENT)).isEqualTo(ENROLLMENT_UID);
         assertThat(contentValues.getAsString(Columns.CREATED)).isEqualTo(dateString);
         assertThat(contentValues.getAsString(Columns.LAST_UPDATED)).isEqualTo(dateString);
         assertThat(contentValues.getAsString(Columns.STATUS)).isEqualTo(STATUS.name());

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventStoreShould.java
@@ -76,7 +76,7 @@ import java.util.Map;
 public class EventStoreShould extends AbsStoreTestCase {
     private static final String[] EVENT_PROJECTION = {
             Columns.UID,
-            Columns.ENROLLMENT_UID,
+            Columns.ENROLLMENT,
             Columns.CREATED, // created
             Columns.LAST_UPDATED, // lastUpdated
             Columns.CREATED_AT_CLIENT,
@@ -408,7 +408,7 @@ public class EventStoreShould extends AbsStoreTestCase {
         eventContentValues.put(Columns.PROGRAM, PROGRAM);
         eventContentValues.put(Columns.PROGRAM_STAGE, PROGRAM_STAGE);
         eventContentValues.put(Columns.ORGANISATION_UNIT, ORGANISATION_UNIT);
-        eventContentValues.put(Columns.ENROLLMENT_UID, ENROLLMENT_UID);
+        eventContentValues.put(Columns.ENROLLMENT, ENROLLMENT_UID);
         eventContentValues.put(Columns.STATUS, STATUS.name());
         eventContentValues.put(Columns.EVENT_DATE, dateString);
         eventContentValues.put(Columns.COMPLETE_DATE, dateString);

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventModel.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventModel.java
@@ -49,7 +49,7 @@ public abstract class EventModel extends BaseDataModel {
 
     public static class Columns extends BaseDataModel.Columns {
         public static final String UID = "uid";
-        public static final String ENROLLMENT_UID = "enrollment";
+        public static final String ENROLLMENT = "enrollment";
         public static final String CREATED = "created";
         public static final String LAST_UPDATED = "lastUpdated";
         public static final String CREATED_AT_CLIENT = "createdAtClient";
@@ -82,8 +82,8 @@ public abstract class EventModel extends BaseDataModel {
 
     // Nullable properties
     @Nullable
-    @ColumnName(Columns.ENROLLMENT_UID)
-    public abstract String enrollmentUid();
+    @ColumnName(Columns.ENROLLMENT)
+    public abstract String enrollment();
 
     @Nullable
     @ColumnName(Columns.CREATED)
@@ -159,7 +159,7 @@ public abstract class EventModel extends BaseDataModel {
     public static abstract class Builder extends BaseDataModel.Builder<Builder> {
         public abstract Builder uid(@NonNull String uid);
 
-        public abstract Builder enrollmentUid(@Nullable String enrollmentUid);
+        public abstract Builder enrollment(@Nullable String enrollment);
 
         public abstract Builder created(@Nullable Date created);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventStoreImpl.java
@@ -59,7 +59,7 @@ public class EventStoreImpl implements EventStore {
 
     private static final String INSERT_STATEMENT = "INSERT INTO " + EventModel.TABLE + " (" +
             Columns.UID + ", " +
-            Columns.ENROLLMENT_UID + ", " +
+            Columns.ENROLLMENT + ", " +
             Columns.CREATED + ", " +
             Columns.LAST_UPDATED + ", " +
             Columns.CREATED_AT_CLIENT + ", " +
@@ -81,7 +81,7 @@ public class EventStoreImpl implements EventStore {
 
     private static final String UPDATE_STATEMENT = "UPDATE " + EventModel.TABLE + " SET " +
             Columns.UID + " =? , " +
-            Columns.ENROLLMENT_UID + " =? , " +
+            Columns.ENROLLMENT + " =? , " +
             Columns.CREATED + " =? , " +
             Columns.LAST_UPDATED + " =? ," +
             Columns.CREATED_AT_CLIENT + " =? , " +


### PR DESCRIPTION
Renames enrollmentUid to to enrollment, so that model field matches column name, and we follow the same criteria as in other models. 