### PR TITLE
fix: [ANDROSDK-894] Use D2JunitRunner in StoreIntegrationShould

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboLinkStoreIntegrationShould.java
@@ -30,15 +30,13 @@ package org.hisp.dhis.android.core.category.internal;
 
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLink;
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLinkTableInfo;
-import org.hisp.dhis.android.core.category.internal.CategoryCategoryComboLinkStore;
 import org.hisp.dhis.android.core.data.category.CategoryCategoryComboLinkSamples;
 import org.hisp.dhis.android.core.data.database.LinkModelStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class CategoryCategoryComboLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<CategoryCategoryComboLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryOptionLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryOptionLinkStoreIntegrationShould.java
@@ -30,15 +30,13 @@ package org.hisp.dhis.android.core.category.internal;
 
 import org.hisp.dhis.android.core.category.CategoryCategoryOptionLink;
 import org.hisp.dhis.android.core.category.CategoryCategoryOptionLinkTableInfo;
-import org.hisp.dhis.android.core.category.internal.CategoryCategoryOptionLinkStore;
 import org.hisp.dhis.android.core.data.category.CategoryCategoryOptionLinkSamples;
 import org.hisp.dhis.android.core.data.database.LinkModelStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class CategoryCategoryOptionLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<CategoryCategoryOptionLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboCategoryOptionLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboCategoryOptionLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.category.CategoryOptionComboCategoryOptionLink
 import org.hisp.dhis.android.core.data.category.CategoryOptionComboCategoryOptionLinkSamples;
 import org.hisp.dhis.android.core.data.database.LinkModelStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class CategoryOptionComboCategoryOptionLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<CategoryOptionComboCategoryOptionLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/IdentifiableObjectStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/IdentifiableObjectStoreIntegrationShould.java
@@ -33,21 +33,20 @@ import android.database.sqlite.SQLiteConstraintException;
 
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.option.OptionSet;
-import org.hisp.dhis.android.core.option.internal.OptionSetStore;
 import org.hisp.dhis.android.core.option.OptionSetTableInfo;
+import org.hisp.dhis.android.core.option.internal.OptionSetStore;
 import org.hisp.dhis.android.core.utils.integration.real.BaseRealIntegrationTest;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import androidx.test.runner.AndroidJUnit4;
