### PR TITLE
[ANDROSDK-789] Remove duplicated call to cursor.close()

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/common/ObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/ObjectStoreImpl.java
@@ -89,7 +89,6 @@ public class ObjectStoreImpl<M extends Model> implements ObjectStore<M> {
     private void addAll(@NonNull Collection<M> collection) {
         Cursor cursor = databaseAdapter.query(builder.selectAll());
         addObjectsToCollection(cursor, collection);
-        cursor.close();
     }
 
     @Override


### PR DESCRIPTION
Also called inside `addObjectsToCollection()`