### PR TITLE
fix: [ANDROSDK-1054-2] Make Peroid related tests independent of current date

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.java
@@ -69,8 +69,7 @@ public class PeriodStoreIntegrationShould extends ObjectWithoutUidStoreAbstractI
 
     @Test
     public void select_correct_period_passing_period_type_and_a_date() throws ParseException {
-        // Update date and periodId if they are outdated
-        new PeriodHandler(periodStore, ParentPeriodGeneratorImpl.create()).generateAndPersist();
+        new PeriodHandler(periodStore, ParentPeriodGeneratorImpl.create(CalendarProviderFactory.createFixed())).generateAndPersist();
 
         Period period = periodStore.selectPeriodByTypeAndDate(PeriodType.SixMonthly,
                 BaseIdentifiableObject.DATE_FORMAT.parse("2019-03-02T12:24:25.319"));

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/CalendarProvider.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/CalendarProvider.java
@@ -26,32 +26,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.utils.runner;
+package org.hisp.dhis.android.core.period.internal;
 
-import android.util.Log;
+import java.util.Calendar;
 
-import org.hisp.dhis.android.core.period.internal.CalendarProviderFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestObjectsFactory;
-import org.junit.runner.Description;
-import org.junit.runner.Result;
-import org.junit.runner.notification.RunListener;
-
-public class D2JunitTestListener extends RunListener {
-
-
-    @Override
-    public void testRunStarted(Description description) {
-        Log.e("D2JunitTestListener", "Test run started");
-        CalendarProviderFactory.setFixed();
-        DatabaseAdapterFactory.setUp();
-    }
-
-    @Override
-    public void testRunFinished(Result result) throws Exception {
-        Log.i("D2JunitTestListener", "Test run finished");
-        DatabaseAdapterFactory.tearDown();
-        CalendarProviderFactory.setRegular();
-        MockIntegrationTestObjectsFactory.tearDown();
-    }
+interface CalendarProvider {
+   Calendar getCalendar();
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/CalendarProviderFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/CalendarProviderFactory.java
@@ -26,32 +26,34 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.utils.runner;
+package org.hisp.dhis.android.core.period.internal;
 
-import android.util.Log;
+import java.util.Calendar;
 
-import org.hisp.dhis.android.core.period.internal.CalendarProviderFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestObjectsFactory;
-import org.junit.runner.Description;
-import org.junit.runner.Result;
-import org.junit.runner.notification.RunListener;
+public final class CalendarProviderFactory {
 
-public class D2JunitTestListener extends RunListener {
+   private static CalendarProvider calendarProvider = new RegularCalendarProvider();
 
+   public static void setRegular() {
+      CalendarProviderFactory.calendarProvider = new RegularCalendarProvider();
+   }
 
-    @Override
-    public void testRunStarted(Description description) {
-        Log.e("D2JunitTestListener", "Test run started");
-        CalendarProviderFactory.setFixed();
-        DatabaseAdapterFactory.setUp();
-    }
+   public static void setFixed() {
+      CalendarProviderFactory.calendarProvider = createFixed();
+   }
 
-    @Override
-    public void testRunFinished(Result result) throws Exception {
-        Log.i("D2JunitTestListener", "Test run finished");
-        DatabaseAdapterFactory.tearDown();
-        CalendarProviderFactory.setRegular();
-        MockIntegrationTestObjectsFactory.tearDown();
-    }
+   static CalendarProvider getCalendarProvider() {
+      return calendarProvider;
+   }
+
+   static CalendarProvider createFixed() {
+      Calendar calendar = Calendar.getInstance();
+      calendar.set(Calendar.YEAR, 2019);
+      calendar.set(Calendar.MONTH, 11);
+      calendar.set(Calendar.DATE, 10);
+      return new FixedCalendarProvider(calendar);
+   }
+
+   private CalendarProviderFactory() {
+   }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/FixedCalendarProvider.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/FixedCalendarProvider.java
@@ -26,32 +26,20 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.utils.runner;
+package org.hisp.dhis.android.core.period.internal;
 
-import android.util.Log;
+import java.util.Calendar;
 
-import org.hisp.dhis.android.core.period.internal.CalendarProviderFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestObjectsFactory;
-import org.junit.runner.Description;
-import org.junit.runner.Result;
-import org.junit.runner.notification.RunListener;
+class FixedCalendarProvider implements CalendarProvider {
 
-public class D2JunitTestListener extends RunListener {
+    private final Calendar calendar;
 
-
-    @Override
-    public void testRunStarted(Description description) {
-        Log.e("D2JunitTestListener", "Test run started");
-        CalendarProviderFactory.setFixed();
-        DatabaseAdapterFactory.setUp();
+    FixedCalendarProvider(Calendar calendar) {
+        this.calendar = (Calendar) calendar.clone();
     }
 
     @Override
-    public void testRunFinished(Result result) throws Exception {
-        Log.i("D2JunitTestListener", "Test run finished");
-        DatabaseAdapterFactory.tearDown();
-        CalendarProviderFactory.setRegular();
-        MockIntegrationTestObjectsFactory.tearDown();
+    public Calendar getCalendar() {
+        return calendar;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.java
@@ -151,8 +151,8 @@ class ParentPeriodGeneratorImpl implements ParentPeriodGenerator {
         }
     }
 
-    static ParentPeriodGeneratorImpl create() {
-        Calendar calendar = Calendar.getInstance();
+    static ParentPeriodGeneratorImpl create(CalendarProvider calendarProvider) {
+        Calendar calendar = calendarProvider.getCalendar();
         return new ParentPeriodGeneratorImpl(
                 new DailyPeriodGenerator(calendar),
                 WeeklyPeriodGenerators.create(calendar),

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodPackageDIModule.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodPackageDIModule.java
@@ -40,13 +40,19 @@ public final class PeriodPackageDIModule {
 
     @Provides
     @Reusable
-    ParentPeriodGenerator parentPeriodGenerator() {
-        return ParentPeriodGeneratorImpl.create();
+    ParentPeriodGenerator parentPeriodGenerator(CalendarProvider calendarProvider) {
+        return ParentPeriodGeneratorImpl.create(calendarProvider);
     }
 
     @Provides
     @Reusable
     PeriodModule periodModule(PeriodModuleImpl impl) {
         return impl;
+    }
+
+    @Provides
+    @Reusable
+    CalendarProvider calendarProvider() {
+        return CalendarProviderFactory.getCalendarProvider();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/RegularCalendarProvider.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/RegularCalendarProvider.java
@@ -26,32 +26,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.utils.runner;
+package org.hisp.dhis.android.core.period.internal;
 
-import android.util.Log;
+import java.util.Calendar;
 
-import org.hisp.dhis.android.core.period.internal.CalendarProviderFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.DatabaseAdapterFactory;
-import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestObjectsFactory;
-import org.junit.runner.Description;
-import org.junit.runner.Result;
-import org.junit.runner.notification.RunListener;
-
-public class D2JunitTestListener extends RunListener {
-
+class RegularCalendarProvider implements CalendarProvider {
 
     @Override
-    public void testRunStarted(Description description) {
-        Log.e("D2JunitTestListener", "Test run started");
-        CalendarProviderFactory.setFixed();
-        DatabaseAdapterFactory.setUp();
-    }
-
-    @Override
-    public void testRunFinished(Result result) throws Exception {
-        Log.i("D2JunitTestListener", "Test run finished");
-        DatabaseAdapterFactory.tearDown();
-        CalendarProviderFactory.setRegular();
-        MockIntegrationTestObjectsFactory.tearDown();
+    public Calendar getCalendar() {
+        return Calendar.getInstance();
     }
 }


### PR DESCRIPTION
Solves [ANDROSDK-1054](https://jira.dhis2.org/browse/ANDROSDK-1054).