### PR TITLE
feat: [androsdk-978] Exclude internal accessors from JavaDocs

### DIFF
--- a/core/plugins/gradle-mvn-push.gradle
+++ b/core/plugins/gradle-mvn-push.gradle
@@ -136,6 +136,7 @@ afterEvaluate { project ->
             source = android.sourceSets.main.java.source
             classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
             exclude "org/hisp/dhis/android/core/**/internal/**"
+            exclude "org/hisp/dhis/android/core/**/*InternalAccessor.java"
         }
 
         task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {


### PR DESCRIPTION
Solves [ANDROSDK-978](https://jira.dhis2.org/browse/ANDROSDK-978).