### PR TITLE
[ANDROSDK-712] and [ANDROSDK-713] Move databaseAdapter and OkHttpClient creation to sdk

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/d2manager/D2ManagerRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/d2manager/D2ManagerRealIntegrationShould.java
@@ -88,9 +88,9 @@ public class D2ManagerRealIntegrationShould {
     }
 
     @Test
-    public void create_a_d2_instance_which_read_data_on_db() throws Exception {
+    public void create_a_d2_instance_which_reads_data_from_db() throws Exception {
         configureD2();
-        persistCredentialsOnDb();
+        persistCredentialsInDb();
 
         UserCredentials userCredentials = d2Manager.getD2().userModule().userCredentials.get();
         assertThat(userCredentials.user().uid().equals("user")).isTrue();
@@ -101,7 +101,7 @@ public class D2ManagerRealIntegrationShould {
      * It works against the demo server.
      */
     //@Test
-    public void create_a_d2_instance_which_download_and_persist_data_from_server() throws Exception {
+    public void create_a_d2_instance_which_downloads_and_persists_data_from_server() throws Exception {
         configureD2();
 
         d2Manager.getD2().userModule().logIn("android", "Android123").call();
@@ -117,7 +117,7 @@ public class D2ManagerRealIntegrationShould {
         d2Manager.configureD2(config);
     }
 
-    private void persistCredentialsOnDb() {
+    private void persistCredentialsInDb() {
         d2Manager.getD2().databaseAdapter().database().setForeignKeyConstraintsEnabled(Boolean.FALSE);
 
         UserCredentialsStoreImpl.create(d2Manager.getD2().databaseAdapter()).insert(UserCredentials.builder()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/d2manager/D2ManagerRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/d2manager/D2ManagerRealIntegrationShould.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.d2manager;
+
+import android.support.test.InstrumentationRegistry;
+
+import com.facebook.stetho.okhttp3.StethoInterceptor;
+import com.google.common.collect.Lists;
+
+import org.hisp.dhis.android.core.configuration.Configuration;
+import org.hisp.dhis.android.core.data.server.RealServerMother;
+import org.hisp.dhis.android.core.user.User;
+import org.hisp.dhis.android.core.user.UserCredentials;
+import org.hisp.dhis.android.core.user.UserCredentialsStoreImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Random;
+
+import okhttp3.HttpUrl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class D2ManagerRealIntegrationShould {
+
+    private D2Manager d2Manager;
+
+    @Before
+    public void setUp() throws IOException {
+        D2Configuration d2Configuration = D2Configuration.builder()
+                .databaseName(generateDatabaseName() + ".db")
+                .appName("app_name")
+                .appVersion("1.0.0")
+                .readTimeoutInSeconds(100)
+                .connectTimeoutInSeconds(100)
+                .writeTimeoutInSeconds(100)
+                .networkInterceptors(Lists.newArrayList(new StethoInterceptor()))
+                .context(InstrumentationRegistry.getTargetContext().getApplicationContext())
+                .build();
+
+        d2Manager = new D2Manager(d2Configuration);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (d2Manager.databaseAdapter != null && d2Manager.databaseAdapter.database() != null) {
+            d2Manager.databaseAdapter.database().close();
+        }
+    }
+
+    @Test
+    public void return_false_if_not_configured() throws Exception {
+        assertThat(d2Manager.isD2Configured()).isFalse();
+    }
+
+    @Test
+    public void return_true_if_configured() throws Exception {
+        configureD2();
+        assertThat(d2Manager.isD2Configured()).isTrue();
+    }
+
+    @Test
+    public void create_a_d2_instance_which_read_data_on_db() throws Exception {
+        configureD2();
+        persistCredentialsOnDb();
+
+        UserCredentials userCredentials = d2Manager.getD2().userModule().userCredentials.get();
+        assertThat(userCredentials.user().uid().equals("user")).isTrue();
+    }
+
+    /**
+     * A quick integration test that is probably flaky, but will help with finding bugs related the d2 instantiation.
+     * It works against the demo server.
+     */
+    //@Test
+    public void create_a_d2_instance_which_download_and_persist_data_from_server() throws Exception {
+        configureD2();
+
+        d2Manager.getD2().userModule().logIn("android", "Android123").call();
+
+        assertThat(d2Manager.getD2().userModule().authenticatedUser.get().user() != null).isTrue();
+    }
+
+    private void configureD2() {
+        Configuration config = Configuration.builder()
+                .serverUrl(HttpUrl.parse(RealServerMother.url))
+                .build();
+
+        d2Manager.configureD2(config);
+    }
+
+    private void persistCredentialsOnDb() {
+        d2Manager.getD2().databaseAdapter().database().setForeignKeyConstraintsEnabled(Boolean.FALSE);
+
+        UserCredentialsStoreImpl.create(d2Manager.getD2().databaseAdapter()).insert(UserCredentials.builder()
+                .user(User.builder().uid("user").build()).uid("uid").username("username").build());
+    }
+
+    private String generateDatabaseName() {
+
+        int leftLimit = 97; // letter 'a'
+        int rightLimit = 122; // letter 'z'
+        int targetStringLength = 10;
+        Random random = new Random();
+        StringBuilder buffer = new StringBuilder(targetStringLength);
+        for (int i = 0; i < targetStringLength; i++) {
+            int randomLimitedInt = leftLimit + (int)
+                    (random.nextFloat() * (rightLimit - leftLimit + 1));
+            buffer.append((char) randomLimitedInt);
+        }
+
+        return buffer.toString();
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Configuration.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Configuration.java
@@ -34,13 +34,11 @@ import com.google.auto.value.AutoValue;
 
 import java.util.List;
 
-import io.reactivex.annotations.Nullable;
 import okhttp3.Interceptor;
 
 @AutoValue
 public abstract class D2Configuration {
 
-    @Nullable
     public abstract String databaseName();
 
     public abstract String appName();

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Configuration.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Configuration.java
@@ -28,9 +28,14 @@
 
 package org.hisp.dhis.android.core.d2manager;
 
-import android.support.annotation.Nullable;
+import android.content.Context;
 
 import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+import io.reactivex.annotations.Nullable;
+import okhttp3.Interceptor;
 
 @AutoValue
 public abstract class D2Configuration {
@@ -38,13 +43,21 @@ public abstract class D2Configuration {
     @Nullable
     public abstract String databaseName();
 
-    public abstract Builder toBuilder();
+    public abstract String appName();
 
-    public static D2Configuration create(String databaseName) {
-        return builder()
-                .databaseName(databaseName)
-                .build();
-    }
+    public abstract String appVersion();
+
+    public abstract Integer readTimeoutInSeconds();
+
+    public abstract Integer connectTimeoutInSeconds();
+
+    public abstract Integer writeTimeoutInSeconds();
+
+    public abstract List<Interceptor> networkInterceptors();
+
+    public abstract Context context();
+
+    public abstract Builder toBuilder();
 
     public static Builder builder() {
         return new AutoValue_D2Configuration.Builder();
@@ -54,6 +67,20 @@ public abstract class D2Configuration {
     public abstract static class Builder {
 
         public abstract Builder databaseName(String databaseName);
+
+        public abstract Builder appName(String appName);
+
+        public abstract Builder appVersion(String appVersion);
+
+        public abstract Builder context(Context context);
+
+        public abstract Builder readTimeoutInSeconds(Integer readTimeoutInSeconds);
+
+        public abstract Builder connectTimeoutInSeconds(Integer connectTimeoutInSeconds);
+
+        public abstract Builder writeTimeoutInSeconds(Integer writeTimeoutInSeconds);
+
+        public abstract Builder networkInterceptors(List<Interceptor> networkInterceptors);
 
         public abstract D2Configuration build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Configuration.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Configuration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.d2manager;
+
+import android.support.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class D2Configuration {
+
+    @Nullable
+    public abstract String databaseName();
+
+    public abstract Builder toBuilder();
+
+    public static D2Configuration create(String databaseName) {
+        return builder()
+                .databaseName(databaseName)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_D2Configuration.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        public abstract Builder databaseName(String databaseName);
+
+        public abstract D2Configuration build();
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
@@ -83,6 +83,10 @@ public final class D2Manager {
     }
 
     public void configureD2(@NonNull Configuration configuration) {
+        if (d2 != null) {
+            throw new IllegalStateException("D2 is already configured");
+        }
+
         ConfigurationManagerFactory.create(databaseAdapter).configure(configuration.serverUrl());
 
         d2 = new D2.Builder()
@@ -95,7 +99,7 @@ public final class D2Manager {
 
     public D2 getD2() throws IllegalStateException {
         if (d2 == null) {
-            throw new IllegalStateException("Not configured D2");
+            throw new IllegalStateException("D2 is not configured");
         }
 
         return d2;

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.d2manager;
+
+import android.content.Context;
+
+import org.hisp.dhis.android.core.D2;
+import org.hisp.dhis.android.core.configuration.Configuration;
+import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
+import org.hisp.dhis.android.core.data.database.DbOpenHelper;
+import org.hisp.dhis.android.core.data.database.SqLiteDatabaseAdapter;
+
+import io.reactivex.annotations.NonNull;
+import okhttp3.OkHttpClient;
+
+public final class D2Manager {
+    private D2 d2;
+    private Configuration configuration;
+    private OkHttpClient client;
+    private Context context;
+
+    D2Manager(@NonNull Configuration configuration,
+              @NonNull OkHttpClient client,
+              @NonNull Context context) {
+        this.configuration = configuration;
+        this.client = client;
+        this.context = context;
+    }
+
+    public boolean isD2Configured() {
+        return d2 != null;
+    }
+
+    public void configureD2(@NonNull D2Configuration d2Configuration) {
+        d2 = new D2.Builder()
+                .configuration(configuration)
+                .databaseAdapter(databaseAdapter(d2Configuration.databaseName()))
+                .okHttpClient(client)
+                .context(context)
+                .build();
+    }
+
+    public D2 getD2() {
+        return d2;
+    }
+
+    private DatabaseAdapter databaseAdapter(@NonNull String databaseName) {
+        DbOpenHelper dbOpenHelper = new DbOpenHelper(context, databaseName);
+        return new SqLiteDatabaseAdapter(dbOpenHelper);
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
@@ -167,10 +167,11 @@ public final class D2Manager {
 
                 client.connectionSpecs(specs);
 
+            } catch (RuntimeException e) {
+                throw e;
             } catch (Exception e) {
-                Log.e(D2Manager.class.getSimpleName(), "", e);
+                Log.e(D2Manager.class.getSimpleName(), e.getMessage(), e);
             }
-
         }
 
         return client.build();

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
@@ -28,50 +28,151 @@
 
 package org.hisp.dhis.android.core.d2manager;
 
-import android.content.Context;
+import android.database.Cursor;
+import android.os.Build;
+import android.util.Log;
 
+import org.hisp.dhis.android.BuildConfig;
 import org.hisp.dhis.android.core.D2;
 import org.hisp.dhis.android.core.configuration.Configuration;
+import org.hisp.dhis.android.core.configuration.ConfigurationManagerFactory;
+import org.hisp.dhis.android.core.configuration.ConfigurationTableInfo;
+import org.hisp.dhis.android.core.data.api.BasicAuthenticatorFactory;
 import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 import org.hisp.dhis.android.core.data.database.DbOpenHelper;
 import org.hisp.dhis.android.core.data.database.SqLiteDatabaseAdapter;
 
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
 import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.Nullable;
+import okhttp3.CipherSuite;
+import okhttp3.ConnectionSpec;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.TlsVersion;
 
 public final class D2Manager {
-    private D2 d2;
-    private Configuration configuration;
-    private OkHttpClient client;
-    private Context context;
 
-    D2Manager(@NonNull Configuration configuration,
-              @NonNull OkHttpClient client,
-              @NonNull Context context) {
-        this.configuration = configuration;
-        this.client = client;
-        this.context = context;
+    private D2 d2;
+    private final D2Configuration d2Configuration;
+    private final DatabaseAdapter databaseAdapter;
+
+    D2Manager(@Nullable D2Configuration d2Configuration) {
+        this.d2Configuration = d2Configuration;
+        this.databaseAdapter = databaseAdapter();
     }
 
     public boolean isD2Configured() {
-        return d2 != null;
+        int count;
+        try (Cursor cursor = databaseAdapter.query("SELECT * from " + ConfigurationTableInfo.TABLE_INFO.name())) {
+            count = cursor.getCount();
+        }
+
+        return count != 0;
     }
 
-    public void configureD2(@NonNull D2Configuration d2Configuration) {
+    public void configureD2(@NonNull Configuration configuration) {
+        ConfigurationManagerFactory.create(databaseAdapter).configure(configuration.serverUrl());
+
         d2 = new D2.Builder()
                 .configuration(configuration)
-                .databaseAdapter(databaseAdapter(d2Configuration.databaseName()))
-                .okHttpClient(client)
-                .context(context)
+                .databaseAdapter(databaseAdapter)
+                .okHttpClient(okHttpClient())
+                .context(d2Configuration.context())
                 .build();
     }
 
-    public D2 getD2() {
+    public D2 getD2() throws IllegalStateException {
+        if (d2 == null) {
+            throw new IllegalStateException("Not configured D2");
+        }
+
         return d2;
     }
 
-    private DatabaseAdapter databaseAdapter(@NonNull String databaseName) {
-        DbOpenHelper dbOpenHelper = new DbOpenHelper(context, databaseName);
+    private DatabaseAdapter databaseAdapter() {
+        DbOpenHelper dbOpenHelper = new DbOpenHelper(d2Configuration.context(), d2Configuration.databaseName());
         return new SqLiteDatabaseAdapter(dbOpenHelper);
+    }
+
+    private OkHttpClient okHttpClient() {
+
+        String userAgent = String.format("%s/%s/%s/Android_%s",
+                d2Configuration.appName(),
+                BuildConfig.VERSION_NAME, //SDK version
+                d2Configuration.appVersion(),
+                Build.VERSION.SDK_INT //Android Version
+        );
+
+        OkHttpClient.Builder client = new OkHttpClient.Builder()
+                .addInterceptor(BasicAuthenticatorFactory.create(databaseAdapter))
+                .addInterceptor(chain -> {
+                    Request originalRequest = chain.request();
+                    Request withUserAgent = originalRequest.newBuilder()
+                            .header("User-Agent", userAgent)
+                            .build();
+                    return chain.proceed(withUserAgent);
+                })
+
+                .readTimeout(d2Configuration.readTimeoutInSeconds(), TimeUnit.SECONDS)
+                .connectTimeout(d2Configuration.connectTimeoutInSeconds(), TimeUnit.SECONDS)
+                .writeTimeout(d2Configuration.writeTimeoutInSeconds(), TimeUnit.SECONDS);
+
+        for (Interceptor interceptor : d2Configuration.networkInterceptors()) {
+            client.addNetworkInterceptor(interceptor);
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            try {
+
+                SSLContext sc = SSLContext.getInstance("TLS" /*"TLSv1.2"*/);
+                sc.init(null, null, null);
+
+                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                        TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init((KeyStore) null);
+                TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+
+                if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+                    throw new IllegalStateException("Unexpected default trust managers:"
+                            + Arrays.toString(trustManagers));
+                }
+
+                X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+                client.sslSocketFactory(new TLSSocketFactory(sc.getSocketFactory()), trustManager);
+
+                ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                        .tlsVersions(TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2)
+                        .cipherSuites(
+                                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                                CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                                CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256)
+                        .build();
+
+                List<ConnectionSpec> specs = new ArrayList<>();
+                specs.add(cs);
+                specs.add(ConnectionSpec.COMPATIBLE_TLS);
+                specs.add(ConnectionSpec.CLEARTEXT);
+
+                client.connectionSpecs(specs);
+
+            } catch (Exception e) {
+                Log.e(D2Manager.class.getSimpleName(), "", e);
+            }
+
+        }
+
+        return client.build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/D2Manager.java
@@ -66,7 +66,7 @@ public final class D2Manager {
 
     private D2 d2;
     private final D2Configuration d2Configuration;
-    private final DatabaseAdapter databaseAdapter;
+    final DatabaseAdapter databaseAdapter;
 
     D2Manager(@Nullable D2Configuration d2Configuration) {
         this.d2Configuration = d2Configuration;

--- a/core/src/main/java/org/hisp/dhis/android/core/d2manager/TLSSocketFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/d2manager/TLSSocketFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.d2manager;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+public class TLSSocketFactory extends SSLSocketFactory {
+
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    private final SSLSocketFactory delegate;
+
+    TLSSocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+            throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentialsStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentialsStore.java
@@ -31,6 +31,6 @@ package org.hisp.dhis.android.core.user;
 
 import org.hisp.dhis.android.core.common.IdentifiableObjectStore;
 
-interface UserCredentialsStore extends IdentifiableObjectStore<UserCredentials> {
+public interface UserCredentialsStore extends IdentifiableObjectStore<UserCredentials> {
     UserCredentials getForUser(String userId);
 }


### PR DESCRIPTION
Solves [ANDROSDK-712](https://jira.dhis2.org/browse/ANDROSDK-712) and [ANDROSDK-713](https://jira.dhis2.org/browse/ANDROSDK-713).

Creates a manager which allow to create the D2 class without the need of passing a database adapter and an http client.