### PR TITLE
[ANDROSDK-652-B] and [ANDROSDK-660] Not call for option groups on 2.29 and delete not downloaded option groups

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionGroupEntityDIModule.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionGroupEntityDIModule.java
@@ -29,6 +29,8 @@
 package org.hisp.dhis.android.core.option;
 
 import org.hisp.dhis.android.core.arch.handlers.SyncHandler;
+import org.hisp.dhis.android.core.common.CollectionCleaner;
+import org.hisp.dhis.android.core.common.CollectionCleanerImpl;
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 
@@ -49,5 +51,11 @@ public final class OptionGroupEntityDIModule {
     @Reusable
     SyncHandler<OptionGroup> handler(OptionGroupHandler impl) {
         return impl;
+    }
+
+    @Provides
+    @Reusable
+    CollectionCleaner<OptionGroup> collectionCleaner(DatabaseAdapter databaseAdapter) {
+        return new CollectionCleanerImpl<>(OptionGroupTableInfo.TABLE_INFO.name(), databaseAdapter);
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionGroupHandler.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionGroupHandler.java
@@ -29,10 +29,12 @@ package org.hisp.dhis.android.core.option;
 
 import org.hisp.dhis.android.core.arch.handlers.IdentifiableSyncHandlerImpl;
 import org.hisp.dhis.android.core.arch.handlers.LinkSyncHandler;
+import org.hisp.dhis.android.core.common.CollectionCleaner;
 import org.hisp.dhis.android.core.common.HandleAction;
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -43,12 +45,15 @@ import dagger.Reusable;
 final class OptionGroupHandler extends IdentifiableSyncHandlerImpl<OptionGroup> {
 
     private final LinkSyncHandler<OptionGroupOptionLink> optionGroupOptionLinkHandler;
+    private final CollectionCleaner<OptionGroup> collectionCleaner;
 
     @Inject
     OptionGroupHandler(IdentifiableObjectStore<OptionGroup> optionStore,
-                       LinkSyncHandler<OptionGroupOptionLink> optionGroupOptionLinkHandler) {
+                       LinkSyncHandler<OptionGroupOptionLink> optionGroupOptionLinkHandler,
+                       CollectionCleaner<OptionGroup> collectionCleaner) {
         super(optionStore);
         this.optionGroupOptionLinkHandler = optionGroupOptionLinkHandler;
+        this.collectionCleaner = collectionCleaner;
     }
 
     @Override
@@ -61,5 +66,10 @@ final class OptionGroupHandler extends IdentifiableSyncHandlerImpl<OptionGroup> 
             }
             optionGroupOptionLinkHandler.handleMany(optionGroup.uid(), optionGroupOptionLinks);
         }
+    }
+
+    @Override
+    protected void afterCollectionHandled(Collection<OptionGroup> optionGroups) {
+        collectionCleaner.deleteNotPresent(optionGroups);
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramModuleDownloader.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramModuleDownloader.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.common.UidsHelper;
 import org.hisp.dhis.android.core.option.OptionGroup;
 import org.hisp.dhis.android.core.option.OptionSet;
 import org.hisp.dhis.android.core.relationship.RelationshipType;
+import org.hisp.dhis.android.core.systeminfo.DHISVersionManager;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType;
 
 import java.util.List;
@@ -54,6 +55,7 @@ public class ProgramModuleDownloader implements MetadataModuleDownloader<List<Pr
     private final ListCallFactory<RelationshipType> relationshipTypeCallFactory;
     private final UidsCallFactory<OptionSet> optionSetCallFactory;
     private final UidsCallFactory<OptionGroup> optionGroupCallFactory;
+    private final DHISVersionManager versionManager;
 
     @Inject
     ProgramModuleDownloader(ListCallFactory<Program> programCallFactory,
@@ -62,7 +64,8 @@ public class ProgramModuleDownloader implements MetadataModuleDownloader<List<Pr
                             UidsCallFactory<TrackedEntityType> trackedEntityTypeCallFactory,
                             ListCallFactory<RelationshipType> relationshipTypeCallFactory,
                             UidsCallFactory<OptionSet> optionSetCallFactory,
-                            UidsCallFactory<OptionGroup> optionGroupCallFactory) {
+                            UidsCallFactory<OptionGroup> optionGroupCallFactory,
+                            DHISVersionManager versionManager) {
         this.programCallFactory = programCallFactory;
         this.programStageCallFactory = programStageCallFactory;
         this.programRuleCallFactory = programRuleCallFactory;
@@ -70,6 +73,7 @@ public class ProgramModuleDownloader implements MetadataModuleDownloader<List<Pr
         this.relationshipTypeCallFactory = relationshipTypeCallFactory;
         this.optionSetCallFactory = optionSetCallFactory;
         this.optionGroupCallFactory = optionGroupCallFactory;
+        this.versionManager = versionManager;
     }
 
     @Override
@@ -90,7 +94,10 @@ public class ProgramModuleDownloader implements MetadataModuleDownloader<List<Pr
 
             Set<String> optionSetUids = ProgramParentUidsHelper.getAssignedOptionSetUids(programs, programStages);
             optionSetCallFactory.create(optionSetUids).call();
-            optionGroupCallFactory.create(optionSetUids).call();
+
+            if (!versionManager.is2_29()) {
+                optionGroupCallFactory.create(optionSetUids).call();
+            }
 
             return programs;
         };

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramModuleDownloaderShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramModuleDownloaderShould.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.common.BaseCallShould;
 import org.hisp.dhis.android.core.option.OptionGroup;
 import org.hisp.dhis.android.core.option.OptionSet;
 import org.hisp.dhis.android.core.relationship.RelationshipType;
+import org.hisp.dhis.android.core.systeminfo.DHISVersionManager;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType;
 import org.junit.After;
 import org.junit.Before;
@@ -111,6 +112,9 @@ public class ProgramModuleDownloaderShould extends BaseCallShould {
     @Mock
     private UidsCallFactory<OptionGroup> optionGroupCallFactory;
 
+    @Mock
+    private DHISVersionManager versionManager;
+
     // object to test
     private Callable<List<Program>> programDownloadCall;
 
@@ -154,6 +158,8 @@ public class ProgramModuleDownloaderShould extends BaseCallShould {
         when(programStageEndpointCall.call()).thenReturn(Collections.emptyList());
         when(programRuleEndpointCall.call()).thenReturn(Collections.emptyList());
 
+        when(versionManager.is2_29()).thenReturn(Boolean.FALSE);
+
         // Metadata call
         programDownloadCall = new ProgramModuleDownloader(
                 programCallFactory,
@@ -162,7 +168,8 @@ public class ProgramModuleDownloaderShould extends BaseCallShould {
                 trackedEntityCallFactory,
                 relationshipTypeCallFactory,
                 optionSetCallFactory,
-                optionGroupCallFactory).downloadMetadata();
+                optionGroupCallFactory,
+                versionManager).downloadMetadata();
     }
 
     @After


### PR DESCRIPTION
Solves [ANDROSDK-652-B](https://jira.dhis2.org/browse/ANDROSDK-652) and [ANDROSDK-660](https://jira.dhis2.org/browse/ANDROSDK-660).