### PR TITLE
[ANDROSDK-442] Ensure our unified classes can be inserted in db as contentValues

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.java
@@ -28,8 +28,10 @@
 
 package org.hisp.dhis.android.core.data.database;
 
+import org.hisp.dhis.android.core.arch.db.TableInfo;
 import org.hisp.dhis.android.core.common.HandleAction;
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
+import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,14 +40,14 @@ import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
 
-public abstract class IdentifiableObjectStoreAbstractIntegrationShould<M extends ObjectWithUidInterface>
+public abstract class IdentifiableObjectStoreAbstractIntegrationShould<M extends ObjectWithUidInterface & Model>
         extends ObjectStoreAbstractIntegrationShould<M> {
 
     private M objectToUpdate;
-    protected IdentifiableObjectStore<M> store;
+    private IdentifiableObjectStore<M> store;
 
-    public IdentifiableObjectStoreAbstractIntegrationShould(IdentifiableObjectStore<M> store) {
-        super(store);
+    public IdentifiableObjectStoreAbstractIntegrationShould(IdentifiableObjectStore<M> store, TableInfo tableInfo, DatabaseAdapter databaseAdapter) {
+        super(store, tableInfo, databaseAdapter);
         this.store = store;
         this.objectToUpdate = buildObjectToUpdate();
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/LinkModelStoreAbstractIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/LinkModelStoreAbstractIntegrationShould.java
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.data.database;
 
+import org.hisp.dhis.android.core.arch.db.TableInfo;
 import org.hisp.dhis.android.core.common.LinkModelStore;
 import org.hisp.dhis.android.core.common.Model;
 import org.junit.Before;
@@ -44,8 +45,10 @@ public abstract class LinkModelStoreAbstractIntegrationShould<M extends Model>
     private String masterUid;
     protected LinkModelStore<M> store;
 
-    public LinkModelStoreAbstractIntegrationShould(LinkModelStore<M> store) {
-        super(store);
+    public LinkModelStoreAbstractIntegrationShould(LinkModelStore<M> store,
+                                                   TableInfo tableInfo,
+                                                   DatabaseAdapter databaseAdapter) {
+        super(store, tableInfo, databaseAdapter);
         this.store = store;
         this.objectWithOtherMasterUid = buildObjectWithOtherMasterUid();
         this.masterUid = addMasterUid();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.java
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.android.core.data.database;
 
+import org.hisp.dhis.android.core.arch.db.TableInfo;
+import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectStore;
 import org.junit.After;
 import org.junit.Before;
@@ -38,16 +40,20 @@ import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 
-public abstract class ObjectStoreAbstractIntegrationShould<M> {
+public abstract class ObjectStoreAbstractIntegrationShould<M extends Model> {
 
-    protected M object;
-    protected M objectWithId;
-    protected ObjectStore<M> store;
+    final M object;
+    final M objectWithId;
+    private final ObjectStore<M> store;
+    private final TableInfo tableInfo;
+    private final DatabaseAdapter databaseAdapter;
 
-    ObjectStoreAbstractIntegrationShould(ObjectStore<M> store) {
+    ObjectStoreAbstractIntegrationShould(ObjectStore<M> store, TableInfo tableInfo, DatabaseAdapter databaseAdapter) {
         this.store = store;
         this.object = buildObject();
         this.objectWithId = buildObjectWithId();
+        this.tableInfo = tableInfo;
+        this.databaseAdapter = databaseAdapter;
     }
 
     protected abstract M buildObject();
@@ -66,6 +72,13 @@ public abstract class ObjectStoreAbstractIntegrationShould<M> {
     @Test
     public void insert_and_select_first_object() {
         store.insert(object);
+        M objectFromDb = store.selectFirst();
+        assertThat(objectFromDb).isEqualTo(object);
+    }
+
+    @Test
+    public void insert_as_content_values_and_select_first_object() {
+        databaseAdapter.database().insert(tableInfo.name(), null, object.toContentValues());
         M objectFromDb = store.selectFirst();
         assertThat(objectFromDb).isEqualTo(object);
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectWithoutUidStoreAbstractIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectWithoutUidStoreAbstractIntegrationShould.java
@@ -28,7 +28,9 @@
 
 package org.hisp.dhis.android.core.data.database;
 
+import org.hisp.dhis.android.core.arch.db.TableInfo;
 import org.hisp.dhis.android.core.common.HandleAction;
+import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithoutUidStore;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,14 +39,16 @@ import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
 
-public abstract class ObjectWithoutUidStoreAbstractIntegrationShould<M>
+public abstract class ObjectWithoutUidStoreAbstractIntegrationShould<M extends Model>
         extends ObjectStoreAbstractIntegrationShould<M> {
 
     private M objectToUpdate;
     protected ObjectWithoutUidStore<M> store;
 
-    public ObjectWithoutUidStoreAbstractIntegrationShould(ObjectWithoutUidStore<M> store) {
-        super(store);
+    public ObjectWithoutUidStoreAbstractIntegrationShould(ObjectWithoutUidStore<M> store,
+                                                          TableInfo tableInfo,
+                                                          DatabaseAdapter databaseAdapter) {
+        super(store, tableInfo, databaseAdapter);
         this.store = store;
         this.objectToUpdate = buildObjectToUpdate();
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/DataInputPeriodLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/DataInputPeriodLinkStoreIntegrationShould.java
@@ -42,7 +42,7 @@ public class DataInputPeriodLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataInputPeriod> {
 
     public DataInputPeriodLinkStoreIntegrationShould() {
-        super(DataInputPeriodLinkStore.create(DatabaseAdapterFactory.get(false)));
+        super(DataInputPeriodLinkStore.create(DatabaseAdapterFactory.get(false)), DataInputPeriodTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/DataSetDataElementLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/DataSetDataElementLinkStoreIntegrationShould.java
@@ -42,7 +42,8 @@ public class DataSetDataElementLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataSetElement> {
 
     public DataSetDataElementLinkStoreIntegrationShould() {
-        super(DataSetDataElementLinkStore.create(DatabaseAdapterFactory.get(false)));
+        super(DataSetDataElementLinkStore.create(DatabaseAdapterFactory.get(false)), DataSetElementLinkTableInfo.TABLE_INFO,
+                DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/IndicatorStoreIntegrationShould.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 public class IndicatorStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Indicator> {
 
     public IndicatorStoreIntegrationShould() {
-        super(IndicatorStore.create(DatabaseAdapterFactory.get(false)));
+        super(IndicatorStore.create(DatabaseAdapterFactory.get(false)), IndicatorTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendSetStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendSetStoreIntegrationShould.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 public class LegendSetStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<LegendSet> {
 
     public LegendSetStoreIntegrationShould() {
-        super(LegendSetStore.create(DatabaseAdapterFactory.get(false)));
+        super(LegendSetStore.create(DatabaseAdapterFactory.get(false)), LegendSetTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/LegendStoreIntegrationShould.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 public class LegendStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Legend> {
 
     public LegendStoreIntegrationShould() {
-        super(LegendStore.create(DatabaseAdapterFactory.get(false)));
+        super(LegendStore.create(DatabaseAdapterFactory.get(false)), LegendTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramIndicatorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramIndicatorStoreIntegrationShould.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 public class ProgramIndicatorStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramIndicator> {
 
     public ProgramIndicatorStoreIntegrationShould() {
-        super(ProgramIndicatorStore.create(DatabaseAdapterFactory.get(false)));
+        super(ProgramIndicatorStore.create(DatabaseAdapterFactory.get(false)), ProgramIndicatorTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStageSectionStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStageSectionStoreIntegrationShould.java
@@ -40,7 +40,7 @@ public class ProgramStageSectionStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramStageSection> {
 
     public ProgramStageSectionStoreIntegrationShould() {
-        super(ProgramStageSectionStore.create(DatabaseAdapterFactory.get(false)));
+        super(ProgramStageSectionStore.create(DatabaseAdapterFactory.get(false)), ProgramStageSectionTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramStoreIntegrationShould.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 public class ProgramStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Program> {
 
     public ProgramStoreIntegrationShould() {
-        super(ProgramStore.create(DatabaseAdapterFactory.get(false)));
+        super(ProgramStore.create(DatabaseAdapterFactory.get(false)), ProgramTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/RelationshipConstraintStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/RelationshipConstraintStoreIntegrationShould.java
@@ -40,7 +40,8 @@ public class RelationshipConstraintStoreIntegrationShould extends
         ObjectWithoutUidStoreAbstractIntegrationShould<RelationshipConstraint> {
 
     public RelationshipConstraintStoreIntegrationShould() {
-        super(RelationshipConstraintStore.create(DatabaseAdapterFactory.get(false)));
+        super(RelationshipConstraintStore.create(DatabaseAdapterFactory.get(false)),
+                RelationshipConstraintTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoStoreIntegrationShould.java
@@ -39,7 +39,8 @@ import org.junit.runner.RunWith;
 public class SystemInfoStoreIntegrationShould extends ObjectWithoutUidStoreAbstractIntegrationShould<SystemInfo> {
 
     public SystemInfoStoreIntegrationShould() {
-        super(SystemInfoStore.create(DatabaseAdapterFactory.get(false)));
+        super(SystemInfoStore.create(DatabaseAdapterFactory.get(false)), SystemInfoTableInfo.TABLE_INFO,
+                DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeStoreIntegrationShould.java
@@ -41,7 +41,7 @@ public class TrackedEntityTypeStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<TrackedEntityType> {
 
     public TrackedEntityTypeStoreIntegrationShould() {
-        super(TrackedEntityTypeStore.create(DatabaseAdapterFactory.get(false)));
+        super(TrackedEntityTypeStore.create(DatabaseAdapterFactory.get(false)), TrackedEntityTypeTableInfo.TABLE_INFO, DatabaseAdapterFactory.get(false));
     }
 
     @Override

--- a/core/src/main/java/org/hisp/dhis/android/core/category/Category.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/Category.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.category;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -66,8 +65,6 @@ public abstract class Category extends BaseNameableObject implements Model {
     @JsonProperty()
     @ColumnAdapter(IgnoreCategoryOptionListColumnAdapter.class)
     public abstract List<CategoryOption> categoryOptions();
-
-    public abstract ContentValues toContentValues();
 
     static Category create(Cursor cursor) {
         return $AutoValue_Category.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCombo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCombo.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.category;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -73,8 +72,6 @@ public abstract class CategoryCombo extends BaseIdentifiableObject implements Mo
     @JsonProperty()
     @ColumnAdapter(IgnoreCategoryOptionComboListColumnAdapter.class)
     public abstract List<CategoryOptionCombo> categoryOptionCombos();
-
-    public abstract ContentValues toContentValues();
 
     static CategoryCombo create(Cursor cursor) {
         return $AutoValue_CategoryCombo.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOption.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOption.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.category;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -75,9 +74,6 @@ public abstract class CategoryOption extends BaseNameableObject implements Model
     @ColumnAdapter(AccessColumnAdapter.class)
     @ColumnName(CategoryOptionTableInfo.Columns.ACCESS_DATA_WRITE)
     public abstract Access access();
-
-
-    public abstract ContentValues toContentValues();
 
     static CategoryOption create(Cursor cursor) {
         return $AutoValue_CategoryOption.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionCombo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionCombo.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.category;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -68,8 +67,6 @@ public abstract class CategoryOptionCombo extends BaseNameableObject implements 
     @JsonProperty()
     @ColumnAdapter(IgnoreCategoryOptionListColumnAdapter.class)
     public abstract List<CategoryOption> categoryOptions();
-
-    public abstract ContentValues toContentValues();
 
     static CategoryOptionCombo create(Cursor cursor) {
         return $AutoValue_CategoryOptionCombo.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/common/BaseIdentifiableObject.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/BaseIdentifiableObject.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
 
 import org.hisp.dhis.android.core.data.database.DbDateColumnAdapter;
+import org.hisp.dhis.android.core.data.database.IgnoreBooleanColumnAdapter;
 
 import java.text.ParseException;
 import java.util.Date;
@@ -81,6 +82,7 @@ public abstract class BaseIdentifiableObject implements IdentifiableObject, Obje
 
     @Override
     @Nullable
+    @ColumnAdapter(IgnoreBooleanColumnAdapter.class)
     public abstract Boolean deleted();
 
     public static Date parseDate(String dateStr) throws ParseException {

--- a/core/src/main/java/org/hisp/dhis/android/core/common/BaseModel.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/BaseModel.java
@@ -28,9 +28,7 @@
 
 package org.hisp.dhis.android.core.common;
 
-import android.content.ContentValues;
 import android.provider.BaseColumns;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.gabrielittner.auto.value.cursor.ColumnName;
@@ -50,9 +48,6 @@ public abstract class BaseModel implements Model {
             return new String[] {};
         }
     }
-
-    @NonNull
-    public abstract ContentValues toContentValues();
 
     @Override
     @Nullable

--- a/core/src/main/java/org/hisp/dhis/android/core/common/Model.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/Model.java
@@ -28,6 +28,9 @@
 
 package org.hisp.dhis.android.core.common;
 
+import android.content.ContentValues;
+
 public interface Model {
     Long id();
+    ContentValues toContentValues();
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/data/database/IgnoreBooleanColumnAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/data/database/IgnoreBooleanColumnAdapter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.data.database;
+
+public final class IgnoreBooleanColumnAdapter extends IgnoreColumnAdapter<Boolean> {
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElement.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElement.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.dataelement;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -123,8 +122,6 @@ public abstract class DataElement extends BaseNameableObject
     static DataElement create(Cursor cursor) {
         return $AutoValue_DataElement.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSet.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSet.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.dataset;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -170,8 +169,6 @@ public abstract class DataSet extends BaseNameableObject implements Model, Objec
     static DataSet create(Cursor cursor) {
         return $AutoValue_DataSet.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetElement.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetElement.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.dataset;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -79,8 +78,6 @@ public abstract class DataSetElement implements Model {
     static DataSetElement create(Cursor cursor) {
         return $AutoValue_DataSetElement.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/Section.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/Section.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.dataset;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -100,8 +99,6 @@ public abstract class Section extends BaseIdentifiableObject implements Model {
     static Section create(Cursor cursor) {
         return $AutoValue_Section.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/note/Note.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/note/Note.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.enrollment.note;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -72,8 +71,6 @@ public abstract class Note extends BaseDataModel implements ObjectWithUidInterfa
     static Note create(Cursor cursor) {
         return $AutoValue_Note.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/Indicator.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/Indicator.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.indicator;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -93,8 +92,6 @@ public abstract class Indicator extends BaseNameableObject implements Model {
     static Indicator create(Cursor cursor) {
         return $AutoValue_Indicator.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorType.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorType.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.indicator;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -69,8 +68,6 @@ public abstract class IndicatorType extends BaseIdentifiableObject implements Mo
     static IndicatorType create(Cursor cursor) {
         return $AutoValue_IndicatorType.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/Legend.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/Legend.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.legendset;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -73,8 +72,6 @@ public abstract class Legend extends BaseIdentifiableObject implements Model {
     @JsonProperty()
     @ColumnAdapter(ObjectWithUidColumnAdapter.class)
     public abstract ObjectWithUid legendSet();
-
-    public abstract ContentValues toContentValues();
 
     static Legend create(Cursor cursor) {
         return $AutoValue_Legend.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendSet.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendSet.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.legendset;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -66,8 +65,6 @@ public abstract class LegendSet extends BaseIdentifiableObject implements Model 
     @JsonProperty()
     @ColumnAdapter(IgnoreLegendListColumnAdapter.class)
     public abstract List<Legend> legends();
-
-    public abstract ContentValues toContentValues();
 
     static LegendSet create(Cursor cursor) {
         return $AutoValue_LegendSet.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/option/Option.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/Option.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.option;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -79,8 +78,6 @@ public abstract class Option extends BaseIdentifiableObject implements Model {
     static Option create(Cursor cursor) {
         return $AutoValue_Option.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionSet.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionSet.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.option;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -81,8 +80,6 @@ public abstract class OptionSet extends BaseIdentifiableObject implements Model 
     static OptionSet create(Cursor cursor) {
         return $AutoValue_OptionSet.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/Program.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/Program.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.program;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -233,8 +232,6 @@ public abstract class Program extends BaseNameableObject implements Model, Objec
     static Program create(Cursor cursor) {
         return $AutoValue_Program.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramIndicator.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramIndicator.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.program;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -97,8 +96,6 @@ public abstract class ProgramIndicator extends BaseNameableObject implements Mod
     @JsonProperty()
     @ColumnAdapter(IgnoreLegendSetListColumnAdapter.class)
     public abstract List<LegendSet> legendSets();
-
-    public abstract ContentValues toContentValues();
 
     static ProgramIndicator create(Cursor cursor) {
         return $AutoValue_ProgramIndicator.createFromCursor(cursor);

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSection.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSection.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.program;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -104,8 +103,6 @@ public abstract class ProgramStageSection extends BaseIdentifiableObject impleme
     static ProgramStageSection create(Cursor cursor) {
         return $AutoValue_ProgramStageSection.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipType.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipType.java
@@ -28,9 +28,7 @@
 
 package org.hisp.dhis.android.core.relationship;
 
-import android.content.ContentValues;
 import android.database.Cursor;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -89,9 +87,6 @@ public abstract class RelationshipType extends BaseIdentifiableObject implements
     static RelationshipType create(Cursor cursor) {
         return AutoValue_RelationshipType.createFromCursor(cursor);
     }
-
-    @NonNull
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityType.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityType.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.trackedentity;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -62,8 +61,6 @@ public abstract class TrackedEntityType extends BaseNameableObject implements Mo
     static TrackedEntityType create(Cursor cursor) {
         return $AutoValue_TrackedEntityType.createFromCursor(cursor);
     }
-
-    public abstract ContentValues toContentValues();
 
     public abstract Builder toBuilder();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/User.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/User.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.user;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -123,9 +122,6 @@ public abstract class User extends BaseIdentifiableObject implements Model {
     public static User create(Cursor cursor) {
         return AutoValue_User.createFromCursor(cursor);
     }
-
-    @NonNull
-    public abstract ContentValues toContentValues();
 
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentials.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentials.java
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.user;
 
-import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
@@ -72,8 +71,6 @@ public abstract class UserCredentials extends BaseIdentifiableObject implements 
     @JsonIgnore
     @ColumnAdapter(UserWithUidColumnAdapter.class)
     public abstract User user();
-
-    public abstract ContentValues toContentValues();
 
     static UserCredentials create(Cursor cursor) {
         return $AutoValue_UserCredentials.createFromCursor(cursor);


### PR DESCRIPTION
Solves [ANDROSDK-442](https://jira.dhis2.org/browse/ANDROSDK-442).

Adds tests that inserts object as `ContentValues` and retrieves it from store and compares both. The test proves that identifiable objects couldn't be inserted as `ContentValues` as the `deleted` property wasn't being ignored (fixed!). 