### PR TITLE
fix: [androsdk-951] Extract file resource directory methods outside internal packages

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/helpers/FileResizerHelperShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/helpers/FileResizerHelperShould.java
@@ -36,7 +36,7 @@ import android.util.Log;
 import androidx.test.InstrumentationRegistry;
 
 import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper;
-import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil;
+import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper;
 import org.hisp.dhis.android.core.maintenance.D2Error;
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.junit.Test;
@@ -129,7 +129,7 @@ public class FileResizerHelperShould {
 
     private static File getFile(Bitmap.CompressFormat compressFormat, Bitmap bitmap) {
         Context context = InstrumentationRegistry.getTargetContext().getApplicationContext();
-        File imageFile = new File(FileResourceUtil.getFileResourceDirectory(context), "image." +
+        File imageFile = new File(FileResourceDirectoryHelper.getFileResourceDirectory(context), "image." +
                 compressFormat.name().toLowerCase());
         OutputStream os;
         try {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceCollectionRepositoryMockIntegrationShould.java
@@ -33,6 +33,7 @@ import android.content.Context;
 import androidx.test.InstrumentationRegistry;
 
 import org.apache.commons.io.FileUtils;
+import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper;
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.common.State;
 import org.hisp.dhis.android.core.data.fileresource.RandomGeneratedInputStream;
@@ -180,13 +181,13 @@ public class FileResourceCollectionRepositoryMockIntegrationShould extends BaseM
     private File getFile() {
         InputStream inputStream = new RandomGeneratedInputStream(1024);
         Context context = InstrumentationRegistry.getTargetContext().getApplicationContext();
-        File destinationFile = new File(FileResourceUtil.getFileResourceDirectory(context), "file1.png");
+        File destinationFile = new File(FileResourceDirectoryHelper.getFileResourceDirectory(context), "file1.png");
         return FileResourceUtil.writeInputStream(inputStream, destinationFile, 1024);
     }
 
     private void cleanFileResources() throws IOException {
         Context context = InstrumentationRegistry.getTargetContext().getApplicationContext();
-        FileUtils.cleanDirectory(FileResourceUtil.getFileResourceDirectory(context));
+        FileUtils.cleanDirectory(FileResourceDirectoryHelper.getFileResourceDirectory(context));
         new TableWiper(databaseAdapter).wipeTable(FileResourceTableInfo.TABLE_INFO);
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.helpers;
+
+import android.content.Context;
+
+import java.io.File;
+
+public final class FileResourceDirectoryHelper {
+
+    public static File getFileResourceDirectory(Context context) {
+        File file = new File(context.getFilesDir(), "sdk_resources");
+        if (!file.exists() && file.mkdirs()) {
+            return file;
+        }
+        return file;
+    }
+
+    public static File getFileCacheResourceDirectory(Context context) {
+        File file = new File(context.getCacheDir(), "sdk_cache_resources");
+        if (!file.exists() && file.mkdirs()) {
+            return file;
+        }
+        return file;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.java
@@ -34,6 +34,8 @@ import java.io.File;
 
 public final class FileResourceDirectoryHelper {
 
+    private FileResourceDirectoryHelper() {}
+
     public static File getFileResourceDirectory(Context context) {
         File file = new File(context.getFilesDir(), "sdk_resources");
         if (!file.exists() && file.mkdirs()) {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUtil.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUtil.java
@@ -3,6 +3,7 @@ package org.hisp.dhis.android.core.fileresource.internal;
 import android.content.Context;
 import android.util.Log;
 
+import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper;
 import org.hisp.dhis.android.core.fileresource.FileResource;
 import org.hisp.dhis.android.core.maintenance.D2Error;
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode;
@@ -25,7 +26,7 @@ public final class FileResourceUtil {
     }
 
     static File getFile(Context context, FileResource fileResource) throws D2Error {
-        File file = new File(getFileResourceDirectory(context),
+        File file = new File(FileResourceDirectoryHelper.getFileResourceDirectory(context),
                 generateFileName(MediaType.get(fileResource.contentType()), fileResource.uid()));
 
         if (file.exists()) {
@@ -37,22 +38,6 @@ public final class FileResourceUtil {
                     .errorDescription("File not found for this file resource uid")
                     .build();
         }
-    }
-
-    public static File getFileResourceDirectory(Context context) {
-        File file = new File(context.getFilesDir(), "sdk_resources");
-        if (!file.exists() && file.mkdirs()) {
-            return file;
-        }
-        return file;
-    }
-
-    public static File getFileCacheResourceDirectory(Context context) {
-        File file = new File(context.getCacheDir(), "sdk_cache_resources");
-        if (!file.exists() && file.mkdirs()) {
-            return file;
-        }
-        return file;
     }
 
     static File renameFile(File file, String newFileName, Context context) {
@@ -72,13 +57,13 @@ public final class FileResourceUtil {
 
         String contentType = URLConnection.guessContentTypeFromName(sourceFile.getName());
         String generatedName = generateFileName(MediaType.get(contentType), fileResourceUid);
-        File destinationFile = new File(getFileResourceDirectory(context), generatedName);
+        File destinationFile = new File(FileResourceDirectoryHelper.getFileResourceDirectory(context), generatedName);
 
         return writeInputStream(inputStream, destinationFile, sourceFile.length());
     }
 
     static File saveFileFromResponse(ResponseBody body, String generatedFileName, Context context) {
-        File destinationFile = new File(FileResourceUtil.getFileResourceDirectory(context),
+        File destinationFile = new File(FileResourceDirectoryHelper.getFileResourceDirectory(context),
                 generateFileName(body.contentType(), generatedFileName));
 
         writeInputStream(body.byteStream(), destinationFile, body.contentLength());


### PR DESCRIPTION
Solves [ANDROSDK-951](https://jira.dhis2.org/browse/ANDROSDK-951).