### PR TITLE
feat: [ANDROSDK-3-B] Make stores independent of SQL implementation

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.android.core.arch.db.access;
 
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
+
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 
 @SuppressWarnings("PMD.UseVarargs")
 public interface DatabaseAdapter {
@@ -42,14 +43,12 @@ public interface DatabaseAdapter {
      * and SQLiteProgram.bindLong each time you want to run the
      * statement. Statements may not return result sets larger than 1x1.
      * <p>
-     * No two threads should be using the same {@link SQLiteStatement} at the same time.
      *
      * @param sql The raw SQL statement, may contain ? for unknown values to be
      *            bound later.
-     * @return A pre-compiled {@link SQLiteStatement} object. Note that
-     * {@link SQLiteStatement}s are not synchronized, see the documentation for more details.
+     * @return A pre-compiled {@link StatementWrapper} object. Note that
      */
-    SQLiteStatement compileStatement(String sql);
+    StatementWrapper compileStatement(String sql);
 
     /**
      * Runs the provided SQL and returns a {@link Cursor} over the result set.
@@ -71,9 +70,8 @@ public interface DatabaseAdapter {
      * @param sqLiteStatement The SQL statement to execute
      * @return the row ID of the last row inserted, if this insert is successful. -1 otherwise.
      * @throws android.database.SQLException If the SQL string is invalid
-     * @see SQLiteStatement#executeInsert()
      */
-    long executeInsert(String table, SQLiteStatement sqLiteStatement);
+    long executeInsert(String table, StatementWrapper sqLiteStatement);
 
     /**
      * Execute this SQL statement, if the the number of rows affected by execution of this SQL
@@ -85,7 +83,7 @@ public interface DatabaseAdapter {
      * @throws android.database.SQLException If the SQL string is invalid for
      *                                       some reason
      */
-    int executeUpdateDelete(String table, SQLiteStatement sqLiteStatement);
+    int executeUpdateDelete(String table, StatementWrapper sqLiteStatement);
 
     /**
      * Convenience method for deleting rows in the database.

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/SqLiteDatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/SqLiteDatabaseAdapter.java
@@ -30,11 +30,12 @@ package org.hisp.dhis.android.core.arch.db.access.internal;
 
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
 
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.access.DbOpenHelper;
 import org.hisp.dhis.android.core.arch.db.access.Transaction;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.SQLStatementWrapper;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 
 import androidx.annotation.NonNull;
 
@@ -58,8 +59,8 @@ public class SqLiteDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public SQLiteStatement compileStatement(String sql) {
-        return database().compileStatement(sql);
+    public StatementWrapper compileStatement(String sql) {
+        return new SQLStatementWrapper(database().compileStatement(sql));
     }
 
     @Override
@@ -68,12 +69,12 @@ public class SqLiteDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public long executeInsert(String table, SQLiteStatement sqLiteStatement) {
+    public long executeInsert(String table, StatementWrapper sqLiteStatement) {
         return sqLiteStatement.executeInsert();
     }
 
     @Override
-    public int executeUpdateDelete(String table, SQLiteStatement sqLiteStatement) {
+    public int executeUpdateDelete(String table, StatementWrapper sqLiteStatement) {
         return sqLiteStatement.executeUpdateDelete();
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/statementwrapper/internal/SQLStatementWrapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/statementwrapper/internal/SQLStatementWrapper.java
@@ -28,15 +28,14 @@
 
 package org.hisp.dhis.android.core.arch.db.statementwrapper.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 
 public class SQLStatementWrapper {
-    public final SQLiteStatement insert;
-    public final SQLiteStatement update;
-    public final SQLiteStatement deleteById;
+    public final StatementWrapper insert;
+    public final StatementWrapper update;
+    public final StatementWrapper deleteById;
     public final String selectUids;
 
     public SQLStatementWrapper(SQLStatementBuilder builder, DatabaseAdapter databaseAdapter) {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/IdentifiableStatementBinder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/IdentifiableStatementBinder.java
@@ -28,23 +28,19 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.common.IdentifiableObject;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public abstract class IdentifiableStatementBinder<O extends IdentifiableObject> implements StatementBinder<O> {
 
     @Override
-    public void bindToStatement(@NonNull O o, @NonNull SQLiteStatement sqLiteStatement) {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.code());
-        sqLiteBind(sqLiteStatement, 3, o.name());
-        sqLiteBind(sqLiteStatement, 4, o.displayName());
-        sqLiteBind(sqLiteStatement, 5, o.created());
-        sqLiteBind(sqLiteStatement, 6, o.lastUpdated());
+    public void bindToStatement(@NonNull O o, @NonNull StatementWrapper w) {
+        w.bind(1, o.uid());
+        w.bind(2, o.code());
+        w.bind(3, o.name());
+        w.bind(4, o.displayName());
+        w.bind(5, o.created());
+        w.bind(6, o.lastUpdated());
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/IdentifiableWithStyleStatementBinder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/IdentifiableWithStyleStatementBinder.java
@@ -28,22 +28,18 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.common.IdentifiableObject;
 import org.hisp.dhis.android.core.common.ObjectWithStyle;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public abstract class IdentifiableWithStyleStatementBinder<O extends IdentifiableObject & ObjectWithStyle>
         extends IdentifiableStatementBinder<O> {
 
     @Override
-    public void bindToStatement(@NonNull O o, @NonNull SQLiteStatement sqLiteStatement) {
-        super.bindToStatement(o, sqLiteStatement);
-        sqLiteBind(sqLiteStatement, 7, o.style().color());
-        sqLiteBind(sqLiteStatement, 8, o.style().icon());
+    public void bindToStatement(@NonNull O o, @NonNull StatementWrapper w) {
+        super.bindToStatement(o, w);
+        w.bind(7, o.style().color());
+        w.bind(8, o.style().icon());
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/NameableStatementBinder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/NameableStatementBinder.java
@@ -28,22 +28,18 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.common.NameableObject;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public abstract class NameableStatementBinder<O extends NameableObject> extends IdentifiableStatementBinder<O> {
 
     @Override
-    public void bindToStatement(@NonNull O o, @NonNull SQLiteStatement sqLiteStatement) {
-        super.bindToStatement(o, sqLiteStatement);
-        sqLiteBind(sqLiteStatement, 7, o.shortName());
-        sqLiteBind(sqLiteStatement, 8, o.displayShortName());
-        sqLiteBind(sqLiteStatement, 9, o.description());
-        sqLiteBind(sqLiteStatement, 10, o.displayDescription());
+    public void bindToStatement(@NonNull O o, @NonNull StatementWrapper w) {
+        super.bindToStatement(o, w);
+        w.bind(7, o.shortName());
+        w.bind(8, o.displayShortName());
+        w.bind(9, o.description());
+        w.bind(10, o.displayDescription());
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/NameableWithStyleStatementBinder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/NameableWithStyleStatementBinder.java
@@ -28,22 +28,18 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.common.NameableObject;
 import org.hisp.dhis.android.core.common.ObjectWithStyle;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public abstract class NameableWithStyleStatementBinder<O extends NameableObject & ObjectWithStyle>
         extends NameableStatementBinder<O> {
 
     @Override
-    public void bindToStatement(@NonNull O o, @NonNull SQLiteStatement sqLiteStatement) {
-        super.bindToStatement(o, sqLiteStatement);
-        sqLiteBind(sqLiteStatement, 11, o.style().color());
-        sqLiteBind(sqLiteStatement, 12, o.style().icon());
+    public void bindToStatement(@NonNull O o, @NonNull StatementWrapper w) {
+        super.bindToStatement(o, w);
+        w.bind(11, o.style().color());
+        w.bind(12, o.style().icon());
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/SQLStatementWrapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/SQLStatementWrapper.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
+
+
+import android.database.sqlite.SQLiteStatement;
+
+import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
+
+import java.util.Date;
+
+public class SQLStatementWrapper implements StatementWrapper {
+
+    private final SQLiteStatement sqLiteStatement;
+
+    public SQLStatementWrapper(SQLiteStatement sqLiteStatement) {
+        this.sqLiteStatement = sqLiteStatement;
+    }
+
+    @Override
+    public void bind(int index, String arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindString(index, arg);
+        }
+    }
+
+    @Override
+    public void bind(int index, Boolean arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindLong(index, arg ? 1 : 0);
+        }
+    }
+
+    @Override
+    public void bind(int index, Integer arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindLong(index, arg);
+        }
+    }
+
+    @Override
+    public void bind(int index, Date arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindString(index, BaseIdentifiableObject.DATE_FORMAT.format(arg));
+        }
+    }
+
+    @Override
+    public void bind(int index, Enum arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindString(index, arg.name());
+        }
+    }
+
+    @Override
+    public void bind(int index, Double arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindDouble(index, arg);
+        }
+    }
+
+    @Override
+    public void bind(int index, Long arg) {
+        if (arg == null) {
+            sqLiteStatement.bindNull(index);
+        } else {
+            sqLiteStatement.bindLong(index, arg);
+        }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/SQLStatementWrapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/SQLStatementWrapper.java
@@ -37,72 +37,87 @@ import java.util.Date;
 
 public class SQLStatementWrapper implements StatementWrapper {
 
-    private final SQLiteStatement sqLiteStatement;
+    private final SQLiteStatement s;
 
-    public SQLStatementWrapper(SQLiteStatement sqLiteStatement) {
-        this.sqLiteStatement = sqLiteStatement;
+    public SQLStatementWrapper(SQLiteStatement s) {
+        this.s = s;
     }
 
     @Override
     public void bind(int index, String arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindString(index, arg);
+            s.bindString(index, arg);
         }
     }
 
     @Override
     public void bind(int index, Boolean arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindLong(index, arg ? 1 : 0);
+            s.bindLong(index, arg ? 1 : 0);
         }
     }
 
     @Override
     public void bind(int index, Integer arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindLong(index, arg);
+            s.bindLong(index, arg);
         }
     }
 
     @Override
     public void bind(int index, Date arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindString(index, BaseIdentifiableObject.DATE_FORMAT.format(arg));
+            s.bindString(index, BaseIdentifiableObject.DATE_FORMAT.format(arg));
         }
     }
 
     @Override
     public void bind(int index, Enum arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindString(index, arg.name());
+            s.bindString(index, arg.name());
         }
     }
 
     @Override
     public void bind(int index, Double arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindDouble(index, arg);
+            s.bindDouble(index, arg);
         }
     }
 
     @Override
     public void bind(int index, Long arg) {
         if (arg == null) {
-            sqLiteStatement.bindNull(index);
+            s.bindNull(index);
         } else {
-            sqLiteStatement.bindLong(index, arg);
+            s.bindLong(index, arg);
         }
+    }
+
+    @Override
+    public void clearBindings() {
+        s.clearBindings();
+    }
+
+    @Override
+    public long executeInsert() {
+        return s.executeInsert();
+    }
+
+    @Override
+    public int executeUpdateDelete() {
+        return s.executeUpdateDelete();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/StatementBinder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/StatementBinder.java
@@ -28,10 +28,8 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import androidx.annotation.NonNull;
 
 public interface StatementBinder<O> {
-    void bindToStatement(@NonNull O object, @NonNull SQLiteStatement sqLiteStatement);
+    void bindToStatement(@NonNull O object, @NonNull StatementWrapper wrapper);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/StatementWrapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/StatementWrapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2004-2019, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
+
+import java.util.Date;
+
+public interface StatementWrapper {
+    /**
+     * Handle if String argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat...
+     * @param index
+     * @param arg
+     */
+    void bind(int index, String arg);
+
+    /**
+     * Handle if Boolean argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat...
+     * Also convert the Boolean to Long...
+     * @param index
+     * @param arg
+     */
+    void bind(int index, Boolean arg);
+
+    /**
+     * Handle if Integer argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat..
+     * @param index
+     * @param arg
+     */
+    void bind(int index, Integer arg);
+
+    /**
+     * Handle if Date argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat..
+     * @param index
+     * @param arg
+     */
+    void bind(int index, Date arg);
+
+    /**
+     * Handle if Enum argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat..
+     * @param index
+     * @param arg
+     */
+    void bind(int index, Enum arg);
+
+    /**
+     * Handle if Double argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat..
+     * @param index
+     * @param arg
+     */
+    void bind(int index, Double arg);
+
+    /**
+     * Handle if Long argument is null and bind it using .bindNull() if so.
+     * A helper function to abstract/clean up boilerplate if/else bloat..
+     * @param index
+     * @param arg
+     */
+    void bind(int index, Long arg);
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/StatementWrapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/StatementWrapper.java
@@ -87,4 +87,19 @@ public interface StatementWrapper {
      * @param arg
      */
     void bind(int index, Long arg);
+
+    /**
+     * Clear statement bindings
+     */
+    void clearBindings();
+
+    /**
+     * Execute insert statement
+     */
+    long executeInsert();
+
+    /**
+     * Execute delete update statement
+     */
+    int executeUpdateDelete();
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/WhereStatementBinder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/binders/internal/WhereStatementBinder.java
@@ -28,10 +28,8 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.binders.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import androidx.annotation.NonNull;
 
 public interface WhereStatementBinder<M> {
-    void bindWhereStatement(@NonNull M m, @NonNull SQLiteStatement sqLiteStatement);
+    void bindWhereStatement(@NonNull M m, @NonNull StatementWrapper w);
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDataObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDataObjectStoreImpl.java
@@ -30,9 +30,6 @@ package org.hisp.dhis.android.core.arch.db.stores.internal;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
 
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.cursors.internal.ObjectFactory;
@@ -40,13 +37,15 @@ import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBui
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder;
 import org.hisp.dhis.android.core.arch.db.statementwrapper.internal.SQLStatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.common.DataObject;
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface;
 import org.hisp.dhis.android.core.common.State;
 
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
+
 import static org.hisp.dhis.android.core.common.DataColumns.STATE;
 import static org.hisp.dhis.android.core.common.IdentifiableColumns.UID;
 
@@ -59,8 +58,8 @@ public class IdentifiableDataObjectStoreImpl<M extends ObjectWithUidInterface & 
 
     private final String selectStateQuery;
     private final String existsQuery;
-    private final SQLiteStatement setStateStatement;
-    private final SQLiteStatement setStateForUpdateStatement;
+    private final StatementWrapper setStateStatement;
+    private final StatementWrapper setStateForUpdateStatement;
     final String tableName;
 
     public IdentifiableDataObjectStoreImpl(DatabaseAdapter databaseAdapter,
@@ -92,10 +91,10 @@ public class IdentifiableDataObjectStoreImpl<M extends ObjectWithUidInterface & 
 
     @Override
     public int setState(@NonNull String uid, @NonNull State state) {
-        sqLiteBind(setStateStatement, 1, state);
+        setStateStatement.bind(1, state);
 
         // bind the where argument
-        sqLiteBind(setStateStatement, 2, uid);
+        setStateStatement.bind(2, uid);
 
         int updatedRow = databaseAdapter.executeUpdateDelete(tableName, setStateStatement);
         setStateStatement.clearBindings();
@@ -117,7 +116,7 @@ public class IdentifiableDataObjectStoreImpl<M extends ObjectWithUidInterface & 
 
     @Override
     public int setStateForUpdate(@NonNull String uid) {
-        sqLiteBind(setStateForUpdateStatement, 1, uid);
+        setStateForUpdateStatement.bind(1, uid);
 
         int updatedRow = databaseAdapter.executeUpdateDelete(tableName, setStateForUpdateStatement);
         setStateForUpdateStatement.clearBindings();

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDeletableDataObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDeletableDataObjectStoreImpl.java
@@ -28,22 +28,20 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.cursors.internal.ObjectFactory;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilder;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder;
 import org.hisp.dhis.android.core.arch.db.statementwrapper.internal.SQLStatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction;
 import org.hisp.dhis.android.core.common.DeletableDataObject;
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface;
 import org.hisp.dhis.android.core.common.State;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
+
 import static org.hisp.dhis.android.core.common.DataColumns.STATE;
 import static org.hisp.dhis.android.core.common.DeletableDataColumns.DELETED;
 import static org.hisp.dhis.android.core.common.IdentifiableColumns.UID;
@@ -53,8 +51,8 @@ public class IdentifiableDeletableDataObjectStoreImpl<M extends ObjectWithUidInt
 
     private final static String EQ = " = ";
 
-    private final SQLiteStatement setStateIfUploadingStatement;
-    private final SQLiteStatement setDeletedStatement;
+    private final StatementWrapper setStateIfUploadingStatement;
+    private final StatementWrapper setDeletedStatement;
 
     public IdentifiableDeletableDataObjectStoreImpl(DatabaseAdapter databaseAdapter,
                                                     SQLStatementWrapper statements,
@@ -96,10 +94,10 @@ public class IdentifiableDeletableDataObjectStoreImpl<M extends ObjectWithUidInt
     }
 
     private void setStateIfUploading(@NonNull String uid, @NonNull State state) {
-        sqLiteBind(setStateIfUploadingStatement, 1, state);
+        setStateIfUploadingStatement.bind(1, state);
 
         // bind the where argument
-        sqLiteBind(setStateIfUploadingStatement, 2, uid);
+        setStateIfUploadingStatement.bind(2, uid);
 
         databaseAdapter.executeUpdateDelete(tableName, setStateIfUploadingStatement);
         setStateIfUploadingStatement.clearBindings();
@@ -107,7 +105,7 @@ public class IdentifiableDeletableDataObjectStoreImpl<M extends ObjectWithUidInt
 
     @Override
     public int setDeleted(@NonNull String uid) {
-        sqLiteBind(setDeletedStatement, 1, uid);
+        setDeletedStatement.bind(1, uid);
 
         int updatedRow = databaseAdapter.executeUpdateDelete(tableName, setDeletedStatement);
         setDeletedStatement.clearBindings();

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStoreImpl.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.android.core.common.ObjectWithUidInterface;
 
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 import static org.hisp.dhis.android.core.arch.helpers.CollectionsHelper.isNull;
 
 public class IdentifiableObjectStoreImpl<M extends CoreObject & ObjectWithUidInterface>
@@ -69,7 +68,7 @@ public class IdentifiableObjectStoreImpl<M extends CoreObject & ObjectWithUidInt
     @Override
     public final void delete(@NonNull String uid) throws RuntimeException {
         isNull(uid);
-        sqLiteBind(statements.deleteById, 1, uid);
+        statements.deleteById.bind(1, uid);
         executeUpdateDelete(statements.deleteById);
     }
 
@@ -88,7 +87,7 @@ public class IdentifiableObjectStoreImpl<M extends CoreObject & ObjectWithUidInt
     public final void update(@NonNull M m) throws RuntimeException {
         isNull(m);
         binder.bindToStatement(m, statements.update);
-        sqLiteBind(statements.update, builder.getColumns().length + 1, m.uid());
+        statements.update.bind(builder.getColumns().length + 1, m.uid());
         executeUpdateDelete(statements.update);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/LinkStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/LinkStoreImpl.java
@@ -28,22 +28,21 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.cursors.internal.ObjectFactory;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.common.CoreObject;
+
+import androidx.annotation.NonNull;
 
 public class LinkStoreImpl<M extends CoreObject> extends ObjectStoreImpl<M> implements LinkStore<M> {
 
     private final String masterColumn;
 
     protected LinkStoreImpl(DatabaseAdapter databaseAdapter,
-                            SQLiteStatement insertStatement,
+                            StatementWrapper insertStatement,
                             SQLStatementBuilder builder,
                             String masterColumn,
                             StatementBinder<M> binder,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.java
@@ -29,27 +29,27 @@
 package org.hisp.dhis.android.core.arch.db.stores.internal;
 
 import android.database.Cursor;
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
 
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.cursors.internal.ObjectFactory;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.common.CoreColumns;
 import org.hisp.dhis.android.core.common.CoreObject;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+
 import static org.hisp.dhis.android.core.arch.helpers.CollectionsHelper.isNull;
 
 public class ObjectStoreImpl<M extends CoreObject> extends ReadableStoreImpl<M> implements ObjectStore<M> {
-    private final SQLiteStatement insertStatement;
+    private final StatementWrapper insertStatement;
     protected final SQLStatementBuilder builder;
     protected final StatementBinder<M> binder;
 
-    public ObjectStoreImpl(DatabaseAdapter databaseAdapter, SQLiteStatement insertStatement,
+    public ObjectStoreImpl(DatabaseAdapter databaseAdapter, StatementWrapper insertStatement,
                            SQLStatementBuilder builder, StatementBinder<M> binder, ObjectFactory<M> objectFactory) {
         super(databaseAdapter, builder, objectFactory);
         this.insertStatement = insertStatement;
@@ -61,7 +61,7 @@ public class ObjectStoreImpl<M extends CoreObject> extends ReadableStoreImpl<M> 
     public long insert(@NonNull M m) throws RuntimeException {
         isNull(m);
         binder.bindToStatement(m, insertStatement);
-        Long insertedRowId = databaseAdapter.executeInsert(builder.getTableName(), insertStatement);
+        long insertedRowId = databaseAdapter.executeInsert(builder.getTableName(), insertStatement);
         insertStatement.clearBindings();
         if (insertedRowId == -1) {
             throw new RuntimeException("Nothing was inserted.");
@@ -80,7 +80,7 @@ public class ObjectStoreImpl<M extends CoreObject> extends ReadableStoreImpl<M> 
         return databaseAdapter.delete(builder.getTableName());
     }
 
-    void executeUpdateDelete(SQLiteStatement statement) throws RuntimeException {
+    void executeUpdateDelete(StatementWrapper statement) throws RuntimeException {
         int numberOfAffectedRows = databaseAdapter.executeUpdateDelete(builder.getTableName(), statement);
         statement.clearBindings();
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithoutUidStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithoutUidStoreImpl.java
@@ -28,24 +28,23 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.cursors.internal.ObjectFactory;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.WhereStatementBinder;
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction;
 import org.hisp.dhis.android.core.common.CoreObject;
+
+import androidx.annotation.NonNull;
 
 import static org.hisp.dhis.android.core.arch.helpers.CollectionsHelper.isNull;
 
 public class ObjectWithoutUidStoreImpl<M extends CoreObject>
         extends ObjectStoreImpl<M> implements ObjectWithoutUidStore<M> {
-    private final SQLiteStatement updateWhereStatement;
-    private final SQLiteStatement deleteWhereStatement;
+    private final StatementWrapper updateWhereStatement;
+    private final StatementWrapper deleteWhereStatement;
     private final WhereStatementBinder<M> whereUpdateBinder;
     private final WhereStatementBinder<M> whereDeleteBinder;
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/StoreUtils.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/StoreUtils.java
@@ -28,8 +28,6 @@
 
 package org.hisp.dhis.android.core.arch.db.stores.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 import org.hisp.dhis.android.core.common.State;
 import org.hisp.dhis.android.core.imports.ImportStatus;
@@ -46,119 +44,6 @@ public final class StoreUtils {
 
     private StoreUtils() {
         // no instances
-    }
-
-    /**
-     * Handle if String argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat..
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, String arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindString(index, arg);
-        }
-    }
-
-    /**
-     * Handle if Boolean argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat...
-     * Also convet the Boolean to Long...
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, Boolean arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindLong(index, arg ? 1 : 0);
-        }
-    }
-
-    /**
-     * Handle if Integer argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat..
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, Integer arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindLong(index, arg);
-        }
-    }
-
-    /**
-     * Handle if Date argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat..
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, Date arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindString(index, BaseIdentifiableObject.DATE_FORMAT.format(arg));
-        }
-    }
-
-    /**
-     * Handle if Enum argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat..
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, Enum arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindString(index, arg.name());
-        }
-    }
-
-    /**
-     * Handle if Double argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat..
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, Double arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindDouble(index, arg);
-        }
-    }
-
-    /**
-     * Handle if Long argument is null and bind it using .bindNull() if so.
-     * A helper function to abstract/clean up boilerplate if/else bloat..
-     *
-     * @param sqLiteStatement
-     * @param index
-     * @param arg
-     */
-    public static void sqLiteBind(SQLiteStatement sqLiteStatement, int index, Long arg) {
-        if (arg == null) {
-            sqLiteStatement.bindNull(index);
-        } else {
-            sqLiteStatement.bindLong(index, arg);
-        }
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboLinkStore.java
@@ -36,15 +36,12 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLink;
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class CategoryCategoryComboLinkStore {
 
-    private static final StatementBinder<CategoryCategoryComboLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.category());
-        sqLiteBind(sqLiteStatement, 2, o.categoryCombo());
-        sqLiteBind(sqLiteStatement, 3, o.sortOrder());
+    private static final StatementBinder<CategoryCategoryComboLink> BINDER = (o, w) -> {
+        w.bind(1, o.category());
+        w.bind(2, o.categoryCombo());
+        w.bind(3, o.sortOrder());
     };
 
     private CategoryCategoryComboLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryOptionLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryOptionLinkStore.java
@@ -35,15 +35,12 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.category.CategoryCategoryOptionLink;
 import org.hisp.dhis.android.core.category.CategoryCategoryOptionLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class CategoryCategoryOptionLinkStore {
 
-    private static final StatementBinder<CategoryCategoryOptionLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.category());
-        sqLiteBind(sqLiteStatement, 2, o.categoryOption());
-        sqLiteBind(sqLiteStatement, 3, o.sortOrder());
+    private static final StatementBinder<CategoryCategoryOptionLink> BINDER = (o, w) -> {
+        w.bind(1, o.category());
+        w.bind(2, o.categoryOption());
+        w.bind(3, o.sortOrder());
     };
 
     private CategoryCategoryOptionLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryComboStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryComboStore.java
@@ -29,11 +29,10 @@
 package org.hisp.dhis.android.core.category.internal;
 
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.category.CategoryCombo;
@@ -41,17 +40,15 @@ import org.hisp.dhis.android.core.category.CategoryComboTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class CategoryComboStore {
 
     private CategoryComboStore() {}
 
     private static StatementBinder<CategoryCombo> BINDER = new IdentifiableStatementBinder<CategoryCombo>() {
         @Override
-        public void bindToStatement(@NonNull CategoryCombo o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.isDefault());
+        public void bindToStatement(@NonNull CategoryCombo o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.isDefault());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboCategoryOptionLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboCategoryOptionLinkStore.java
@@ -36,14 +36,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.category.CategoryOptionComboCategoryOptionLink;
 import org.hisp.dhis.android.core.category.CategoryOptionComboCategoryOptionLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class CategoryOptionComboCategoryOptionLinkStore {
 
-    private static final StatementBinder<CategoryOptionComboCategoryOptionLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.categoryOptionCombo());
-        sqLiteBind(sqLiteStatement, 2, o.categoryOption());
+    private static final StatementBinder<CategoryOptionComboCategoryOptionLink> BINDER = (o, w) -> {
+        w.bind(1, o.categoryOptionCombo());
+        w.bind(2, o.categoryOption());
     };
 
     private CategoryOptionComboCategoryOptionLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboStoreImpl.java
@@ -28,14 +28,13 @@
 
 package org.hisp.dhis.android.core.category.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder;
 import org.hisp.dhis.android.core.arch.db.statementwrapper.internal.SQLStatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStoreImpl;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.category.CategoryOptionCombo;
@@ -44,8 +43,6 @@ import org.hisp.dhis.android.core.category.CategoryOptionComboTableInfo;
 import java.util.List;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 public final class CategoryOptionComboStoreImpl extends IdentifiableObjectStoreImpl<CategoryOptionCombo>
         implements CategoryOptionComboStore {
@@ -68,9 +65,9 @@ public final class CategoryOptionComboStoreImpl extends IdentifiableObjectStoreI
             = new IdentifiableStatementBinder<CategoryOptionCombo>() {
 
         @Override
-        public void bindToStatement(@NonNull CategoryOptionCombo o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, UidsHelper.getUidOrNull(o.categoryCombo()));
+        public void bindToStatement(@NonNull CategoryOptionCombo o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, UidsHelper.getUidOrNull(o.categoryCombo()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionStore.java
@@ -28,19 +28,16 @@
 
 package org.hisp.dhis.android.core.category.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.category.CategoryOption;
 import org.hisp.dhis.android.core.category.CategoryOptionTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 final class CategoryOptionStore {
 
@@ -49,11 +46,11 @@ final class CategoryOptionStore {
 
     private static StatementBinder<CategoryOption> BINDER = new NameableStatementBinder<CategoryOption>() {
         @Override
-        public void bindToStatement(@NonNull CategoryOption o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 11, o.startDate());
-            sqLiteBind(sqLiteStatement, 12, o.endDate());
-            sqLiteBind(sqLiteStatement, 13, o.access().data().write());
+        public void bindToStatement(@NonNull CategoryOption o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(11, o.startDate());
+            w.bind(12, o.endDate());
+            w.bind(13, o.access().data().write());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.category.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.category.Category;
@@ -40,17 +39,15 @@ import org.hisp.dhis.android.core.category.CategoryTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class CategoryStore {
 
     private CategoryStore() {}
 
     private static StatementBinder<Category> BINDER = new IdentifiableStatementBinder<Category>() {
         @Override
-        public void bindToStatement(@NonNull Category o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.dataDimensionType());
+        public void bindToStatement(@NonNull Category o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.dataDimensionType());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/common/valuetype/devicerendering/internal/ValueTypeDeviceRenderingStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/valuetype/devicerendering/internal/ValueTypeDeviceRenderingStore.java
@@ -36,33 +36,28 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.common.ValueTypeDeviceRendering;
 import org.hisp.dhis.android.core.common.ValueTypeDeviceRenderingTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ValueTypeDeviceRenderingStore {
 
-    private static final StatementBinder<ValueTypeDeviceRendering> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.objectTable());
-        sqLiteBind(sqLiteStatement, 3, o.deviceType());
-        sqLiteBind(sqLiteStatement, 4, o.type());
-        sqLiteBind(sqLiteStatement, 5, o.min());
-        sqLiteBind(sqLiteStatement, 6, o.max());
-        sqLiteBind(sqLiteStatement, 7, o.step());
-        sqLiteBind(sqLiteStatement, 8, o.decimalPoints());
+    private static final StatementBinder<ValueTypeDeviceRendering> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.objectTable());
+        w.bind(3, o.deviceType());
+        w.bind(4, o.type());
+        w.bind(5, o.min());
+        w.bind(6, o.max());
+        w.bind(7, o.step());
+        w.bind(8, o.decimalPoints());
     };
 
-    private static final WhereStatementBinder<ValueTypeDeviceRendering> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 9, o.uid());
-        sqLiteBind(sqLiteStatement, 10, o.deviceType());
+    private static final WhereStatementBinder<ValueTypeDeviceRendering> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(9, o.uid());
+        w.bind(10, o.deviceType());
     };
 
 
-    private static final WhereStatementBinder<ValueTypeDeviceRendering> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.deviceType());
+    private static final WhereStatementBinder<ValueTypeDeviceRendering> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.deviceType());
     };
 
     private ValueTypeDeviceRenderingStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreImpl.java
@@ -32,16 +32,14 @@ import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBui
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectStoreImpl;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ConfigurationStoreImpl extends ObjectStoreImpl<Configuration> implements ConfigurationStore {
 
-    private static final StatementBinder<Configuration> BINDER = (configuration, sqLiteStatement) ->
-            sqLiteBind(sqLiteStatement, 1, configuration.serverUrl().toString());
+    private static final StatementBinder<Configuration> BINDER = (configuration, w) ->
+            w.bind(1, configuration.serverUrl().toString());
 
     private ConfigurationStoreImpl(DatabaseAdapter databaseAdapter,
                                    SQLStatementBuilderImpl builder) {
-        super(databaseAdapter,  databaseAdapter.compileStatement(builder.insert()), builder, BINDER,
+        super(databaseAdapter, databaseAdapter.compileStatement(builder.insert()), builder, BINDER,
                 Configuration::create);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/constant/internal/ConstantStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/constant/internal/ConstantStore.java
@@ -28,19 +28,16 @@
 
 package org.hisp.dhis.android.core.constant.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.constant.Constant;
 import org.hisp.dhis.android.core.constant.ConstantTableInfo;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 final class ConstantStore {
 
@@ -49,9 +46,9 @@ final class ConstantStore {
 
     private static StatementBinder<Constant> BINDER = new IdentifiableStatementBinder<Constant>() {
         @Override
-        public void bindToStatement(@NonNull Constant o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.value());
+        public void bindToStatement(@NonNull Constant o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.value());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataapproval/internal/DataApprovalStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataapproval/internal/DataApprovalStore.java
@@ -37,35 +37,33 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.dataapproval.DataApproval;
 import org.hisp.dhis.android.core.dataapproval.DataApprovalTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class DataApprovalStore {
 
     private static final StatementBinder<DataApproval> BINDER
-            = (dataApproval, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, dataApproval.workflow());
-        sqLiteBind(sqLiteStatement, 2, dataApproval.organisationUnit());
-        sqLiteBind(sqLiteStatement, 3, dataApproval.period());
-        sqLiteBind(sqLiteStatement, 4, dataApproval.attributeOptionCombo());
-        sqLiteBind(sqLiteStatement, 5, dataApproval.state());
+            = (dataApproval, w) -> {
+        w.bind(1, dataApproval.workflow());
+        w.bind(2, dataApproval.organisationUnit());
+        w.bind(3, dataApproval.period());
+        w.bind(4, dataApproval.attributeOptionCombo());
+        w.bind(5, dataApproval.state());
     };
 
     private static final WhereStatementBinder<DataApproval> WHERE_UPDATE_BINDER
-            = (dataApproval, sqLiteStatement) -> {
+            = (dataApproval, w) -> {
 
-        sqLiteBind(sqLiteStatement, 6, dataApproval.workflow());
-        sqLiteBind(sqLiteStatement, 7, dataApproval.organisationUnit());
-        sqLiteBind(sqLiteStatement, 8, dataApproval.period());
-        sqLiteBind(sqLiteStatement, 9, dataApproval.attributeOptionCombo());
+        w.bind(6, dataApproval.workflow());
+        w.bind(7, dataApproval.organisationUnit());
+        w.bind(8, dataApproval.period());
+        w.bind(9, dataApproval.attributeOptionCombo());
     };
 
     private static final WhereStatementBinder<DataApproval> WHERE_DELETE_BINDER
-            = (dataApproval, sqLiteStatement) -> {
+            = (dataApproval, w) -> {
 
-        sqLiteBind(sqLiteStatement, 1, dataApproval.workflow());
-        sqLiteBind(sqLiteStatement, 2, dataApproval.organisationUnit());
-        sqLiteBind(sqLiteStatement, 3, dataApproval.period());
-        sqLiteBind(sqLiteStatement, 4, dataApproval.attributeOptionCombo());
+        w.bind(1, dataApproval.workflow());
+        w.bind(2, dataApproval.organisationUnit());
+        w.bind(3, dataApproval.period());
+        w.bind(4, dataApproval.attributeOptionCombo());
     };
 
     public static ObjectWithoutUidStore<DataApproval> create(DatabaseAdapter databaseAdapter) {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementOperandStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementOperandStore.java
@@ -36,15 +36,12 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.dataelement.DataElementOperand;
 import org.hisp.dhis.android.core.dataelement.DataElementOperandTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class DataElementOperandStore {
 
-    private static final StatementBinder<DataElementOperand> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, UidsHelper.getUidOrNull(o.dataElement()));
-        sqLiteBind(sqLiteStatement, 3, UidsHelper.getUidOrNull(o.categoryOptionCombo()));
+    private static final StatementBinder<DataElementOperand> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, UidsHelper.getUidOrNull(o.dataElement()));
+        w.bind(3, UidsHelper.getUidOrNull(o.categoryOptionCombo()));
     };
 
     private DataElementOperandStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementStore.java
@@ -28,19 +28,16 @@
 
 package org.hisp.dhis.android.core.dataelement.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.dataelement.DataElement;
 import org.hisp.dhis.android.core.dataelement.DataElementTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class DataElementStore {
 
@@ -48,17 +45,17 @@ public final class DataElementStore {
 
     private static StatementBinder<DataElement> BINDER = new NameableWithStyleStatementBinder<DataElement>() {
         @Override
-        public void bindToStatement(@NonNull DataElement o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 13, o.valueType());
-            sqLiteBind(sqLiteStatement, 14, o.zeroIsSignificant());
-            sqLiteBind(sqLiteStatement, 15, o.aggregationType());
-            sqLiteBind(sqLiteStatement, 16, o.formName());
-            sqLiteBind(sqLiteStatement, 17, o.domainType());
-            sqLiteBind(sqLiteStatement, 18, o.displayFormName());
-            sqLiteBind(sqLiteStatement, 19, o.optionSetUid());
-            sqLiteBind(sqLiteStatement, 20, o.categoryComboUid());
-            sqLiteBind(sqLiteStatement, 21, o.fieldMask());
+        public void bindToStatement(@NonNull DataElement o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(13, o.valueType());
+            w.bind(14, o.zeroIsSignificant());
+            w.bind(15, o.aggregationType());
+            w.bind(16, o.formName());
+            w.bind(17, o.domainType());
+            w.bind(18, o.displayFormName());
+            w.bind(19, o.optionSetUid());
+            w.bind(20, o.categoryComboUid());
+            w.bind(21, o.fieldMask());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataInputPeriodLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataInputPeriodLinkStore.java
@@ -37,16 +37,14 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.dataset.DataInputPeriod;
 import org.hisp.dhis.android.core.dataset.DataInputPeriodTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class DataInputPeriodLinkStore {
 
     private static final StatementBinder<DataInputPeriod> BINDER =
-            (dataInputPeriod, sqLiteStatement) -> {
-                sqLiteBind(sqLiteStatement, 1, UidsHelper.getUidOrNull(dataInputPeriod.dataSet()));
-                sqLiteBind(sqLiteStatement, 2, UidsHelper.getUidOrNull(dataInputPeriod.period()));
-                sqLiteBind(sqLiteStatement, 3, dataInputPeriod.openingDate());
-                sqLiteBind(sqLiteStatement, 4, dataInputPeriod.closingDate());
+            (dataInputPeriod, w) -> {
+                w.bind(1, UidsHelper.getUidOrNull(dataInputPeriod.dataSet()));
+                w.bind(2, UidsHelper.getUidOrNull(dataInputPeriod.period()));
+                w.bind(3, dataInputPeriod.openingDate());
+                w.bind(4, dataInputPeriod.closingDate());
             };
 
     static final SingleParentChildProjection CHILD_PROJECTION = new SingleParentChildProjection(

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompleteRegistrationStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompleteRegistrationStoreImpl.java
@@ -37,37 +37,35 @@ import org.hisp.dhis.android.core.common.State;
 import org.hisp.dhis.android.core.dataset.DataSetCompleteRegistration;
 import org.hisp.dhis.android.core.dataset.DataSetCompleteRegistrationTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class DataSetCompleteRegistrationStoreImpl extends
         ObjectWithoutUidStoreImpl<DataSetCompleteRegistration> implements DataSetCompleteRegistrationStore {
 
     private static final StatementBinder<DataSetCompleteRegistration> BINDER =
-            (dataSetCompleteRegistration, sqLiteStatement) -> {
-                sqLiteBind(sqLiteStatement, 1, dataSetCompleteRegistration.period());
-                sqLiteBind(sqLiteStatement, 2, dataSetCompleteRegistration.dataSet());
-                sqLiteBind(sqLiteStatement, 3, dataSetCompleteRegistration.organisationUnit());
-                sqLiteBind(sqLiteStatement, 4, dataSetCompleteRegistration.attributeOptionCombo());
-                sqLiteBind(sqLiteStatement, 5, dataSetCompleteRegistration.date());
-                sqLiteBind(sqLiteStatement, 6, dataSetCompleteRegistration.storedBy());
-                sqLiteBind(sqLiteStatement, 7, dataSetCompleteRegistration.state());
-                sqLiteBind(sqLiteStatement, 8, dataSetCompleteRegistration.deleted());
+            (dataSetCompleteRegistration, w) -> {
+                w.bind(1, dataSetCompleteRegistration.period());
+                w.bind(2, dataSetCompleteRegistration.dataSet());
+                w.bind(3, dataSetCompleteRegistration.organisationUnit());
+                w.bind(4, dataSetCompleteRegistration.attributeOptionCombo());
+                w.bind(5, dataSetCompleteRegistration.date());
+                w.bind(6, dataSetCompleteRegistration.storedBy());
+                w.bind(7, dataSetCompleteRegistration.state());
+                w.bind(8, dataSetCompleteRegistration.deleted());
             };
 
     private static final WhereStatementBinder<DataSetCompleteRegistration> WHERE_UPDATE_BINDER =
-            (dataSetCompleteRegistration, sqLiteStatement) -> {
-                sqLiteBind(sqLiteStatement, 9, dataSetCompleteRegistration.period());
-                sqLiteBind(sqLiteStatement, 10, dataSetCompleteRegistration.dataSet());
-                sqLiteBind(sqLiteStatement, 11, dataSetCompleteRegistration.organisationUnit());
-                sqLiteBind(sqLiteStatement, 12, dataSetCompleteRegistration.attributeOptionCombo());
+            (dataSetCompleteRegistration, w) -> {
+                w.bind(9, dataSetCompleteRegistration.period());
+                w.bind(10, dataSetCompleteRegistration.dataSet());
+                w.bind(11, dataSetCompleteRegistration.organisationUnit());
+                w.bind(12, dataSetCompleteRegistration.attributeOptionCombo());
             };
 
     private static final WhereStatementBinder<DataSetCompleteRegistration> WHERE_DELETE_BINDER =
-            (dataSetCompleteRegistration, sqLiteStatement) -> {
-                sqLiteBind(sqLiteStatement, 1, dataSetCompleteRegistration.period());
-                sqLiteBind(sqLiteStatement, 2, dataSetCompleteRegistration.dataSet());
-                sqLiteBind(sqLiteStatement, 3, dataSetCompleteRegistration.organisationUnit());
-                sqLiteBind(sqLiteStatement, 4, dataSetCompleteRegistration.attributeOptionCombo());
+            (dataSetCompleteRegistration, w) -> {
+                w.bind(1, dataSetCompleteRegistration.period());
+                w.bind(2, dataSetCompleteRegistration.dataSet());
+                w.bind(3, dataSetCompleteRegistration.organisationUnit());
+                w.bind(4, dataSetCompleteRegistration.attributeOptionCombo());
             };
 
     private DataSetCompleteRegistrationStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompulsoryDataElementOperandLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompulsoryDataElementOperandLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLink;
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class DataSetCompulsoryDataElementOperandLinkStore {
 
-    private static final StatementBinder<DataSetCompulsoryDataElementOperandLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.dataSet());
-        sqLiteBind(sqLiteStatement, 2, o.dataElementOperand());
+    private static final StatementBinder<DataSetCompulsoryDataElementOperandLink> BINDER = (o, w) -> {
+        w.bind(1, o.dataSet());
+        w.bind(2, o.dataElementOperand());
     };
 
     private DataSetCompulsoryDataElementOperandLinkStore() {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetDataElementLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetDataElementLinkStore.java
@@ -36,14 +36,12 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.dataset.DataSetElement;
 import org.hisp.dhis.android.core.dataset.DataSetElementLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class DataSetDataElementLinkStore {
 
-    private static final StatementBinder<DataSetElement> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, UidsHelper.getUidOrNull(o.dataSet()));
-        sqLiteBind(sqLiteStatement, 2, UidsHelper.getUidOrNull(o.dataElement()));
-        sqLiteBind(sqLiteStatement, 3, UidsHelper.getUidOrNull(o.categoryCombo()));
+    private static final StatementBinder<DataSetElement> BINDER = (o, w) -> {
+        w.bind(1, UidsHelper.getUidOrNull(o.dataSet()));
+        w.bind(2, UidsHelper.getUidOrNull(o.dataElement()));
+        w.bind(3, UidsHelper.getUidOrNull(o.categoryCombo()));
     };
 
     private DataSetDataElementLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetOrganisationUnitLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetOrganisationUnitLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLink;
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class DataSetOrganisationUnitLinkStore {
 
-    private static final StatementBinder<DataSetOrganisationUnitLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.dataSet());
-        sqLiteBind(sqLiteStatement, 2, o.organisationUnit());
+    private static final StatementBinder<DataSetOrganisationUnitLink> BINDER = (o, w) -> {
+        w.bind(1, o.dataSet());
+        w.bind(2, o.organisationUnit());
     };
 
     private DataSetOrganisationUnitLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetStore.java
@@ -28,20 +28,17 @@
 
 package org.hisp.dhis.android.core.dataset.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.dataset.DataSet;
 import org.hisp.dhis.android.core.dataset.DataSetTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 final class DataSetStore {
 
@@ -49,25 +46,25 @@ final class DataSetStore {
 
     private static StatementBinder<DataSet> BINDER = new NameableWithStyleStatementBinder<DataSet>() {
         @Override
-        public void bindToStatement(@NonNull DataSet o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 13, o.periodType());
-            sqLiteBind(sqLiteStatement, 14, UidsHelper.getUidOrNull(o.categoryCombo()));
-            sqLiteBind(sqLiteStatement, 15, o.mobile());
-            sqLiteBind(sqLiteStatement, 16, o.version());
-            sqLiteBind(sqLiteStatement, 17, o.expiryDays());
-            sqLiteBind(sqLiteStatement, 18, o.timelyDays());
-            sqLiteBind(sqLiteStatement, 19, o.notifyCompletingUser());
-            sqLiteBind(sqLiteStatement, 20, o.openFuturePeriods());
-            sqLiteBind(sqLiteStatement, 21, o.fieldCombinationRequired());
-            sqLiteBind(sqLiteStatement, 22, o.validCompleteOnly());
-            sqLiteBind(sqLiteStatement, 23, o.noValueRequiresComment());
-            sqLiteBind(sqLiteStatement, 24, o.skipOffline());
-            sqLiteBind(sqLiteStatement, 25, o.dataElementDecoration());
-            sqLiteBind(sqLiteStatement, 26, o.renderAsTabs());
-            sqLiteBind(sqLiteStatement, 27, o.renderHorizontally());
-            sqLiteBind(sqLiteStatement, 28, o.access().data().write());
-            sqLiteBind(sqLiteStatement, 29, UidsHelper.getUidOrNull(o.workflow()));
+        public void bindToStatement(@NonNull DataSet o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(13, o.periodType());
+            w.bind(14, UidsHelper.getUidOrNull(o.categoryCombo()));
+            w.bind(15, o.mobile());
+            w.bind(16, o.version());
+            w.bind(17, o.expiryDays());
+            w.bind(18, o.timelyDays());
+            w.bind(19, o.notifyCompletingUser());
+            w.bind(20, o.openFuturePeriods());
+            w.bind(21, o.fieldCombinationRequired());
+            w.bind(22, o.validCompleteOnly());
+            w.bind(23, o.noValueRequiresComment());
+            w.bind(24, o.skipOffline());
+            w.bind(25, o.dataElementDecoration());
+            w.bind(26, o.renderAsTabs());
+            w.bind(27, o.renderHorizontally());
+            w.bind(28, o.access().data().write());
+            w.bind(29, UidsHelper.getUidOrNull(o.workflow()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionDataElementLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionDataElementLinkStore.java
@@ -35,15 +35,12 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.dataset.SectionDataElementLink;
 import org.hisp.dhis.android.core.dataset.SectionDataElementLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class SectionDataElementLinkStore {
 
-    private static final StatementBinder<SectionDataElementLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.section());
-        sqLiteBind(sqLiteStatement, 2, o.dataElement());
-        sqLiteBind(sqLiteStatement, 3, o.sortOrder());
+    private static final StatementBinder<SectionDataElementLink> BINDER = (o, w) -> {
+        w.bind(1, o.section());
+        w.bind(2, o.dataElement());
+        w.bind(3, o.sortOrder());
     };
 
     private SectionDataElementLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionGreyedFieldsLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionGreyedFieldsLinkStore.java
@@ -35,15 +35,12 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLink;
 import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class SectionGreyedFieldsLinkStore {
 
-    private static final StatementBinder<SectionGreyedFieldsLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.section());
-        sqLiteBind(sqLiteStatement, 2, o.dataElementOperand());
-        sqLiteBind(sqLiteStatement, 3, o.categoryOptionCombo());
+    private static final StatementBinder<SectionGreyedFieldsLink> BINDER = (o, w) -> {
+        w.bind(1, o.section());
+        w.bind(2, o.dataElementOperand());
+        w.bind(3, o.categoryOptionCombo());
     };
 
     private SectionGreyedFieldsLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.dataset.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -41,19 +40,17 @@ import org.hisp.dhis.android.core.dataset.SectionTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class SectionStore {
 
     private static StatementBinder<Section> BINDER = new IdentifiableStatementBinder<Section>() {
         @Override
-        public void bindToStatement(@NonNull Section o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.description());
-            sqLiteBind(sqLiteStatement, 8, o.sortOrder());
-            sqLiteBind(sqLiteStatement, 9, UidsHelper.getUidOrNull(o.dataSet()));
-            sqLiteBind(sqLiteStatement, 10, o.showRowTotals());
-            sqLiteBind(sqLiteStatement, 11, o.showColumnTotals());
+        public void bindToStatement(@NonNull Section o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.description());
+            w.bind(8, o.sortOrder());
+            w.bind(9, UidsHelper.getUidOrNull(o.dataSet()));
+            w.bind(10, o.showRowTotals());
+            w.bind(11, o.showColumnTotals());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/internal/DataValueStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/internal/DataValueStore.java
@@ -40,44 +40,43 @@ import org.hisp.dhis.android.core.datavalue.DataValueTableInfo;
 
 import java.util.Collection;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 import static org.hisp.dhis.android.core.datavalue.DataValueTableInfo.Columns;
 
 @SuppressWarnings("PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal")
 public class DataValueStore extends ObjectWithoutUidStoreImpl<DataValue> {
 
-    private static final StatementBinder<DataValue> BINDER = (dataValue, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, dataValue.dataElement());
-        sqLiteBind(sqLiteStatement, 2, dataValue.period());
-        sqLiteBind(sqLiteStatement, 3, dataValue.organisationUnit());
-        sqLiteBind(sqLiteStatement, 4, dataValue.categoryOptionCombo());
-        sqLiteBind(sqLiteStatement, 5, dataValue.attributeOptionCombo());
-        sqLiteBind(sqLiteStatement, 6, dataValue.value());
-        sqLiteBind(sqLiteStatement, 7, dataValue.storedBy());
-        sqLiteBind(sqLiteStatement, 8, dataValue.created());
-        sqLiteBind(sqLiteStatement, 9, dataValue.lastUpdated());
-        sqLiteBind(sqLiteStatement, 10, dataValue.comment());
-        sqLiteBind(sqLiteStatement, 11, dataValue.followUp());
-        sqLiteBind(sqLiteStatement, 12, dataValue.state());
-        sqLiteBind(sqLiteStatement, 13, dataValue.deleted());
+    private static final StatementBinder<DataValue> BINDER = (dataValue, w) -> {
+        w.bind(1, dataValue.dataElement());
+        w.bind(2, dataValue.period());
+        w.bind(3, dataValue.organisationUnit());
+        w.bind(4, dataValue.categoryOptionCombo());
+        w.bind(5, dataValue.attributeOptionCombo());
+        w.bind(6, dataValue.value());
+        w.bind(7, dataValue.storedBy());
+        w.bind(8, dataValue.created());
+        w.bind(9, dataValue.lastUpdated());
+        w.bind(10, dataValue.comment());
+        w.bind(11, dataValue.followUp());
+        w.bind(12, dataValue.state());
+        w.bind(13, dataValue.deleted());
     };
 
     private static final WhereStatementBinder<DataValue> WHERE_UPDATE_BINDER
-            = (dataValue, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 14, dataValue.dataElement());
-        sqLiteBind(sqLiteStatement, 15, dataValue.period());
-        sqLiteBind(sqLiteStatement, 16, dataValue.organisationUnit());
-        sqLiteBind(sqLiteStatement, 17, dataValue.categoryOptionCombo());
-        sqLiteBind(sqLiteStatement, 18, dataValue.attributeOptionCombo());
+            = (dataValue, w) -> {
+        w.bind(14, dataValue.dataElement());
+        w.bind(15, dataValue.period());
+        w.bind(16, dataValue.organisationUnit());
+        w.bind(17, dataValue.categoryOptionCombo());
+        w.bind(18, dataValue.attributeOptionCombo());
     };
 
     private static final WhereStatementBinder<DataValue> WHERE_DELETE_BINDER
-            = (dataValue, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, dataValue.dataElement());
-        sqLiteBind(sqLiteStatement, 2, dataValue.period());
-        sqLiteBind(sqLiteStatement, 3, dataValue.organisationUnit());
-        sqLiteBind(sqLiteStatement, 4, dataValue.categoryOptionCombo());
-        sqLiteBind(sqLiteStatement, 5, dataValue.attributeOptionCombo());
+            = (dataValue, w) -> {
+        w.bind(1, dataValue.dataElement());
+        w.bind(2, dataValue.period());
+        w.bind(3, dataValue.organisationUnit());
+        w.bind(4, dataValue.categoryOptionCombo());
+        w.bind(5, dataValue.attributeOptionCombo());
     };
 
     private DataValueStore(DatabaseAdapter databaseAdapter, SQLStatementBuilderImpl builder) {

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreImpl.java
@@ -46,28 +46,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class EnrollmentStoreImpl
         extends IdentifiableDeletableDataObjectStoreImpl<Enrollment> implements EnrollmentStore {
 
-    private static final StatementBinder<Enrollment> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.created());
-        sqLiteBind(sqLiteStatement, 3, o.lastUpdated());
-        sqLiteBind(sqLiteStatement, 4, o.createdAtClient());
-        sqLiteBind(sqLiteStatement, 5, o.lastUpdatedAtClient());
-        sqLiteBind(sqLiteStatement, 6, o.organisationUnit());
-        sqLiteBind(sqLiteStatement, 7, o.program());
-        sqLiteBind(sqLiteStatement, 8, o.enrollmentDate());
-        sqLiteBind(sqLiteStatement, 9, o.incidentDate());
-        sqLiteBind(sqLiteStatement, 10, o.followUp());
-        sqLiteBind(sqLiteStatement, 11, o.status());
-        sqLiteBind(sqLiteStatement, 12, o.trackedEntityInstance());
-        sqLiteBind(sqLiteStatement, 13, o.geometry() == null ? null : o.geometry().type());
-        sqLiteBind(sqLiteStatement, 14, o.geometry() == null ? null : o.geometry().coordinates());
-        sqLiteBind(sqLiteStatement, 15, o.state());
-        sqLiteBind(sqLiteStatement, 16, o.deleted());
+    private static final StatementBinder<Enrollment> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.created());
+        w.bind(3, o.lastUpdated());
+        w.bind(4, o.createdAtClient());
+        w.bind(5, o.lastUpdatedAtClient());
+        w.bind(6, o.organisationUnit());
+        w.bind(7, o.program());
+        w.bind(8, o.enrollmentDate());
+        w.bind(9, o.incidentDate());
+        w.bind(10, o.followUp());
+        w.bind(11, o.status());
+        w.bind(12, o.trackedEntityInstance());
+        w.bind(13, o.geometry() == null ? null : o.geometry().type());
+        w.bind(14, o.geometry() == null ? null : o.geometry().coordinates());
+        w.bind(15, o.state());
+        w.bind(16, o.deleted());
     };
 
     private EnrollmentStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventStoreImpl.java
@@ -50,31 +50,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class EventStoreImpl extends IdentifiableDeletableDataObjectStoreImpl<Event> implements EventStore {
 
     private static final String QUERY_SINGLE_EVENTS = "SELECT Event.* FROM Event WHERE Event.enrollment IS NULL";
 
-    private static final StatementBinder<Event> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.enrollment());
-        sqLiteBind(sqLiteStatement, 3, o.created());
-        sqLiteBind(sqLiteStatement, 4, o.lastUpdated());
-        sqLiteBind(sqLiteStatement, 5, o.createdAtClient());
-        sqLiteBind(sqLiteStatement, 6, o.lastUpdatedAtClient());
-        sqLiteBind(sqLiteStatement, 7, o.status());
-        sqLiteBind(sqLiteStatement, 8, o.geometry() == null ? null : o.geometry().type());
-        sqLiteBind(sqLiteStatement, 9, o.geometry() == null ? null : o.geometry().coordinates());
-        sqLiteBind(sqLiteStatement, 10, o.program());
-        sqLiteBind(sqLiteStatement, 11, o.programStage());
-        sqLiteBind(sqLiteStatement, 12, o.organisationUnit());
-        sqLiteBind(sqLiteStatement, 13, o.eventDate());
-        sqLiteBind(sqLiteStatement, 14, o.completedDate());
-        sqLiteBind(sqLiteStatement, 15, o.dueDate());
-        sqLiteBind(sqLiteStatement, 16, o.state());
-        sqLiteBind(sqLiteStatement, 17, o.attributeOptionCombo());
-        sqLiteBind(sqLiteStatement, 18, o.deleted());
+    private static final StatementBinder<Event> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.enrollment());
+        w.bind(3, o.created());
+        w.bind(4, o.lastUpdated());
+        w.bind(5, o.createdAtClient());
+        w.bind(6, o.lastUpdatedAtClient());
+        w.bind(7, o.status());
+        w.bind(8, o.geometry() == null ? null : o.geometry().type());
+        w.bind(9, o.geometry() == null ? null : o.geometry().coordinates());
+        w.bind(10, o.program());
+        w.bind(11, o.programStage());
+        w.bind(12, o.organisationUnit());
+        w.bind(13, o.eventDate());
+        w.bind(14, o.completedDate());
+        w.bind(15, o.dueDate());
+        w.bind(16, o.state());
+        w.bind(17, o.attributeOptionCombo());
+        w.bind(18, o.deleted());
     };
 
     private EventStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStoreImpl.java
@@ -37,19 +37,17 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableDataObject
 import org.hisp.dhis.android.core.fileresource.FileResource;
 import org.hisp.dhis.android.core.fileresource.FileResourceTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class FileResourceStoreImpl extends IdentifiableDataObjectStoreImpl<FileResource> {
 
-    private static final StatementBinder<FileResource> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.name());
-        sqLiteBind(sqLiteStatement, 3, o.created());
-        sqLiteBind(sqLiteStatement, 4, o.lastUpdated());
-        sqLiteBind(sqLiteStatement, 5, o.contentType());
-        sqLiteBind(sqLiteStatement, 6, o.contentLength());
-        sqLiteBind(sqLiteStatement, 7, o.path());
-        sqLiteBind(sqLiteStatement, 8, o.state());
+    private static final StatementBinder<FileResource> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.name());
+        w.bind(3, o.created());
+        w.bind(4, o.lastUpdated());
+        w.bind(5, o.contentType());
+        w.bind(6, o.contentLength());
+        w.bind(7, o.path());
+        w.bind(8, o.state());
     };
 
     private FileResourceStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictStore.java
@@ -35,20 +35,18 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.imports.TrackerImportConflict;
 import org.hisp.dhis.android.core.imports.TrackerImportConflictTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class TrackerImportConflictStore {
 
-    private static final StatementBinder<TrackerImportConflict> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.conflict());
-        sqLiteBind(sqLiteStatement, 2, o.value());
-        sqLiteBind(sqLiteStatement, 3, o.trackedEntityInstance());
-        sqLiteBind(sqLiteStatement, 4, o.enrollment());
-        sqLiteBind(sqLiteStatement, 5, o.event());
-        sqLiteBind(sqLiteStatement, 6, o.tableReference());
-        sqLiteBind(sqLiteStatement, 7, o.errorCode());
-        sqLiteBind(sqLiteStatement, 8, o.status());
-        sqLiteBind(sqLiteStatement, 9, o.created());
+    private static final StatementBinder<TrackerImportConflict> BINDER = (o, w) -> {
+        w.bind(1, o.conflict());
+        w.bind(2, o.value());
+        w.bind(3, o.trackedEntityInstance());
+        w.bind(4, o.enrollment());
+        w.bind(5, o.event());
+        w.bind(6, o.tableReference());
+        w.bind(7, o.errorCode());
+        w.bind(8, o.status());
+        w.bind(9, o.created());
     };
 
     private TrackerImportConflictStore() {

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/DataSetIndicatorLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/DataSetIndicatorLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.indicator.DataSetIndicatorLink;
 import org.hisp.dhis.android.core.indicator.DataSetIndicatorLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class DataSetIndicatorLinkStore {
 
-    private static final StatementBinder<DataSetIndicatorLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.dataSet());
-        sqLiteBind(sqLiteStatement, 2, o.indicator());
+    private static final StatementBinder<DataSetIndicatorLink> BINDER = (o, w) -> {
+        w.bind(1, o.dataSet());
+        w.bind(2, o.indicator());
     };
 
     private DataSetIndicatorLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/IndicatorStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/IndicatorStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.indicator.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -41,23 +40,21 @@ import org.hisp.dhis.android.core.indicator.IndicatorTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class IndicatorStore {
 
     private IndicatorStore() {}
 
     private static StatementBinder<Indicator> BINDER = new NameableStatementBinder<Indicator>() {
         @Override
-        public void bindToStatement(@NonNull Indicator o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 11, o.annualized());
-            sqLiteBind(sqLiteStatement, 12, UidsHelper.getUidOrNull(o.indicatorType()));
-            sqLiteBind(sqLiteStatement, 13, o.numerator());
-            sqLiteBind(sqLiteStatement, 14, o.numeratorDescription());
-            sqLiteBind(sqLiteStatement, 15, o.denominator());
-            sqLiteBind(sqLiteStatement, 16, o.denominatorDescription());
-            sqLiteBind(sqLiteStatement, 17, o.url());
+        public void bindToStatement(@NonNull Indicator o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(11, o.annualized());
+            w.bind(12, UidsHelper.getUidOrNull(o.indicatorType()));
+            w.bind(13, o.numerator());
+            w.bind(14, o.numeratorDescription());
+            w.bind(15, o.denominator());
+            w.bind(16, o.denominatorDescription());
+            w.bind(17, o.url());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/IndicatorTypeStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/IndicatorTypeStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.indicator.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.indicator.IndicatorType;
@@ -40,18 +39,16 @@ import org.hisp.dhis.android.core.indicator.IndicatorTypeTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class IndicatorTypeStore {
 
     private IndicatorTypeStore() {}
 
     private static StatementBinder<IndicatorType> BINDER = new IdentifiableStatementBinder<IndicatorType>() {
         @Override
-        public void bindToStatement(@NonNull IndicatorType o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.number());
-            sqLiteBind(sqLiteStatement, 8, o.factor());
+        public void bindToStatement(@NonNull IndicatorType o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.number());
+            w.bind(8, o.factor());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/LegendSetStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/LegendSetStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.legendset.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.legendset.LegendSet;
@@ -40,17 +39,15 @@ import org.hisp.dhis.android.core.legendset.LegendSetTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class LegendSetStore {
 
     private LegendSetStore() {}
 
     private static StatementBinder<LegendSet> BINDER = new IdentifiableStatementBinder<LegendSet>() {
         @Override
-        public void bindToStatement(@NonNull LegendSet o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.symbolizer());
+        public void bindToStatement(@NonNull LegendSet o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.symbolizer());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/LegendStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/LegendStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.legendset.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -41,8 +40,6 @@ import org.hisp.dhis.android.core.legendset.Legend;
 import org.hisp.dhis.android.core.legendset.LegendTableInfo;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 public final class LegendStore {
 
@@ -53,12 +50,12 @@ public final class LegendStore {
 
     private static StatementBinder<Legend> BINDER = new IdentifiableStatementBinder<Legend>() {
         @Override
-        public void bindToStatement(@NonNull Legend o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.startValue());
-            sqLiteBind(sqLiteStatement, 8, o.endValue());
-            sqLiteBind(sqLiteStatement, 9, o.color());
-            sqLiteBind(sqLiteStatement, 10, UidsHelper.getUidOrNull(o.legendSet()));
+        public void bindToStatement(@NonNull Legend o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.startValue());
+            w.bind(8, o.endValue());
+            w.bind(9, o.color());
+            w.bind(10, UidsHelper.getUidOrNull(o.legendSet()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/ProgramIndicatorLegendSetLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/ProgramIndicatorLegendSetLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.legendset.ProgramIndicatorLegendSetLink;
 import org.hisp.dhis.android.core.legendset.ProgramIndicatorLegendSetLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ProgramIndicatorLegendSetLinkStore {
 
-    private static final StatementBinder<ProgramIndicatorLegendSetLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.programIndicator());
-        sqLiteBind(sqLiteStatement, 2, o.legendSet());
+    private static final StatementBinder<ProgramIndicatorLegendSetLink> BINDER = (o, w) -> {
+        w.bind(1, o.programIndicator());
+        w.bind(2, o.legendSet());
     };
 
     private ProgramIndicatorLegendSetLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/D2ErrorStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/D2ErrorStore.java
@@ -35,17 +35,15 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.maintenance.D2Error;
 import org.hisp.dhis.android.core.maintenance.D2ErrorTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class D2ErrorStore {
 
-    private static final StatementBinder<D2Error> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.url());
-        sqLiteBind(sqLiteStatement, 2, o.errorComponent());
-        sqLiteBind(sqLiteStatement, 3, o.errorCode());
-        sqLiteBind(sqLiteStatement, 4, o.errorDescription());
-        sqLiteBind(sqLiteStatement, 5, o.httpErrorCode());
-        sqLiteBind(sqLiteStatement, 6, o.created());
+    private static final StatementBinder<D2Error> BINDER = (o, w) -> {
+        w.bind(1, o.url());
+        w.bind(2, o.errorComponent());
+        w.bind(3, o.errorCode());
+        w.bind(4, o.errorDescription());
+        w.bind(5, o.httpErrorCode());
+        w.bind(6, o.created());
     };
 
     private D2ErrorStore() {

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyViolationStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyViolationStore.java
@@ -35,19 +35,17 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolation;
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolationTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ForeignKeyViolationStore {
 
-    private static final StatementBinder<ForeignKeyViolation> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.fromTable());
-        sqLiteBind(sqLiteStatement, 2, o.fromColumn());
-        sqLiteBind(sqLiteStatement, 3, o.toTable());
-        sqLiteBind(sqLiteStatement, 4, o.toColumn());
-        sqLiteBind(sqLiteStatement, 5, o.notFoundValue());
-        sqLiteBind(sqLiteStatement, 6, o.fromObjectUid());
-        sqLiteBind(sqLiteStatement, 7, o.fromObjectRow());
-        sqLiteBind(sqLiteStatement, 8, o.created());
+    private static final StatementBinder<ForeignKeyViolation> BINDER = (o, w) -> {
+        w.bind(1, o.fromTable());
+        w.bind(2, o.fromColumn());
+        w.bind(3, o.toTable());
+        w.bind(4, o.toColumn());
+        w.bind(5, o.notFoundValue());
+        w.bind(6, o.fromObjectUid());
+        w.bind(7, o.fromObjectRow());
+        w.bind(8, o.created());
     };
 
     private ForeignKeyViolationStore() {

--- a/core/src/main/java/org/hisp/dhis/android/core/note/internal/NoteStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/note/internal/NoteStore.java
@@ -37,33 +37,29 @@ import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SinglePare
 import org.hisp.dhis.android.core.note.Note;
 import org.hisp.dhis.android.core.note.NoteTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class NoteStore {
 
-    private static final StatementBinder<Note> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.enrollment());
-        sqLiteBind(sqLiteStatement, 2, o.value());
-        sqLiteBind(sqLiteStatement, 3, o.storedBy());
-        sqLiteBind(sqLiteStatement, 4, o.storedDate());
-        sqLiteBind(sqLiteStatement, 5, o.uid());
-        sqLiteBind(sqLiteStatement, 6, o.state());
+    private static final StatementBinder<Note> BINDER = (o, w) -> {
+        w.bind(1, o.enrollment());
+        w.bind(2, o.value());
+        w.bind(3, o.storedBy());
+        w.bind(4, o.storedDate());
+        w.bind(5, o.uid());
+        w.bind(6, o.state());
     };
 
-    private static final WhereStatementBinder<Note> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 7, o.enrollment());
-        sqLiteBind(sqLiteStatement, 8, o.value());
-        sqLiteBind(sqLiteStatement, 9, o.storedBy());
-        sqLiteBind(sqLiteStatement, 10, o.storedDate());
+    private static final WhereStatementBinder<Note> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(7, o.enrollment());
+        w.bind(8, o.value());
+        w.bind(9, o.storedBy());
+        w.bind(10, o.storedDate());
     };
 
-    private static final WhereStatementBinder<Note> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.enrollment());
-        sqLiteBind(sqLiteStatement, 2, o.value());
-        sqLiteBind(sqLiteStatement, 3, o.storedBy());
-        sqLiteBind(sqLiteStatement, 4, o.storedDate());
+    private static final WhereStatementBinder<Note> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, o.enrollment());
+        w.bind(2, o.value());
+        w.bind(3, o.storedBy());
+        w.bind(4, o.storedDate());
     };
 
     static final SingleParentChildProjection CHILD_PROJECTION = new SingleParentChildProjection(

--- a/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionGroupOptionLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionGroupOptionLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.option.OptionGroupOptionLink;
 import org.hisp.dhis.android.core.option.OptionGroupOptionLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class OptionGroupOptionLinkStore {
 
-    private static final StatementBinder<OptionGroupOptionLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.optionGroup());
-        sqLiteBind(sqLiteStatement, 2, o.option());
+    private static final StatementBinder<OptionGroupOptionLink> BINDER = (o, w) -> {
+        w.bind(1, o.optionGroup());
+        w.bind(2, o.option());
     };
 
     private OptionGroupOptionLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionGroupStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionGroupStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.option.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -41,17 +40,15 @@ import org.hisp.dhis.android.core.option.OptionGroupTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class OptionGroupStore {
 
     private OptionGroupStore() {}
 
     private static StatementBinder<OptionGroup> BINDER = new IdentifiableStatementBinder<OptionGroup>() {
         @Override
-        public void bindToStatement(@NonNull OptionGroup o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, UidsHelper.getUidOrNull(o.optionSet()));
+        public void bindToStatement(@NonNull OptionGroup o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, UidsHelper.getUidOrNull(o.optionSet()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionSetStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionSetStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.option.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.option.OptionSet;
@@ -40,18 +39,16 @@ import org.hisp.dhis.android.core.option.OptionSetTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class OptionSetStore {
 
     private OptionSetStore() {}
 
     private static StatementBinder<OptionSet> BINDER = new IdentifiableStatementBinder<OptionSet>() {
         @Override
-        public void bindToStatement(@NonNull OptionSet o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.version());
-            sqLiteBind(sqLiteStatement, 8, o.valueType());
+        public void bindToStatement(@NonNull OptionSet o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.version());
+            w.bind(8, o.valueType());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.option.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -41,18 +40,16 @@ import org.hisp.dhis.android.core.option.OptionTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class OptionStore {
 
     private OptionStore() {}
 
     private static StatementBinder<Option> BINDER = new IdentifiableWithStyleStatementBinder<Option>() {
         @Override
-        public void bindToStatement(@NonNull Option o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 9, o.sortOrder());
-            sqLiteBind(sqLiteStatement, 10, UidsHelper.getUidOrNull(o.optionSet()));
+        public void bindToStatement(@NonNull Option o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(9, o.sortOrder());
+            w.bind(10, UidsHelper.getUidOrNull(o.optionSet()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitGroupStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitGroupStore.java
@@ -28,19 +28,16 @@
 
 package org.hisp.dhis.android.core.organisationunit.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitGroupTableInfo;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 final class OrganisationUnitGroupStore {
 
@@ -49,11 +46,10 @@ final class OrganisationUnitGroupStore {
     private static StatementBinder<OrganisationUnitGroup> BINDER
             = new IdentifiableStatementBinder<OrganisationUnitGroup>() {
         @Override
-        public void bindToStatement(@NonNull OrganisationUnitGroup organisationUnitGroup,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(organisationUnitGroup, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, organisationUnitGroup.shortName());
-            sqLiteBind(sqLiteStatement, 8, organisationUnitGroup.displayShortName());
+        public void bindToStatement(@NonNull OrganisationUnitGroup organisationUnitGroup, @NonNull StatementWrapper w) {
+            super.bindToStatement(organisationUnitGroup, w);
+            w.bind(7, organisationUnitGroup.shortName());
+            w.bind(8, organisationUnitGroup.displayShortName());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitLevelStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitLevelStore.java
@@ -28,19 +28,16 @@
 
 package org.hisp.dhis.android.core.organisationunit.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitLevelTableInfo;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 final class OrganisationUnitLevelStore {
 
@@ -50,9 +47,9 @@ final class OrganisationUnitLevelStore {
             = new IdentifiableStatementBinder<OrganisationUnitLevel>() {
         @Override
         public void bindToStatement(@NonNull OrganisationUnitLevel organisationUnitLevel,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(organisationUnitLevel, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, organisationUnitLevel.level());
+                                    @NonNull StatementWrapper w) {
+            super.bindToStatement(organisationUnitLevel, w);
+            w.bind(7, organisationUnitLevel.level());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitOrganisationUnitGroupLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitOrganisationUnitGroupLinkStore.java
@@ -35,13 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitOrganisationUnitGroupLink;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitOrganisationUnitGroupLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class OrganisationUnitOrganisationUnitGroupLinkStore {
 
-    private static final StatementBinder<OrganisationUnitOrganisationUnitGroupLink> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.organisationUnit());
-        sqLiteBind(sqLiteStatement, 2, o.organisationUnitGroup());
+    private static final StatementBinder<OrganisationUnitOrganisationUnitGroupLink> BINDER = (o, w) -> {
+        w.bind(1, o.organisationUnit());
+        w.bind(2, o.organisationUnitGroup());
     };
 
     private OrganisationUnitOrganisationUnitGroupLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitProgramLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitProgramLinkStore.java
@@ -34,14 +34,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class OrganisationUnitProgramLinkStore {
 
-    private static final StatementBinder<OrganisationUnitProgramLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.program());
-        sqLiteBind(sqLiteStatement, 2, o.organisationUnit());
+    private static final StatementBinder<OrganisationUnitProgramLink> BINDER = (o, w) -> {
+        w.bind(1, o.program());
+        w.bind(2, o.organisationUnit());
     };
 
     private OrganisationUnitProgramLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStore.java
@@ -28,12 +28,11 @@
 
 package org.hisp.dhis.android.core.organisationunit.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.adapters.custom.internal.StringArrayColumnAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -42,22 +41,20 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class OrganisationUnitStore {
 
     private OrganisationUnitStore() {}
 
     private static final StatementBinder<OrganisationUnit> BINDER = new NameableStatementBinder<OrganisationUnit>() {
         @Override
-        public void bindToStatement(@NonNull OrganisationUnit o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 11, o.path());
-            sqLiteBind(sqLiteStatement, 12, o.openingDate());
-            sqLiteBind(sqLiteStatement, 13, o.closedDate());
-            sqLiteBind(sqLiteStatement, 14, o.level());
-            sqLiteBind(sqLiteStatement, 15, UidsHelper.getUidOrNull(o.parent()));
-            sqLiteBind(sqLiteStatement, 16, StringArrayColumnAdapter.serialize(o.displayNamePath()));
+        public void bindToStatement(@NonNull OrganisationUnit o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(11, o.path());
+            w.bind(12, o.openingDate());
+            w.bind(13, o.closedDate());
+            w.bind(14, o.level());
+            w.bind(15, UidsHelper.getUidOrNull(o.parent()));
+            w.bind(16, StringArrayColumnAdapter.serialize(o.displayNamePath()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodStoreImpl.java
@@ -42,22 +42,20 @@ import org.hisp.dhis.android.core.period.PeriodType;
 
 import java.util.Date;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class PeriodStoreImpl extends ObjectWithoutUidStoreImpl<Period> implements PeriodStore {
 
-    private static final StatementBinder<Period> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.periodId());
-        sqLiteBind(sqLiteStatement, 2, o.periodType());
-        sqLiteBind(sqLiteStatement, 3, o.startDate());
-        sqLiteBind(sqLiteStatement, 4, o.endDate());
+    private static final StatementBinder<Period> BINDER = (o, w) -> {
+        w.bind(1, o.periodId());
+        w.bind(2, o.periodType());
+        w.bind(3, o.startDate());
+        w.bind(4, o.endDate());
     };
 
     private static final WhereStatementBinder<Period> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 5, o.periodId());
+            = (o, w) -> w.bind(5, o.periodId());
 
     private static final WhereStatementBinder<Period> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, o.periodId());
+            = (o, w) -> w.bind(1, o.periodId());
 
     private PeriodStoreImpl(DatabaseAdapter databaseAdapter,
                             SQLStatementBuilderImpl builder) {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,8 +41,6 @@ import org.hisp.dhis.android.core.program.ProgramIndicatorTableInfo;
 import org.hisp.dhis.android.core.program.ProgramIndicatorTableInfo.Columns;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 public final class ProgramIndicatorStore {
 
@@ -55,15 +52,15 @@ public final class ProgramIndicatorStore {
 
         @Override
         public void bindToStatement(@NonNull ProgramIndicator o,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 11, o.displayInForm());
-            sqLiteBind(sqLiteStatement, 12, o.expression());
-            sqLiteBind(sqLiteStatement, 13, o.dimensionItem());
-            sqLiteBind(sqLiteStatement, 14, o.filter());
-            sqLiteBind(sqLiteStatement, 15, o.decimals());
-            sqLiteBind(sqLiteStatement, 16, o.aggregationType());
-            sqLiteBind(sqLiteStatement, 17, UidsHelper.getUidOrNull(o.program()));
+                                    @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(11, o.displayInForm());
+            w.bind(12, o.expression());
+            w.bind(13, o.dimensionItem());
+            w.bind(14, o.filter());
+            w.bind(15, o.decimals());
+            w.bind(16, o.aggregationType());
+            w.bind(17, UidsHelper.getUidOrNull(o.program()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramOrganisationUnitLastUpdatedStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramOrganisationUnitLastUpdatedStore.java
@@ -33,28 +33,25 @@ import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinde
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.WhereStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStoreImpl;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ProgramOrganisationUnitLastUpdatedStore
         extends ObjectWithoutUidStoreImpl<ProgramOrganisationUnitLastUpdated> {
 
-    private static final StatementBinder<ProgramOrganisationUnitLastUpdated> BINDER =
-            (o, sqLiteStatement) -> {
-                sqLiteBind(sqLiteStatement, 1, o.program());
-                sqLiteBind(sqLiteStatement, 2, o.organisationUnit());
-                sqLiteBind(sqLiteStatement, 3, o.lastSynced());
+    private static final StatementBinder<ProgramOrganisationUnitLastUpdated> BINDER = (o, w) -> {
+                w.bind(1, o.program());
+                w.bind(2, o.organisationUnit());
+                w.bind(3, o.lastSynced());
             };
 
     private static final WhereStatementBinder<ProgramOrganisationUnitLastUpdated>
-            WHERE_UPDATE_BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 4, o.program());
-        sqLiteBind(sqLiteStatement, 5, o.organisationUnit());
+            WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(4, o.program());
+        w.bind(5, o.organisationUnit());
     };
 
     private static final WhereStatementBinder<ProgramOrganisationUnitLastUpdated>
-            WHERE_DELETE_BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.program());
-        sqLiteBind(sqLiteStatement, 2, o.organisationUnit());
+            WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, o.program());
+        w.bind(2, o.organisationUnit());
     };
 
     private ProgramOrganisationUnitLastUpdatedStore(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,26 +41,24 @@ import org.hisp.dhis.android.core.program.ProgramRuleActionTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ProgramRuleActionStore {
 
     private static StatementBinder<ProgramRuleAction> BINDER = new IdentifiableStatementBinder<ProgramRuleAction>() {
         @Override
-        public void bindToStatement(@NonNull ProgramRuleAction o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.data());
-            sqLiteBind(sqLiteStatement, 8, o.content());
-            sqLiteBind(sqLiteStatement, 9, o.location());
-            sqLiteBind(sqLiteStatement, 10, UidsHelper.getUidOrNull(o.trackedEntityAttribute()));
-            sqLiteBind(sqLiteStatement, 11, UidsHelper.getUidOrNull(o.programIndicator()));
-            sqLiteBind(sqLiteStatement, 12, UidsHelper.getUidOrNull(o.programStageSection()));
-            sqLiteBind(sqLiteStatement, 13, o.programRuleActionType());
-            sqLiteBind(sqLiteStatement, 14, UidsHelper.getUidOrNull(o.programStage()));
-            sqLiteBind(sqLiteStatement, 15, UidsHelper.getUidOrNull(o.dataElement()));
-            sqLiteBind(sqLiteStatement, 16, UidsHelper.getUidOrNull(o.programRule()));
-            sqLiteBind(sqLiteStatement, 17, UidsHelper.getUidOrNull(o.option()));
-            sqLiteBind(sqLiteStatement, 18, UidsHelper.getUidOrNull(o.optionGroup()));
+        public void bindToStatement(@NonNull ProgramRuleAction o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.data());
+            w.bind(8, o.content());
+            w.bind(9, o.location());
+            w.bind(10, UidsHelper.getUidOrNull(o.trackedEntityAttribute()));
+            w.bind(11, UidsHelper.getUidOrNull(o.programIndicator()));
+            w.bind(12, UidsHelper.getUidOrNull(o.programStageSection()));
+            w.bind(13, o.programRuleActionType());
+            w.bind(14, UidsHelper.getUidOrNull(o.programStage()));
+            w.bind(15, UidsHelper.getUidOrNull(o.dataElement()));
+            w.bind(16, UidsHelper.getUidOrNull(o.programRule()));
+            w.bind(17, UidsHelper.getUidOrNull(o.option()));
+            w.bind(18, UidsHelper.getUidOrNull(o.optionGroup()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,20 +41,17 @@ import org.hisp.dhis.android.core.program.ProgramRuleTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ProgramRuleStore {
 
     private static StatementBinder<ProgramRule> BINDER = new IdentifiableStatementBinder<ProgramRule>() {
 
         @Override
-        public void bindToStatement(@NonNull ProgramRule o,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.priority());
-            sqLiteBind(sqLiteStatement, 8, o.condition());
-            sqLiteBind(sqLiteStatement, 9, UidsHelper.getUidOrNull(o.program()));
-            sqLiteBind(sqLiteStatement, 10, UidsHelper.getUidOrNull(o.programStage()));
+        public void bindToStatement(@NonNull ProgramRule o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.priority());
+            w.bind(8, o.condition());
+            w.bind(9, UidsHelper.getUidOrNull(o.program()));
+            w.bind(10, UidsHelper.getUidOrNull(o.programStage()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleVariableStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleVariableStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,23 +41,20 @@ import org.hisp.dhis.android.core.program.ProgramRuleVariableTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ProgramRuleVariableStore {
 
     private static StatementBinder<ProgramRuleVariable> BINDER =
             new IdentifiableStatementBinder<ProgramRuleVariable>() {
 
         @Override
-        public void bindToStatement(@NonNull ProgramRuleVariable o,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.useCodeForOptionSet());
-            sqLiteBind(sqLiteStatement, 8, UidsHelper.getUidOrNull(o.program()));
-            sqLiteBind(sqLiteStatement, 9, UidsHelper.getUidOrNull(o.programStage()));
-            sqLiteBind(sqLiteStatement, 10, UidsHelper.getUidOrNull(o.dataElement()));
-            sqLiteBind(sqLiteStatement, 11, UidsHelper.getUidOrNull(o.trackedEntityAttribute()));
-            sqLiteBind(sqLiteStatement, 12, o.programRuleVariableSourceType());
+        public void bindToStatement(@NonNull ProgramRuleVariable o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.useCodeForOptionSet());
+            w.bind(8, UidsHelper.getUidOrNull(o.program()));
+            w.bind(9, UidsHelper.getUidOrNull(o.programStage()));
+            w.bind(10, UidsHelper.getUidOrNull(o.dataElement()));
+            w.bind(11, UidsHelper.getUidOrNull(o.trackedEntityAttribute()));
+            w.bind(12, o.programRuleVariableSourceType());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramSectionAttributeLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramSectionAttributeLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.program.ProgramSectionAttributeLink;
 import org.hisp.dhis.android.core.program.ProgramSectionAttributeLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ProgramSectionAttributeLinkStore {
 
-    private static final StatementBinder<ProgramSectionAttributeLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.programSection());
-        sqLiteBind(sqLiteStatement, 2, o.attribute());
+    private static final StatementBinder<ProgramSectionAttributeLink> BINDER = (o, w) -> {
+        w.bind(1, o.programSection());
+        w.bind(2, o.attribute());
     };
 
     private ProgramSectionAttributeLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramSectionStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramSectionStore.java
@@ -28,13 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,7 +39,7 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.program.ProgramSection;
 import org.hisp.dhis.android.core.program.ProgramSectionTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class ProgramSectionStore {
 
@@ -50,12 +47,12 @@ public final class ProgramSectionStore {
             = new IdentifiableWithStyleStatementBinder<ProgramSection>() {
 
         @Override
-        public void bindToStatement(@NonNull ProgramSection o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 9, o.description());
-            sqLiteBind(sqLiteStatement, 10, UidsHelper.getUidOrNull(o.program()));
-            sqLiteBind(sqLiteStatement, 11, o.sortOrder());
-            sqLiteBind(sqLiteStatement, 12, o.formName());
+        public void bindToStatement(@NonNull ProgramSection o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(9, o.description());
+            w.bind(10, UidsHelper.getUidOrNull(o.program()));
+            w.bind(11, o.sortOrder());
+            w.bind(12, o.formName());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageDataElementStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageDataElementStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -40,8 +39,6 @@ import org.hisp.dhis.android.core.program.ProgramStageDataElement;
 import org.hisp.dhis.android.core.program.ProgramStageDataElementTableInfo;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 final class ProgramStageDataElementStore {
 
@@ -52,15 +49,15 @@ final class ProgramStageDataElementStore {
 
         @Override
         public void bindToStatement(@NonNull ProgramStageDataElement programStageDataElement,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(programStageDataElement, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, programStageDataElement.displayInReports());
-            sqLiteBind(sqLiteStatement, 8, UidsHelper.getUidOrNull(programStageDataElement.dataElement()));
-            sqLiteBind(sqLiteStatement, 9, programStageDataElement.compulsory());
-            sqLiteBind(sqLiteStatement, 10, programStageDataElement.allowProvidedElsewhere());
-            sqLiteBind(sqLiteStatement, 11, programStageDataElement.sortOrder());
-            sqLiteBind(sqLiteStatement, 12, programStageDataElement.allowFutureDate());
-            sqLiteBind(sqLiteStatement, 13, UidsHelper.getUidOrNull(programStageDataElement.programStage()));
+                                    @NonNull StatementWrapper w) {
+            super.bindToStatement(programStageDataElement, w);
+            w.bind(7, programStageDataElement.displayInReports());
+            w.bind(8, UidsHelper.getUidOrNull(programStageDataElement.dataElement()));
+            w.bind(9, programStageDataElement.compulsory());
+            w.bind(10, programStageDataElement.allowProvidedElsewhere());
+            w.bind(11, programStageDataElement.sortOrder());
+            w.bind(12, programStageDataElement.allowFutureDate());
+            w.bind(13, UidsHelper.getUidOrNull(programStageDataElement.programStage()));
 
         }
     };

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionDataElementLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionDataElementLinkStore.java
@@ -35,15 +35,12 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.program.ProgramStageSectionDataElementLink;
 import org.hisp.dhis.android.core.program.ProgramStageSectionDataElementLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ProgramStageSectionDataElementLinkStore {
 
-    private static final StatementBinder<ProgramStageSectionDataElementLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.programStageSection());
-        sqLiteBind(sqLiteStatement, 2, o.dataElement());
-        sqLiteBind(sqLiteStatement, 3, o.sortOrder());
+    private static final StatementBinder<ProgramStageSectionDataElementLink> BINDER = (o, w) -> {
+        w.bind(1, o.programStageSection());
+        w.bind(2, o.dataElement());
+        w.bind(3, o.sortOrder());
     };
 
     private ProgramStageSectionDataElementLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionProgramIndicatorLinkStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionProgramIndicatorLinkStore.java
@@ -35,14 +35,11 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.program.ProgramStageSectionProgramIndicatorLink;
 import org.hisp.dhis.android.core.program.ProgramStageSectionProgramIndicatorLinkTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ProgramStageSectionProgramIndicatorLinkStore {
 
-    private static final StatementBinder<ProgramStageSectionProgramIndicatorLink> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.programStageSection());
-        sqLiteBind(sqLiteStatement, 2, o.programIndicator());
+    private static final StatementBinder<ProgramStageSectionProgramIndicatorLink> BINDER = (o, w) -> {
+        w.bind(1, o.programStageSection());
+        w.bind(2, o.programIndicator());
     };
 
     private ProgramStageSectionProgramIndicatorLinkStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
@@ -41,19 +40,17 @@ import org.hisp.dhis.android.core.program.ProgramStageSectionTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ProgramStageSectionStore {
 
     private static StatementBinder<ProgramStageSection> BINDER =
             new IdentifiableStatementBinder<ProgramStageSection>() {
         @Override
-        public void bindToStatement(@NonNull ProgramStageSection o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.sortOrder());
-            sqLiteBind(sqLiteStatement, 8, UidsHelper.getUidOrNull(o.programStage()));
-            sqLiteBind(sqLiteStatement, 9, ProgramStageSectionRenderingHelper.desktopRenderType(o.renderType()));
-            sqLiteBind(sqLiteStatement, 10, ProgramStageSectionRenderingHelper.mobileRenderType(o.renderType()));
+        public void bindToStatement(@NonNull ProgramStageSection o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.sortOrder());
+            w.bind(8, UidsHelper.getUidOrNull(o.programStage()));
+            w.bind(9, ProgramStageSectionRenderingHelper.desktopRenderType(o.renderType()));
+            w.bind(10, ProgramStageSectionRenderingHelper.mobileRenderType(o.renderType()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageStore.java
@@ -28,13 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,37 +39,37 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.program.ProgramStage;
 import org.hisp.dhis.android.core.program.ProgramStageTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class ProgramStageStore {
 
     private static StatementBinder<ProgramStage> BINDER = new IdentifiableWithStyleStatementBinder<ProgramStage>() {
 
         @Override
-        public void bindToStatement(@NonNull ProgramStage o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 9, o.description());
-            sqLiteBind(sqLiteStatement, 10, o.displayDescription());
-            sqLiteBind(sqLiteStatement, 11, o.executionDateLabel());
-            sqLiteBind(sqLiteStatement, 12, o.allowGenerateNextVisit());
-            sqLiteBind(sqLiteStatement, 13, o.validCompleteOnly());
-            sqLiteBind(sqLiteStatement, 14, o.reportDateToUse());
-            sqLiteBind(sqLiteStatement, 15, o.openAfterEnrollment());
-            sqLiteBind(sqLiteStatement, 16, o.repeatable());
-            sqLiteBind(sqLiteStatement, 17, o.formType().name());
-            sqLiteBind(sqLiteStatement, 18, o.displayGenerateEventBox());
-            sqLiteBind(sqLiteStatement, 19, o.generatedByEnrollmentDate());
-            sqLiteBind(sqLiteStatement, 20, o.autoGenerateEvent());
-            sqLiteBind(sqLiteStatement, 21, o.sortOrder());
-            sqLiteBind(sqLiteStatement, 22, o.hideDueDate());
-            sqLiteBind(sqLiteStatement, 23, o.blockEntryForm());
-            sqLiteBind(sqLiteStatement, 24, o.minDaysFromStart());
-            sqLiteBind(sqLiteStatement, 25, o.standardInterval());
-            sqLiteBind(sqLiteStatement, 26, UidsHelper.getUidOrNull(o.program()));
-            sqLiteBind(sqLiteStatement, 27, o.periodType());
-            sqLiteBind(sqLiteStatement, 28, o.access().data().write());
-            sqLiteBind(sqLiteStatement, 29, o.remindCompleted());
-            sqLiteBind(sqLiteStatement, 30, o.featureType());
+        public void bindToStatement(@NonNull ProgramStage o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(9, o.description());
+            w.bind(10, o.displayDescription());
+            w.bind(11, o.executionDateLabel());
+            w.bind(12, o.allowGenerateNextVisit());
+            w.bind(13, o.validCompleteOnly());
+            w.bind(14, o.reportDateToUse());
+            w.bind(15, o.openAfterEnrollment());
+            w.bind(16, o.repeatable());
+            w.bind(17, o.formType().name());
+            w.bind(18, o.displayGenerateEventBox());
+            w.bind(19, o.generatedByEnrollmentDate());
+            w.bind(20, o.autoGenerateEvent());
+            w.bind(21, o.sortOrder());
+            w.bind(22, o.hideDueDate());
+            w.bind(23, o.blockEntryForm());
+            w.bind(24, o.minDaysFromStart());
+            w.bind(25, o.standardInterval());
+            w.bind(26, UidsHelper.getUidOrNull(o.program()));
+            w.bind(27, o.periodType());
+            w.bind(28, o.access().data().write());
+            w.bind(29, o.remindCompleted());
+            w.bind(30, o.featureType());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStore.java
@@ -28,16 +28,13 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder;
 import org.hisp.dhis.android.core.arch.db.statementwrapper.internal.SQLStatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStoreImpl;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.common.IdentifiableColumns;
@@ -47,7 +44,7 @@ import org.hisp.dhis.android.core.program.ProgramType;
 
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class ProgramStore extends IdentifiableObjectStoreImpl<Program> implements ProgramStoreInterface {
 
@@ -60,32 +57,32 @@ public final class ProgramStore extends IdentifiableObjectStoreImpl<Program> imp
     private static StatementBinder<Program> BINDER = new NameableWithStyleStatementBinder<Program>() {
         
         @Override
-        public void bindToStatement(@NonNull Program o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 13, o.version());
-            sqLiteBind(sqLiteStatement, 14, o.onlyEnrollOnce());
-            sqLiteBind(sqLiteStatement, 15, o.enrollmentDateLabel());
-            sqLiteBind(sqLiteStatement, 16, o.displayIncidentDate());
-            sqLiteBind(sqLiteStatement, 17, o.incidentDateLabel());
-            sqLiteBind(sqLiteStatement, 18, o.registration());
-            sqLiteBind(sqLiteStatement, 19, o.selectEnrollmentDatesInFuture());
-            sqLiteBind(sqLiteStatement, 20, o.dataEntryMethod());
-            sqLiteBind(sqLiteStatement, 21, o.ignoreOverdueEvents());
-            sqLiteBind(sqLiteStatement, 22, o.selectIncidentDatesInFuture());
-            sqLiteBind(sqLiteStatement, 23, o.useFirstStageDuringRegistration());
-            sqLiteBind(sqLiteStatement, 24, o.displayFrontPageList());
-            sqLiteBind(sqLiteStatement, 25, o.programType());
-            sqLiteBind(sqLiteStatement, 26, UidsHelper.getUidOrNull(o.relatedProgram()));
-            sqLiteBind(sqLiteStatement, 27, UidsHelper.getUidOrNull(o.trackedEntityType()));
-            sqLiteBind(sqLiteStatement, 28, o.categoryComboUid());
-            sqLiteBind(sqLiteStatement, 29, o.access().data().write());
-            sqLiteBind(sqLiteStatement, 30, o.expiryDays());
-            sqLiteBind(sqLiteStatement, 31, o.completeEventsExpiryDays());
-            sqLiteBind(sqLiteStatement, 32, o.expiryPeriodType());
-            sqLiteBind(sqLiteStatement, 33, o.minAttributesRequiredToSearch());
-            sqLiteBind(sqLiteStatement, 34, o.maxTeiCountToReturn());
-            sqLiteBind(sqLiteStatement, 35, o.featureType());
-            sqLiteBind(sqLiteStatement, 36, o.accessLevel());
+        public void bindToStatement(@NonNull Program o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(13, o.version());
+            w.bind(14, o.onlyEnrollOnce());
+            w.bind(15, o.enrollmentDateLabel());
+            w.bind(16, o.displayIncidentDate());
+            w.bind(17, o.incidentDateLabel());
+            w.bind(18, o.registration());
+            w.bind(19, o.selectEnrollmentDatesInFuture());
+            w.bind(20, o.dataEntryMethod());
+            w.bind(21, o.ignoreOverdueEvents());
+            w.bind(22, o.selectIncidentDatesInFuture());
+            w.bind(23, o.useFirstStageDuringRegistration());
+            w.bind(24, o.displayFrontPageList());
+            w.bind(25, o.programType());
+            w.bind(26, UidsHelper.getUidOrNull(o.relatedProgram()));
+            w.bind(27, UidsHelper.getUidOrNull(o.trackedEntityType()));
+            w.bind(28, o.categoryComboUid());
+            w.bind(29, o.access().data().write());
+            w.bind(30, o.expiryDays());
+            w.bind(31, o.completeEventsExpiryDays());
+            w.bind(32, o.expiryPeriodType());
+            w.bind(33, o.minAttributesRequiredToSearch());
+            w.bind(34, o.maxTeiCountToReturn());
+            w.bind(35, o.featureType());
+            w.bind(36, o.accessLevel());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.SingleParentChildProjection;
@@ -42,8 +41,6 @@ import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttributeTableInfo
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class ProgramTrackedEntityAttributeStore {
 
     private static StatementBinder<ProgramTrackedEntityAttribute> BINDER
@@ -51,15 +48,15 @@ public final class ProgramTrackedEntityAttributeStore {
 
         @Override
         public void bindToStatement(@NonNull ProgramTrackedEntityAttribute o,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 11, o.mandatory());
-            sqLiteBind(sqLiteStatement, 12, UidsHelper.getUidOrNull(o.trackedEntityAttribute()));
-            sqLiteBind(sqLiteStatement, 13, o.allowFutureDate());
-            sqLiteBind(sqLiteStatement, 14, o.displayInList());
-            sqLiteBind(sqLiteStatement, 15, UidsHelper.getUidOrNull(o.program()));
-            sqLiteBind(sqLiteStatement, 16, o.sortOrder());
-            sqLiteBind(sqLiteStatement, 17, o.searchable());
+                                    @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(11, o.mandatory());
+            w.bind(12, UidsHelper.getUidOrNull(o.trackedEntityAttribute()));
+            w.bind(13, o.allowFutureDate());
+            w.bind(14, o.displayInList());
+            w.bind(15, UidsHelper.getUidOrNull(o.program()));
+            w.bind(16, o.sortOrder());
+            w.bind(17, o.searchable());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintStore.java
@@ -37,30 +37,25 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.relationship.RelationshipConstraint;
 import org.hisp.dhis.android.core.relationship.RelationshipConstraintTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class RelationshipConstraintStore {
 
-    private static final StatementBinder<RelationshipConstraint> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, UidsHelper.getUidOrNull(o.relationshipType()));
-        sqLiteBind(sqLiteStatement, 2, o.constraintType());
-        sqLiteBind(sqLiteStatement, 3, o.relationshipEntity());
-        sqLiteBind(sqLiteStatement, 4, UidsHelper.getUidOrNull(o.trackedEntityType()));
-        sqLiteBind(sqLiteStatement, 5, UidsHelper.getUidOrNull(o.program()));
-        sqLiteBind(sqLiteStatement, 6, UidsHelper.getUidOrNull(o.programStage()));
+    private static final StatementBinder<RelationshipConstraint> BINDER = (o, w) -> {
+        w.bind(1, UidsHelper.getUidOrNull(o.relationshipType()));
+        w.bind(2, o.constraintType());
+        w.bind(3, o.relationshipEntity());
+        w.bind(4, UidsHelper.getUidOrNull(o.trackedEntityType()));
+        w.bind(5, UidsHelper.getUidOrNull(o.program()));
+        w.bind(6, UidsHelper.getUidOrNull(o.programStage()));
     };
 
-    private static final WhereStatementBinder<RelationshipConstraint> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 7, UidsHelper.getUidOrNull(o.relationshipType()));
-        sqLiteBind(sqLiteStatement, 8, o.constraintType());
+    private static final WhereStatementBinder<RelationshipConstraint> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(7, UidsHelper.getUidOrNull(o.relationshipType()));
+        w.bind(8, o.constraintType());
     };
 
-    private static final WhereStatementBinder<RelationshipConstraint> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, UidsHelper.getUidOrNull(o.relationshipType()));
-        sqLiteBind(sqLiteStatement, 2, o.constraintType());
+    private static final WhereStatementBinder<RelationshipConstraint> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, UidsHelper.getUidOrNull(o.relationshipType()));
+        w.bind(2, o.constraintType());
     };
 
     private RelationshipConstraintStore() {}

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreImpl.java
@@ -47,34 +47,30 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class RelationshipItemStoreImpl extends ObjectWithoutUidStoreImpl<RelationshipItem>
         implements RelationshipItemStore {
 
-    private static final StatementBinder<RelationshipItem> BINDER = (o, sqLiteStatement) -> {
+    private static final StatementBinder<RelationshipItem> BINDER = (o, w) -> {
         String trackedEntityInstance = o.trackedEntityInstance() == null ? null :
                 o.trackedEntityInstance().trackedEntityInstance();
         String enrollment = o.enrollment() == null ? null : o.enrollment().enrollment();
         String event = o.event() == null ? null : o.event().event();
 
-        sqLiteBind(sqLiteStatement, 1, UidsHelper.getUidOrNull(o.relationship()));
-        sqLiteBind(sqLiteStatement, 2, o.relationshipItemType());
-        sqLiteBind(sqLiteStatement, 3, trackedEntityInstance);
-        sqLiteBind(sqLiteStatement, 4, enrollment);
-        sqLiteBind(sqLiteStatement, 5, event);
+        w.bind(1, UidsHelper.getUidOrNull(o.relationship()));
+        w.bind(2, o.relationshipItemType());
+        w.bind(3, trackedEntityInstance);
+        w.bind(4, enrollment);
+        w.bind(5, event);
     };
 
-    private static final WhereStatementBinder<RelationshipItem> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 6, UidsHelper.getUidOrNull(o.relationship()));
-        sqLiteBind(sqLiteStatement, 7, o.relationshipItemType());
+    private static final WhereStatementBinder<RelationshipItem> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(6, UidsHelper.getUidOrNull(o.relationship()));
+        w.bind(7, o.relationshipItemType());
     };
 
-    private static final WhereStatementBinder<RelationshipItem> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, UidsHelper.getUidOrNull(o.relationship()));
-        sqLiteBind(sqLiteStatement, 2, o.relationshipItemType());
+    private static final WhereStatementBinder<RelationshipItem> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, UidsHelper.getUidOrNull(o.relationship()));
+        w.bind(2, o.relationshipItemType());
     };
 
     private RelationshipItemStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreImpl.java
@@ -41,17 +41,15 @@ import org.hisp.dhis.android.core.relationship.RelationshipTableInfo;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class RelationshipStoreImpl extends IdentifiableObjectStoreImpl<Relationship>
         implements RelationshipStore {
 
-    private static StatementBinder<Relationship> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.name());
-        sqLiteBind(sqLiteStatement, 3, o.created());
-        sqLiteBind(sqLiteStatement, 4, o.lastUpdated());
-        sqLiteBind(sqLiteStatement, 5, o.relationshipType());
+    private static StatementBinder<Relationship> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.name());
+        w.bind(3, o.created());
+        w.bind(4, o.lastUpdated());
+        w.bind(5, o.relationshipType());
     };
 
     private RelationshipStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipTypeStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipTypeStore.java
@@ -28,19 +28,16 @@
 
 package org.hisp.dhis.android.core.relationship.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.relationship.RelationshipType;
 import org.hisp.dhis.android.core.relationship.RelationshipTypeTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class RelationshipTypeStore {
 
@@ -49,12 +46,12 @@ public final class RelationshipTypeStore {
     private static StatementBinder<RelationshipType> BINDER = new IdentifiableStatementBinder<RelationshipType>() {
 
         @Override
-        public void bindToStatement(@NonNull RelationshipType o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.fromToName());
-            sqLiteBind(sqLiteStatement, 8, o.toFromName());
-            sqLiteBind(sqLiteStatement, 9, o.bidirectional());
-            sqLiteBind(sqLiteStatement, 10, o.access().data().write());
+        public void bindToStatement(@NonNull RelationshipType o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.fromToName());
+            w.bind(8, o.toFromName());
+            w.bind(9, o.bidirectional());
+            w.bind(10, o.access().data().write());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/resource/internal/ResourceStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/resource/internal/ResourceStoreImpl.java
@@ -37,20 +37,18 @@ import org.hisp.dhis.android.core.common.BaseIdentifiableObject;
 
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class ResourceStoreImpl extends ObjectWithoutUidStoreImpl<Resource> implements ResourceStore {
 
-    private static final StatementBinder<Resource> BINDER = (resource, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, resource.resourceType());
-        sqLiteBind(sqLiteStatement, 2, resource.lastSynced());
+    private static final StatementBinder<Resource> BINDER = (resource, w) -> {
+        w.bind(1, resource.resourceType());
+        w.bind(2, resource.lastSynced());
     };
 
     private static final WhereStatementBinder<Resource> WHERE_UPDATE_BINDER
-            = (resource, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 3, resource.resourceType());
+            = (resource, w) -> w.bind(3, resource.resourceType());
 
     private static final WhereStatementBinder<Resource> WHERE_DELETE_BINDER
-            = (resource, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, resource.resourceType());
+            = (resource, w) -> w.bind(1, resource.resourceType());
 
     private ResourceStoreImpl(DatabaseAdapter databaseAdapter,
                              SQLStatementBuilderImpl builder) {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/SystemSettingStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/SystemSettingStore.java
@@ -36,20 +36,18 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.settings.SystemSetting;
 import org.hisp.dhis.android.core.settings.SystemSettingTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class SystemSettingStore {
 
-    private static final StatementBinder<SystemSetting> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.key());
-        sqLiteBind(sqLiteStatement, 2, o.value());
+    private static final StatementBinder<SystemSetting> BINDER = (o, w) -> {
+        w.bind(1, o.key());
+        w.bind(2, o.value());
     };
 
     private static final WhereStatementBinder<SystemSetting> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 3, o.key());
+            = (o, w) -> w.bind(3, o.key());
 
     private static final WhereStatementBinder<SystemSetting> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, o.key());
+            = (o, w) -> w.bind(1, o.key());
 
     private SystemSettingStore() {}
 

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/SystemInfoStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/SystemInfoStore.java
@@ -36,23 +36,21 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.systeminfo.SystemInfo;
 import org.hisp.dhis.android.core.systeminfo.SystemInfoTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class SystemInfoStore {
 
-    private static final StatementBinder<SystemInfo> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.serverDate());
-        sqLiteBind(sqLiteStatement, 2, o.dateFormat());
-        sqLiteBind(sqLiteStatement, 3, o.version());
-        sqLiteBind(sqLiteStatement, 4, o.contextPath());
-        sqLiteBind(sqLiteStatement, 5, o.systemName());
+    private static final StatementBinder<SystemInfo> BINDER = (o, w) -> {
+        w.bind(1, o.serverDate());
+        w.bind(2, o.dateFormat());
+        w.bind(3, o.version());
+        w.bind(4, o.contextPath());
+        w.bind(5, o.systemName());
     };
 
     private static final WhereStatementBinder<SystemInfo> WHERE_UPDATE_BINDER =
-            (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 6, o.contextPath());
+            (o, w) -> w.bind(6, o.contextPath());
 
     private static final WhereStatementBinder<SystemInfo> WHERE_DELETE_BINDER =
-            (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, o.contextPath());
+            (o, w) -> w.bind(1, o.contextPath());
 
     private SystemInfoStore() {
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeReservedValueStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeReservedValueStore.java
@@ -44,36 +44,31 @@ import java.util.Date;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class TrackedEntityAttributeReservedValueStore
         extends ObjectWithoutUidStoreImpl<TrackedEntityAttributeReservedValue>
         implements TrackedEntityAttributeReservedValueStoreInterface {
 
-    private static final StatementBinder<TrackedEntityAttributeReservedValue> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.ownerObject());
-        sqLiteBind(sqLiteStatement, 2, o.ownerUid());
-        sqLiteBind(sqLiteStatement, 3, o.key());
-        sqLiteBind(sqLiteStatement, 4, o.value());
-        sqLiteBind(sqLiteStatement, 5, o.created());
-        sqLiteBind(sqLiteStatement, 6, o.expiryDate());
-        sqLiteBind(sqLiteStatement, 7, o.organisationUnit());
-        sqLiteBind(sqLiteStatement, 8, o.temporalValidityDate());
+    private static final StatementBinder<TrackedEntityAttributeReservedValue> BINDER = (o, w) -> {
+        w.bind(1, o.ownerObject());
+        w.bind(2, o.ownerUid());
+        w.bind(3, o.key());
+        w.bind(4, o.value());
+        w.bind(5, o.created());
+        w.bind(6, o.expiryDate());
+        w.bind(7, o.organisationUnit());
+        w.bind(8, o.temporalValidityDate());
     };
 
-    private static final WhereStatementBinder<TrackedEntityAttributeReservedValue> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 9, o.ownerUid());
-        sqLiteBind(sqLiteStatement, 10, o.value());
-        sqLiteBind(sqLiteStatement, 11, o.organisationUnit());
+    private static final WhereStatementBinder<TrackedEntityAttributeReservedValue> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(9, o.ownerUid());
+        w.bind(10, o.value());
+        w.bind(11, o.organisationUnit());
     };
 
-    private static final WhereStatementBinder<TrackedEntityAttributeReservedValue> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.ownerUid());
-        sqLiteBind(sqLiteStatement, 2, o.value());
-        sqLiteBind(sqLiteStatement, 3, o.organisationUnit());
+    private static final WhereStatementBinder<TrackedEntityAttributeReservedValue> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, o.ownerUid());
+        w.bind(2, o.value());
+        w.bind(3, o.organisationUnit());
     };
 
     private TrackedEntityAttributeReservedValueStore(

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeStore.java
@@ -28,20 +28,17 @@
 
 package org.hisp.dhis.android.core.trackedentity.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class TrackedEntityAttributeStore {
 
@@ -51,23 +48,22 @@ public final class TrackedEntityAttributeStore {
             new NameableWithStyleStatementBinder<TrackedEntityAttribute>() {
 
         @Override
-        public void bindToStatement(@NonNull TrackedEntityAttribute o,
-                                    @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 13, o.pattern());
-            sqLiteBind(sqLiteStatement, 14, o.sortOrderInListNoProgram());
-            sqLiteBind(sqLiteStatement, 15, UidsHelper.getUidOrNull(o.optionSet()));
-            sqLiteBind(sqLiteStatement, 16, o.valueType());
-            sqLiteBind(sqLiteStatement, 17, o.expression());
-            sqLiteBind(sqLiteStatement, 18, o.programScope());
-            sqLiteBind(sqLiteStatement, 19, o.displayInListNoProgram());
-            sqLiteBind(sqLiteStatement, 20, o.generated());
-            sqLiteBind(sqLiteStatement, 21, o.displayOnVisitSchedule());
-            sqLiteBind(sqLiteStatement, 22, o.orgUnitScope());
-            sqLiteBind(sqLiteStatement, 23, o.unique());
-            sqLiteBind(sqLiteStatement, 24, o.inherit());
-            sqLiteBind(sqLiteStatement, 25, o.formName());
-            sqLiteBind(sqLiteStatement, 26, o.fieldMask());
+        public void bindToStatement(@NonNull TrackedEntityAttribute o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(13, o.pattern());
+            w.bind(14, o.sortOrderInListNoProgram());
+            w.bind(15, UidsHelper.getUidOrNull(o.optionSet()));
+            w.bind(16, o.valueType());
+            w.bind(17, o.expression());
+            w.bind(18, o.programScope());
+            w.bind(19, o.displayInListNoProgram());
+            w.bind(20, o.generated());
+            w.bind(21, o.displayOnVisitSchedule());
+            w.bind(22, o.orgUnitScope());
+            w.bind(23, o.unique());
+            w.bind(24, o.inherit());
+            w.bind(25, o.formName());
+            w.bind(26, o.fieldMask());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreImpl.java
@@ -48,31 +48,26 @@ import java.util.Map;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class TrackedEntityAttributeValueStoreImpl
         extends ObjectWithoutUidStoreImpl<TrackedEntityAttributeValue> implements TrackedEntityAttributeValueStore {
 
-    private static final StatementBinder<TrackedEntityAttributeValue> BINDER =
-            (o, sqLiteStatement) -> {
-                sqLiteBind(sqLiteStatement, 1, o.value());
-                sqLiteBind(sqLiteStatement, 2, o.created());
-                sqLiteBind(sqLiteStatement, 3, o.lastUpdated());
-                sqLiteBind(sqLiteStatement, 4, o.trackedEntityAttribute());
-                sqLiteBind(sqLiteStatement, 5, o.trackedEntityInstance());
-            };
+    private static final StatementBinder<TrackedEntityAttributeValue> BINDER = (o, w) -> {
+        w.bind(1, o.value());
+        w.bind(2, o.created());
+        w.bind(3, o.lastUpdated());
+        w.bind(4, o.trackedEntityAttribute());
+        w.bind(5, o.trackedEntityInstance());
+    };
 
-    private static final WhereStatementBinder<TrackedEntityAttributeValue> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 6, o.trackedEntityAttribute());
-        sqLiteBind(sqLiteStatement, 7, o.trackedEntityInstance());
+    private static final WhereStatementBinder<TrackedEntityAttributeValue> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(6, o.trackedEntityAttribute());
+        w.bind(7, o.trackedEntityInstance());
     };
 
 
-    private static final WhereStatementBinder<TrackedEntityAttributeValue> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.trackedEntityAttribute());
-        sqLiteBind(sqLiteStatement, 2, o.trackedEntityInstance());
+    private static final WhereStatementBinder<TrackedEntityAttributeValue> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, o.trackedEntityAttribute());
+        w.bind(2, o.trackedEntityInstance());
     };
 
     static final SingleParentChildProjection CHILD_PROJECTION = new SingleParentChildProjection(
@@ -80,7 +75,7 @@ public final class TrackedEntityAttributeValueStoreImpl
             TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_INSTANCE);
 
     private TrackedEntityAttributeValueStoreImpl(DatabaseAdapter databaseAdapter,
-                                SQLStatementBuilderImpl builder) {
+                                                 SQLStatementBuilderImpl builder) {
         super(databaseAdapter, builder, BINDER, WHERE_UPDATE_BINDER, WHERE_DELETE_BINDER,
                 TrackedEntityAttributeValue::create);
     }
@@ -89,9 +84,9 @@ public final class TrackedEntityAttributeValueStoreImpl
     public Map<String, List<TrackedEntityAttributeValue>> queryTrackedEntityAttributeValueToPost() {
         String toPostQuery =
                 "SELECT TrackedEntityAttributeValue.* " +
-                "FROM (TrackedEntityAttributeValue INNER JOIN TrackedEntityInstance " +
-                "ON TrackedEntityAttributeValue.trackedEntityInstance = TrackedEntityInstance.uid) " +
-                "WHERE " + teiInUploadableState() + ";";
+                        "FROM (TrackedEntityAttributeValue INNER JOIN TrackedEntityInstance " +
+                        "ON TrackedEntityAttributeValue.trackedEntityInstance = TrackedEntityInstance.uid) " +
+                        "WHERE " + teiInUploadableState() + ";";
 
         List<TrackedEntityAttributeValue> valueList = trackedEntityAttributeValueListFromQuery(toPostQuery);
 
@@ -138,7 +133,7 @@ public final class TrackedEntityAttributeValueStoreImpl
     }
 
     private void addTrackedEntityAttributeValueToMap(Map<String, List<TrackedEntityAttributeValue>> valueMap,
-                                    TrackedEntityAttributeValue trackedEntityAttributeValue) {
+                                                     TrackedEntityAttributeValue trackedEntityAttributeValue) {
         if (valueMap.get(trackedEntityAttributeValue.trackedEntityInstance()) == null) {
             valueMap.put(trackedEntityAttributeValue.trackedEntityInstance(),
                     new ArrayList<>());

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreImpl.java
@@ -30,8 +30,6 @@ package org.hisp.dhis.android.core.trackedentity.internal;
 
 import android.database.Cursor;
 
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.cursors.internal.ObjectFactory;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl;
@@ -49,32 +47,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class TrackedEntityDataValueStoreImpl extends ObjectWithoutUidStoreImpl<TrackedEntityDataValue>
         implements TrackedEntityDataValueStore {
 
-    private static final StatementBinder<TrackedEntityDataValue> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.event());
-        sqLiteBind(sqLiteStatement, 2, o.created());
-        sqLiteBind(sqLiteStatement, 3, o.lastUpdated());
-        sqLiteBind(sqLiteStatement, 4, o.dataElement());
-        sqLiteBind(sqLiteStatement, 5, o.storedBy());
-        sqLiteBind(sqLiteStatement, 6, o.value());
-        sqLiteBind(sqLiteStatement, 7, o.providedElsewhere());
+    private static final StatementBinder<TrackedEntityDataValue> BINDER = (o, w) -> {
+        w.bind(1, o.event());
+        w.bind(2, o.created());
+        w.bind(3, o.lastUpdated());
+        w.bind(4, o.dataElement());
+        w.bind(5, o.storedBy());
+        w.bind(6, o.value());
+        w.bind(7, o.providedElsewhere());
     };
 
-    private static final WhereStatementBinder<TrackedEntityDataValue> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 8, o.event());
-        sqLiteBind(sqLiteStatement, 9, o.dataElement());
+    private static final WhereStatementBinder<TrackedEntityDataValue> WHERE_UPDATE_BINDER = (o, w) -> {
+        w.bind(8, o.event());
+        w.bind(9, o.dataElement());
     };
 
-    private static final WhereStatementBinder<TrackedEntityDataValue> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.event());
-        sqLiteBind(sqLiteStatement, 2, o.dataElement());
+    private static final WhereStatementBinder<TrackedEntityDataValue> WHERE_DELETE_BINDER = (o, w) -> {
+        w.bind(1, o.event());
+        w.bind(2, o.dataElement());
     };
 
     static final SingleParentChildProjection CHILD_PROJECTION = new SingleParentChildProjection(

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreImpl.java
@@ -42,24 +42,22 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceTableInfo;
 
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class TrackedEntityInstanceStoreImpl
         extends IdentifiableDeletableDataObjectStoreImpl<TrackedEntityInstance>
         implements TrackedEntityInstanceStore {
 
-    private static final StatementBinder<TrackedEntityInstance> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.uid());
-        sqLiteBind(sqLiteStatement, 2, o.created());
-        sqLiteBind(sqLiteStatement, 3, o.lastUpdated());
-        sqLiteBind(sqLiteStatement, 4, o.createdAtClient());
-        sqLiteBind(sqLiteStatement, 5, o.lastUpdatedAtClient());
-        sqLiteBind(sqLiteStatement, 6, o.organisationUnit());
-        sqLiteBind(sqLiteStatement, 7, o.trackedEntityType());
-        sqLiteBind(sqLiteStatement, 8, o.geometry() == null ? null : o.geometry().type());
-        sqLiteBind(sqLiteStatement, 9, o.geometry() == null ? null : o.geometry().coordinates());
-        sqLiteBind(sqLiteStatement, 10, o.state());
-        sqLiteBind(sqLiteStatement, 11, o.deleted());
+    private static final StatementBinder<TrackedEntityInstance> BINDER = (o, w) -> {
+        w.bind(1, o.uid());
+        w.bind(2, o.created());
+        w.bind(3, o.lastUpdated());
+        w.bind(4, o.createdAtClient());
+        w.bind(5, o.lastUpdatedAtClient());
+        w.bind(6, o.organisationUnit());
+        w.bind(7, o.trackedEntityType());
+        w.bind(8, o.geometry() == null ? null : o.geometry().type());
+        w.bind(9, o.geometry() == null ? null : o.geometry().coordinates());
+        w.bind(10, o.state());
+        w.bind(11, o.deleted());
     };
 
     public TrackedEntityInstanceStoreImpl(DatabaseAdapter databaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeAttributeStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeAttributeStore.java
@@ -38,18 +38,15 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeAttributeTableInfo;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeAttributeTableInfo.Columns;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class TrackedEntityTypeAttributeStore {
 
-    private static final StatementBinder<TrackedEntityTypeAttribute> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.trackedEntityType().uid());
-        sqLiteBind(sqLiteStatement, 2, o.trackedEntityAttribute().uid());
-        sqLiteBind(sqLiteStatement, 3, o.displayInList());
-        sqLiteBind(sqLiteStatement, 4, o.mandatory());
-        sqLiteBind(sqLiteStatement, 5, o.searchable());
-        sqLiteBind(sqLiteStatement, 6, o.sortOrder());
+    private static final StatementBinder<TrackedEntityTypeAttribute> BINDER = (o, w) -> {
+        w.bind(1, o.trackedEntityType().uid());
+        w.bind(2, o.trackedEntityAttribute().uid());
+        w.bind(3, o.displayInList());
+        w.bind(4, o.mandatory());
+        w.bind(5, o.searchable());
+        w.bind(6, o.sortOrder());
     };
 
     static final SingleParentChildProjection CHILD_PROJECTION = new SingleParentChildProjection(

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeStore.java
@@ -28,28 +28,25 @@
 
 package org.hisp.dhis.android.core.trackedentity.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
-import androidx.annotation.NonNull;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.NameableWithStyleStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
+import androidx.annotation.NonNull;
 
 public final class TrackedEntityTypeStore {
 
     private static StatementBinder<TrackedEntityType> BINDER =
             new NameableWithStyleStatementBinder<TrackedEntityType>() {
         @Override
-        public void bindToStatement(@NonNull TrackedEntityType o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 13, o.featureType());
+        public void bindToStatement(@NonNull TrackedEntityType o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(13, o.featureType());
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AuthenticatedUserStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AuthenticatedUserStore.java
@@ -36,21 +36,18 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.user.AuthenticatedUser;
 import org.hisp.dhis.android.core.user.AuthenticatedUserTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class AuthenticatedUserStore {
 
-    private static final StatementBinder<AuthenticatedUser> BINDER
-            = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.user());
-        sqLiteBind(sqLiteStatement, 2, o.hash());
+    private static final StatementBinder<AuthenticatedUser> BINDER = (o, w) -> {
+        w.bind(1, o.user());
+        w.bind(2, o.hash());
     };
 
     private static final WhereStatementBinder<AuthenticatedUser> WHERE_UPDATE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 3, o.user());
+            = (o, w) -> w.bind(3, o.user());
 
     private static final WhereStatementBinder<AuthenticatedUser> WHERE_DELETE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, o.user());
+            = (o, w) -> w.bind(1, o.user());
 
     private AuthenticatedUserStore() {}
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AuthorityStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AuthorityStore.java
@@ -36,15 +36,13 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.user.Authority;
 import org.hisp.dhis.android.core.user.AuthorityTableInfo;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class AuthorityStore {
 
     private static final StatementBinder<Authority> BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, o.name());
+            = (o, w) -> w.bind(1, o.name());
 
     private static final WhereStatementBinder<Authority> WHERE_BINDER
-            = (o, sqLiteStatement) -> sqLiteBind(sqLiteStatement, 1, o.name());
+            = (o, w) -> w.bind(1, o.name());
 
     private AuthorityStore() {}
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserCredentialsStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserCredentialsStoreImpl.java
@@ -28,22 +28,19 @@
 
 package org.hisp.dhis.android.core.user.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder;
 import org.hisp.dhis.android.core.arch.db.statementwrapper.internal.SQLStatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStoreImpl;
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.user.UserCredentials;
 import org.hisp.dhis.android.core.user.UserCredentialsTableInfo;
 
 import androidx.annotation.NonNull;
-
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
 
 public final class UserCredentialsStoreImpl extends IdentifiableObjectStoreImpl<UserCredentials>
         implements UserCredentialsStore {
@@ -64,10 +61,10 @@ public final class UserCredentialsStoreImpl extends IdentifiableObjectStoreImpl<
 
     private static StatementBinder<UserCredentials> BINDER = new IdentifiableStatementBinder<UserCredentials>() {
         @Override
-        public void bindToStatement(@NonNull UserCredentials o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.username());
-            sqLiteBind(sqLiteStatement, 8, UidsHelper.getUidOrNull(o.user()));
+        public void bindToStatement(@NonNull UserCredentials o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.username());
+            w.bind(8, UidsHelper.getUidOrNull(o.user()));
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkStoreImpl.java
@@ -28,12 +28,11 @@
 
 package org.hisp.dhis.android.core.user.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl;
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.LinkStoreImpl;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit;
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLink;
@@ -42,20 +41,18 @@ import org.hisp.dhis.android.core.user.UserOrganisationUnitLinkTableInfo.Columns
 
 import java.util.List;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 public final class UserOrganisationUnitLinkStoreImpl extends LinkStoreImpl<UserOrganisationUnitLink>
         implements UserOrganisationUnitLinkStore {
 
-    private static final StatementBinder<UserOrganisationUnitLink> BINDER = (o, sqLiteStatement) -> {
-        sqLiteBind(sqLiteStatement, 1, o.user());
-        sqLiteBind(sqLiteStatement, 2, o.organisationUnit());
-        sqLiteBind(sqLiteStatement, 3, o.organisationUnitScope());
-        sqLiteBind(sqLiteStatement, 4, o.root());
+    private static final StatementBinder<UserOrganisationUnitLink> BINDER = (o, w) -> {
+        w.bind(1, o.user());
+        w.bind(2, o.organisationUnit());
+        w.bind(3, o.organisationUnitScope());
+        w.bind(4, o.root());
     };
 
     private UserOrganisationUnitLinkStoreImpl(DatabaseAdapter databaseAdapter,
-                                              SQLiteStatement insertStatement,
+                                              StatementWrapper insertStatement,
                                               String masterColumn,
                                               SQLStatementBuilderImpl builder,
                                               StatementBinder<UserOrganisationUnitLink> binder) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserRoleStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserRoleStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.user.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.user.UserRole;
@@ -46,8 +45,8 @@ public final class UserRoleStore {
 
     private static StatementBinder<UserRole> BINDER = new IdentifiableStatementBinder<UserRole>() {
         @Override
-        public void bindToStatement(@NonNull UserRole o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
+        public void bindToStatement(@NonNull UserRole o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
         }
     };
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserStore.java
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.user.internal;
 
-import android.database.sqlite.SQLiteStatement;
-
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.IdentifiableStatementBinder;
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinder;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore;
 import org.hisp.dhis.android.core.arch.db.stores.internal.StoreFactory;
 import org.hisp.dhis.android.core.user.User;
@@ -40,29 +39,27 @@ import org.hisp.dhis.android.core.user.UserTableInfo;
 
 import androidx.annotation.NonNull;
 
-import static org.hisp.dhis.android.core.arch.db.stores.internal.StoreUtils.sqLiteBind;
-
 final class UserStore {
     private UserStore() {}
 
     private static StatementBinder<User> BINDER = new IdentifiableStatementBinder<User>() {
 
         @Override
-        public void bindToStatement(@NonNull User o, @NonNull SQLiteStatement sqLiteStatement) {
-            super.bindToStatement(o, sqLiteStatement);
-            sqLiteBind(sqLiteStatement, 7, o.birthday());
-            sqLiteBind(sqLiteStatement, 8, o.education());
-            sqLiteBind(sqLiteStatement, 9, o.gender());
-            sqLiteBind(sqLiteStatement, 10, o.jobTitle());
-            sqLiteBind(sqLiteStatement, 11, o.surname());
-            sqLiteBind(sqLiteStatement, 12, o.firstName());
-            sqLiteBind(sqLiteStatement, 13, o.introduction());
-            sqLiteBind(sqLiteStatement, 14, o.employer());
-            sqLiteBind(sqLiteStatement, 15, o.interests());
-            sqLiteBind(sqLiteStatement, 16, o.languages());
-            sqLiteBind(sqLiteStatement, 17, o.email());
-            sqLiteBind(sqLiteStatement, 18, o.phoneNumber());
-            sqLiteBind(sqLiteStatement, 19, o.nationality());
+        public void bindToStatement(@NonNull User o, @NonNull StatementWrapper w) {
+            super.bindToStatement(o, w);
+            w.bind(7, o.birthday());
+            w.bind(8, o.education());
+            w.bind(9, o.gender());
+            w.bind(10, o.jobTitle());
+            w.bind(11, o.surname());
+            w.bind(12, o.firstName());
+            w.bind(13, o.introduction());
+            w.bind(14, o.employer());
+            w.bind(15, o.interests());
+            w.bind(16, o.languages());
+            w.bind(17, o.email());
+            w.bind(18, o.phoneNumber());
+            w.bind(19, o.nationality());
         }
     };
 

--- a/core/src/test/java/org/hisp/dhis/android/core/data/database/SqLiteDatabaseAdapterShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/data/database/SqLiteDatabaseAdapterShould.java
@@ -29,10 +29,10 @@
 package org.hisp.dhis.android.core.data.database;
 
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
 
 import org.hisp.dhis.android.core.arch.db.access.DbOpenHelper;
 import org.hisp.dhis.android.core.arch.db.access.internal.SqLiteDatabaseAdapter;
+import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -53,9 +53,9 @@ public class SqLiteDatabaseAdapterShould {
     DbOpenHelper dbOpenHelper;
 
     @Mock
-    SQLiteStatement sqLiteStatement;
+    StatementWrapper sqLiteStatement;
 
-    SqLiteDatabaseAdapter sqLiteDatabaseAdapter; // the class we are testing
+    private SqLiteDatabaseAdapter sqLiteDatabaseAdapter; // the class we are testing
 
     @Before
     public void setup() {


### PR DESCRIPTION
Introduces a StatementWrapper that wraps the SQLiteStatement, which is dependent of each SQL implementation. Before it, we had to change the imports in all the stores to use SQL Cipher. After this, we will only have to change the database adapter.