### PR TITLE
[ANDROSDK-374] Close all cursors in tests and add code to fail when c…

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/CategoryEndpointCallShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/CategoryEndpointCallShould.java
@@ -29,6 +29,7 @@ public class CategoryEndpointCallShould extends AbsStoreTestCase {
     @Override
     @After
     public void tearDown() throws IOException {
+        super.tearDown();
         dhis2MockServer.shutdown();
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/DatabaseAssert.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/DatabaseAssert.java
@@ -17,52 +17,6 @@ public final class DatabaseAssert {
         this.databaseAdapter = databaseAdapter;
     }
 
-    public DatabaseAssert ifValueExist(String tableName, String fieldName, String fieldValue) {
-        boolean isExist = false;
-
-        Cursor res = databaseAdapter.query(
-                "SELECT " + fieldName + " from " + tableName + " where " + fieldName + " = '"
-                        + fieldValue + "'", null);
-        int value = res.getCount();
-        if (value == 1) {
-            isExist = true;
-        }
-
-        assertThat(isExist, is(true));
-
-        return this;
-    }
-
-    public DatabaseAssert isFieldExist(String tableName, String fieldName) {
-        boolean isExist = false;
-        Cursor res = databaseAdapter.query("PRAGMA table_info(" + tableName + ")", null);
-        int value = res.getColumnIndex("name");
-        if (value != -1) {
-            while (res.moveToNext()) {
-                if (res.getString(value).equals(fieldName)) {
-                    isExist = true;
-                    break;
-                }
-            }
-        }
-        assertThat(isExist, is(true));
-
-        return this;
-    }
-
-    public DatabaseAssert ifTableExist(String table) {
-        boolean isExist = false;
-        Cursor res = databaseAdapter.query("PRAGMA table_info(" + table + ")", null);
-        int value = res.getColumnIndex("name");
-        if (value != -1) {
-            isExist = true;
-        }
-        assertThat(isExist, is(true));
-
-        return this;
-    }
-
-
     public DatabaseAssert isEmpty() {
         verifyEmptyDatabase(true);
 
@@ -90,18 +44,19 @@ public final class DatabaseAssert {
     private void verifyEmptyDatabase(boolean expectedEmpty) {
         boolean isEmpty = true;
 
-        Cursor res = databaseAdapter.query(" SELECT name FROM sqlite_master "
+        Cursor cursor = databaseAdapter.query(" SELECT name FROM sqlite_master "
                 + "WHERE type='table' and name!='android_metadata' and name!='sqlite_sequence'");
-        int value = res.getColumnIndex("name");
+        int value = cursor.getColumnIndex("name");
         if (value != -1) {
-            while (res.moveToNext()) {
-                String tableName = res.getString(value);
+            while (cursor.moveToNext()) {
+                String tableName = cursor.getString(value);
 
                 if (tableCount(tableName) > 0) {
                     isEmpty = false;
                 }
             }
         }
+        cursor.close();
         assertThat(isEmpty, is(expectedEmpty));
     }
 
@@ -118,6 +73,7 @@ public final class DatabaseAssert {
             }
         }
 
+        cursor.close();
         return count;
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/DbOpenHelperShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/DbOpenHelperShould.java
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.data.database;
 
+import android.database.sqlite.SQLiteDatabase;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -43,6 +44,8 @@ public class DbOpenHelperShould {
     public void have_tests_on_database_versions() {
         DbOpenHelper dbOpenHelper = new DbOpenHelper(InstrumentationRegistry.getTargetContext().getApplicationContext()
                 , null);
+        SQLiteDatabase database = dbOpenHelper.getWritableDatabase();
         assertThat(dbOpenHelper.getWritableDatabase().getVersion()).isEqualTo(DbOpenHelper.VERSION);
+        database.close();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/migrations/DataBaseMigrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/migrations/DataBaseMigrationShould.java
@@ -27,15 +27,20 @@ public class DataBaseMigrationShould {
 
     @Before
     public void deleteDB() {
-        if (dbName != null) {
-            InstrumentationRegistry.getContext().deleteDatabase(dbName);
-        }
+        this.closeAndDeleteDatabase();
         dbOpenHelper = null;
         databaseInMemory = null;
     }
 
     @After
     public void tearDown() {
+        this.closeAndDeleteDatabase();
+    }
+
+    private void closeAndDeleteDatabase() {
+        if (databaseInMemory != null) {
+            databaseInMemory.close();
+        }
         if (dbName != null) {
             InstrumentationRegistry.getContext().deleteDatabase(dbName);
         }
@@ -65,7 +70,7 @@ public class DataBaseMigrationShould {
                     InstrumentationRegistry.getTargetContext().getApplicationContext()
                     , dbName, databaseVersion);
             databaseAdapter = new SqLiteDatabaseAdapter(dbOpenHelper);
-            databaseInMemory = ((SqLiteDatabaseAdapter) databaseAdapter).database();
+            databaseInMemory = databaseAdapter.database();
         } else if (dbName == null) {
             if (databaseInMemory.getVersion() < databaseVersion) {
                 dbOpenHelper.onUpgrade(databaseInMemory, databaseInMemory.getVersion(),

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/EnrollmentStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/EnrollmentStoreShould.java
@@ -171,6 +171,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
                 LONGITUDE,
                 STATE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -228,6 +229,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
                 LONGITUDE,
                 STATE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -239,6 +241,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor).hasRow(UID, null, null, null, null, ORGANISATION_UNIT, PROGRAM,
                 null, null, null, null, TRACKED_ENTITY_INSTANCE, null, null, null).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -256,6 +259,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
 
         // check that enrollment was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID, ENROLLMENT_STATUS.name()).isExhausted();
+        cursor.close();
 
         EnrollmentStatus updatedStatus = EnrollmentStatus.CANCELLED;
         store.update(UID, null, null, null, null,
@@ -265,10 +269,11 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
                 TRACKED_ENTITY_INSTANCE,
                 null, null, null, UID);
 
-        cursor = database().query(TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(TABLE, projection, null, null, null, null, null);
 
         // check that enrollment was successfully updated
-        assertThatCursor(cursor).hasRow(UID, updatedStatus.name()).isExhausted();
+        assertThatCursor(cursor2).hasRow(UID, updatedStatus.name()).isExhausted();
+        cursor2.close();
 
     }
 
@@ -286,13 +291,15 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
 
         // check that enrollment was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID).isExhausted();
+        cursor.close();
 
         store.delete(UID);
 
-        cursor = database().query(TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(TABLE, projection, null, null, null, null, null);
 
         // check that enrollment is deleted
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
     }
 
     @Test
@@ -320,6 +327,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
         //Query for Enrollment:
         Cursor cursor = database().query(TABLE, PROJECTION, null, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -348,6 +356,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
 
         Cursor cursor = database().query(TABLE, PROJECTION, null, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -375,6 +384,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
 
         Cursor cursor = database().query(TABLE, PROJECTION, null, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -394,15 +404,17 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
 
         // check that enrollment was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID, STATE).isExhausted();
+        cursor.close();
 
         State updatedState = State.ERROR;
         store.setState(UID, updatedState);
 
-        cursor = database().query(EnrollmentModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(EnrollmentModel.TABLE, projection, null, null, null, null, null);
 
         // check that state is updated
-        assertThatCursor(cursor).hasRow(UID, updatedState);
+        assertThatCursor(cursor2).hasRow(UID, updatedState);
 
+        cursor2.close();
     }
 
     @Test
@@ -421,6 +433,7 @@ public class EnrollmentStoreShould extends AbsStoreTestCase {
 
         // check that enrollment was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID).isExhausted();
+        cursor.close();
 
         Map<String, List<Enrollment>> map = store.query();
         assertThat(map.size()).isEqualTo(1);

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventStoreShould.java
@@ -210,6 +210,7 @@ public class EventStoreShould extends AbsStoreTestCase {
                 ATTRIBUTE_OPTION_COMBO_UID,
                 TRACKED_ENTITY_INSTANCE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -227,6 +228,7 @@ public class EventStoreShould extends AbsStoreTestCase {
                 ATTRIBUTE_CATEGORY_OPTION_UID,
                 ATTRIBUTE_OPTION_COMBO_UID,
                 TRACKED_ENTITY_INSTANCE).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -285,6 +287,7 @@ public class EventStoreShould extends AbsStoreTestCase {
         database().delete(ProgramStageModel.TABLE, ProgramStageModel.Columns.UID + "=?", new String[]{PROGRAM_STAGE});
         Cursor cursor = database().query(EventModel.TABLE, EVENT_PROJECTION, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -316,6 +319,7 @@ public class EventStoreShould extends AbsStoreTestCase {
 
         Cursor cursor = database().query(EventModel.TABLE, EVENT_PROJECTION, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -333,6 +337,7 @@ public class EventStoreShould extends AbsStoreTestCase {
 
         // check that event was successfully inserted into database
         assertThatCursor(cursor).hasRow(EVENT_UID, dateString).isExhausted();
+        cursor.close();
 
         Date updatedDate = new Date();
 
@@ -344,12 +349,13 @@ public class EventStoreShould extends AbsStoreTestCase {
 
         assertTrue(updated==1);
 
-        cursor = database().query(EventModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(EventModel.TABLE, projection, null, null, null, null, null);
 
         String updatedDateString = BaseIdentifiableObject.DATE_FORMAT.format(updatedDate);
 
         // check that event was updated with updatedDateString
-        assertThatCursor(cursor).hasRow(EVENT_UID, updatedDateString).isExhausted();
+        assertThatCursor(cursor2).hasRow(EVENT_UID, updatedDateString).isExhausted();
+        cursor2.close();
     }
 
     @Test
@@ -366,13 +372,15 @@ public class EventStoreShould extends AbsStoreTestCase {
 
         // check that event was successfully inserted into database
         assertThatCursor(cursor).hasRow(EVENT_UID, ORGANISATION_UNIT).isExhausted();
+        cursor.close();
 
         eventStore.delete(EVENT_UID);
 
-        cursor = database().query(EventModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(EventModel.TABLE, projection, null, null, null, null, null);
 
         // check that event is deleted
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
     }
 
     @Test
@@ -390,13 +398,16 @@ public class EventStoreShould extends AbsStoreTestCase {
 
         // check that event was successfully inserted into database
         assertThatCursor(cursor).hasRow(EVENT_UID, STATE).isExhausted();
+        cursor.close();
+
         State updatedState = State.ERROR;
         eventStore.setState(EVENT_UID, updatedState);
 
-        cursor = database().query(EventModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(EventModel.TABLE, projection, null, null, null, null, null);
 
         // check that state was updated
-        assertThatCursor(cursor).hasRow(EVENT_UID, updatedState);
+        assertThatCursor(cursor2).hasRow(EVENT_UID, updatedState);
+        cursor2.close();
 
     }
 
@@ -430,12 +441,14 @@ public class EventStoreShould extends AbsStoreTestCase {
         Cursor dataValueCursor = database().query(TrackedEntityDataValueModel.TABLE, dataValueProjection,
                 null, null, null, null, null);
         assertThatCursor(dataValueCursor).hasRow(EVENT_UID).isExhausted();
+        dataValueCursor.close();
 
         String[] projection = {Columns.UID};
         Cursor cursor = database().query(EventModel.TABLE, projection, Columns.UID + " =?",
                 new String[]{EVENT_UID}, null, null, null);
         // verify that eventContentValues was successfully inserted
         assertThatCursor(cursor).hasRow(EVENT_UID).isExhausted();
+        cursor.close();
 
 
         // query for events

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCallMockIntegrationShould.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.android.core.common.GenericHandler;
 import org.hisp.dhis.android.core.data.database.AbsStoreTestCase;
 import org.hisp.dhis.android.core.data.file.AssetsFileReader;
 import org.hisp.dhis.android.core.data.server.Dhis2MockServer;
-import org.hisp.dhis.android.core.dataset.DataSetModel;
 import org.hisp.dhis.android.core.program.ProgramModel;
 import org.hisp.dhis.android.core.resource.ResourceModel;
 import org.hisp.dhis.android.core.user.User;
@@ -192,6 +191,10 @@ public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase 
 
         assertThatCursor(resourceCursor).hasRow(ResourceModel.Type.ORGANISATION_UNIT,
                 BaseIdentifiableObject.DATE_FORMAT.format(genericCallData.serverDate()));
+
+        organisationUnitCursor.close();
+        userOrganisationUnitCursor.close();
+        resourceCursor.close();
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramRuleActionStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramRuleActionStoreShould.java
@@ -185,6 +185,7 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
                 DATA_ELEMENT,
                 PROGRAM_RULE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -231,6 +232,7 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
                 deferredDataElement,
                 deferredProgramRule
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -256,6 +258,7 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
                 null,
                 PROGRAM_RULE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test(expected = SQLiteConstraintException.class)
@@ -324,12 +327,15 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
         // checking that program rule action was successfully inserted
         assertThatCursor(cursor).hasRow(ID, UID, PROGRAM_RULE).isExhausted();
+        cursor.close();
+
         // deleting program rule
         database().delete(ProgramRuleModel.TABLE, ProgramRuleModel.Columns.UID + " =?", new String[]{PROGRAM_RULE});
 
-        cursor = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
         // checking that program rule action is deleted
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
 
     }
 
@@ -352,6 +358,8 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
         // check that program rule action was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID, LOCATION);
+        cursor.close();
+
         String updatedLocation = "updated_location_program_rule_action";
         int update = store.update(
                 UID, CODE, NAME, DISPLAY_NAME, date, date,
@@ -361,10 +369,11 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
         // check that store returns 1 on successful update
         assertThat(update).isEqualTo(1);
 
-        cursor = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
 
         // check that program rule action is updated in database
-        assertThatCursor(cursor).hasRow(UID, updatedLocation).isExhausted();
+        assertThatCursor(cursor2).hasRow(UID, updatedLocation).isExhausted();
+        cursor2.close();
     }
 
     @Test
@@ -385,6 +394,7 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
         // check that program rule action was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID);
+        cursor.close();
 
         // Delete program rule action
         int delete = store.delete(UID);
@@ -392,10 +402,11 @@ public class ProgramRuleActionStoreShould extends AbsStoreTestCase {
         // check that store returns 1 on successful delete
         assertThat(delete).isEqualTo(1);
 
-        cursor = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(ProgramRuleActionModel.TABLE, projection, null, null, null, null, null);
 
         // check that program rule action is deleted in database
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
     }
 
     // ToDo: consider introducing conflict resolution strategy

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramRuleVariableStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramRuleVariableStoreShould.java
@@ -154,6 +154,7 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
                 TRACKED_ENTITY_ATTRIBUTE,
                 PROGRAM_RULE_VARIABLE_SOURCE_TYPE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -194,6 +195,7 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
                 deferredTrackedEntityAttribute,
                 PROGRAM_RULE_VARIABLE_SOURCE_TYPE
         ).isExhausted();
+        cursor.close();
 
     }
 
@@ -230,6 +232,7 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
                 null,
                 PROGRAM_RULE_VARIABLE_SOURCE_TYPE
         ).isExhausted();
+        cursor.close();
 
     }
 
@@ -248,12 +251,14 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION, null, null, null, null, null);
 
         assertThatCursor(cursor).hasRow(ID, UID, PROGRAM).isExhausted();
+        cursor.close();
 
         database().delete(ProgramModel.TABLE, ProgramModel.Columns.UID + " =?", new String[]{PROGRAM});
 
-        cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION, null, null, null, null, null);
+        Cursor cursor2 = database().query(ProgramRuleVariableModel.TABLE, PROJECTION, null, null, null, null, null);
 
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
     }
 
     @Test
@@ -272,13 +277,14 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION, null, null, null, null, null);
 
         assertThatCursor(cursor).hasRow(ID, UID, PROGRAM, PROGRAM_STAGE);
+        cursor.close();
 
         database().delete(ProgramStageModel.TABLE, ProgramStageModel.Columns.UID + " =?", new String[]{PROGRAM_STAGE});
 
-        cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION,
+        Cursor cursor2 = database().query(ProgramRuleVariableModel.TABLE, PROJECTION,
                 null, null, null, null, null);
 
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
     }
 
     @Test
@@ -297,13 +303,15 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION, null, null, null, null, null);
 
         assertThatCursor(cursor).hasRow(ID, UID, PROGRAM, DATA_ELEMENT);
+        cursor.close();
 
         database().delete(DataElementModel.TABLE, DataElementModel.Columns.UID + " =?", new String[]{DATA_ELEMENT});
 
-        cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION,
+        Cursor cursor2 = database().query(ProgramRuleVariableModel.TABLE, PROJECTION,
                 null, null, null, null, null);
 
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
     }
 
     @Test
@@ -322,14 +330,16 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION, null, null, null, null, null);
 
         assertThatCursor(cursor).hasRow(ID, UID, PROGRAM, TRACKED_ENTITY_ATTRIBUTE);
+        cursor.close();
 
         database().delete(TrackedEntityAttributeModel.TABLE,
                 TrackedEntityAttributeModel.Columns.UID + " =?", new String[]{TRACKED_ENTITY_ATTRIBUTE});
 
-        cursor = database().query(ProgramRuleVariableModel.TABLE, PROJECTION,
+        Cursor cursor2 = database().query(ProgramRuleVariableModel.TABLE, PROJECTION,
                 null, null, null, null, null);
 
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
 
     }
 
@@ -348,6 +358,8 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
 
         // check that program rule variable was successfully inserted
         assertThatCursor(cursor).hasRow(UID, 1); // 1 == Boolean.TRUE
+        cursor.close();
+
         boolean updatedUseCodeForOptionSet = Boolean.FALSE;
 
         int update = store.update(
@@ -357,9 +369,10 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
 
         assertThat(update).isEqualTo(1);
 
-        cursor = database().query(ProgramRuleVariableModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(ProgramRuleVariableModel.TABLE, projection, null, null, null, null, null);
 
-        assertThatCursor(cursor).hasRow(UID, 0).isExhausted(); // 0 == Boolean.FALSE
+        assertThatCursor(cursor2).hasRow(UID, 0).isExhausted(); // 0 == Boolean.FALSE
+        cursor.close();
     }
 
     @Test
@@ -376,15 +389,17 @@ public class ProgramRuleVariableStoreShould extends AbsStoreTestCase {
 
         // check that program rule variable was successfully inserted
         assertThatCursor(cursor).hasRow(UID);
+        cursor.close();
 
         int delete = store.delete(UID);
 
         // check that store returns 1 on successful delete
         assertThat(delete).isEqualTo(1);
 
-        cursor = database().query(ProgramRuleVariableModel.TABLE, projection, null, null, null, null, null);
+        Cursor cursor2 = database().query(ProgramRuleVariableModel.TABLE, projection, null, null, null, null, null);
         // check that program rule variable is not in database
-        assertThatCursor(cursor).isExhausted();
+        assertThatCursor(cursor2).isExhausted();
+        cursor2.close();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStageDataElementStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStageDataElementStoreShould.java
@@ -369,6 +369,8 @@ public class ProgramStageDataElementStoreShould extends AbsStoreTestCase {
 
         // checking that psde was successfully inserted
         assertThatCursor(cursor).hasRow(UID, DISPLAY_NAME, 0); // 0 == Boolean.FALSE
+        cursor.close();
+
         String updatedDisplayName = "updatedDisplayName";
         Boolean updatedCompulsory = Boolean.TRUE;
 
@@ -391,6 +393,7 @@ public class ProgramStageDataElementStoreShould extends AbsStoreTestCase {
 
         // checking that row was updated
         assertThatCursor(cursor).hasRow(UID, updatedDisplayName, 1); // 1 == Boolean.TRUE
+        cursor.close();
 
     }
 
@@ -419,6 +422,7 @@ public class ProgramStageDataElementStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramStageDataElementModel.TABLE, projection, null, null, null, null, null);
         // checking that psde was successfully inserted
         assertThatCursor(cursor).hasRow(UID);
+        cursor.close();
 
         int delete = store.delete(UID);
 
@@ -428,6 +432,7 @@ public class ProgramStageDataElementStoreShould extends AbsStoreTestCase {
         cursor = database().query(ProgramStageDataElementModel.TABLE, projection, null, null, null, null, null);
 
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStageSectionStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStageSectionStoreShould.java
@@ -143,6 +143,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
                 SORT_ORDER,
                 PROGRAM_STAGE
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -162,6 +163,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
         assertThatCursor(cursor).hasRow(UID, CODE, NAME, DISPLAY_NAME, dateString, dateString, SORT_ORDER,
                 deferredProgramStage
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -178,6 +180,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
                 null, null, null, null, null);
         // checking that program stage section was successfully inserted
         assertThatCursor(cursor).hasRow(ID, UID, PROGRAM_STAGE).isExhausted();
+        cursor.close();
 
         // deleting foreign key reference
         database().delete(ProgramStageModel.TABLE,
@@ -187,6 +190,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
                 null, null, null, null, null);
         // checking that program stage section is deleted.
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test(expected = SQLiteConstraintException.class)
@@ -222,6 +226,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
 
         // check that row was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID, DISPLAY_NAME);
+        cursor.close();
         String updatedDisplayName = "updated_display_name";
 
         // update program stage section with new display name
@@ -236,6 +241,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
 
         // check that row was updated
         assertThatCursor(cursor).hasRow(UID, updatedDisplayName);
+        cursor.close();
     }
 
     @Test
@@ -254,6 +260,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(ProgramStageSectionModel.TABLE, projection, null, null, null, null, null);
         // check that program stage section was successfully inserted
         assertThatCursor(cursor).hasRow(UID);
+        cursor.close();
 
         // delete program stage section
         int delete = store.delete(UID);
@@ -265,6 +272,7 @@ public class ProgramStageSectionStoreShould extends AbsStoreTestCase {
 
         // check that row doesn't exist in database
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeStoreShould.java
@@ -175,6 +175,7 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
                 toInteger(UNIQUE),
                 toInteger(INHERIT)
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -201,6 +202,7 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
                 toInteger(GENERATED), toInteger(DISPLAY_ON_VISIT_SCHEDULE), toInteger(ORG_UNIT_SCOPE),
                 toInteger(UNIQUE), toInteger(INHERIT)
         ).isExhausted();
+        cursor.close();
     }
 
     @Test(expected = SQLiteConstraintException.class)
@@ -226,12 +228,14 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(TrackedEntityAttributeModel.TABLE, projection, null, null, null, null, null);
         // checking that tracked entity attribute is successfully inserted
         assertThatCursor(cursor).hasRow(1L, UID, OPTION_SET_UID);
+        cursor.close();
 
         database().delete(OptionSetModel.TABLE, OptionSetModel.Columns.UID + " =?", new String[]{OPTION_SET_UID});
         cursor = database().query(TrackedEntityAttributeModel.TABLE, projection, null, null, null, null, null);
 
         // checking that tracked entity attribute is deleted
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
 
     }
 
@@ -249,6 +253,7 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
 
         // check that tracked entity attribute was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID, EXPRESSION);
+        cursor.close();
 
         String updatedExpression = "updated_expression";
 
@@ -266,6 +271,7 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
 
         // check that tracked entity attribute is updated in database
         assertThatCursor(cursor).hasRow(UID, updatedExpression).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -280,6 +286,7 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
 
         // check that tracked entity attribute was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID);
+        cursor.close();
 
         int delete = store.delete(UID);
 
@@ -289,6 +296,7 @@ public class TrackedEntityAttributeStoreShould extends AbsStoreTestCase {
 
         // check that tracked entity attribute doesn't exist in database
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     // ToDo: consider introducing conflict resolution strategy

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueStoreShould.java
@@ -175,6 +175,7 @@ public class TrackedEntityDataValueStoreShould extends AbsStoreTestCase {
                 VALUE,
                 toInteger(PROVIDED_ELSEWHERE)
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -187,6 +188,7 @@ public class TrackedEntityDataValueStoreShould extends AbsStoreTestCase {
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor).hasRow(EVENT_1, null, null, DATA_ELEMENT_1, null, null,
                 null).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -205,6 +207,7 @@ public class TrackedEntityDataValueStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(TrackedEntityDataValueModel.TABLE,
                 PROJECTION, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     //@Test
@@ -225,6 +228,7 @@ public class TrackedEntityDataValueStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(TrackedEntityDataValueModel.TABLE,
                 PROJECTION, null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -246,6 +250,7 @@ public class TrackedEntityDataValueStoreShould extends AbsStoreTestCase {
 
         // verify that TEDV was successfully inserted
         assertThatCursor(cursor).hasRow(EVENT_1).isExhausted();
+        cursor.close();
 
         Map<String, List<TrackedEntityDataValue>> map =
                 trackedEntityDataValueStore.queryTrackedEntityDataValues(Boolean.FALSE);
@@ -317,6 +322,7 @@ public class TrackedEntityDataValueStoreShould extends AbsStoreTestCase {
                 STORED_BY,
                 VALUE,
                 toInteger(PROVIDED_ELSEWHERE));
+        cursor.close();
 
         assertThat(updateReturn).isEqualTo(1);
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/UserAuthenticateCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/UserAuthenticateCallMockIntegrationShould.java
@@ -96,13 +96,6 @@ public class UserAuthenticateCallMockIntegrationShould extends AbsStoreTestCase 
             AuthenticatedUserModel.Columns.CREDENTIALS
     };
 
-    private static String[] USER_ORGANISATION_UNIT_PROJECTION = {
-            UserOrganisationUnitLinkModel.Columns.ID,
-            UserOrganisationUnitLinkModel.Columns.USER,
-            UserOrganisationUnitLinkModel.Columns.ORGANISATION_UNIT,
-            UserOrganisationUnitLinkModel.Columns.ORGANISATION_UNIT_SCOPE,
-    };
-
     private static String[] RESOURCE_PROJECTION = {
             ResourceModel.Columns.ID,
             ResourceModel.Columns.RESOURCE_TYPE,
@@ -136,12 +129,10 @@ public class UserAuthenticateCallMockIntegrationShould extends AbsStoreTestCase 
                 USER_PROJECTION, null, null, null, null, null);
         Cursor userCredentialsCursor = database().query(UserCredentialsModel.TABLE,
                 USER_CREDENTIALS_PROJECTION, null, null, null, null, null);
-        Cursor authenticatedUsers = database().query(AuthenticatedUserModel.TABLE,
+        Cursor authenticatedUsersCursor = database().query(AuthenticatedUserModel.TABLE,
                 AUTHENTICATED_USERS_PROJECTION, null, null, null, null, null);
-        Cursor userOrganisationUnitLinks = database().query(UserOrganisationUnitLinkModel.TABLE,
-                USER_ORGANISATION_UNIT_PROJECTION, null, null, null, null, null);
 
-        Cursor resource = database().query(ResourceModel.TABLE, RESOURCE_PROJECTION,
+        Cursor resourceCursor = database().query(ResourceModel.TABLE, RESOURCE_PROJECTION,
                 null, null, null, null, null);
 
         assertThatCursor(userCursor)
@@ -183,7 +174,7 @@ public class UserAuthenticateCallMockIntegrationShould extends AbsStoreTestCase 
                 )
                 .isExhausted();
 
-        assertThatCursor(authenticatedUsers)
+        assertThatCursor(authenticatedUsersCursor)
                 .hasRow(
                         1L, // id
                         "DXyJmlo9rge", // user
@@ -193,33 +184,38 @@ public class UserAuthenticateCallMockIntegrationShould extends AbsStoreTestCase 
 
         String dateString = "2017-11-29T11:27:46.935";
 
-        assertThatCursor(resource)
+        assertThatCursor(resourceCursor)
                 .hasRow(
                         1L,
                         ResourceModel.Type.SYSTEM_INFO,
                         dateString
                 );
 
-        assertThatCursor(resource)
+        assertThatCursor(resourceCursor)
                 .hasRow(
                         2L,
                         ResourceModel.Type.USER,
                         dateString
                 );
 
-        assertThatCursor(resource)
+        assertThatCursor(resourceCursor)
                 .hasRow(
                         3L,
                         ResourceModel.Type.USER_CREDENTIALS,
                         dateString
                 );
 
-        assertThatCursor(resource)
+        assertThatCursor(resourceCursor)
                 .hasRow(
                         4L,
                         ResourceModel.Type.AUTHENTICATED_USER,
                         dateString
                 );
+
+        userCursor.close();
+        userCredentialsCursor.close();
+        authenticatedUsersCursor.close();
+        resourceCursor.close();
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/UserCredentialsStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/UserCredentialsStoreShould.java
@@ -120,6 +120,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
                 USER_CREDENTIALS_USERNAME,
                 USER_UID
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -156,6 +157,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
                 USER_CREDENTIALS_USERNAME,
                 deferredUid
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -182,6 +184,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
                 null,
                 USER_UID
         ).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -200,6 +203,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(UserCredentialsModel.TABLE, USER_CREDENTIALS_PROJECTION,
                 null, null, null, null, null);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test
@@ -223,6 +227,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
 
         // checking that userCredentials was successfully inserted into database
         assertThatCursor(cursor).hasRow(ID, UID, NAME, USER_UID);
+        cursor.close();
 
         Date date = new Date();
 
@@ -235,6 +240,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
         // checking that userCredentials was successfully updated
         assertThat(updatedRow).isEqualTo(1);
         assertThatCursor(cursor).hasRow(ID, UID, "new name", USER_UID);
+        cursor.close();
 
     }
 
@@ -261,6 +267,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
 
         // checking that userCredentials was successfully inserted into database
         assertThatCursor(cursor).hasRow(ID, UID, NAME, USER_UID);
+        cursor.close();
 
         int deletedRow = store.delete(UID);
 
@@ -268,6 +275,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
 
         assertThat(deletedRow).isEqualTo(1);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
 
     }
 
@@ -293,6 +301,7 @@ public class UserCredentialsStoreShould extends AbsStoreTestCase {
         Cursor cursor = database().query(UserCredentialsModel.TABLE, null, null, null, null, null, null);
         assertThat(deleted).isEqualTo(1);
         assertThatCursor(cursor).isExhausted();
+        cursor.close();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/core/src/main/java/org/hisp/dhis/android/core/D2.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.java
@@ -99,6 +99,8 @@ public final class D2 {
                     .penaltyDeath()
                     .build());
         } else {
+            /* SSLContextInitializer, necessary to ensure everything works in Android 4.4 crashes
+            when running the StrictMode above. That's why it's in the else clause */
             SSLContextInitializer.initializeSSLContext(context);
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/D2.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.java
@@ -29,9 +29,11 @@
 package org.hisp.dhis.android.core;
 
 import android.content.Context;
+import android.os.StrictMode;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import org.hisp.dhis.android.BuildConfig;
 import org.hisp.dhis.android.core.calls.AggregatedDataCall;
 import org.hisp.dhis.android.core.calls.MetadataCall;
 import org.hisp.dhis.android.core.calls.TrackedEntityInstancePostCall;
@@ -88,11 +90,22 @@ public final class D2 {
     @VisibleForTesting
     D2(@NonNull Retrofit retrofit, @NonNull DatabaseAdapter databaseAdapter,
        @NonNull Context context) {
+
+        if (BuildConfig.DEBUG) {
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                    .detectLeakedSqlLiteObjects()
+                    .detectLeakedClosableObjects()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build());
+        } else {
+            SSLContextInitializer.initializeSSLContext(context);
+        }
+
         this.retrofit = retrofit;
         this.databaseAdapter = databaseAdapter;
         this.internalModules = D2InternalModules.create(databaseAdapter, retrofit);
         this.wipeModule = WipeModuleImpl.create(databaseAdapter, internalModules);
-        SSLContextInitializer.initializeSSLContext(context);
     }
 
     @NonNull

--- a/core/src/main/java/org/hisp/dhis/android/core/data/database/SqliteCheckerUtility.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/data/database/SqliteCheckerUtility.java
@@ -9,22 +9,23 @@ final public class SqliteCheckerUtility {
 
     public static boolean isTableEmpty(DatabaseAdapter databaseAdapter, String table) {
         boolean isTableEmpty = true;
-        Cursor res = databaseAdapter.query(" SELECT * FROM "+table);
-        int value = res.getCount();
+        Cursor cursor = databaseAdapter.query(" SELECT * FROM "+table);
+        int value = cursor.getCount();
         if (value > 0) {
             isTableEmpty = false;
         }
+        cursor.close();
         return isTableEmpty;
     }
 
     public static boolean isDatabaseEmpty(DatabaseAdapter databaseAdapter) {
         boolean isDatabaseEmpty = true;
-        Cursor res = databaseAdapter.query(" SELECT name FROM sqlite_master WHERE "
+        Cursor cursor = databaseAdapter.query(" SELECT name FROM sqlite_master WHERE "
                 + "type='table' and name!='android_metadata' and name!='sqlite_sequence'");
-        int value = res.getColumnIndex("name");
+        int value = cursor.getColumnIndex("name");
         if (value != -1) {
-            while (res.moveToNext()){
-                String tableName = res.getString(value);
+            while (cursor.moveToNext()){
+                String tableName = cursor.getString(value);
                 Cursor resTable = databaseAdapter.query(
                         "SELECT * from " + tableName , null);
                 if (resTable.getCount() > 0) {
@@ -33,44 +34,48 @@ final public class SqliteCheckerUtility {
                 }
             }
         }
+        cursor.close();
         return isDatabaseEmpty;
     }
 
     public static Boolean ifValueExist(String tableName, String fieldName, String fieldValue,
             DatabaseAdapter db) {
         boolean isExist = false;
-        Cursor res = db.query(
+        Cursor cursor = db.query(
                 "SELECT " + fieldName + " from " + tableName + " where " + fieldName + " = '"
                         + fieldValue + "'", null);
-        int value = res.getCount();
+        int value = cursor.getCount();
         if (value == 1) {
             isExist = true;
         }
+        cursor.close();
         return isExist;
     }
 
     public static boolean isFieldExist(String tableName, String fieldName,  DatabaseAdapter db) {
         boolean isExist = false;
-        Cursor res = db.query("PRAGMA table_info(" + tableName + ")", null);
-        int value = res.getColumnIndex("name");
+        Cursor cursor = db.query("PRAGMA table_info(" + tableName + ")", null);
+        int value = cursor.getColumnIndex("name");
         if (value != -1) {
-            while (res.moveToNext()) {
-                if (res.getString(value).equals(fieldName)) {
+            while (cursor.moveToNext()) {
+                if (cursor.getString(value).equals(fieldName)) {
                     isExist = true;
                     break;
                 }
             }
         }
+        cursor.close();
         return isExist;
     }
 
     public static boolean ifTableExist(String table, DatabaseAdapter db) {
         boolean isExist = false;
-        Cursor res = db.query("PRAGMA table_info(" + table + ")");
-        int itemsCount = res.getCount();
+        Cursor cursor = db.query("PRAGMA table_info(" + table + ")");
+        int itemsCount = cursor.getCount();
         if (itemsCount > 0) {
             isExist = true;
         }
+        cursor.close();
         return isExist;
     }
 }


### PR DESCRIPTION
Solves [ANDROSDK-374](https://jira.dhis2.org/browse/ANDROSDK-374):
- Closed cursors in all tests (no open cursors found in main)
- Leave code to make SDK crash when cursors remain open in Debug mode (already discussed with Pablo). 