### PR TITLE
feat: [androsdk-948] Add a method to get a sdk cache resources directory

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUtil.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUtil.java
@@ -47,6 +47,14 @@ public final class FileResourceUtil {
         return file;
     }
 
+    public static File getFileCacheResourceDirectory(Context context) {
+        File file = new File(context.getCacheDir(), "sdk_cache_resources");
+        if (!file.exists() && file.mkdirs()) {
+            return file;
+        }
+        return file;
+    }
+
     static File renameFile(File file, String newFileName, Context context) {
         String contentType = URLConnection.guessContentTypeFromName(file.getName());
         String generatedName = generateFileName(MediaType.get(contentType), newFileName);


### PR DESCRIPTION
Solves [ANDROSDK-948](https://jira.dhis2.org/browse/ANDROSDK-948).