### PR TITLE
[ANDROSDK-347-2] Catch error 409 in SingleEventPostCall

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventPostCall.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventPostCall.java
@@ -11,6 +11,7 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValueStore;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValueStoreImpl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -48,8 +49,8 @@ public final class EventPostCall extends SyncCall<WebResponse> {
 
         String strategy = "CREATE_AND_UPDATE";
 
-        WebResponse webResponse =
-                new APICallExecutor().executeObjectCall(eventService.postEvents(eventPayload, strategy));
+        WebResponse webResponse = new APICallExecutor().executeObjectCallWithAcceptedErrorCodes(
+                eventService.postEvents(eventPayload, strategy), Collections.singletonList(409), WebResponse.class);
 
         handleWebResponse(webResponse);
         return webResponse;


### PR DESCRIPTION
Related to [ANDROSDK-347](https://jira.dhis2.org/browse/ANDROSDK-347). Catch error 409 and process the payload.