-
 import static org.hisp.dhis.android.core.common.StoreMocks.optionSetCursorAssert;
 import static org.hisp.dhis.android.core.data.database.CursorAssert.assertThatCursor;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class IdentifiableObjectStoreIntegrationShould extends BaseRealIntegrationTest {
 
     private IdentifiableObjectStore<OptionSet> store;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/ObjectStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/ObjectStoreIntegrationShould.java
@@ -33,20 +33,19 @@ import android.database.sqlite.SQLiteConstraintException;
 
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.option.OptionSet;
-import org.hisp.dhis.android.core.option.internal.OptionSetStore;
 import org.hisp.dhis.android.core.option.OptionSetTableInfo;
+import org.hisp.dhis.android.core.option.internal.OptionSetStore;
 import org.hisp.dhis.android.core.utils.integration.real.BaseRealIntegrationTest;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import androidx.test.runner.AndroidJUnit4;
-
 import static org.hisp.dhis.android.core.common.StoreMocks.optionSetCursorAssert;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ObjectStoreIntegrationShould extends BaseRealIntegrationTest {
 
     private IdentifiableObjectStore<OptionSet> store;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingStoreIntegrationShould.java
@@ -32,12 +32,11 @@ import org.hisp.dhis.android.core.common.valuetype.devicerendering.internal.Valu
 import org.hisp.dhis.android.core.data.common.ValueTypeDeviceRenderingSamples;
 import org.hisp.dhis.android.core.data.database.ObjectWithoutUidStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
-public class ValueTypeDeviceRenderingStoreIntegrationShould 
+@RunWith(D2JunitRunner.class)
+public class ValueTypeDeviceRenderingStoreIntegrationShould
         extends ObjectWithoutUidStoreAbstractIntegrationShould<ValueTypeDeviceRendering> {
 
     public ValueTypeDeviceRenderingStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreIntegrationShould.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo;
 import org.hisp.dhis.android.core.data.configuration.ConfigurationSamples;
 import org.hisp.dhis.android.core.data.database.DatabaseAdapter;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,12 +41,11 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.List;
 
-import androidx.test.runner.AndroidJUnit4;
 import okhttp3.HttpUrl;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ConfigurationStoreIntegrationShould {
 
     private final Configuration configuration;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/constant/internal/ConstantStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/constant/internal/ConstantStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.constant.ConstantTableInfo;
 import org.hisp.dhis.android.core.data.constant.ConstantSamples;
 import org.hisp.dhis.android.core.data.database.IdentifiableObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ConstantStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<Constant> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataelement/internal/DataElementOperandStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataelement/internal/DataElementOperandStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.data.dataelement.DataElementOperandSamples;
 import org.hisp.dhis.android.core.dataelement.DataElementOperand;
 import org.hisp.dhis.android.core.dataelement.DataElementOperandTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataElementOperandStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<DataElementOperand> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataInputPeriodLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataInputPeriodLinkStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.data.dataset.DataInputPeriodSamples;
 import org.hisp.dhis.android.core.dataset.DataInputPeriod;
 import org.hisp.dhis.android.core.dataset.DataInputPeriodTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataInputPeriodLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataInputPeriod> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompulsoryDataElementOperandLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompulsoryDataElementOperandLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.dataset.DataSetCompulsoryDataElementOpera
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLink;
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataSetCompulsoryDataElementOperandLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataSetCompulsoryDataElementOperandLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetDataElementLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetDataElementLinkStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.data.dataset.DataSetElementSamples;
 import org.hisp.dhis.android.core.dataset.DataSetElement;
 import org.hisp.dhis.android.core.dataset.DataSetElementLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataSetDataElementLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataSetElement> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetOrganisationUnitLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetOrganisationUnitLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.dataset.DataSetOrganisationUnitLinkSample
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLink;
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataSetOrganisationUnitLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataSetOrganisationUnitLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.dataset.DataSetSamples;
 import org.hisp.dhis.android.core.dataset.DataSet;
 import org.hisp.dhis.android.core.dataset.DataSetTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataSetStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<DataSet> {
 
     public DataSetStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionDataElementLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionDataElementLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.dataset.SectionDataElementLinkSamples;
 import org.hisp.dhis.android.core.dataset.SectionDataElementLink;
 import org.hisp.dhis.android.core.dataset.SectionDataElementLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class SectionDataElementLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<SectionDataElementLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionGreyedFieldsLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionGreyedFieldsLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.dataset.SectionGreyedFieldsLinkSamples;
 import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLink;
 import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class SectionGreyedFieldsLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<SectionGreyedFieldsLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.dataset.SectionSamples;
 import org.hisp.dhis.android.core.dataset.Section;
 import org.hisp.dhis.android.core.dataset.SectionTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class SectionStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Section> {
 
     public SectionStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreIntegrationShould.java
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.data.database.IdentifiableDataObjectStoreAbstr
 import org.hisp.dhis.android.core.data.enrollment.EnrollmentSamples;
 import org.hisp.dhis.android.core.enrollment.Enrollment;
 import org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo;
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class EnrollmentStoreIntegrationShould extends IdentifiableDataObjectStoreAbstractIntegrationShould<Enrollment> {
 
     public EnrollmentStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventStoreIntegrationShould.java
@@ -35,11 +35,10 @@ import org.hisp.dhis.android.core.event.Event;
 import org.hisp.dhis.android.core.event.EventStatus;
 import org.hisp.dhis.android.core.event.EventTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class EventStoreIntegrationShould extends IdentifiableDataObjectStoreAbstractIntegrationShould<Event> {
 
     public EventStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.imports.TrackerImportConflictSamples;
 import org.hisp.dhis.android.core.imports.TrackerImportConflict;
 import org.hisp.dhis.android.core.imports.TrackerImportConflictTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackerImportConflictStoreIntegrationShould
         extends ObjectStoreAbstractIntegrationShould<TrackerImportConflict> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/DataSetIndicatorLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/DataSetIndicatorLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.indicator.DataSetIndicatorLinkSamples;
 import org.hisp.dhis.android.core.indicator.DataSetIndicatorLink;
 import org.hisp.dhis.android.core.indicator.DataSetIndicatorLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class DataSetIndicatorLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<DataSetIndicatorLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.data.indicator.IndicatorSamples;
 import org.hisp.dhis.android.core.indicator.Indicator;
 import org.hisp.dhis.android.core.indicator.IndicatorTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class IndicatorStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Indicator> {
 
     public IndicatorStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/ProgramIndicatorLegendSetLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/ProgramIndicatorLegendSetLinkStoreIntegrationShould.java
@@ -32,11 +32,10 @@ import org.hisp.dhis.android.core.data.database.LinkModelStoreAbstractIntegratio
 import org.hisp.dhis.android.core.data.legendset.ProgramIndicatorLegendSetLinkSamples;
 import org.hisp.dhis.android.core.legendset.internal.ProgramIndicatorLegendSetLinkStore;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramIndicatorLegendSetLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<ProgramIndicatorLegendSetLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.legendset.LegendSetSamples;
 import org.hisp.dhis.android.core.legendset.LegendSet;
 import org.hisp.dhis.android.core.legendset.LegendSetTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class LegendSetStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<LegendSet> {
 
     public LegendSetStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.data.legendset.LegendSamples;
 import org.hisp.dhis.android.core.legendset.Legend;
 import org.hisp.dhis.android.core.legendset.LegendTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class LegendStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Legend> {
 
     public LegendStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/D2ErrorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/D2ErrorStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.maintenance.D2ErrorSamples;
 import org.hisp.dhis.android.core.maintenance.D2Error;
 import org.hisp.dhis.android.core.maintenance.D2ErrorTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class D2ErrorStoreIntegrationShould extends ObjectStoreAbstractIntegrationShould<D2Error> {
 
     public D2ErrorStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyViolationStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyViolationStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.maintenance.ForeignKeyViolationSamples;
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolation;
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolationTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ForeignKeyViolationStoreIntegrationShould
         extends ObjectStoreAbstractIntegrationShould<ForeignKeyViolation> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionGroupOptionLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionGroupOptionLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.option.OptionGroupOptionLinkSamples;
 import org.hisp.dhis.android.core.option.OptionGroupOptionLink;
 import org.hisp.dhis.android.core.option.OptionGroupOptionLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OptionGroupOptionLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<OptionGroupOptionLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionGroupStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionGroupStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.option.OptionGroupSamples;
 import org.hisp.dhis.android.core.option.OptionGroup;
 import org.hisp.dhis.android.core.option.OptionGroupTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OptionGroupStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<OptionGroup> {
 
     public OptionGroupStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitGroupStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitGroupStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitGroupSam
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitGroupTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OrganisationUnitGroupStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<OrganisationUnitGroup> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitLevelStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitLevelStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitLevelSam
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitLevelTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OrganisationUnitLevelStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<OrganisationUnitLevel> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitOrganisationUnitGroupLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitOrganisationUnitGroupLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitOrganisa
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitOrganisationUnitGroupLink;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitOrganisationUnitGroupLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OrganisationUnitOrganisationUnitGroupLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<OrganisationUnitOrganisationUnitGroupLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitProgramLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitProgramLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitProgramL
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OrganisationUnitProgramLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<OrganisationUnitProgramLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitSamples;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class OrganisationUnitStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<OrganisationUnit> {
 
     public OrganisationUnitStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.java
@@ -34,22 +34,17 @@ import org.hisp.dhis.android.core.data.period.PeriodSamples;
 import org.hisp.dhis.android.core.period.Period;
 import org.hisp.dhis.android.core.period.PeriodTableInfo;
 import org.hisp.dhis.android.core.period.PeriodType;
-import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl;
-import org.hisp.dhis.android.core.period.internal.PeriodHandler;
-import org.hisp.dhis.android.core.period.internal.PeriodStore;
-import org.hisp.dhis.android.core.period.internal.PeriodStoreImpl;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.text.ParseException;
 import java.util.Date;
 
-import androidx.test.runner.AndroidJUnit4;
-
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class PeriodStoreIntegrationShould extends ObjectWithoutUidStoreAbstractIntegrationShould<Period> {
 
     private PeriodStore periodStore;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramIndicatorSamples;
 import org.hisp.dhis.android.core.program.ProgramIndicator;
 import org.hisp.dhis.android.core.program.ProgramIndicatorTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramIndicatorStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramIndicator> {
 
     public ProgramIndicatorStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramOrganisationUnitLastUpdatedStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramOrganisationUnitLastUpdatedStoreIntegrationShould.java
@@ -28,16 +28,15 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import androidx.test.runner.AndroidJUnit4;
-
 import org.hisp.dhis.android.core.data.database.ObjectWithoutUidStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.program.ProgramOrganisationUnitLastUpdatedSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
 import java.util.Date;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramOrganisationUnitLastUpdatedStoreIntegrationShould
         extends ObjectWithoutUidStoreAbstractIntegrationShould<ProgramOrganisationUnitLastUpdated> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramRuleActionSamples;
 import org.hisp.dhis.android.core.program.ProgramRuleAction;
 import org.hisp.dhis.android.core.program.ProgramRuleActionTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramRuleActionStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramRuleAction> {
 
     public ProgramRuleActionStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramRuleSamples;
 import org.hisp.dhis.android.core.program.ProgramRule;
 import org.hisp.dhis.android.core.program.ProgramRuleTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramRuleStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramRule> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleVariableStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleVariableStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.program.ProgramRuleVariable;
 import org.hisp.dhis.android.core.program.ProgramRuleVariableSourceType;
 import org.hisp.dhis.android.core.program.ProgramRuleVariableTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramRuleVariableStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramRuleVariable> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramSectionAttributeLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramSectionAttributeLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramSectionAttributeLinkSample
 import org.hisp.dhis.android.core.program.ProgramSectionAttributeLink;
 import org.hisp.dhis.android.core.program.ProgramSectionAttributeLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramSectionAttributeLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<ProgramSectionAttributeLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramSectionStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramSectionStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramSectionSamples;
 import org.hisp.dhis.android.core.program.ProgramSection;
 import org.hisp.dhis.android.core.program.ProgramSectionTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramSectionStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramSection> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageDataElementStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageDataElementStoreIntegrationShould.java
@@ -33,7 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramStageDataElementSamples;
 import org.hisp.dhis.android.core.program.ProgramStageDataElement;
 import org.hisp.dhis.android.core.program.ProgramStageDataElementTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
+import org.junit.runner.RunWith;
 
+@RunWith(D2JunitRunner.class)
 public class ProgramStageDataElementStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramStageDataElement> {
 
     public ProgramStageDataElementStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionDataElementLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionDataElementLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramStageSectionDataElementLin
 import org.hisp.dhis.android.core.program.ProgramStageSectionDataElementLink;
 import org.hisp.dhis.android.core.program.ProgramStageSectionDataElementLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramStageSectionDataElementLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<ProgramStageSectionDataElementLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramStageSectionSamples;
 import org.hisp.dhis.android.core.program.ProgramStageSection;
 import org.hisp.dhis.android.core.program.ProgramStageSectionTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramStageSectionStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramStageSection> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramStageSamples;
 import org.hisp.dhis.android.core.program.ProgramStage;
 import org.hisp.dhis.android.core.program.ProgramStageTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramStageStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramStage> {
 
     public ProgramStageStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramSamples;
 import org.hisp.dhis.android.core.program.Program;
 import org.hisp.dhis.android.core.program.ProgramTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Program> {
 
     public ProgramStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.program.ProgramTrackedEntityAttributeSamp
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttributeTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ProgramTrackedEntityAttributeStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<ProgramTrackedEntityAttribute> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.relationship.RelationshipConstraint;
 import org.hisp.dhis.android.core.relationship.RelationshipConstraintTableInfo;
 import org.hisp.dhis.android.core.relationship.RelationshipEntityType;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class RelationshipConstraintStoreIntegrationShould extends
         ObjectWithoutUidStoreAbstractIntegrationShould<RelationshipConstraint> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreIntegrationShould.java
@@ -34,11 +34,10 @@ import org.hisp.dhis.android.core.relationship.RelationshipItem;
 import org.hisp.dhis.android.core.relationship.RelationshipItemEvent;
 import org.hisp.dhis.android.core.relationship.RelationshipItemTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class RelationshipItemStoreIntegrationShould extends
         ObjectWithoutUidStoreAbstractIntegrationShould<RelationshipItem> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.relationship.RelationshipSamples;
 import org.hisp.dhis.android.core.relationship.Relationship;
 import org.hisp.dhis.android.core.relationship.RelationshipTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class RelationshipStoreIntegrationShould extends IdentifiableObjectStoreAbstractIntegrationShould<Relationship> {
 
     public RelationshipStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/resource/internal/ResourceStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/resource/internal/ResourceStoreIntegrationShould.java
@@ -32,16 +32,15 @@ import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.data.database.ObjectWithoutUidStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.resource.ResourceSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Date;
 
-import androidx.test.runner.AndroidJUnit4;
-
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class ResourceStoreIntegrationShould extends ObjectWithoutUidStoreAbstractIntegrationShould<Resource> {
 
     private ResourceStore store;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/SystemSettingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/SystemSettingStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.settings.SystemSettingSamples;
 import org.hisp.dhis.android.core.settings.SystemSetting;
 import org.hisp.dhis.android.core.settings.SystemSettingTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class SystemSettingStoreIntegrationShould extends ObjectWithoutUidStoreAbstractIntegrationShould<SystemSetting> {
 
     public SystemSettingStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoStoreIntegrationShould.java
@@ -31,11 +31,10 @@ package org.hisp.dhis.android.core.systeminfo;
 import org.hisp.dhis.android.core.data.database.ObjectWithoutUidStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.systeminfo.SystemInfoSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class SystemInfoStoreIntegrationShould extends ObjectWithoutUidStoreAbstractIntegrationShould<SystemInfo> {
 
     public SystemInfoStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeStoreIntegrationShould.java
@@ -31,11 +31,10 @@ package org.hisp.dhis.android.core.trackedentity;
 import org.hisp.dhis.android.core.data.database.IdentifiableObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityAttributeSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackedEntityAttributeStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<TrackedEntityAttribute> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueStoreIntegrationShould.java
@@ -31,11 +31,10 @@ package org.hisp.dhis.android.core.trackedentity;
 import org.hisp.dhis.android.core.data.database.ObjectWithoutUidStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityAttributeValueSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackedEntityAttributeValueStoreIntegrationShould
         extends ObjectWithoutUidStoreAbstractIntegrationShould<TrackedEntityAttributeValue> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueStoreIntegrationShould.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl;
 import org.hisp.dhis.android.core.event.internal.EventStore;
 import org.hisp.dhis.android.core.event.internal.EventStoreImpl;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,11 +49,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import androidx.test.runner.AndroidJUnit4;
-
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackedEntityDataValueStoreIntegrationShould
         extends ObjectWithoutUidStoreAbstractIntegrationShould<TrackedEntityDataValue> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.database.IdentifiableDataObjectStoreAbstr
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityInstanceSamples;
 import org.hisp.dhis.android.core.period.FeatureType;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackedEntityInstanceStoreIntegrationShould extends
         IdentifiableDataObjectStoreAbstractIntegrationShould<TrackedEntityInstance> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeStoreIntegrationShould.java
@@ -32,11 +32,10 @@ import org.hisp.dhis.android.core.common.ObjectWithUid;
 import org.hisp.dhis.android.core.data.database.LinkModelStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityTypeAttributeSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackedEntityTypeAttributeStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<TrackedEntityTypeAttribute> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeStoreIntegrationShould.java
@@ -31,11 +31,10 @@ package org.hisp.dhis.android.core.trackedentity;
 import org.hisp.dhis.android.core.data.database.IdentifiableObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityTypeSamples;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class TrackedEntityTypeStoreIntegrationShould
         extends IdentifiableObjectStoreAbstractIntegrationShould<TrackedEntityType> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/AuthenticatedUserStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/AuthenticatedUserStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.user.AuthenticatedUserSamples;
 import org.hisp.dhis.android.core.user.AuthenticatedUser;
 import org.hisp.dhis.android.core.user.AuthenticatedUserTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class AuthenticatedUserStoreIntegrationShould
         extends ObjectWithoutUidStoreAbstractIntegrationShould<AuthenticatedUser> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/AuthorityStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/AuthorityStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.user.AuthoritySamples;
 import org.hisp.dhis.android.core.user.Authority;
 import org.hisp.dhis.android.core.user.AuthorityTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class AuthorityStoreIntegrationShould extends ObjectStoreAbstractIntegrationShould<Authority> {
 
     public AuthorityStoreIntegrationShould() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.user.UserOrganisationUnitLinkSamples;
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLink;
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLinkTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class UserOrganisationUnitLinkStoreIntegrationShould
         extends LinkModelStoreAbstractIntegrationShould<UserOrganisationUnitLink> {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserRoleStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserRoleStoreIntegrationShould.java
@@ -33,11 +33,10 @@ import org.hisp.dhis.android.core.data.user.UserRoleSamples;
 import org.hisp.dhis.android.core.user.UserRole;
 import org.hisp.dhis.android.core.user.UserRoleTableInfo;
 import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.runner.RunWith;
 
-import androidx.test.runner.AndroidJUnit4;
-
-@RunWith(AndroidJUnit4.class)
+@RunWith(D2JunitRunner.class)
 public class UserRoleStoreIntegrationShould extends
         IdentifiableObjectStoreAbstractIntegrationShould<UserRole> {
 


### PR DESCRIPTION
Solves [ANDROSDK-894](https://jira.dhis2.org/browse/ANDROSDK-894)

Except in TrackedEntityAttributeReservedValueStoreIntegrationShould