### PR TITLE
[ANDROSDK-449] Remove explicit id in unified classes

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCallMockIntegrationShould.java
@@ -40,33 +40,35 @@ import org.hisp.dhis.android.core.calls.Call;
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.common.D2Factory;
 import org.hisp.dhis.android.core.common.GenericCallData;
+import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.data.database.AbsStoreTestCase;
 import org.hisp.dhis.android.core.data.file.ResourcesFileReader;
+import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitSamples;
 import org.hisp.dhis.android.core.data.server.Dhis2MockServer;
 import org.hisp.dhis.android.core.program.ProgramModel;
 import org.hisp.dhis.android.core.resource.ResourceModel;
 import org.hisp.dhis.android.core.user.User;
 import org.hisp.dhis.android.core.user.UserModel;
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLinkModel;
+import org.hisp.dhis.android.core.user.UserOrganisationUnitLinkStore;
+import org.hisp.dhis.android.core.user.UserOrganisationUnitLinkStoreInterface;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.hisp.dhis.android.core.data.database.CursorAssert.assertThatCursor;
 
 @RunWith(AndroidJUnit4.class)
 public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase {
-    private static String[] USER_ORGANISATION_UNIT_PROJECTION = {
-            UserOrganisationUnitLinkModel.Columns.USER,
-            UserOrganisationUnitLinkModel.Columns.ORGANISATION_UNIT,
-    };
-
     private static String[] RESOURCE_PROJECTION = {
             ResourceModel.Columns.RESOURCE_TYPE,
             ResourceModel.Columns.LAST_SYNCED
@@ -77,6 +79,12 @@ public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase 
 
     //The return of the organisationUnitCall to be tested:
     private Call<List<OrganisationUnit>> organisationUnitCall;
+
+    private OrganisationUnit expectedAfroArabicClinic = OrganisationUnitSamples.getAfroArabClinic();
+    private OrganisationUnit expectedAdonkiaCHP = OrganisationUnitSamples.getAdonkiaCHP();
+
+    public OrganisationUnitCallMockIntegrationShould() throws ParseException {
+    }
 
     @Before
     @Override
@@ -96,6 +104,7 @@ public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase 
 
         // Create a user with the root as assigned organisation unit (for the test):
         User user = User.builder().uid("user_uid").organisationUnits(organisationUnits).build();
+        database().insert(UserModel.TABLE, null, user.toContentValues());
 
         ContentValues userContentValues = new ContentValues();
         userContentValues.put(UserModel.Columns.ID, "user_uid");
@@ -122,61 +131,44 @@ public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase 
     }
 
     @Test
-    public void persist_organisation_unit_tree_in_data_base_after_call() throws Exception {
-        //Insert User in the User tables, such that UserOrganisationUnitLink's foreign key is satisfied:
-        ContentValues userContentValues = new ContentValues();
-        userContentValues.put(UserModel.Columns.UID, "user_uid");
-        userContentValues.put(UserModel.Columns.CODE, "code");
-        userContentValues.put(UserModel.Columns.NAME, "name");
-        userContentValues.put(UserModel.Columns.DISPLAY_NAME, "displayName");
-        userContentValues.put(UserModel.Columns.LAST_UPDATED, "dateString");
-        userContentValues.put(UserModel.Columns.CREATED, "dateString");
-        userContentValues.put(UserModel.Columns.BIRTHDAY, "birthday");
-        userContentValues.put(UserModel.Columns.EDUCATION, "education");
-        userContentValues.put(UserModel.Columns.GENDER, "gender");
-        userContentValues.put(UserModel.Columns.JOB_TITLE, "jobTitle");
-        userContentValues.put(UserModel.Columns.SURNAME, "surname");
-        userContentValues.put(UserModel.Columns.FIRST_NAME, "firstName");
-        userContentValues.put(UserModel.Columns.INTRODUCTION, "introduction");
-        userContentValues.put(UserModel.Columns.EMPLOYER, "employer");
-        userContentValues.put(UserModel.Columns.INTERESTS, "interests");
-        userContentValues.put(UserModel.Columns.LANGUAGES, "languages");
-        userContentValues.put(UserModel.Columns.EMAIL, "email");
-        userContentValues.put(UserModel.Columns.PHONE_NUMBER, "phoneNumber");
-        userContentValues.put(UserModel.Columns.NATIONALITY, "nationality");
-        database().insert(UserModel.TABLE, null, userContentValues);
-
-
+    public void persist_organisation_unit_tree() throws Exception {
         organisationUnitCall.call();
 
-        Cursor organisationUnitCursor = database().query(OrganisationUnitTableInfo.TABLE_INFO.name(),
-                OrganisationUnitTableInfo.TABLE_INFO.columns().all(), null, null, null, null, null);
-        Cursor userOrganisationUnitCursor = database().query(UserOrganisationUnitLinkModel.TABLE,
-                USER_ORGANISATION_UNIT_PROJECTION, null, null, null, null, null);
+        IdentifiableObjectStore<OrganisationUnit> organisationUnitStore = OrganisationUnitStore.create(databaseAdapter());
+        OrganisationUnit dbAfroArabicClinic = organisationUnitStore.selectByUid(expectedAfroArabicClinic.uid());
+        OrganisationUnit dbAdonkiaCHP = organisationUnitStore.selectByUid(expectedAdonkiaCHP.uid());
+
+        assertThat(expectedAfroArabicClinic).isEqualTo(dbAfroArabicClinic.toBuilder().id(null).build());
+        assertThat(expectedAdonkiaCHP).isEqualTo(dbAdonkiaCHP.toBuilder().id(null).build());
+    }
+
+    @Test
+    public void persist_organisation_unit_user_links() throws Exception {
+        organisationUnitCall.call();
+
+        UserOrganisationUnitLinkStoreInterface userOrganisationUnitStore = UserOrganisationUnitLinkStore.create(databaseAdapter());
+        List<UserOrganisationUnitLinkModel> linkList = userOrganisationUnitStore.selectAll();
+
+        Set<String> linkOrganisationUnits = new HashSet<>(2);
+        for (UserOrganisationUnitLinkModel linkModel: linkList) {
+            assertThat(linkModel.user()).isEqualTo("user_uid");
+            linkOrganisationUnits.add(linkModel.organisationUnit());
+        }
+
+        assertThat(linkOrganisationUnits.contains(expectedAfroArabicClinic.uid())).isTrue();
+        assertThat(linkOrganisationUnits.contains(expectedAdonkiaCHP.uid())).isTrue();
+    }
+
+    @Test
+    public void update_resource_handler() throws Exception {
+       organisationUnitCall.call();
 
         Cursor resourceCursor = database().query(ResourceModel.TABLE,
                 RESOURCE_PROJECTION, null, null, null, null, null);
 
-        assertThatCursor(organisationUnitCursor).hasRow("cDw53Ej8rju", "OU_278371", "Afro Arab Clinic",
-                "Afro Arab Clinic", "2012-02-17T15:54:39.987", "2017-05-22T15:21:48.518", "Afro Arab Clinic",
-                "Afro Arab Clinic", null, null, "/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/cDw53Ej8rju",
-                "2008-01-01T00:00:00.000", null, 4, "qtr8GGlm4gg", "/Afro Arab Clinic");
-
-        assertThatCursor(organisationUnitCursor).hasRow("Rp268JB6Ne4", "OU_651071", "Adonkia CHP",
-                "Adonkia CHP", "2012-02-17T15:54:39.987", "2017-05-22T15:21:48.515", "Adonkia CHP",
-                "Adonkia CHP", null, null, "/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/Rp268JB6Ne4",
-                "2010-01-01T00:00:00.000", null, 4, "qtr8GGlm4gg", "/Adonkia CHP");
-
-        //Link tables:
-        assertThatCursor(userOrganisationUnitCursor).hasRow("user_uid", "cDw53Ej8rju");
-        assertThatCursor(userOrganisationUnitCursor).hasRow("user_uid", "Rp268JB6Ne4");
-        assertThatCursor(userOrganisationUnitCursor).isExhausted();
-
         assertThatCursor(resourceCursor).hasRow(ResourceModel.Type.ORGANISATION_UNIT,
                 BaseIdentifiableObject.DATE_FORMAT.format(genericCallData.serverDate()));
 
-        organisationUnitCursor.close();
-        userOrganisationUnitCursor.close();
         resourceCursor.close();
     }
 
@@ -187,24 +179,4 @@ public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase 
 
         dhis2MockServer.shutdown();
     }
-
-/*//TODO: consider testing these cases when we decide to write more thorough Integration Tests:
-    @Test
-    public void call_shouldReturnCorrectOrganisationUnitModel() {
-    }
-
-    @Test
-    public void call_shouldReturnCorrectOrganisationUnitTreeModel() {
-    }
-        @Test
-    public void call_shouldInsertOrganisationUnitInDatabase() {
-    }
-
-    @Test
-    public void call_shouldUpdateOrganisationUnitInDatabase() {
-    }
-
-    @Test
-    public void call_shouldDeleteOrganisationUnitInDatabase() {
-    }*/
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCallMockIntegrationShould.java
@@ -157,19 +157,20 @@ public class OrganisationUnitCallMockIntegrationShould extends AbsStoreTestCase 
         Cursor resourceCursor = database().query(ResourceModel.TABLE,
                 RESOURCE_PROJECTION, null, null, null, null, null);
 
-        assertThatCursor(organisationUnitCursor).hasRow("Rp268JB6Ne4", "OU_651071", "Adonkia CHP",
-                "Adonkia CHP", "2012-02-17T15:54:39.987", "2017-05-22T15:21:48.515", "Adonkia CHP",
-                "Adonkia CHP", null, null, "/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/Rp268JB6Ne4",
-                "2010-01-01T00:00:00.000", null, 4, "qtr8GGlm4gg", "/Adonkia CHP");
-
         assertThatCursor(organisationUnitCursor).hasRow("cDw53Ej8rju", "OU_278371", "Afro Arab Clinic",
                 "Afro Arab Clinic", "2012-02-17T15:54:39.987", "2017-05-22T15:21:48.518", "Afro Arab Clinic",
                 "Afro Arab Clinic", null, null, "/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/cDw53Ej8rju",
                 "2008-01-01T00:00:00.000", null, 4, "qtr8GGlm4gg", "/Afro Arab Clinic");
 
+        assertThatCursor(organisationUnitCursor).hasRow("Rp268JB6Ne4", "OU_651071", "Adonkia CHP",
+                "Adonkia CHP", "2012-02-17T15:54:39.987", "2017-05-22T15:21:48.515", "Adonkia CHP",
+                "Adonkia CHP", null, null, "/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/Rp268JB6Ne4",
+                "2010-01-01T00:00:00.000", null, 4, "qtr8GGlm4gg", "/Adonkia CHP");
+
         //Link tables:
+        assertThatCursor(userOrganisationUnitCursor).hasRow("user_uid", "cDw53Ej8rju");
         assertThatCursor(userOrganisationUnitCursor).hasRow("user_uid", "Rp268JB6Ne4");
-        assertThatCursor(userOrganisationUnitCursor).hasRow("user_uid", "cDw53Ej8rju").isExhausted();
+        assertThatCursor(userOrganisationUnitCursor).isExhausted();
 
         assertThatCursor(resourceCursor).hasRow(ResourceModel.Type.ORGANISATION_UNIT,
                 BaseIdentifiableObject.DATE_FORMAT.format(genericCallData.serverDate()));

--- a/core/src/main/java/org/hisp/dhis/android/core/category/Category.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/Category.java
@@ -31,15 +31,12 @@ package org.hisp.dhis.android.core.category;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreCategoryOptionListColumnAdapter;
@@ -49,13 +46,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_Category.Builder.class)
 public abstract class Category extends BaseNameableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCombo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCombo.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.category;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreCategoryListColumnAdapter;
 import org.hisp.dhis.android.core.data.database.IgnoreCategoryOptionComboListColumnAdapter;
