### PR TITLE
refactor: [androsdk-913-2] Fix typo on geometry helper

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/GeometryHelper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/GeometryHelper.java
@@ -46,7 +46,7 @@ public final class GeometryHelper {
     private GeometryHelper() {
     }
 
-    public static boolean conatainsAPoint(Geometry geometry) {
+    public static boolean containsAPoint(Geometry geometry) {
         return geometry != null && geometry.type() == FeatureType.POINT;
     }
 


### PR DESCRIPTION
Fix a typo on the containsAPoint() method from the GeometryHelper class.