### PR TITLE
[ANDROSDK-405] Implement generic link table child store

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/CategoryModuleMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/CategoryModuleMockIntegrationShould.java
@@ -32,12 +32,20 @@ public class CategoryModuleMockIntegrationShould extends MockIntegrationShould {
     }
 
     @Test
-    public void allow_access_to_combos_with_children() {
+    public void allow_access_to_combos_with_category_option_combos() {
         Set<CategoryCombo> combos = d2.categoryModule().categoryCombos.getSetWithAllChildren();
         assertThat(combos.size(), is(2));
         for (CategoryCombo combo : combos) {
-            // TODO assertThat(combo.categories() == null, is(false));
             assertThat(combo.categoryOptionCombos() == null, is(false));
+        }
+    }
+
+    @Test
+    public void allow_access_to_combos_with_categories() {
+        Set<CategoryCombo> combos = d2.categoryModule().categoryCombos.getSetWithAllChildren();
+        assertThat(combos.size(), is(2));
+        for (CategoryCombo combo : combos) {
+            assertThat(combo.categories() == null, is(false));
         }
     }
 
@@ -47,21 +55,32 @@ public class CategoryModuleMockIntegrationShould extends MockIntegrationShould {
         assertThat(combo.uid(), is("m2jTvAj5kkm"));
         assertThat(combo.code(), is("BIRTHS"));
         assertThat(combo.name(), is("Births"));
-        // TODO assertThat(combo.categories() == null, is(false));
+        assertThat(combo.categories() == null, is(true));
         assertThat(combo.categoryOptionCombos() == null, is(true));
     }
 
     @Test
-    public void allow_access_to_combo_by_uid_with_children() {
+    public void allow_access_to_combo_by_uid_with_category_option_combos() {
         CategoryCombo combo = d2.categoryModule().categoryCombos.uid("m2jTvAj5kkm").getWithAllChildren();
         assertThat(combo.uid(), is("m2jTvAj5kkm"));
         assertThat(combo.code(), is("BIRTHS"));
         assertThat(combo.name(), is("Births"));
-        // TODO assertThat(combo.categories() == null, is(true));
         List<CategoryOptionCombo> optionCombos = combo.categoryOptionCombos();
         assertThat(optionCombos == null, is(false));
         assertThat(optionCombos.size(), is(1));
         assertThat(optionCombos.iterator().next().name(), is("Trained TBA, At PHU"));
+    }
+
+    @Test
+    public void allow_access_to_combo_by_uid_with_categories() {
+        CategoryCombo combo = d2.categoryModule().categoryCombos.uid("m2jTvAj5kkm").getWithAllChildren();
+        assertThat(combo.uid(), is("m2jTvAj5kkm"));
+        assertThat(combo.code(), is("BIRTHS"));
+        assertThat(combo.name(), is("Births"));
+        List<Category> categories = combo.categories();
+        assertThat(combo.categories() == null, is(false));
+        assertThat(categories.size(), is(2));
+        assertThat(categories.iterator().next().code(), is("BIRTHS_ATTENDED"));
     }
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/executors/CursorExecutor.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/executors/CursorExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.db.executors;
+
+import android.database.Cursor;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface CursorExecutor<M> {
+
+    void addObjectsToCollection(Cursor cursor, Collection<M> collection);
+
+    List<M> getObjects(Cursor cursor);
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/executors/CursorExecutorImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/executors/CursorExecutorImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.db.executors;
+
+import android.database.Cursor;
+
+import org.hisp.dhis.android.core.common.CursorModelFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CursorExecutorImpl<M> implements CursorExecutor<M> {
+
+    private final CursorModelFactory<M> modelFactory;
+
+    public CursorExecutorImpl(CursorModelFactory<M> modelFactory) {
+        this.modelFactory = modelFactory;
+    }
+
+    @Override
+    public void addObjectsToCollection(Cursor cursor, Collection<M> collection) {
+        try {
+            if (cursor.getCount() > 0) {
+                cursor.moveToFirst();
+                do {
+                    collection.add(modelFactory.fromCursor(cursor));
+                }
+                while (cursor.moveToNext());
+            }
+        } finally {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public List<M> getObjects(Cursor cursor) {
+        List<M> list = new ArrayList<>();
+        addObjectsToCollection(cursor, list);
+        return list;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/LinkModelChildStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/LinkModelChildStore.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.db.stores;
+
+import org.hisp.dhis.android.core.common.ObjectWithUidInterface;
+
+import java.util.List;
+
+public interface LinkModelChildStore<P extends ObjectWithUidInterface, C extends ObjectWithUidInterface> {
+    List<C> getChildren(P p);
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/LinkModelChildStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/LinkModelChildStoreImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.db.stores;
+
+import org.hisp.dhis.android.core.arch.db.executors.CursorExecutor;
+import org.hisp.dhis.android.core.arch.db.tableinfos.LinkTableChildProjection;
+import org.hisp.dhis.android.core.common.ObjectWithUidInterface;
+import org.hisp.dhis.android.core.common.SQLStatementBuilder;
+import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
+
+import java.util.List;
+
+public class LinkModelChildStoreImpl<P extends ObjectWithUidInterface, C extends ObjectWithUidInterface>
+        implements LinkModelChildStore<P, C> {
+
+    private final LinkTableChildProjection linkTableChildProjection;
+
+    private final DatabaseAdapter databaseAdapter;
+    private final SQLStatementBuilder statementBuilder;
+
+    private final CursorExecutor<C> cursorExecutor;
+
+    public LinkModelChildStoreImpl(LinkTableChildProjection linkTableChildProjection,
+                                   DatabaseAdapter databaseAdapter,
+                                   SQLStatementBuilder statementBuilder,
+                                   CursorExecutor<C> cursorExecutor) {
+        this.linkTableChildProjection = linkTableChildProjection;
+        this.databaseAdapter = databaseAdapter;
+        this.statementBuilder = statementBuilder;
+        this.cursorExecutor = cursorExecutor;
+    }
+
+    @Override
+    public List<C> getChildren(P p) {
+        String selectStatement = statementBuilder.selectChildrenWithLinkTable(linkTableChildProjection, p.uid());
+        return cursorExecutor.getObjects(databaseAdapter.query(selectStatement));
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/tableinfos/LinkTableChildProjection.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/tableinfos/LinkTableChildProjection.java
@@ -31,16 +31,13 @@ import org.hisp.dhis.android.core.arch.db.TableInfo;
 
 public class LinkTableChildProjection {
 
-    public final TableInfo linkTableInfo;
     public final TableInfo childTableInfo;
     public final String parentColumn;
     public final String childColumn;
 
-    public LinkTableChildProjection(TableInfo linkTableInfo,
-                                    TableInfo childTableInfo,
+    public LinkTableChildProjection(TableInfo childTableInfo,
                                     String parentColumn,
                                     String childColumn) {
-        this.linkTableInfo = linkTableInfo;
         this.childTableInfo = childTableInfo;
         this.parentColumn = parentColumn;
         this.childColumn = childColumn;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/tableinfos/LinkTableChildProjection.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/tableinfos/LinkTableChildProjection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.db.tableinfos;
+
+import org.hisp.dhis.android.core.arch.db.TableInfo;
+
+public class LinkTableChildProjection {
+
+    public final TableInfo linkTableInfo;
+    public final TableInfo childTableInfo;
+    public final String parentColumn;
+    public final String childColumn;
+
+    public LinkTableChildProjection(TableInfo linkTableInfo,
+                                    TableInfo childTableInfo,
+                                    String parentColumn,
+                                    String childColumn) {
+        this.linkTableInfo = linkTableInfo;
+        this.childTableInfo = childTableInfo;
+        this.parentColumn = parentColumn;
+        this.childColumn = childColumn;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/ChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/ChildrenAppender.java
@@ -29,7 +29,14 @@ package org.hisp.dhis.android.core.arch.repositories.children;
 
 import java.util.Collection;
 
-public interface ChildrenAppender<M> {
-    void prepareChildren(Collection<M> collection);
-    M appendChildren(M m);
+public abstract class ChildrenAppender<M> {
+
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+    protected void prepareChildren(Collection<M> collection) {
+        /* Method is not abstract since empty action is the default action and we don't want it to
+         * be unnecessarily written in every child.
+         */
+    }
+
+    protected abstract M appendChildren(M m);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkChildStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkChildStore.java
@@ -25,44 +25,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.arch.repositories.children;
 
-import org.hisp.dhis.android.core.common.Model;
+package org.hisp.dhis.android.core.category;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import org.hisp.dhis.android.core.arch.db.executors.CursorExecutorImpl;
+import org.hisp.dhis.android.core.arch.db.stores.LinkModelChildStore;
+import org.hisp.dhis.android.core.arch.db.stores.LinkModelChildStoreImpl;
+import org.hisp.dhis.android.core.common.SQLStatementBuilder;
+import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 
-public final class ChildrenAppenderExecutor {
+final class CategoryCategoryComboLinkChildStore {
 
-    private ChildrenAppenderExecutor() {
-    }
-
-    public static <M extends Model> M appendInObject(M m, Collection<ChildrenAppender<M>> childrenAppenders) {
-        M mWithChildren = m;
-        for (ChildrenAppender<M> appender: childrenAppenders) {
-            appender.prepareChildren(Collections.singleton(mWithChildren));
-            mWithChildren = appender.appendChildren(mWithChildren);
-        }
-        return mWithChildren;
-    }
-
-    public static <M extends Model> Set<M> appendInObjectSet(Set<M> set,
-                                                             Collection<ChildrenAppender<M>> childrenAppenders) {
-
-        for (ChildrenAppender<M> appender: childrenAppenders) {
-            appender.prepareChildren(set);
-        }
-
-        Set<M> setWithChildren = new HashSet<>(set.size());
-        for (M m: set) {
-            M mWithChildren = m;
-            for (ChildrenAppender<M> appender: childrenAppenders) {
-                mWithChildren = appender.appendChildren(mWithChildren);
-            }
-            setWithChildren.add(mWithChildren);
-        }
-        return setWithChildren;
+    static LinkModelChildStore<CategoryCombo, Category> create(DatabaseAdapter databaseAdapter) {
+        return new LinkModelChildStoreImpl<>(
+                CategoryCategoryComboLinkTableInfo.CHILD_PROJECTION,
+                databaseAdapter,
+                new SQLStatementBuilder(CategoryCategoryComboLinkTableInfo.TABLE_INFO),
+                new CursorExecutorImpl<>(CategoryStore.FACTORY));
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkChildStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkChildStore.java
@@ -36,6 +36,9 @@ import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 
 final class CategoryCategoryComboLinkChildStore {
 
+    private CategoryCategoryComboLinkChildStore() {
+    }
+
     static LinkModelChildStore<CategoryCombo, Category> create(DatabaseAdapter databaseAdapter) {
         return new LinkModelChildStoreImpl<>(
                 CategoryCategoryComboLinkTableInfo.CHILD_PROJECTION,

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkStore.java
@@ -37,8 +37,7 @@ final class CategoryCategoryComboLinkStore {
     };
 
     public static LinkModelStore<CategoryCategoryComboLinkModel> create(DatabaseAdapter databaseAdapter) {
-        return StoreFactory.linkModelStore(databaseAdapter, CategoryCategoryComboLinkModel.TABLE,
-                new CategoryCategoryComboLinkModel.Columns(),
-                CategoryCategoryComboLinkModel.Columns.CATEGORY_COMBO, BINDER, FACTORY);
+        return StoreFactory.linkModelStore(databaseAdapter, CategoryCategoryComboTableInfo.TABLE_INFO,
+                CategoryCategoryComboTableInfo.Columns.CATEGORY_COMBO, BINDER, FACTORY);
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkStore.java
@@ -37,7 +37,7 @@ final class CategoryCategoryComboLinkStore {
     };
 
     public static LinkModelStore<CategoryCategoryComboLinkModel> create(DatabaseAdapter databaseAdapter) {
-        return StoreFactory.linkModelStore(databaseAdapter, CategoryCategoryComboTableInfo.TABLE_INFO,
-                CategoryCategoryComboTableInfo.Columns.CATEGORY_COMBO, BINDER, FACTORY);
+        return StoreFactory.linkModelStore(databaseAdapter, CategoryCategoryComboLinkTableInfo.TABLE_INFO,
+                CategoryCategoryComboLinkTableInfo.Columns.CATEGORY_COMBO, BINDER, FACTORY);
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
@@ -35,8 +35,7 @@ import org.hisp.dhis.android.core.utils.Utils;
 
 public final class CategoryCategoryComboLinkTableInfo {
 
-    private CategoryCategoryComboLinkTableInfo() {
-    }
+
 
     public static final TableInfo TABLE_INFO = new TableInfo() {
 
@@ -55,6 +54,9 @@ public final class CategoryCategoryComboLinkTableInfo {
             CategoryTableInfo.TABLE_INFO,
             Columns.CATEGORY_COMBO,
             Columns.CATEGORY);
+
+    private CategoryCategoryComboLinkTableInfo() {
+    }
 
     static class Columns extends BaseModel.Columns {
 

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
@@ -72,7 +72,6 @@ public final class CategoryCategoryComboLinkTableInfo {
     }
 
     static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
-            TABLE_INFO,
             CategoryTableInfo.TABLE_INFO,
             Columns.CATEGORY_COMBO,
             Columns.CATEGORY);

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
@@ -29,13 +29,13 @@
 package org.hisp.dhis.android.core.category;
 
 import org.hisp.dhis.android.core.arch.db.TableInfo;
-import org.hisp.dhis.android.core.common.BaseIdentifiableObjectModel;
+import org.hisp.dhis.android.core.arch.db.tableinfos.LinkTableChildProjection;
 import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.utils.Utils;
 
-public final class CategoryCategoryComboTableInfo {
+public final class CategoryCategoryComboLinkTableInfo {
 
-    private CategoryCategoryComboTableInfo() {
+    private CategoryCategoryComboLinkTableInfo() {
     }
 
     public static final TableInfo TABLE_INFO = new TableInfo() {
@@ -51,6 +51,8 @@ public final class CategoryCategoryComboTableInfo {
         }
     };
 
+
+
     static class Columns extends BaseModel.Columns {
 
         private static final String CATEGORY = "category";
@@ -65,8 +67,13 @@ public final class CategoryCategoryComboTableInfo {
 
         @Override
         public String[] whereUpdate() {
-            return Utils.appendInNewArray(super.all(),
-                    CATEGORY, CATEGORY_COMBO, SORT_ORDER);
+            return all();
         }
     }
+
+    static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
+            TABLE_INFO,
+            CategoryTableInfo.TABLE_INFO,
+            Columns.CATEGORY_COMBO,
+            Columns.CATEGORY);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboLinkTableInfo.java
@@ -51,7 +51,10 @@ public final class CategoryCategoryComboLinkTableInfo {
         }
     };
 
-
+    static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
+            CategoryTableInfo.TABLE_INFO,
+            Columns.CATEGORY_COMBO,
+            Columns.CATEGORY);
 
     static class Columns extends BaseModel.Columns {
 
@@ -70,9 +73,4 @@ public final class CategoryCategoryComboLinkTableInfo {
             return all();
         }
     }
-
-    static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
-            CategoryTableInfo.TABLE_INFO,
-            Columns.CATEGORY_COMBO,
-            Columns.CATEGORY);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboTableInfo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCategoryComboTableInfo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.category;
+
+import org.hisp.dhis.android.core.arch.db.TableInfo;
+import org.hisp.dhis.android.core.common.BaseIdentifiableObjectModel;
+import org.hisp.dhis.android.core.common.BaseModel;
+import org.hisp.dhis.android.core.utils.Utils;
+
+public final class CategoryCategoryComboTableInfo {
+
+    private CategoryCategoryComboTableInfo() {
+    }
+
+    public static final TableInfo TABLE_INFO = new TableInfo() {
+
+        @Override
+        public String name() {
+            return "CategoryCategoryComboLink";
+        }
+
+        @Override
+        public Columns columns() {
+            return new Columns();
+        }
+    };
+
+    static class Columns extends BaseModel.Columns {
+
+        private static final String CATEGORY = "category";
+        static final String CATEGORY_COMBO = "categoryCombo";
+        private static final String SORT_ORDER = "sortOrder";
+
+        @Override
+        public String[] all() {
+            return Utils.appendInNewArray(super.all(),
+                    CATEGORY, CATEGORY_COMBO, SORT_ORDER);
+        }
+
+        @Override
+        public String[] whereUpdate() {
+            return Utils.appendInNewArray(super.all(),
+                    CATEGORY, CATEGORY_COMBO, SORT_ORDER);
+        }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryChildrenAppender.java
@@ -30,24 +30,17 @@ package org.hisp.dhis.android.core.category;
 import org.hisp.dhis.android.core.arch.db.stores.LinkModelChildStore;
 import org.hisp.dhis.android.core.arch.repositories.children.ChildrenAppender;
 
-import java.util.Collection;
-
-public final class CategoryChildrenAppender implements ChildrenAppender<CategoryCombo> {
+final class CategoryChildrenAppender extends ChildrenAppender<CategoryCombo> {
 
 
     private final LinkModelChildStore<CategoryCombo, Category> linkModelChildStore;
 
-    public CategoryChildrenAppender(LinkModelChildStore<CategoryCombo, Category> linkModelChildStore) {
+    CategoryChildrenAppender(LinkModelChildStore<CategoryCombo, Category> linkModelChildStore) {
         this.linkModelChildStore = linkModelChildStore;
     }
 
     @Override
-    public void prepareChildren(Collection<CategoryCombo> collection) {
-
-    }
-
-    @Override
-    public CategoryCombo appendChildren(CategoryCombo categoryCombo) {
+    protected CategoryCombo appendChildren(CategoryCombo categoryCombo) {
         CategoryCombo.Builder builder = categoryCombo.toBuilder();
         builder.categories(linkModelChildStore.getChildren(categoryCombo));
         return builder.build();

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryChildrenAppender.java
@@ -25,44 +25,31 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.arch.repositories.children;
+package org.hisp.dhis.android.core.category;
 
-import org.hisp.dhis.android.core.common.Model;
+import org.hisp.dhis.android.core.arch.db.stores.LinkModelChildStore;
+import org.hisp.dhis.android.core.arch.repositories.children.ChildrenAppender;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
-public final class ChildrenAppenderExecutor {
+public final class CategoryChildrenAppender implements ChildrenAppender<CategoryCombo> {
 
-    private ChildrenAppenderExecutor() {
+
+    private final LinkModelChildStore<CategoryCombo, Category> linkModelChildStore;
+
+    public CategoryChildrenAppender(LinkModelChildStore<CategoryCombo, Category> linkModelChildStore) {
+        this.linkModelChildStore = linkModelChildStore;
     }
 
-    public static <M extends Model> M appendInObject(M m, Collection<ChildrenAppender<M>> childrenAppenders) {
-        M mWithChildren = m;
-        for (ChildrenAppender<M> appender: childrenAppenders) {
-            appender.prepareChildren(Collections.singleton(mWithChildren));
-            mWithChildren = appender.appendChildren(mWithChildren);
-        }
-        return mWithChildren;
+    @Override
+    public void prepareChildren(Collection<CategoryCombo> collection) {
+
     }
 
-    public static <M extends Model> Set<M> appendInObjectSet(Set<M> set,
-                                                             Collection<ChildrenAppender<M>> childrenAppenders) {
-
-        for (ChildrenAppender<M> appender: childrenAppenders) {
-            appender.prepareChildren(set);
-        }
-
-        Set<M> setWithChildren = new HashSet<>(set.size());
-        for (M m: set) {
-            M mWithChildren = m;
-            for (ChildrenAppender<M> appender: childrenAppenders) {
-                mWithChildren = appender.appendChildren(mWithChildren);
-            }
-            setWithChildren.add(mWithChildren);
-        }
-        return setWithChildren;
+    @Override
+    public CategoryCombo appendChildren(CategoryCombo categoryCombo) {
+        CategoryCombo.Builder builder = categoryCombo.toBuilder();
+        builder.categories(linkModelChildStore.getChildren(categoryCombo));
+        return builder.build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryComboCollectionRepository.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryComboCollectionRepository.java
@@ -32,7 +32,7 @@ import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyIdentifia
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyIdentifiableCollectionRepositoryImpl;
 import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 final class CategoryComboCollectionRepository {
 
@@ -40,13 +40,20 @@ final class CategoryComboCollectionRepository {
     }
 
     static ReadOnlyIdentifiableCollectionRepository<CategoryCombo> create(DatabaseAdapter databaseAdapter) {
-        ChildrenAppender<CategoryCombo> childrenAppender = new CategoryOptionComboChildrenAppender(
+        ChildrenAppender<CategoryCombo> categoryOptionComboChildrenAppender = new CategoryOptionComboChildrenAppender(
                 CategoryOptionComboStoreImpl.create(databaseAdapter)
+        );
+
+        ChildrenAppender<CategoryCombo> categoryChildrenAppender = new CategoryChildrenAppender(
+                CategoryCategoryComboLinkChildStore.create(databaseAdapter)
         );
 
         return new ReadOnlyIdentifiableCollectionRepositoryImpl<>(
                 CategoryComboStore.create(databaseAdapter),
-                Collections.singletonList(childrenAppender)
+                Arrays.asList(
+                        categoryChildrenAppender,
+                        categoryOptionComboChildrenAppender
+                )
         );
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboChildrenAppender.java
@@ -29,10 +29,9 @@ package org.hisp.dhis.android.core.category;
 
 import org.hisp.dhis.android.core.arch.repositories.children.ChildrenAppender;
 
-import java.util.Collection;
 import java.util.List;
 
-final class CategoryOptionComboChildrenAppender implements ChildrenAppender<CategoryCombo> {
+final class CategoryOptionComboChildrenAppender extends ChildrenAppender<CategoryCombo> {
 
     private final CategoryOptionComboStore store;
 
@@ -41,12 +40,7 @@ final class CategoryOptionComboChildrenAppender implements ChildrenAppender<Cate
     }
 
     @Override
-    public void prepareChildren(Collection<CategoryCombo> collection) {
-        // no previous set call is needed
-    }
-
-    @Override
-    public CategoryCombo appendChildren(CategoryCombo categoryCombo) {
+    protected CategoryCombo appendChildren(CategoryCombo categoryCombo) {
         CategoryCombo.Builder builder = categoryCombo.toBuilder();
         List<CategoryOptionCombo> optionCombos = store.getForCategoryCombo(categoryCombo.uid());
         return builder.categoryOptionCombos(optionCombos).build();

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryStore.java
@@ -26,7 +26,7 @@ final class CategoryStore {
         }
     };
 
-    private static final CursorModelFactory<Category> FACTORY = new CursorModelFactory<Category>() {
+    static final CursorModelFactory<Category> FACTORY = new CursorModelFactory<Category>() {
         @Override
         public Category fromCursor(Cursor cursor) {
             return Category.create(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/common/ObjectStyleChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/ObjectStyleChildrenAppender.java
@@ -30,10 +30,8 @@ package org.hisp.dhis.android.core.common;
 import org.hisp.dhis.android.core.arch.db.TableInfo;
 import org.hisp.dhis.android.core.arch.repositories.children.ChildrenAppender;
 
-import java.util.Collection;
-
 public final class ObjectStyleChildrenAppender<O extends ObjectWithUidInterface & ObjectWithStyle<O, B>,
-        B extends ObjectWithStyle.Builder<O, B>> implements ChildrenAppender<O> {
+        B extends ObjectWithStyle.Builder<O, B>> extends ChildrenAppender<O> {
 
     private final ObjectStyleStore objectStyleStore;
     private final TableInfo objectWithStyleTableInfo;
@@ -46,12 +44,7 @@ public final class ObjectStyleChildrenAppender<O extends ObjectWithUidInterface 
     }
 
     @Override
-    public void prepareChildren(Collection<O> collection) {
-        // Intentionally empty
-    }
-
-    @Override
-    public O appendChildren(O objectWithStyle) {
+    protected O appendChildren(O objectWithStyle) {
         B builder = objectWithStyle.toBuilder();
         ObjectStyle style = objectStyleStore.getStyle(objectWithStyle, objectWithStyleTableInfo);
         return builder.style(style).build();

--- a/core/src/main/java/org/hisp/dhis/android/core/common/SQLStatementBuilder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/SQLStatementBuilder.java
@@ -29,8 +29,10 @@
 package org.hisp.dhis.android.core.common;
 
 import org.hisp.dhis.android.core.arch.db.TableInfo;
+import org.hisp.dhis.android.core.arch.db.tableinfos.LinkTableChildProjection;
 import org.hisp.dhis.android.core.utils.Utils;
 
+import static org.hisp.dhis.android.core.common.BaseIdentifiableObjectModel.Columns.UID;
 import static org.hisp.dhis.android.core.utils.Utils.commaAndSpaceSeparatedArrayValues;
 
 public class SQLStatementBuilder {
@@ -42,6 +44,7 @@ public class SQLStatementBuilder {
     private final static String LIMIT = " LIMIT ";
     private final static String FROM = " FROM ";
     private final static String SELECT = "SELECT ";
+    private static final String AND = " AND ";
 
     @SuppressWarnings("PMD.UseVarargs")
     SQLStatementBuilder(String tableName, String[] columns, String[] updateWhereColumns) {
@@ -91,23 +94,30 @@ public class SQLStatementBuilder {
     }
 
     String deleteById() {
-        return "DELETE" + FROM + tableName + WHERE + BaseIdentifiableObjectModel.Columns.UID + "=?;";
+        return "DELETE" + FROM + tableName + WHERE + UID + "=?;";
     }
 
     String selectUids() {
-        return SELECT + BaseIdentifiableObjectModel.Columns.UID + FROM + tableName;
+        return SELECT + UID + FROM + tableName;
     }
 
     String selectUidsWhere(String whereClause) {
-        return SELECT + BaseIdentifiableObjectModel.Columns.UID + FROM + tableName + WHERE + whereClause + ";";
+        return SELECT + UID + FROM + tableName + WHERE + whereClause + ";";
     }
 
     String selectColumnWhere(String column, String whereClause) {
         return SELECT + column + FROM + tableName + WHERE + whereClause + ";";
     }
 
+    public String selectChildrenWithLinkTable(LinkTableChildProjection projection, String parentUid) {
+        return SELECT + "c.*" + FROM + projection.linkTableInfo.name() + " AS l, " +
+                projection.childTableInfo.name() + " AS c" +
+                WHERE + "l." + projection.childColumn + "=" + "c." + UID +
+                AND + "l." + projection.parentColumn + "='" + parentUid + "';";
+    }
+
     String selectByUid() {
-        return selectWhere(andSeparatedColumnEqualInterrogationMark(BaseIdentifiableObjectModel.Columns.UID));
+        return selectWhere(andSeparatedColumnEqualInterrogationMark(UID));
     }
 
     String selectWhere(String whereClause) {
@@ -128,7 +138,7 @@ public class SQLStatementBuilder {
 
     public String update() {
         return "UPDATE " + tableName + " SET " + commaSeparatedColumnEqualInterrogationMark(columns) +
-                WHERE + BaseIdentifiableObjectModel.Columns.UID + "=?;";
+                WHERE + UID + "=?;";
     }
 
     public String updateWhere() {
@@ -151,7 +161,7 @@ public class SQLStatementBuilder {
 
     private static String[] identifiableColumns() {
         return Utils.appendInNewArray(idColumn(),
-                BaseIdentifiableObjectModel.Columns.UID + TEXT + " NOT NULL UNIQUE",
+                UID + TEXT + " NOT NULL UNIQUE",
                 BaseIdentifiableObjectModel.Columns.CODE + TEXT,
                 BaseIdentifiableObjectModel.Columns.NAME + TEXT,
                 BaseIdentifiableObjectModel.Columns.DISPLAY_NAME + TEXT,

--- a/core/src/main/java/org/hisp/dhis/android/core/common/SQLStatementBuilder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/SQLStatementBuilder.java
@@ -110,7 +110,7 @@ public class SQLStatementBuilder {
     }
 
     public String selectChildrenWithLinkTable(LinkTableChildProjection projection, String parentUid) {
-        return SELECT + "c.*" + FROM + projection.linkTableInfo.name() + " AS l, " +
+        return SELECT + "c.*" + FROM + tableName + " AS l, " +
                 projection.childTableInfo.name() + " AS c" +
                 WHERE + "l." + projection.childColumn + "=" + "c." + UID +
                 AND + "l." + projection.parentColumn + "='" + parentUid + "';";

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipConstraintChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipConstraintChildrenAppender.java
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.common.ObjectWithoutUidStore;
 import java.util.Collection;
 import java.util.Set;
 
-final class RelationshipConstraintChildrenAppender implements ChildrenAppender<RelationshipType> {
+final class RelationshipConstraintChildrenAppender extends ChildrenAppender<RelationshipType> {
 
     private final ObjectWithoutUidStore<RelationshipConstraint> constraintStore;
     private Set<RelationshipConstraint> constraintsSet;
@@ -49,7 +49,7 @@ final class RelationshipConstraintChildrenAppender implements ChildrenAppender<R
     }
 
     @Override
-    public RelationshipType appendChildren(RelationshipType relationshipType) {
+    protected RelationshipType appendChildren(RelationshipType relationshipType) {
         RelationshipType.Builder builder = relationshipType.toBuilder();
         for (RelationshipConstraint constraint : this.constraintsSet) {
             if (constraint.relationshipType().uid().equals(relationshipType.uid())) {

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipItemChildrenAppender.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipItemChildrenAppender.java
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.core.relationship;
 import org.hisp.dhis.android.core.arch.repositories.children.ChildrenAppender;
 import org.hisp.dhis.android.core.common.PojoBuilder;
 
-import java.util.Collection;
-
-final class RelationshipItemChildrenAppender implements ChildrenAppender<Relationship> {
+final class RelationshipItemChildrenAppender extends ChildrenAppender<Relationship> {
 
     private final RelationshipItemStore store;
     private final PojoBuilder<RelationshipItem, RelationshipItemModel> pojoBuilder;
@@ -44,12 +42,7 @@ final class RelationshipItemChildrenAppender implements ChildrenAppender<Relatio
     }
 
     @Override
-    public void prepareChildren(Collection<Relationship> collection) {
-        // no previous set call is needed
-    }
-
-    @Override
-    public Relationship appendChildren(Relationship relationship) {
+    protected Relationship appendChildren(Relationship relationship) {
         RelationshipItemModel fromItemModel = store.getForRelationshipUidAndConstraintType(
                 relationship.uid(), RelationshipConstraintType.FROM);
         RelationshipItemModel toItemModel = store.getForRelationshipUidAndConstraintType(

--- a/core/src/test/java/org/hisp/dhis/android/core/common/SQLStatementBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/SQLStatementBuilderShould.java
@@ -27,11 +27,17 @@
  */
 package org.hisp.dhis.android.core.common;
 
+import org.hisp.dhis.android.core.arch.db.TableInfo;
+import org.hisp.dhis.android.core.arch.db.tableinfos.LinkTableChildProjection;
+import org.hisp.dhis.android.core.category.CategoryCategoryComboLinkTableInfo;
+import org.hisp.dhis.android.core.category.CategoryComboTableInfo;
+import org.hisp.dhis.android.core.category.CategoryTableInfo;
 import org.hisp.dhis.android.core.dataset.DataSetModel;
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLinkModel;
 import org.hisp.dhis.android.core.legendset.LegendModel;
 import org.hisp.dhis.android.core.legendset.LegendSetModel;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitModel;
+import org.hisp.dhis.android.core.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,15 +50,23 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class SQLStatementBuilderShould {
 
-    private SQLStatementBuilder builder;
+    private final static String TABLE_NAME = "Test_Table";
+    private final static String COL_1 = "Test_Column_Name1";
+    private final static String COL_2 = "Test_Column_Name2";
+
+    private final static String[] columns = new String[]{COL_1, COL_2};
+
+    private SQLStatementBuilder builder = new SQLStatementBuilder("Test_Table", columns, columns);
+
+    static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
+            CategoryCategoryComboLinkTableInfo.TABLE_INFO,
+            CategoryTableInfo.TABLE_INFO,
+            COL_1,
+            COL_2);
 
     @Before
     public void setUp() throws IOException {
-        String[] columns = new String[]{
-                "Test_Column_Name1",
-                "Test_Column_Name2"
-        };
-        this.builder = new SQLStatementBuilder("Test_Table", columns, columns);
+
     }
 
     @Test
@@ -198,6 +212,13 @@ public class SQLStatementBuilderShould {
     public void generate_select_by_uid_statement() {
         assertThat(builder.selectByUid()).isEqualTo(
                 "SELECT * FROM Test_Table WHERE uid=?;"
+        );
+    }
+
+    @Test
+    public void generate_select_children_with_link_table() {
+        assertThat(builder.selectChildrenWithLinkTable(CHILD_PROJECTION, "UID")).isEqualTo(
+                "SELECT c.* FROM Test_Table AS l, Category AS c WHERE l." + COL_2 + "=c.uid AND l." + COL_1 + "='UID';"
         );
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/common/SQLStatementBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/SQLStatementBuilderShould.java
@@ -52,7 +52,7 @@ public class SQLStatementBuilderShould {
 
     private final static String[] columns = new String[]{COL_1, COL_2};
 
-    private SQLStatementBuilder builder = new SQLStatementBuilder("Test_Table", columns, columns);
+    private SQLStatementBuilder builder = new SQLStatementBuilder(TABLE_NAME, columns, columns);
 
     static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
             CategoryTableInfo.TABLE_INFO,

--- a/core/src/test/java/org/hisp/dhis/android/core/common/SQLStatementBuilderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/SQLStatementBuilderShould.java
@@ -27,17 +27,13 @@
  */
 package org.hisp.dhis.android.core.common;
 
-import org.hisp.dhis.android.core.arch.db.TableInfo;
 import org.hisp.dhis.android.core.arch.db.tableinfos.LinkTableChildProjection;
-import org.hisp.dhis.android.core.category.CategoryCategoryComboLinkTableInfo;
-import org.hisp.dhis.android.core.category.CategoryComboTableInfo;
 import org.hisp.dhis.android.core.category.CategoryTableInfo;
 import org.hisp.dhis.android.core.dataset.DataSetModel;
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLinkModel;
 import org.hisp.dhis.android.core.legendset.LegendModel;
 import org.hisp.dhis.android.core.legendset.LegendSetModel;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitModel;
-import org.hisp.dhis.android.core.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,7 +55,6 @@ public class SQLStatementBuilderShould {
     private SQLStatementBuilder builder = new SQLStatementBuilder("Test_Table", columns, columns);
 
     static final LinkTableChildProjection CHILD_PROJECTION = new LinkTableChildProjection(
-            CategoryCategoryComboLinkTableInfo.TABLE_INFO,
             CategoryTableInfo.TABLE_INFO,
             COL_1,
             COL_2);


### PR DESCRIPTION
- Solves [ANDROSDK-405](ANDROSDK-405)
- Implements children appender for CategoryCategoryOption as use case of LinkTableChildStore, partially solving [ANDROSDK-409](https://jira.dhis2.org/browse/ANDROSDK-409)
- Makes ChildrenAppender a base class so we don't have to implement prepareChildren in most cases