@@ -50,14 +47,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_CategoryCombo.Builder.class)
 public abstract class CategoryCombo extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
-
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOption.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOption.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.android.core.category;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -40,7 +39,6 @@ import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.Access;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.AccessColumnAdapter;
@@ -51,13 +49,6 @@ import java.util.Date;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_CategoryOption.Builder.class)
 public abstract class CategoryOption extends BaseNameableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionCombo.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionCombo.java
@@ -31,15 +31,12 @@ package org.hisp.dhis.android.core.category;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.CategoryComboWithUidColumnAdapter;
@@ -50,13 +47,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_CategoryOptionCombo.Builder.class)
 public abstract class CategoryOptionCombo extends BaseNameableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/common/BaseIdentifiableObject.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/BaseIdentifiableObject.java
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.common;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -115,7 +116,15 @@ public abstract class BaseIdentifiableObject implements IdentifiableObject, Obje
 
         public abstract T created(@Nullable Date created);
 
+        public T created(@NonNull String createdStr) throws ParseException {
+            return created(BaseIdentifiableObject.DATE_FORMAT.parse(createdStr));
+        }
+
         public abstract T lastUpdated(@Nullable Date lastUpdated);
+
+        public T lastUpdated(@NonNull String lastUpdatedStr) throws ParseException {
+            return lastUpdated(BaseIdentifiableObject.DATE_FORMAT.parse(lastUpdatedStr));
+        }
 
         public abstract T deleted(@Nullable Boolean deleted);
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/common/BaseModel.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/BaseModel.java
@@ -29,9 +29,6 @@
 package org.hisp.dhis.android.core.common;
 
 import android.provider.BaseColumns;
