### PR TITLE
refactor: [androsdk-960] Remove organisation unit ancestors method visibility from OrganisationUnit

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.android.core.common.BaseIdentifiableObjectModel;
 import org.hisp.dhis.android.core.common.Unit;
 import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitSamples;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitAncestorsAccessor;
 import org.hisp.dhis.android.core.program.ProgramTableInfo;
 import org.hisp.dhis.android.core.user.User;
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLink;
@@ -101,8 +102,11 @@ public class OrganisationUnitCallMockIntegrationShould extends BaseMockIntegrati
 
         APICallExecutor apiCallExecutor = APICallExecutorImpl.create(databaseAdapter);
 
+        OrganisationUnitDisplayPathTransformer pathTransformer = new OrganisationUnitDisplayPathTransformer(
+                new OrganisationUnitDisplayPathGenerator(new OrganisationUnitAncestorsAccessor()));
+
         organisationUnitCall = new OrganisationUnitCallFactory(organisationUnitService,
-                organisationUnitHandler, apiCallExecutor, objects.resourceHandler).create(user, programUids, null);
+                organisationUnitHandler, pathTransformer, apiCallExecutor, objects.resourceHandler).create(user, programUids, null);
     }
 
     private void insertProgramWithUid(String uid) {

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnit.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnit.java
@@ -102,7 +102,7 @@ public abstract class OrganisationUnit extends BaseNameableObject implements Mod
     @Nullable
     @JsonProperty()
     @ColumnAdapter(IgnoreOrganisationUnitListAdapter.class)
-    public abstract List<OrganisationUnit> ancestors();
+    abstract List<OrganisationUnit> ancestors();
 
     @Nullable
     @JsonProperty()
@@ -151,7 +151,7 @@ public abstract class OrganisationUnit extends BaseNameableObject implements Mod
 
         public abstract Builder dataSets(List<DataSet> dataSets);
 
-        public abstract Builder ancestors(List<OrganisationUnit> ancestors);
+        abstract Builder ancestors(List<OrganisationUnit> ancestors);
 
         public abstract Builder organisationUnitGroups(List<OrganisationUnitGroup> organisationUnitGroups);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitAncestorsAccessor.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitAncestorsAccessor.java
@@ -26,39 +26,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.organisationunit.internal;
-
-import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
-import org.hisp.dhis.android.core.organisationunit.OrganisationUnitAncestorsAccessor;
+package org.hisp.dhis.android.core.organisationunit;
 
 import java.util.List;
-
-import javax.inject.Inject;
 
 import dagger.Reusable;
 
 @Reusable
-class OrganisationUnitDisplayPathGenerator {
+public class OrganisationUnitAncestorsAccessor {
 
-    private final OrganisationUnitAncestorsAccessor organisationUnitAncestorsAccessor;
-
-    @Inject
-    OrganisationUnitDisplayPathGenerator(OrganisationUnitAncestorsAccessor organisationUnitAncestorsAccessor) {
-        this.organisationUnitAncestorsAccessor = organisationUnitAncestorsAccessor;
-    }
-
-    String generateDisplayPath(OrganisationUnit organisationUnit) {
-        List<OrganisationUnit> ancestors = organisationUnitAncestorsAccessor.accessAncestors(organisationUnit);
-        if (ancestors == null) {
-            return "";
-        } else {
-            String separator = "/";
-            StringBuilder sb = new StringBuilder();
-            for (OrganisationUnit ancestor: ancestors) {
-                sb.append(separator).append(ancestor.displayName());
-            }
-            sb.append(separator).append(organisationUnit.displayName());
-            return sb.toString();
-        }
+    public List<OrganisationUnit> accessAncestors(OrganisationUnit organisationUnit) {
+        return organisationUnit.ancestors();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallFactory.java
@@ -53,6 +53,7 @@ class OrganisationUnitCallFactory {
 
     private final OrganisationUnitService organisationUnitService;
     private final OrganisationUnitHandler handler;
+    private final OrganisationUnitDisplayPathTransformer pathTransformer;
 
     private final APICallExecutor apiCallExecutor;
     private final ResourceHandler resourceHandler;
@@ -60,10 +61,12 @@ class OrganisationUnitCallFactory {
     @Inject
     OrganisationUnitCallFactory(@NonNull OrganisationUnitService organisationUnitService,
                                 @NonNull OrganisationUnitHandler handler,
+                                @NonNull OrganisationUnitDisplayPathTransformer pathTransformer,
                                 @NonNull APICallExecutor apiCallExecutor,
                                 @NonNull ResourceHandler resourceHandler) {
         this.organisationUnitService = organisationUnitService;
         this.handler = handler;
+        this.pathTransformer = pathTransformer;
         this.apiCallExecutor = apiCallExecutor;
         this.resourceHandler = resourceHandler;
     }
@@ -110,7 +113,6 @@ class OrganisationUnitCallFactory {
                                   final Set<String> dataSetUids) throws D2Error {
 
         handler.setData(programUids, dataSetUids, user, scope);
-        OrganisationUnitDisplayPathTransformer transformer = new OrganisationUnitDisplayPathTransformer();
 
         for (String uid : orgUnits) {
             OrganisationUnitQuery.Builder queryBuilder = OrganisationUnitQuery.builder().orgUnit(uid);
@@ -121,7 +123,7 @@ class OrganisationUnitCallFactory {
                 pageQuery = queryBuilder.build();
                 pageOrgunits = apiCallExecutor.executePayloadCall(getOrganisationUnitAndDescendants(pageQuery));
 
-                handler.handleMany(pageOrgunits, transformer);
+                handler.handleMany(pageOrgunits, pathTransformer);
 
                 queryBuilder.page(pageQuery.page() + 1);
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitDisplayPathTransformer.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitDisplayPathTransformer.java
@@ -31,11 +31,23 @@ package org.hisp.dhis.android.core.organisationunit.internal;
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 
+import javax.inject.Inject;
+
+import dagger.Reusable;
+
+@Reusable
 class OrganisationUnitDisplayPathTransformer implements Transformer<OrganisationUnit, OrganisationUnit> {
+
+    private final OrganisationUnitDisplayPathGenerator organisationUnitDisplayPathGenerator;
+
+    @Inject
+    OrganisationUnitDisplayPathTransformer(OrganisationUnitDisplayPathGenerator organisationUnitDisplayPathGenerator) {
+        this.organisationUnitDisplayPathGenerator = organisationUnitDisplayPathGenerator;
+    }
 
     @Override
     public OrganisationUnit transform(OrganisationUnit organisationUnit) {
-        String path = new OrganisationUnitDisplayPathGenerator().generateDisplayPath(organisationUnit);
+        String path = organisationUnitDisplayPathGenerator.generateDisplayPath(organisationUnit);
         OrganisationUnit.Builder builder = organisationUnit.toBuilder();
         builder.displayNamePath(path);
         return builder.build();

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitEntityDIModule.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitEntityDIModule.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStor
 import org.hisp.dhis.android.core.arch.di.internal.IdentifiableStoreProvider;
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitAncestorsAccessor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,6 +56,24 @@ public final class OrganisationUnitEntityDIModule implements IdentifiableStorePr
     @Reusable
     public OrganisationUnitHandler handler(DatabaseAdapter databaseAdapter) {
         return OrganisationUnitHandlerImpl.create(databaseAdapter);
+    }
+
+    @Provides
+    @Reusable
+    public OrganisationUnitDisplayPathTransformer pathTransformer(OrganisationUnitDisplayPathGenerator pathGenerator) {
+        return new OrganisationUnitDisplayPathTransformer(pathGenerator);
+    }
+
+    @Provides
+    @Reusable
+    public OrganisationUnitDisplayPathGenerator generator(OrganisationUnitAncestorsAccessor ancestorsAccessor) {
+        return new OrganisationUnitDisplayPathGenerator(ancestorsAccessor);
+    }
+
+    @Provides
+    @Reusable
+    public OrganisationUnitAncestorsAccessor ancestorsAccessor() {
+        return new OrganisationUnitAncestorsAccessor();
     }
 
     @Provides

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/SearchOrganisationUnitOnDemandCallFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/SearchOrganisationUnitOnDemandCallFactory.java
@@ -56,16 +56,19 @@ final class SearchOrganisationUnitOnDemandCallFactory {
     private final APICallExecutor apiCallExecutor;
     private final D2CallExecutor d2CallExecutor;
     private final OrganisationUnitHandler handler;
+    private final OrganisationUnitDisplayPathTransformer pathTransformer;
 
     @Inject
     SearchOrganisationUnitOnDemandCallFactory(OrganisationUnitService service,
                                               APICallExecutor apiCallExecutor,
                                               D2CallExecutor d2CallExecutor,
-                                              OrganisationUnitHandler handler) {
+                                              OrganisationUnitHandler handler,
+                                              OrganisationUnitDisplayPathTransformer pathTransformer) {
         this.service = service;
         this.apiCallExecutor = apiCallExecutor;
         this.d2CallExecutor = d2CallExecutor;
         this.handler = handler;
+        this.pathTransformer = pathTransformer;
     }
 
     public Callable<List<OrganisationUnit>> create(Set<String> uids, User user) {
@@ -89,7 +92,7 @@ final class SearchOrganisationUnitOnDemandCallFactory {
             if (objectList != null && !objectList.isEmpty()) {
                 d2CallExecutor.executeD2CallTransactionally(() -> {
                     handler.setData(null, null, user, OrganisationUnit.Scope.SCOPE_TEI_SEARCH);
-                    handler.handleMany(objectList, new OrganisationUnitDisplayPathTransformer());
+                    handler.handleMany(objectList, pathTransformer);
                     return null;
                 });
             }

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.java
@@ -120,6 +120,9 @@ public class OrganisationUnitCallUnitShould {
     @Mock
     private OrganisationUnitHandler organisationUnitHandler;
 
+    @Mock
+    private OrganisationUnitDisplayPathTransformer organisationUnitDisplayPathTransformer;
+
     //the call we are testing:
     private Callable<Unit> organisationUnitCall;
 
@@ -168,7 +171,7 @@ public class OrganisationUnitCallUnitShould {
         when(user.nationality()).thenReturn("user_nationality");
 
         organisationUnitCall = new OrganisationUnitCallFactory(organisationUnitService, organisationUnitHandler,
-                apiCallExecutor, resourceHandler)
+                organisationUnitDisplayPathTransformer, apiCallExecutor, resourceHandler)
                 .create(user, new HashSet<>(), new HashSet<>());
 
         //Return only one organisationUnit.

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitDisplayPathGeneratorShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitDisplayPathGeneratorShould.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.organisationunit.internal;
 
 import org.assertj.core.util.Lists;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitAncestorsAccessor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,6 +55,9 @@ public class OrganisationUnitDisplayPathGeneratorShould {
     @Mock
     private OrganisationUnit organisationUnit;
 
+    @Mock
+    private OrganisationUnitAncestorsAccessor organisationUnitAncestorsAccessor;
+
     private static final String GRANDPARENT_DISPLAY_NAME = "grandparentDisplayName";
     private static final String PARENT_DISPLAY_NAME = "parentDisplayName";
     private static final String ORG_UNIT_DISPLAY_NAME = "orgUnitDisplayName";
@@ -62,7 +66,8 @@ public class OrganisationUnitDisplayPathGeneratorShould {
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
 
-        when(organisationUnit.ancestors()).thenReturn(Lists.newArrayList(grandparent, parent));
+        when(organisationUnitAncestorsAccessor.accessAncestors(organisationUnit))
+                .thenReturn(Lists.newArrayList(grandparent, parent));
         when(parent.uid()).thenReturn("parentUid");
 
         when(grandparent.displayName()).thenReturn(GRANDPARENT_DISPLAY_NAME);
@@ -74,7 +79,8 @@ public class OrganisationUnitDisplayPathGeneratorShould {
     public void build_display_name_path_from_ancestors() {
         String expectedDisplayNamePath = "/" + GRANDPARENT_DISPLAY_NAME + "/" + PARENT_DISPLAY_NAME
                 + "/" + ORG_UNIT_DISPLAY_NAME;
-        OrganisationUnitDisplayPathGenerator generator = new OrganisationUnitDisplayPathGenerator();
-        assertThat(generator.generateDisplayPath(organisationUnit)).isEqualTo(expectedDisplayNamePath);
+
+        assertThat(new OrganisationUnitDisplayPathGenerator(organisationUnitAncestorsAccessor)
+                .generateDisplayPath(organisationUnit)).isEqualTo(expectedDisplayNamePath);
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitHandlerShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitHandlerShould.java
@@ -25,6 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package org.hisp.dhis.android.core.organisationunit.internal;
 
 import org.assertj.core.util.Lists;
@@ -95,6 +96,11 @@ public class OrganisationUnitHandlerShould {
     @Mock
     private User user;
 
+    @Mock
+    private OrganisationUnitDisplayPathGenerator pathGenerator;
+
+    private OrganisationUnitDisplayPathTransformer pathTransformer;
+
     private Set<String> programUids;
 
     private Set<String> dataSetUids;
@@ -113,6 +119,8 @@ public class OrganisationUnitHandlerShould {
         programUids = Sets.newHashSet(Lists.newArrayList(programUid));
         String dataSetUid = "test_data_set_uid";
         dataSetUids = Sets.newHashSet(Lists.newArrayList(dataSetUid));
+
+        pathTransformer = new OrganisationUnitDisplayPathTransformer(pathGenerator);
 
         organisationUnitHandler = new OrganisationUnitHandlerImpl(
                 organisationUnitStore, userOrganisationUnitLinkHandler, organisationUnitProgramLinkHandler,
@@ -142,13 +150,13 @@ public class OrganisationUnitHandlerShould {
     @Test
     public void persist_user_organisation_unit_link() {
         organisationUnitHandler.setData(programUids, dataSetUids, user, OrganisationUnit.Scope.SCOPE_DATA_CAPTURE);
-        organisationUnitHandler.handleMany(organisationUnits, new OrganisationUnitDisplayPathTransformer());
+        organisationUnitHandler.handleMany(organisationUnits, pathTransformer);
     }
 
     @Test
     public void persist_program_organisation_unit_link_when_programs_uids() {
         organisationUnitHandler.setData(programUids, dataSetUids, user, OrganisationUnit.Scope.SCOPE_DATA_CAPTURE);
-        organisationUnitHandler.handleMany(organisationUnits, new OrganisationUnitDisplayPathTransformer());
+        organisationUnitHandler.handleMany(organisationUnits, pathTransformer);
         verify(organisationUnitProgramLinkHandler).handleMany(anyString(), anyListOf(Program.class),
                 any(Transformer.class));
     }
@@ -157,7 +165,7 @@ public class OrganisationUnitHandlerShould {
     public void persist_program_organisation_unit_link_when_no_programs_uids() {
         organisationUnitHandler.setData(null, null, user,
                 OrganisationUnit.Scope.SCOPE_DATA_CAPTURE);
-        organisationUnitHandler.handleMany(organisationUnits, new OrganisationUnitDisplayPathTransformer());
+        organisationUnitHandler.handleMany(organisationUnits, pathTransformer);
 
         verifyNoMoreInteractions(organisationUnitProgramLinkStore);
     }
@@ -165,7 +173,7 @@ public class OrganisationUnitHandlerShould {
     @Test
     public void persist_organisation_unit_groups() {
         organisationUnitHandler.setData(programUids, dataSetUids, user, OrganisationUnit.Scope.SCOPE_DATA_CAPTURE);
-        organisationUnitHandler.handleMany(organisationUnits, new OrganisationUnitDisplayPathTransformer());
+        organisationUnitHandler.handleMany(organisationUnits, pathTransformer);
 
         verify(organisationUnitGroupHandler).handleMany(anyListOf(OrganisationUnitGroup.class));
     }
@@ -173,7 +181,7 @@ public class OrganisationUnitHandlerShould {
     @Test
     public void persist_organisation_unit_organisation_unit_group_link() {
         organisationUnitHandler.setData(programUids, dataSetUids, user, OrganisationUnit.Scope.SCOPE_DATA_CAPTURE);
-        organisationUnitHandler.handleMany(organisationUnits, new OrganisationUnitDisplayPathTransformer());
+        organisationUnitHandler.handleMany(organisationUnits, pathTransformer);
 
         verify(organisationUnitGroupLinkHandler).handleMany(anyString(), anyListOf(OrganisationUnitGroup.class),
                 any(Transformer.class));
@@ -183,7 +191,7 @@ public class OrganisationUnitHandlerShould {
     public void dont_persist_organisation_unit_organisation_unit_group_link_when_no_organisation_unit_groups() {
         organisationUnitHandler.setData(programUids, dataSetUids, user, OrganisationUnit.Scope.SCOPE_DATA_CAPTURE);
 
-        organisationUnitHandler.handleMany(Lists.newArrayList(organisationUnitWithoutGroups), new OrganisationUnitDisplayPathTransformer());
+        organisationUnitHandler.handleMany(Lists.newArrayList(organisationUnitWithoutGroups), pathTransformer);
 
         verify(organisationUnitGroupLinkHandler, never()).handleMany(anyString(),
                 anyListOf(OrganisationUnitGroup.class), any(Transformer.class));


### PR DESCRIPTION
Solves [ANDROSDK-960](https://jira.dhis2.org/browse/ANDROSDK-960).