-import android.support.annotation.Nullable;
-
-import com.gabrielittner.auto.value.cursor.ColumnName;
 
 @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
 public abstract class BaseModel implements Model {
@@ -48,11 +45,6 @@ public abstract class BaseModel implements Model {
             return new String[] {};
         }
     }
-
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    public abstract Long id();
 
     public static abstract class Builder<T extends Builder> {
         public abstract T id(Long id);

--- a/core/src/main/java/org/hisp/dhis/android/core/common/Model.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/Model.java
@@ -29,8 +29,16 @@
 package org.hisp.dhis.android.core.common;
 
 import android.content.ContentValues;
+import android.support.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.gabrielittner.auto.value.cursor.ColumnName;
 
 public interface Model {
+    @Nullable
+    @ColumnName(BaseModel.Columns.ID)
+    @JsonIgnore()
     Long id();
+
     ContentValues toContentValues();
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElement.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElement.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.dataelement;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.category.CategoryComboModel;
 import org.hisp.dhis.android.core.common.Access;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithStyle;
@@ -56,13 +53,6 @@ import org.hisp.dhis.android.core.data.database.ObjectWithUidColumnAdapter;
 @JsonDeserialize(builder = AutoValue_DataElement.Builder.class)
 public abstract class DataElement extends BaseNameableObject
         implements Model, ObjectWithStyle<DataElement, DataElement.Builder> {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @ColumnAdapter(DbValueTypeColumnAdapter.class)

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSet.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSet.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.dataset;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.Access;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithStyle;
@@ -62,13 +59,6 @@ import java.util.List;
 @JsonDeserialize(builder = AutoValue_DataSet.Builder.class)
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 public abstract class DataSet extends BaseNameableObject implements Model, ObjectWithStyle<DataSet, DataSet.Builder> {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetElement.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetElement.java
@@ -32,12 +32,10 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseModel;
@@ -48,13 +46,6 @@ import org.hisp.dhis.android.core.data.database.ObjectWithUidColumnAdapter;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_DataSetElement.Builder.class)
 public abstract class DataSetElement implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @NonNull
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/Section.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/Section.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.dataset;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.data.database.IgnoreDataElementOperandListColumnAdapter;
@@ -53,13 +50,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_Section.Builder.class)
 public abstract class Section extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/Indicator.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/Indicator.java
@@ -31,15 +31,12 @@ package org.hisp.dhis.android.core.indicator;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithUid;
@@ -48,13 +45,6 @@ import org.hisp.dhis.android.core.data.database.ObjectWithUidColumnAdapter;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_Indicator.Builder.class)
 public abstract class Indicator extends BaseNameableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorType.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorType.java
@@ -31,27 +31,17 @@ package org.hisp.dhis.android.core.indicator;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 
 @AutoValue
 @JsonDeserialize(builder = AutoValue_IndicatorType.Builder.class)
 public abstract class IndicatorType extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/Legend.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/Legend.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.legendset;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.data.database.ObjectWithUidColumnAdapter;
@@ -48,13 +45,6 @@ import org.hisp.dhis.android.core.data.database.ObjectWithUidColumnAdapter;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_Legend.Builder.class)
 public abstract class Legend extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendSet.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendSet.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.legendset;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreLegendListColumnAdapter;
 
@@ -49,13 +46,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_LegendSet.Builder.class)
 public abstract class LegendSet extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/option/Option.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/Option.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.option;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectStyle;
 import org.hisp.dhis.android.core.data.database.IgnoreObjectStyleAdapter;
@@ -49,13 +46,6 @@ import org.hisp.dhis.android.core.data.database.OptionSetWithUidColumnAdapter;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_Option.Builder.class)
 public abstract class Option extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionSet.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionSet.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.option;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ValueType;
 import org.hisp.dhis.android.core.data.database.DbValueTypeColumnAdapter;
@@ -51,13 +48,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_OptionSet.Builder.class)
 public abstract class OptionSet extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnit.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnit.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
 import com.google.auto.value.AutoValue;
 
+import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.DbDateColumnAdapter;
@@ -50,6 +51,7 @@ import org.hisp.dhis.android.core.data.database.OrganisationUnitWithUidColumnAda
 import org.hisp.dhis.android.core.dataset.DataSet;
 import org.hisp.dhis.android.core.program.Program;
 
+import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 
@@ -131,7 +133,15 @@ public abstract class OrganisationUnit extends BaseNameableObject implements Mod
 
         public abstract Builder openingDate(Date openingDate);
 
+        public Builder openingDate(@NonNull String openingDateStr) throws ParseException {
+            return openingDate(BaseIdentifiableObject.DATE_FORMAT.parse(openingDateStr));
+        }
+
         public abstract Builder closedDate(Date closedDate);
+
+        public Builder closedDate(@NonNull String closedDateStr) throws ParseException {
+            return closedDate(BaseIdentifiableObject.DATE_FORMAT.parse(closedDateStr));
+        }
 
         public abstract Builder level(Integer level);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnit.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnit.java
@@ -37,10 +37,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.DbDateColumnAdapter;
@@ -63,13 +61,6 @@ public abstract class OrganisationUnit extends BaseNameableObject implements Mod
         SCOPE_DATA_CAPTURE,
         SCOPE_TEI_SEARCH
     }
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/program/Program.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/Program.java
@@ -42,7 +42,6 @@ import com.google.auto.value.AutoValue;
 import org.hisp.dhis.android.core.category.CategoryCombo;
 import org.hisp.dhis.android.core.category.CategoryComboModel;
 import org.hisp.dhis.android.core.common.Access;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithStyle;
@@ -70,13 +69,6 @@ import java.util.List;
 @JsonDeserialize(builder = AutoValue_Program.Builder.class)
 @SuppressWarnings({"PMD.ExcessivePublicCount", "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects", "PMD.GodClass"})
 public abstract class Program extends BaseNameableObject implements Model, ObjectWithStyle<Program, Program.Builder> {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramIndicator.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramIndicator.java
@@ -31,16 +31,13 @@ package org.hisp.dhis.android.core.program;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.AggregationType;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithUid;
@@ -54,13 +51,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_ProgramIndicator.Builder.class)
 public abstract class ProgramIndicator extends BaseNameableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRule.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRule.java
@@ -31,15 +31,12 @@ package org.hisp.dhis.android.core.program;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreProgramRuleActionListAdapter;
 import org.hisp.dhis.android.core.data.database.ProgramStageWithUidColumnAdapter;
@@ -50,13 +47,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_ProgramRule.Builder.class)
 public abstract class ProgramRule extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     public abstract Integer priority();

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSection.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSection.java
@@ -36,11 +36,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.data.database.IgnoreDataElementListColumnAdapter;
@@ -54,13 +52,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_ProgramStageSection.Builder.class)
 public abstract class ProgramStageSection extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipType.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipType.java
@@ -31,7 +31,6 @@ package org.hisp.dhis.android.core.relationship;
 import android.database.Cursor;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
@@ -39,21 +38,12 @@ import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreRelationshipConstraintAdapter;
 
 @AutoValue
 @JsonDeserialize(builder = AutoValue_RelationshipType.Builder.class)
 public abstract class RelationshipType extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
-
 
     /**
      * @deprecated since 2.29, replaced by {@link #fromConstraint()}

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValue.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValue.java
@@ -36,10 +36,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.DbDateColumnAdapter;
 
@@ -48,13 +46,6 @@ import java.util.Date;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_TrackedEntityDataValue.Builder.class)
 public abstract class TrackedEntityDataValue implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonIgnore()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityType.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityType.java
@@ -29,15 +29,11 @@
 package org.hisp.dhis.android.core.trackedentity;
 
 import android.database.Cursor;
-import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.BaseNameableObject;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.common.ObjectWithStyle;
@@ -46,13 +42,6 @@ import org.hisp.dhis.android.core.common.ObjectWithStyle;
 @JsonDeserialize(builder = AutoValue_TrackedEntityType.Builder.class)
 public abstract class TrackedEntityType extends BaseNameableObject implements Model,
         ObjectWithStyle<TrackedEntityType, TrackedEntityType.Builder> {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     public static Builder builder() {
         return new $$AutoValue_TrackedEntityType.Builder();

--- a/core/src/main/java/org/hisp/dhis/android/core/user/User.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/User.java
@@ -32,15 +32,12 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreOrganisationUnitListAdapter;
 import org.hisp.dhis.android.core.data.database.IgnoreUserCredentialsAdapter;
@@ -51,13 +48,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_User.Builder.class)
 public abstract class User extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     public abstract String birthday();

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentials.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentials.java
@@ -36,11 +36,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.gabrielittner.auto.value.cursor.ColumnAdapter;
-import com.gabrielittner.auto.value.cursor.ColumnName;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
-import org.hisp.dhis.android.core.common.BaseModel;
 import org.hisp.dhis.android.core.common.Model;
 import org.hisp.dhis.android.core.data.database.IgnoreUserRoleListColumnAdapter;
 import org.hisp.dhis.android.core.data.database.UserWithUidColumnAdapter;
@@ -50,13 +48,6 @@ import java.util.List;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_UserCredentials.Builder.class)
 public abstract class UserCredentials extends BaseIdentifiableObject implements Model {
-
-    // TODO move to base class after whole object refactor
-    @Override
-    @Nullable
-    @ColumnName(BaseModel.Columns.ID)
-    @JsonIgnore()
-    public abstract Long id();
 
     @Nullable
     @JsonProperty()

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/organisationunit/OrganisationUnitSamples.java
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/organisationunit/OrganisationUnitSamples.java
@@ -31,6 +31,8 @@ package org.hisp.dhis.android.core.data.organisationunit;
 import org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 
+import java.text.ParseException;
+
 import static org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.fillNameableProperties;
 
 public class OrganisationUnitSamples {
@@ -57,5 +59,46 @@ public class OrganisationUnitSamples {
 
     public static OrganisationUnit getOrganisationUnit() {
         return getOrganisationUnit(1L, "UID");
+    }
+
+    public static OrganisationUnit getAfroArabClinic() throws ParseException {
+        return OrganisationUnit.builder()
+                .uid("cDw53Ej8rju")
+                .code("OU_278371")
+                .name("Afro Arab Clinic")
+                .displayName("Afro Arab Clinic")
+                .created("2012-02-17T15:54:39.987")
+                .lastUpdated("2017-05-22T15:21:48.518")
+                .shortName("Afro Arab Clinic")
+                .displayShortName("Afro Arab Clinic")
+                .description(null)
+                .displayDescription(null)
+                .path("/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/cDw53Ej8rju")
+                .openingDate("2008-01-01T00:00:00.000")
+                .level(4)
+                .parent(OrganisationUnit.builder().uid("qtr8GGlm4gg").build())
+                .displayNamePath("/Afro Arab Clinic")
+                .build();
+    }
+
+
+    public static OrganisationUnit getAdonkiaCHP() throws ParseException {
+        return OrganisationUnit.builder()
+                .uid("Rp268JB6Ne4")
+                .code("OU_651071")
+                .name("Adonkia CHP")
+                .displayName("Adonkia CHP")
+                .created("2012-02-17T15:54:39.987")
+                .lastUpdated("2017-05-22T15:21:48.515")
+                .shortName("Adonkia CHP")
+                .displayShortName("Adonkia CHP")
+                .description(null)
+                .displayDescription(null)
+                .path("/ImspTQPwCqd/at6UHUQatSo/qtr8GGlm4gg/Rp268JB6Ne4")
+                .openingDate("2010-01-01T00:00:00.000")
+                .level(4)
+                .parent(OrganisationUnit.builder().uid("qtr8GGlm4gg").build())
+                .displayNamePath("/Adonkia CHP")
+                .build();
     }
 }


### PR DESCRIPTION
Solves [ANDROSDK-449](https://jira.dhis2.org/browse/ANDROSDK-449).

Removed id from unified classes since annotations could be moved to interface. Id still has to be included in the builders. 