### PR TITLE
feat: [ANDROSDK-3-F] Extend Database adapter

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboEndpointCallRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboEndpointCallRealIntegrationShould.java
@@ -64,7 +64,7 @@ public class CategoryComboEndpointCallRealIntegrationShould extends BaseRealInte
     public void download_categories_combos_and_relatives() throws Exception {
         d2.userModule().logIn(username, password, url).blockingGet();
 
-        d2.databaseAdapter().database().setForeignKeyConstraintsEnabled(false);
+        d2.databaseAdapter().setForeignKeyConstraintsEnabled(false);
 
         assertNotCombosInDB();
         assertTrue(getCategoryCategoryComboLinks().isEmpty());

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/IdentifiableObjectStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/IdentifiableObjectStoreIntegrationShould.java
@@ -63,7 +63,7 @@ public class IdentifiableObjectStoreIntegrationShould extends BaseRealIntegratio
     }
 
     private Cursor getCursor() {
-        return getCursor(OptionSetTableInfo.TABLE_INFO.name(), OptionSetTableInfo.TABLE_INFO.columns().all());
+        return databaseAdapter().query(OptionSetTableInfo.TABLE_INFO.name(), OptionSetTableInfo.TABLE_INFO.columns().all());
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/ObjectStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/ObjectStoreIntegrationShould.java
@@ -62,7 +62,7 @@ public class ObjectStoreIntegrationShould extends BaseRealIntegrationTest {
     @Test
     public void insert_option_set() {
         store.insert(optionSet);
-        Cursor cursor = getCursor(OptionSetTableInfo.TABLE_INFO.name(), OptionSetTableInfo.TABLE_INFO.columns().all());
+        Cursor cursor = databaseAdapter().query(OptionSetTableInfo.TABLE_INFO.name(), OptionSetTableInfo.TABLE_INFO.columns().all());
         optionSetCursorAssert(cursor, optionSet);
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreIntegrationShould.java
@@ -79,8 +79,7 @@ public class ConfigurationStoreIntegrationShould {
 
     @Test
     public void insert_as_content_values_and_select_first_object() {
-        long rowsInserted = databaseAdapter.database()
-                .insert(tableInfo.name(), null, configuration.toContentValues());
+        long rowsInserted = databaseAdapter.insert(tableInfo.name(), null, configuration.toContentValues());
         assertThat(rowsInserted).isEqualTo(1);
         Configuration objectFromDb = store.selectFirst();
         assertThat(objectFromDb).isEqualTo(configuration);

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreShould.java
@@ -62,8 +62,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
     public void persist_row_in_database_when_save() {
         store.save(Configuration.builder().serverUrl(HttpUrl.parse(URL1)).build());
 
-        Cursor cursor = database().query(ConfigurationTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(ConfigurationTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThatCursor(cursor)
                 .hasRow(1L, URL1)
@@ -80,8 +79,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
         // trying to configure configuration with server url (which is set to be unique in the table)
         store.save(Configuration.builder().serverUrl(HttpUrl.parse(URL1)).build());
 
-        Cursor cursor = database().query(ConfigurationTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(ConfigurationTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor)
                 .hasRow(2L, URL1)
                 .isExhausted();
@@ -97,8 +95,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
         HttpUrl url = HttpUrl.parse(URL2);
         store.save(Configuration.builder().serverUrl(url).build());
 
-        Cursor cursor = database().query(ConfigurationTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(ConfigurationTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor)
                 .hasRow(2L, URL2)
                 .isExhausted();
@@ -113,8 +110,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
 
         long deleted = store.delete();
 
-        Cursor cursor = database().query(ConfigurationTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(ConfigurationTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThat(deleted).isEqualTo(1);
         assertThatCursor(cursor).isExhausted();
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/ConfigurationStoreShould.java
@@ -75,7 +75,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
         ContentValues contentValues = new ContentValues();
         contentValues.put(ConfigurationTableInfo.Columns.SERVER_URL, URL1);
 
-        database().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
+        databaseAdapter().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
 
         // trying to configure configuration with server url (which is set to be unique in the table)
         store.save(Configuration.builder().serverUrl(HttpUrl.parse(URL1)).build());
@@ -92,7 +92,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
         ContentValues contentValues = new ContentValues();
         contentValues.put(ConfigurationTableInfo.Columns.SERVER_URL, URL1);
 
-        database().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
+        databaseAdapter().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
 
         HttpUrl url = HttpUrl.parse(URL2);
         store.save(Configuration.builder().serverUrl(url).build());
@@ -109,7 +109,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
         ContentValues contentValues = new ContentValues();
         contentValues.put(ConfigurationTableInfo.Columns.SERVER_URL, URL1);
 
-        database().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
+        databaseAdapter().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
 
         long deleted = store.delete();
 
@@ -130,7 +130,7 @@ public class ConfigurationStoreShould extends BaseRealIntegrationTest {
         ContentValues contentValues = new ContentValues();
         contentValues.put(ConfigurationTableInfo.Columns.SERVER_URL, URL1);
 
-        database().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
+        databaseAdapter().insert(ConfigurationTableInfo.TABLE_INFO.name(), null, contentValues);
 
         HttpUrl url = HttpUrl.parse(URL2);
         store.save(Configuration.builder().serverUrl(url).build());

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/DatabaseAssert.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/DatabaseAssert.java
@@ -74,7 +74,7 @@ public final class DatabaseAssert {
     private void verifyEmptyDatabase(boolean expectedEmpty) {
         boolean isEmpty = true;
 
-        Cursor cursor = databaseAdapter.query(" SELECT name FROM sqlite_master "
+        Cursor cursor = databaseAdapter.rawQuery(" SELECT name FROM sqlite_master "
                 + "WHERE type='table' and name!='android_metadata' and name!='sqlite_sequence'");
         int value = cursor.getColumnIndex("name");
         if (value != -1) {
@@ -98,7 +98,7 @@ public final class DatabaseAssert {
         int count;
 
         try {
-            cursor = databaseAdapter.query("SELECT COUNT(*) from " + tableName);
+            cursor = databaseAdapter.rawQuery("SELECT COUNT(*) from " + tableName);
             cursor.moveToFirst();
             count = cursor.getInt(0);
         } finally {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.java
@@ -74,8 +74,7 @@ public abstract class ObjectStoreAbstractIntegrationShould<M extends CoreObject>
 
     @Test
     public void insert_as_content_values_and_select_first_object() {
-        long rowsInserted = databaseAdapter.database()
-                .insert(tableInfo.name(), null, object.toContentValues());
+        long rowsInserted = databaseAdapter.insert(tableInfo.name(), null, object.toContentValues());
         assertThat(rowsInserted).isEqualTo(1);
         M objectFromDb = store.selectFirst();
         assertEqualsIgnoreId(objectFromDb);

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerShould.java
@@ -136,7 +136,7 @@ public class ForeignKeyCleanerShould extends BaseRealIntegrationTest {
                     .sortOrder(2)
                     .build();
 
-            d2.databaseAdapter().database().insert(CategoryCategoryComboLinkTableInfo.TABLE_INFO.name(),
+            d2.databaseAdapter().insert(CategoryCategoryComboLinkTableInfo.TABLE_INFO.name(),
                     null, categoryCategoryComboLink.toContentValues());
 
             ForeignKeyCleanerImpl.create(d2.databaseAdapter()).cleanForeignKeyErrors();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerShould.java
@@ -268,18 +268,15 @@ public class ForeignKeyCleanerShould extends BaseRealIntegrationTest {
     }
 
     private Cursor getUserCredentialsCursor() {
-        return database().query(UserCredentialsTableInfo.TABLE_INFO.name(), USER_CREDENTIALS_PROJECTION,
-                null, null, null, null, null);
+        return databaseAdapter().query(UserCredentialsTableInfo.TABLE_INFO.name(), USER_CREDENTIALS_PROJECTION);
     }
 
     private Cursor getProgramRuleCursor() {
-        return database().query(ProgramRuleTableInfo.TABLE_INFO.name(), PROGRAM_RULE_PROJECTION,
-                null, null, null, null, null);
+        return databaseAdapter().query(ProgramRuleTableInfo.TABLE_INFO.name(), PROGRAM_RULE_PROJECTION);
     }
 
     private Cursor getProgramRuleActionCursor() {
-        return database().query(ProgramRuleActionTableInfo.TABLE_INFO.name(), PROGRAM_RULE_ACTION_PROJECTION,
-                null, null, null, null, null);
+        return databaseAdapter().query(ProgramRuleActionTableInfo.TABLE_INFO.name(), PROGRAM_RULE_ACTION_PROJECTION);
     }
 
     private void assertThatCursorHasRowCount(Cursor cursor, int rowCount) {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.java
@@ -89,11 +89,11 @@ public class OrganisationUnitCallMockIntegrationShould extends BaseMockIntegrati
         User user = UserInternalAccessor.insertOrganisationUnits(User.builder(), organisationUnits)
                 .uid("user_uid").build();
 
-        database.insert(UserTableInfo.TABLE_INFO.name(), null, user.toContentValues());
+        databaseAdapter.insert(UserTableInfo.TABLE_INFO.name(), null, user.toContentValues());
 
         ContentValues userContentValues = new ContentValues();
         userContentValues.put(IdentifiableColumns.UID, "user_uid");
-        database.insert(UserTableInfo.TABLE_INFO.name(), null, userContentValues);
+        databaseAdapter.insert(UserTableInfo.TABLE_INFO.name(), null, userContentValues);
 
         // inserting programs for creating OrgUnitProgramLinks
         String programUid = "lxAQ7Zs9VYR";
@@ -114,7 +114,7 @@ public class OrganisationUnitCallMockIntegrationShould extends BaseMockIntegrati
     private void insertProgramWithUid(String uid) {
         ContentValues program = new ContentValues();
         program.put(IdentifiableColumns.UID, uid);
-        database.insert(ProgramTableInfo.TABLE_INFO.name(), null, program);
+        databaseAdapter.insert(ProgramTableInfo.TABLE_INFO.name(), null, program);
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramIndicatorEngineIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/ProgramIndicatorEngineIntegrationShould.java
@@ -125,7 +125,7 @@ public class ProgramIndicatorEngineIntegrationShould extends BaseMockIntegration
         teiStore.insert(trackedEntityInstance);
 
         ContentValues categoryCombo = CreateCategoryComboUtils.create(1L, CategoryCombo.DEFAULT_UID);
-        database.insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo);
+        databaseAdapter.insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo);
 
         Access access = Access.create(true, null, DataAccess.create(true, true));
         Program program = Program.builder().uid(programUid)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.java
@@ -135,8 +135,7 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
         // Fake call to api
         programEndpointCall.call();
 
-        Cursor programCursor = database.query(ProgramTableInfo.TABLE_INFO.name(), PROGRAM_PROJECTION,
-                null, null, null, null, null);
+        Cursor programCursor = databaseAdapter.query(ProgramTableInfo.TABLE_INFO.name(), PROGRAM_PROJECTION);
 
         assertThatCursor(programCursor).hasRow(
                 "IpHINAT79UW",
@@ -188,8 +187,8 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
                 ProgramRuleVariableTableInfo.Columns.PROGRAM_RULE_VARIABLE_SOURCE_TYPE
         };
 
-        Cursor programRuleVariableCursor = database.query(ProgramRuleVariableTableInfo.TABLE_INFO.name(), projection,
-                UID + "=?", new String[]{"g2GooOydipB"}, null, null, null);
+        Cursor programRuleVariableCursor = databaseAdapter.query(ProgramRuleVariableTableInfo.TABLE_INFO.name(), projection,
+                UID + "=?", new String[]{"g2GooOydipB"});
 
         assertThatCursor(programRuleVariableCursor).hasRow(
                 "g2GooOydipB",
@@ -229,12 +228,11 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
                 ProgramTrackedEntityAttributeTableInfo.Columns.SORT_ORDER
         };
 
-        Cursor programTrackedEntityAttributeCursor = database.query(
+        Cursor programTrackedEntityAttributeCursor = databaseAdapter.query(
                 ProgramTrackedEntityAttributeTableInfo.TABLE_INFO.name(),
                 projection,
                 UID + "=?",
-                new String[]{"l2T72XzBCLd"},
-                null, null, null);
+                new String[]{"l2T72XzBCLd"});
 
         assertThatCursor(programTrackedEntityAttributeCursor).hasRow(
                 "l2T72XzBCLd",
@@ -260,10 +258,10 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
     public void persist_program_indicators_when_call() throws Exception {
         programEndpointCall.call();
 
-        Cursor programIndicatorCursor = database.query(
+        Cursor programIndicatorCursor = databaseAdapter.query(
                 ProgramIndicatorTableInfo.TABLE_INFO.name(),
                 ProgramIndicatorTableInfo.TABLE_INFO.columns().all(),
-                UID + "=?", new String[]{"rXoaHGAXWy9"}, null, null, null);
+                UID + "=?", new String[]{"rXoaHGAXWy9"});
         assertThatCursor(programIndicatorCursor).hasRow(
                 "rXoaHGAXWy9",
                 null,
@@ -292,10 +290,10 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
     public void persist_legend_sets_when_call() throws Exception {
         programEndpointCall.call();
 
-        Cursor programIndicatorCursor = database.query(
+        Cursor programIndicatorCursor = databaseAdapter.query(
                 LegendSetTableInfo.TABLE_INFO.name(),
                 LegendSetTableInfo.TABLE_INFO.columns().all(),
-                UID + "=?", new String[]{"TiOkbpGEud4"}, null, null, null);
+                UID + "=?", new String[]{"TiOkbpGEud4"});
         assertThatCursor(programIndicatorCursor).hasRow(
                 "TiOkbpGEud4",
                 "AGE15YINT",
@@ -311,10 +309,10 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
     public void persist_legends_when_call() throws Exception {
         programEndpointCall.call();
 
-        Cursor programIndicatorCursor = database.query(
+        Cursor programIndicatorCursor = databaseAdapter.query(
                 LegendTableInfo.TABLE_INFO.name(),
                 LegendTableInfo.TABLE_INFO.columns().all(),
-                UID + "=?", new String[]{"ZUUGJnvX40X"}, null, null, null);
+                UID + "=?", new String[]{"ZUUGJnvX40X"});
         assertThatCursor(programIndicatorCursor).hasRow(
                 "ZUUGJnvX40X",
                 null,
@@ -339,8 +337,7 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
     public void not_persist_relationship_type_when_call() throws Exception {
         programEndpointCall.call();
 
-        Cursor relationshipTypeCursor = database.query(RelationshipTypeTableInfo.TABLE_INFO.name(), RelationshipTypeTableInfo.TABLE_INFO.columns().all(),
-                null, null, null, null, null);
+        Cursor relationshipTypeCursor = databaseAdapter.query(RelationshipTypeTableInfo.TABLE_INFO.name(), RelationshipTypeTableInfo.TABLE_INFO.columns().all());
 
         assertThatCursor(relationshipTypeCursor).isExhausted();
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.java
@@ -102,24 +102,24 @@ public class ProgramEndpointCallMockIntegrationShould extends BaseMockIntegratio
         BaseMockIntegrationTestEmptyEnqueable.setUpClass();
 
         ContentValues categoryCombo = CreateCategoryComboUtils.create(1L, "nM3u9s5a52V");
-        database.insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo);
+        databaseAdapter.insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo);
 
         ContentValues categoryCombo2 = CreateCategoryComboUtils.create(2L, "x31y45jvIQL");
-        database.insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo2);
+        databaseAdapter.insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo2);
 
         // inserting tracked entity
         ContentValues trackedEntityType = CreateTrackedEntityUtils.create(1L, "nEenWmSyUEp");
-        database.insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
+        databaseAdapter.insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
 
         // inserting tracked entity attributes
         ContentValues trackedEntityAttribute1 = CreateTrackedEntityAttributeUtils.create(1L, "w75KJ2mc4zz", null);
-        database.insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute1);
+        databaseAdapter.insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute1);
 
         ContentValues trackedEntityAttribute2 = CreateTrackedEntityAttributeUtils.create(2L, "zDhUuAYrxNC", null);
-        database.insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute2);
+        databaseAdapter.insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute2);
 
         ContentValues trackedEntityAttribute3 = CreateTrackedEntityAttributeUtils.create(3L, "cejWyOfXge6", null);
-        database.insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute3);
+        databaseAdapter.insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute3);
 
         programEndpointCall = objects.d2DIComponent.programCallFactory().create();
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoCallMockIntegrationShould.java
@@ -59,7 +59,7 @@ public class SystemInfoCallMockIntegrationShould extends BaseMockIntegrationTest
     @Before
     public void setUp() {
         dhis2MockServer.enqueueMockResponse("systeminfo/system_info.json");
-        database.delete(tableInfo.name(), "1", new String[]{});
+        databaseAdapter.delete(tableInfo.name(), "1", new String[]{});
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoCallMockIntegrationShould.java
@@ -70,7 +70,7 @@ public class SystemInfoCallMockIntegrationShould extends BaseMockIntegrationTest
 
     @Test
     public void update_system_info_when_call() {
-        database.insert(tableInfo.name(), null, systemInfoFromDB.toContentValues());
+        databaseAdapter.insert(tableInfo.name(), null, systemInfoFromDB.toContentValues());
         isSystemInfoInDb(systemInfoFromDB);
 
         systemInfoRepository.blockingDownload();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManagerRealIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManagerRealIntegrationShould.java
@@ -143,7 +143,7 @@ public class TrackedEntityAttributeReservedValueManagerRealIntegrationShould ext
         trackedEntityAttributeStore.updateOrInsert(TrackedEntityAttribute.builder().uid(ownerUid).pattern(pattern).build());
 
         CategoryCombo categoryCombo = CategoryCombo.builder().uid(categoryComboUid).build();
-        database().insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo.toContentValues());
+        databaseAdapter().insert(CategoryComboTableInfo.TABLE_INFO.name(), null, categoryCombo.toContentValues());
 
         Program program = Program.builder().uid(programUid).categoryCombo(ObjectWithUid.create(categoryCombo.uid()))
                 .access(Access.create(null, null, DataAccess.create(true, true))).build();

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreShould.java
@@ -124,8 +124,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
     public void insert_tracked_entity_attribute_value_in_data_base_when_insert() {
         long rowId = trackedEntityAttributeValueStore.insert(trackedEntityAttributeValue);
 
-        Cursor cursor = database().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor)
@@ -152,8 +151,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
         database().setTransactionSuccessful();
         database().endTransaction();
 
-        Cursor cursor = database().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor)
@@ -166,9 +164,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
     public void insert_nullable_tracked_entity_attribute_value_in_data_base_when_insert_nullable_tracked_entity_attribute_value() {
         long rowId = trackedEntityAttributeValueStore.insert(trackedEntityAttributeValue.toBuilder().value(null).build());
 
-        Cursor cursor = database().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
-                PROJECTION,
-                null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor)
@@ -182,9 +178,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
         trackedEntityAttributeValueStore.insert(trackedEntityAttributeValue.toBuilder().value("0").build());
         trackedEntityAttributeValueStore.updateOrInsertWhere(trackedEntityAttributeValue.toBuilder().value("4").build());
 
-        Cursor cursor = database().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION, null,
-                null, null,
-                null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThatCursor(cursor).hasRow(
                 "4",
@@ -246,8 +240,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
                 IdentifiableColumns.UID + "=?",
                 new String[]{TRACKED_ENTITY_ATTRIBUTE});
 
-        Cursor cursor = database().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor).isExhausted();
     }
 
@@ -259,8 +252,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
                 TrackedEntityInstanceTableInfo.Columns.UID + "=?",
                 new String[]{TRACKED_ENTITY_INSTANCE});
 
-        Cursor cursor = database().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor).isExhausted();
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreShould.java
@@ -242,7 +242,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
     public void delete_tracked_entity_attribute_value_in_data_base_when_delete_tracked_entity_attribute() {
         insert_nullable_tracked_entity_attribute_value_in_data_base_when_insert_nullable_tracked_entity_attribute_value();
 
-        database().delete(TrackedEntityAttributeTableInfo.TABLE_INFO.name(),
+        databaseAdapter().delete(TrackedEntityAttributeTableInfo.TABLE_INFO.name(),
                 IdentifiableColumns.UID + "=?",
                 new String[]{TRACKED_ENTITY_ATTRIBUTE});
 
@@ -255,7 +255,7 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
     public void delete_tracked_entity_attribute_value_in_data_base_when_delete_tracked_entity_instance() {
         insert_nullable_tracked_entity_attribute_value_in_data_base_when_insert_nullable_tracked_entity_attribute_value();
 
-        database().delete(TrackedEntityInstanceTableInfo.TABLE_INFO.name(),
+        databaseAdapter().delete(TrackedEntityInstanceTableInfo.TABLE_INFO.name(),
                 TrackedEntityInstanceTableInfo.Columns.UID + "=?",
                 new String[]{TRACKED_ENTITY_INSTANCE});
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreShould.java
@@ -107,12 +107,12 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
         ContentValues trackedEntityAttribute2 = CreateTrackedEntityAttributeUtils
                 .create(2L, TRACKED_ENTITY_ATTRIBUTE_2, null);
 
-        database().insert(OrganisationUnitTableInfo.TABLE_INFO.name(), null, organisationUnit.toContentValues());
-        database().insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
-        database().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance);
-        database().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance_2);
-        database().insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute);
-        database().insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute2);
+        databaseAdapter().insert(OrganisationUnitTableInfo.TABLE_INFO.name(), null, organisationUnit.toContentValues());
+        databaseAdapter().insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
+        databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance);
+        databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance_2);
+        databaseAdapter().insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute);
+        databaseAdapter().insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute2);
 
         trackedEntityAttributeValue = TrackedEntityAttributeValue.builder()
                 .value(VALUE).created(date).lastUpdated(date).trackedEntityAttribute(TRACKED_ENTITY_ATTRIBUTE)
@@ -147,8 +147,8 @@ public class TrackedEntityAttributeValueStoreShould extends BaseRealIntegrationT
                 deferredTrackedEntityInstance, ORGANIZATION_UNIT, TRACKED_ENTITY);
         ContentValues trackedEntityAttribute = CreateTrackedEntityAttributeUtils.create(3L,
                 deferredTrackedEntityAttribute, null);
-        database().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance);
-        database().insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute);
+        databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance);
+        databaseAdapter().insert(TrackedEntityAttributeTableInfo.TABLE_INFO.name(), null, trackedEntityAttribute);
         database().setTransactionSuccessful();
         database().endTransaction();
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreShould.java
@@ -151,20 +151,20 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
         ContentValues dataElement1 = CreateDataElementUtils.create(1L, DATA_ELEMENT_1, CategoryCombo.DEFAULT_UID, null);
         ContentValues dataElement2 = CreateDataElementUtils.create(2L, DATA_ELEMENT_2, CategoryCombo.DEFAULT_UID, null);
 
-        database().insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
-        database().insert(RelationshipTypeTableInfo.TABLE_INFO.name(), null,
+        databaseAdapter().insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
+        databaseAdapter().insert(RelationshipTypeTableInfo.TABLE_INFO.name(), null,
                 relationshipType);
-        database().insert(ProgramTableInfo.TABLE_INFO.name(), null, program);
-        database().insert(OrganisationUnitTableInfo.TABLE_INFO.name(), null, organisationUnit.toContentValues());
-        database().insert(ProgramStageTableInfo.TABLE_INFO.name(), null, programStage);
-        database().insert(CategoryComboTableInfo.TABLE_INFO.name(), null, defaultCategoryCombo);
-        database().insert(DataElementTableInfo.TABLE_INFO.name(), null, dataElement1);
-        database().insert(DataElementTableInfo.TABLE_INFO.name(), null, dataElement2);
-        database().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null,
+        databaseAdapter().insert(ProgramTableInfo.TABLE_INFO.name(), null, program);
+        databaseAdapter().insert(OrganisationUnitTableInfo.TABLE_INFO.name(), null, organisationUnit.toContentValues());
+        databaseAdapter().insert(ProgramStageTableInfo.TABLE_INFO.name(), null, programStage);
+        databaseAdapter().insert(CategoryComboTableInfo.TABLE_INFO.name(), null, defaultCategoryCombo);
+        databaseAdapter().insert(DataElementTableInfo.TABLE_INFO.name(), null, dataElement1);
+        databaseAdapter().insert(DataElementTableInfo.TABLE_INFO.name(), null, dataElement2);
+        databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null,
                 trackedEntityInstance);
-        database().insert(EnrollmentTableInfo.TABLE_INFO.name(), null, enrollment);
-        database().insert(EventTableInfo.TABLE_INFO.name(), null, event1);
-        database().insert(EventTableInfo.TABLE_INFO.name(), null, event2);
+        databaseAdapter().insert(EnrollmentTableInfo.TABLE_INFO.name(), null, enrollment);
+        databaseAdapter().insert(EventTableInfo.TABLE_INFO.name(), null, event1);
+        databaseAdapter().insert(EventTableInfo.TABLE_INFO.name(), null, event2);
 
         trackedEntityDataValue = TrackedEntityDataValue.builder()
                 .event(EVENT_1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreShould.java
@@ -217,7 +217,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
     public void delete_tracked_entity_data_value_when_delete_event_foreign_key() {
         trackedEntityDataValueStore.insert(trackedEntityDataValue);
 
-        database().delete(EventTableInfo.TABLE_INFO.name(), EventTableInfo.Columns.UID + "=?",
+        databaseAdapter().delete(EventTableInfo.TABLE_INFO.name(), EventTableInfo.Columns.UID + "=?",
                 new String[]{EVENT_1});
 
         Cursor cursor = database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
@@ -231,7 +231,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
     public void delete_tracked_entity_data_value_when_delete_data_element_foreign_key() {
         trackedEntityDataValueStore.insert(trackedEntityDataValue);
 
-        database().delete(DataElementTableInfo.TABLE_INFO.name(),
+        databaseAdapter().delete(DataElementTableInfo.TABLE_INFO.name(),
                 IdentifiableColumns.UID + "=?",
                 new String[]{DATA_ELEMENT_1});
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreShould.java
@@ -180,8 +180,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
     @Test
     public void insert_tracked_entity_data_value_in_data_base_when_insert() {
         long rowId = trackedEntityDataValueStore.insert(trackedEntityDataValue);
-        Cursor cursor = database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor).hasRow(
                 EVENT_1,
@@ -204,8 +203,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
                 .value(null)
                 .providedElsewhere(null).build());
 
-        Cursor cursor = database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThat(rowId).isEqualTo(1L);
         assertThatCursor(cursor).hasRow(EVENT_1, null, null, DATA_ELEMENT_1, null, null,
@@ -220,8 +218,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
         databaseAdapter().delete(EventTableInfo.TABLE_INFO.name(), EventTableInfo.Columns.UID + "=?",
                 new String[]{EVENT_1});
 
-        Cursor cursor = database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor).isExhausted();
         cursor.close();
     }
@@ -235,8 +232,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
                 IdentifiableColumns.UID + "=?",
                 new String[]{DATA_ELEMENT_1});
 
-        Cursor cursor = database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor).isExhausted();
         cursor.close();
     }
@@ -247,10 +243,10 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
 
         String[] projection = {Columns.EVENT};
         Cursor cursor =
-                database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
+                databaseAdapter().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
                         projection,
                 Columns.EVENT + "=?",
-                new String[]{EVENT_1}, null, null, null);
+                new String[]{EVENT_1});
         assertThatCursor(cursor).hasRow(EVENT_1).isExhausted();
         cursor.close();
 
@@ -294,8 +290,7 @@ public class TrackedEntityDataValueStoreShould extends BaseRealIntegrationTest {
 
         trackedEntityDataValueStore.updateWhere(trackedEntityDataValue);
 
-        Cursor cursor = database().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(),
-                PROJECTION, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityDataValueTableInfo.TABLE_INFO.name(), PROJECTION);
 
         assertThatCursor(cursor).hasRow(EVENT_1,
                 dateString,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreShould.java
@@ -119,7 +119,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
     public void delete_tei_in_data_base_when_delete_organisation_unit_foreign_key() {
         trackedEntityInstanceStore.insert(trackedEntityInstance);
 
-        database().delete(OrganisationUnitTableInfo.TABLE_INFO.name(),
+        databaseAdapter().delete(OrganisationUnitTableInfo.TABLE_INFO.name(),
                 IdentifiableColumns.UID + "=?",
                 new String[]{ ORGANISATION_UNIT });
 
@@ -132,7 +132,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
     public void delete_tracked_entity_instance_in_data_base_when_delete_tracked_entity_foreign_key() {
         trackedEntityInstanceStore.insert(trackedEntityInstance);
 
-        database().delete(TrackedEntityTypeTableInfo.TABLE_INFO.name(),
+        databaseAdapter().delete(TrackedEntityTypeTableInfo.TABLE_INFO.name(),
                 TrackedEntityTypeTableInfo.Columns.UID + "=?",
                 new String[]{ TRACKED_ENTITY} );
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreShould.java
@@ -100,8 +100,8 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
         trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl.create(databaseAdapter());
         OrganisationUnit organisationUnit = OrganisationUnitSamples.getOrganisationUnit(ORGANISATION_UNIT);
         ContentValues trackedEntityType = CreateTrackedEntityUtils.create(1L, TRACKED_ENTITY);
-        database().insert(OrganisationUnitTableInfo.TABLE_INFO.name(), null, organisationUnit.toContentValues());
-        database().insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
+        databaseAdapter().insert(OrganisationUnitTableInfo.TABLE_INFO.name(), null, organisationUnit.toContentValues());
+        databaseAdapter().insert(TrackedEntityTypeTableInfo.TABLE_INFO.name(), null, trackedEntityType);
         trackedEntityInstance = TrackedEntityInstance.builder()
                 .uid(UID)
                 .created(date)
@@ -149,7 +149,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
         trackedEntityInstance.put(Columns.TRACKED_ENTITY_TYPE, TRACKED_ENTITY);
         trackedEntityInstance.put(DataColumns.STATE, STATE.name());
 
-        database().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance);
+        databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstance);
 
         String[] projection = {
                 Columns.UID,
@@ -177,7 +177,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
         trackedEntityInstanceContentValues.put(Columns.ORGANISATION_UNIT, ORGANISATION_UNIT);
         trackedEntityInstanceContentValues.put(Columns.TRACKED_ENTITY_TYPE, TRACKED_ENTITY);
         trackedEntityInstanceContentValues.put(DataColumns.STATE, State.TO_POST.name());
-        database().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstanceContentValues);
+        databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstanceContentValues);
 
         String[] projection = {Columns.UID};
         Cursor cursor = database().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection, null, null, null, null, null);

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreShould.java
@@ -123,8 +123,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
                 IdentifiableColumns.UID + "=?",
                 new String[]{ ORGANISATION_UNIT });
 
-        Cursor cursor = database().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), PROJECTION, null, null,
-                null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor).isExhausted();
     }
 
@@ -136,8 +135,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
                 TrackedEntityTypeTableInfo.Columns.UID + "=?",
                 new String[]{ TRACKED_ENTITY} );
 
-        Cursor cursor = database().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), PROJECTION, null, null,
-                null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), PROJECTION);
         assertThatCursor(cursor).isExhausted();
     }
 
@@ -158,13 +156,13 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
                 DataColumns.STATE
         };
 
-        Cursor cursor = database().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection);
         // check that tracked entity instance was successfully inserted
         assertThatCursor(cursor).hasRow(UID, ORGANISATION_UNIT, TRACKED_ENTITY, STATE).isExhausted();
         State updatedState = State.SYNCED;
         trackedEntityInstanceStore.setState(UID, updatedState);
 
-        cursor = database().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection, null, null, null, null, null);
+        cursor = databaseAdapter().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection);
 
         // check that trackedEntityInstance is updated with updated state
         assertThatCursor(cursor).hasRow(UID, ORGANISATION_UNIT, TRACKED_ENTITY, updatedState).isExhausted();
@@ -180,7 +178,7 @@ public class TrackedEntityInstanceStoreShould extends BaseRealIntegrationTest {
         databaseAdapter().insert(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), null, trackedEntityInstanceContentValues);
 
         String[] projection = {Columns.UID};
-        Cursor cursor = database().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection, null, null, null, null, null);
+        Cursor cursor = databaseAdapter().query(TrackedEntityInstanceTableInfo.TABLE_INFO.name(), projection);
         // verify that tei was successfully inserted into database
         assertThatCursor(cursor).hasRow(UID).isExhausted();
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserCallMockIntegrationShould.java
@@ -77,7 +77,7 @@ public class UserCallMockIntegrationShould extends BaseMockIntegrationTestEmptyE
 
         userCall.call();
 
-        Cursor userCursor = database.query(UserTableInfo.TABLE_INFO.name(), UserTableInfo.TABLE_INFO.columns().all(), null, null, null, null, null);
+        Cursor userCursor = databaseAdapter.query(UserTableInfo.TABLE_INFO.name(), UserTableInfo.TABLE_INFO.columns().all());
 
         assertThatCursor(userCursor).hasRow(
                 "DXyJmlo9rge",
@@ -120,8 +120,7 @@ public class UserCallMockIntegrationShould extends BaseMockIntegrationTestEmptyE
         };
 
 
-        Cursor userCredentialsCursor = database.query(UserCredentialsTableInfo.TABLE_INFO.name(), projection,
-                null, null, null, null, null);
+        Cursor userCredentialsCursor = databaseAdapter.query(UserCredentialsTableInfo.TABLE_INFO.name(), projection);
 
         assertThatCursor(userCredentialsCursor).hasRow(
                 "M0fCOxtkURr",

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserCallMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserCallMockIntegrationShould.java
@@ -64,11 +64,11 @@ public class UserCallMockIntegrationShould extends BaseMockIntegrationTestEmptyE
         ContentValues program4 = CreateProgramUtils.create(4L, "WSGAb5XwJ3Y", null, null);
         ContentValues program5 = CreateProgramUtils.create(5L, "IpHINAT79UW", null, null);
 
-        database.insert(ProgramTableInfo.TABLE_INFO.name(), null, program1);
-        database.insert(ProgramTableInfo.TABLE_INFO.name(), null, program2);
-        database.insert(ProgramTableInfo.TABLE_INFO.name(), null, program3);
-        database.insert(ProgramTableInfo.TABLE_INFO.name(), null, program4);
-        database.insert(ProgramTableInfo.TABLE_INFO.name(), null, program5);
+        databaseAdapter.insert(ProgramTableInfo.TABLE_INFO.name(), null, program1);
+        databaseAdapter.insert(ProgramTableInfo.TABLE_INFO.name(), null, program2);
+        databaseAdapter.insert(ProgramTableInfo.TABLE_INFO.name(), null, program3);
+        databaseAdapter.insert(ProgramTableInfo.TABLE_INFO.name(), null, program4);
+        databaseAdapter.insert(ProgramTableInfo.TABLE_INFO.name(), null, program5);
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/mock/DatabaseAdapterFactory.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/mock/DatabaseAdapterFactory.java
@@ -45,7 +45,7 @@ public class DatabaseAdapterFactory {
     public static void setUp() {
         if (databaseAdapter == null) {
             databaseAdapter = create();
-            databaseAdapter.database().setForeignKeyConstraintsEnabled(false);
+            databaseAdapter.setForeignKeyConstraintsEnabled(false);
         }
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/real/BaseRealIntegrationTest.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/real/BaseRealIntegrationTest.java
@@ -29,7 +29,6 @@
 package org.hisp.dhis.android.core.utils.integration.real;
 
 import android.content.Context;
-import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.facebook.stetho.Stetho;
@@ -97,11 +96,6 @@ public abstract class BaseRealIntegrationTest {
     protected GenericCallData getGenericCallData(D2 d2) {
         return GenericCallData.create(
                 databaseAdapter(), d2.retrofit(), resourceHandler, d2.systemInfoModule().versionManager());
-    }
-
-    protected Cursor getCursor(String table, String[] columns) {
-        return sqLiteDatabase.query(table, columns,
-                null, null, null, null, null);
     }
 
     protected D2DIComponent getD2DIComponent(D2 d2) {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/CollectionCleanerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/CollectionCleanerImpl.java
@@ -53,6 +53,6 @@ public class CollectionCleanerImpl<P extends ObjectWithUidInterface> implements 
 
         String objectUids = UidsHelper.commaSeparatedUidsWithSingleQuotationMarks(objects);
         String clause = IdentifiableColumns.UID + " NOT IN (" + objectUids + ");";
-        return databaseAdapter.database().delete(tableName, clause, null) > 0;
+        return databaseAdapter.delete(tableName, clause, null) > 0;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/DataOrphanCleanerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/DataOrphanCleanerImpl.java
@@ -64,6 +64,6 @@ public class DataOrphanCleanerImpl<P extends ObjectWithUidInterface, C extends O
                         + stateColumn + " IN ('" + State.SYNCED + "','" + State.SYNCED_VIA_SMS + "')"
                         + " AND "
                         + IdentifiableColumns.UID + " NOT IN (" + childrenUids + ");";
-        return databaseAdapter.database().delete(tableName, clause, null) > 0;
+        return databaseAdapter.delete(tableName, clause, null) > 0;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/OrphanCleanerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/OrphanCleanerImpl.java
@@ -58,6 +58,6 @@ public class OrphanCleanerImpl<P extends ObjectWithUidInterface, C extends Objec
                 parentColumn + "='" + parent.uid() + "'"
                 + " AND "
                 + IdentifiableColumns.UID + " NOT IN (" + childrenUids + ");";
-        return databaseAdapter.database().delete(tableName, clause, null) > 0;
+        return databaseAdapter.delete(tableName, clause, null) > 0;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/SubCollectionCleanerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/cleaners/internal/SubCollectionCleanerImpl.java
@@ -71,7 +71,7 @@ public class SubCollectionCleanerImpl<P extends ObjectWithUidInterface> implemen
                             + " AND "
                             + IdentifiableColumns.UID + " NOT IN (" + childrenUids + ");";
 
-            result = result || databaseAdapter.database().delete(tableName, clause, null) > 0;
+            result = result || databaseAdapter.delete(tableName, clause, null) > 0;
         }
 
         return result;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.java
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.arch.db.access;
 
+import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
@@ -60,9 +61,13 @@ public interface DatabaseAdapter {
      * @return A {@link Cursor} object, which is positioned before the first entry. Note that
      * {@link Cursor}s are not synchronized, see the documentation for more details.
      */
-    Cursor query(String sql, String... selectionArgs);
 
-    /**
+    Cursor rawQuery(String sql, String... selectionArgs);
+
+    Cursor query(String sql, String... columns);
+
+    Cursor query(String table, String[] columns, String selection, String[] selectionArgs);
+                               /**
      * Execute {@code statement} and return the ID of the row inserted due to this call.
      * The SQL statement should be an INSERT for this to be a useful call.
      *
@@ -108,6 +113,13 @@ public interface DatabaseAdapter {
      */
     int delete(String table);
 
+    long insert(String table, String nullColumnHack, ContentValues values);
+
+    int update(String table, ContentValues values, String whereClause, String[] whereArgs);
+
+    void setForeignKeyConstraintsEnabled(boolean enable);
+
+    void close();
 
     /**
      * @return A newly started {@link Transaction}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.java
@@ -119,8 +119,6 @@ public interface DatabaseAdapter {
 
     void setForeignKeyConstraintsEnabled(boolean enable);
 
-    void close();
-
     /**
      * @return A newly started {@link Transaction}
      */

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/SqliteCheckerUtility.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/SqliteCheckerUtility.java
@@ -37,7 +37,7 @@ final public class SqliteCheckerUtility {
 
     public static boolean isTableEmpty(DatabaseAdapter databaseAdapter, String table) {
         boolean isTableEmpty = true;
-        Cursor cursor = databaseAdapter.query(" SELECT * FROM "+table);
+        Cursor cursor = databaseAdapter.rawQuery(" SELECT * FROM "+table);
         int value = cursor.getCount();
         if (value > 0) {
             isTableEmpty = false;
@@ -48,13 +48,13 @@ final public class SqliteCheckerUtility {
 
     public static boolean isDatabaseEmpty(DatabaseAdapter databaseAdapter) {
         boolean isDatabaseEmpty = true;
-        Cursor cursor = databaseAdapter.query(" SELECT name FROM sqlite_master WHERE "
+        Cursor cursor = databaseAdapter.rawQuery(" SELECT name FROM sqlite_master WHERE "
                 + "type='table' and name!='android_metadata' and name!='sqlite_sequence'");
         int value = cursor.getColumnIndex("name");
         if (value != -1) {
             while (cursor.moveToNext()){
                 String tableName = cursor.getString(value);
-                Cursor resTable = databaseAdapter.query("SELECT * from " + tableName);
+                Cursor resTable = databaseAdapter.rawQuery("SELECT * from " + tableName);
                 if (resTable.getCount() > 0) {
                     isDatabaseEmpty = false;
                     break;
@@ -67,7 +67,7 @@ final public class SqliteCheckerUtility {
 
     public static boolean ifTableExist(String table, DatabaseAdapter db) {
         boolean isExist = false;
-        Cursor cursor = db.query("PRAGMA table_info(" + table + ")");
+        Cursor cursor = db.rawQuery("PRAGMA table_info(" + table + ")");
         int itemsCount = cursor.getCount();
         if (itemsCount > 0) {
             isExist = true;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/SqliteCheckerUtility.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/SqliteCheckerUtility.java
@@ -65,9 +65,9 @@ final public class SqliteCheckerUtility {
         return isDatabaseEmpty;
     }
 
-    public static boolean ifTableExist(String table, DatabaseAdapter db) {
+    public static boolean ifTableExist(String table, DatabaseAdapter databaseAdapter) {
         boolean isExist = false;
-        Cursor cursor = db.rawQuery("PRAGMA table_info(" + table + ")");
+        Cursor cursor = databaseAdapter.rawQuery("PRAGMA table_info(" + table + ")");
         int itemsCount = cursor.getCount();
         if (itemsCount > 0) {
             isExist = true;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/SqLiteDatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/SqLiteDatabaseAdapter.java
@@ -114,11 +114,6 @@ public class SqLiteDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public void close() {
-        database().close();
-    }
-
-    @Override
     public SQLiteDatabase database() {
         return dbOpenHelper.getWritableDatabase();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/SqLiteDatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/SqLiteDatabaseAdapter.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2004-2019, University of Oslo
  * All rights reserved.
- *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this
@@ -28,6 +27,7 @@
 
 package org.hisp.dhis.android.core.arch.db.access.internal;
 
+import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
@@ -64,8 +64,18 @@ public class SqLiteDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public Cursor query(String sql, String... selectionArgs) {
+    public Cursor rawQuery(String sql, String... selectionArgs) {
         return readableDatabase().rawQuery(sql, selectionArgs);
+    }
+
+    @Override
+    public Cursor query(String sql, String[] columns) {
+        return readableDatabase().query(sql, columns, null, null, null, null, null);
+    }
+
+    @Override
+    public Cursor query(String table, String[] columns, String selection, String[] selectionArgs) {
+        return readableDatabase().query(table, columns, selection, selectionArgs, null, null, null);
     }
 
     @Override
@@ -88,6 +98,27 @@ public class SqLiteDatabaseAdapter implements DatabaseAdapter {
         return delete(table, "1", null);
     }
 
+    @Override
+    public long insert(String table, String nullColumnHack, ContentValues values) {
+        return database().insert(table, nullColumnHack, values);
+    }
+
+    @Override
+    public int update(String table, ContentValues values, String whereClause, String[] whereArgs) {
+        return database().update(table, values, whereClause, whereArgs);
+    }
+
+    @Override
+    public void setForeignKeyConstraintsEnabled(boolean enable) {
+        database().setForeignKeyConstraintsEnabled(enable);
+    }
+
+    @Override
+    public void close() {
+        database().close();
+    }
+
+    @Override
     public SQLiteDatabase database() {
         return dbOpenHelper.getWritableDatabase();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDataObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDataObjectStoreImpl.java
@@ -126,7 +126,7 @@ public class IdentifiableDataObjectStoreImpl<M extends ObjectWithUidInterface & 
 
     @Override
     public State getState(@NonNull String uid) {
-        Cursor cursor = databaseAdapter.query(selectStateQuery, uid);
+        Cursor cursor = databaseAdapter.rawQuery(selectStateQuery, uid);
         State state = null;
         if (cursor.getCount() > 0) {
             cursor.moveToFirst();
@@ -139,7 +139,7 @@ public class IdentifiableDataObjectStoreImpl<M extends ObjectWithUidInterface & 
 
     @Override
     public Boolean exists(@NonNull String uid) {
-        Cursor cursor = databaseAdapter.query(existsQuery, uid);
+        Cursor cursor = databaseAdapter.rawQuery(existsQuery, uid);
         int count = cursor.getCount();
         cursor.close();
         return count > 0;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDataObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableDataObjectStoreImpl.java
@@ -111,7 +111,7 @@ public class IdentifiableDataObjectStoreImpl<M extends ObjectWithUidInterface & 
                 .appendInKeyStringValues(UID, uids)
                 .build();
 
-        return databaseAdapter.database().update(tableName, updates, whereClause, null);
+        return databaseAdapter.update(tableName, updates, whereClause, null);
     }
 
     @Override

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStoreImpl.java
@@ -104,18 +104,18 @@ public class IdentifiableObjectStoreImpl<M extends CoreObject & ObjectWithUidInt
 
     @Override
     public List<String> selectUids() throws RuntimeException {
-        Cursor cursor = databaseAdapter.query(statements.selectUids);
+        Cursor cursor = databaseAdapter.rawQuery(statements.selectUids);
         return mapStringColumnSetFromCursor(cursor);
     }
 
     public List<String> selectUidsWhere(String whereClause) throws RuntimeException {
-        Cursor cursor = databaseAdapter.query(builder.selectUidsWhere(whereClause));
+        Cursor cursor = databaseAdapter.rawQuery(builder.selectUidsWhere(whereClause));
         return mapStringColumnSetFromCursor(cursor);
     }
 
     @Override
     public M selectByUid(String uid) throws RuntimeException {
-        Cursor cursor = databaseAdapter.query(builder.selectByUid(), uid);
+        Cursor cursor = databaseAdapter.rawQuery(builder.selectByUid(), uid);
         return mapObjectFromCursor(cursor);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/LinkChildStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/LinkChildStoreImpl.java
@@ -64,6 +64,6 @@ class LinkChildStoreImpl<P extends ObjectWithUidInterface, C extends ObjectWithU
     public List<C> getChildrenWhere(P p, String whereClause) {
         String selectStatement = statementBuilder.selectChildrenWithLinkTable(
                 linkTableChildProjection, p.uid(), whereClause);
-        return cursorExecutor.getObjects(databaseAdapter.query(selectStatement));
+        return cursorExecutor.getObjects(databaseAdapter.rawQuery(selectStatement));
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.java
@@ -71,7 +71,7 @@ public class ObjectStoreImpl<M extends CoreObject> extends ReadableStoreImpl<M> 
 
     @Override
     public List<String> selectStringColumnsWhereClause(String column, String clause) {
-        Cursor cursor = databaseAdapter.query(builder.selectColumnWhere(column, clause));
+        Cursor cursor = databaseAdapter.rawQuery(builder.selectColumnWhere(column, clause));
         return mapStringColumnSetFromCursor(cursor);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.java
@@ -107,7 +107,7 @@ public class ObjectStoreImpl<M extends CoreObject> extends ReadableStoreImpl<M> 
 
     @Override
     public boolean deleteWhere(String clause) {
-        return databaseAdapter.database().delete(builder.getTableName(), clause, null) > 0;
+        return databaseAdapter.delete(builder.getTableName(), clause, null) > 0;
     }
 
     @Override

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithUidChildStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithUidChildStoreImpl.java
@@ -63,6 +63,6 @@ class ObjectWithUidChildStoreImpl<P extends ObjectWithUidInterface> implements O
             return ObjectWithUid.create(cursor.getString(idColumnIndex));
         });
 
-        return cursorExecutor.getObjects(databaseAdapter.query(selectStatement));
+        return cursorExecutor.getObjects(databaseAdapter.rawQuery(selectStatement));
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStoreImpl.java
@@ -81,7 +81,7 @@ public class ReadableStoreImpl<M extends CoreObject> implements ReadableStore<M>
 
     @Override
     public M selectOneOrderedBy(String orderingColumName, SQLOrderType orderingType) {
-        Cursor cursor = databaseAdapter.query(builder.selectOneOrderedBy(orderingColumName, orderingType));
+        Cursor cursor = databaseAdapter.rawQuery(builder.selectOneOrderedBy(orderingColumName, orderingType));
         return getFirstFromCursor(cursor);
     }
 
@@ -89,7 +89,7 @@ public class ReadableStoreImpl<M extends CoreObject> implements ReadableStore<M>
 
     @Override
     public List<M> selectRawQuery(String sqlRawQuery) {
-        Cursor cursor = databaseAdapter.query(sqlRawQuery);
+        Cursor cursor = databaseAdapter.rawQuery(sqlRawQuery);
         List<M> list = new ArrayList<>();
         addObjectsToCollection(cursor, list);
         return list;
@@ -97,13 +97,13 @@ public class ReadableStoreImpl<M extends CoreObject> implements ReadableStore<M>
 
     @Override
     public M selectOneWhere(@NonNull String whereClause) {
-        Cursor cursor = databaseAdapter.query(builder.selectWhere(whereClause, 1));
+        Cursor cursor = databaseAdapter.rawQuery(builder.selectWhere(whereClause, 1));
         return getFirstFromCursor(cursor);
     }
 
     @Override
     public M selectFirst() {
-        Cursor cursor = databaseAdapter.query(builder.selectAll());
+        Cursor cursor = databaseAdapter.rawQuery(builder.selectAll());
         return getFirstFromCursor(cursor);
     }
 
@@ -122,12 +122,12 @@ public class ReadableStoreImpl<M extends CoreObject> implements ReadableStore<M>
 
     @Override
     public int count() {
-        return processCount(databaseAdapter.query(builder.count()));
+        return processCount(databaseAdapter.rawQuery(builder.count()));
     }
 
     @Override
     public int countWhere(@NonNull String whereClause) {
-        return processCount(databaseAdapter.query(builder.countWhere(whereClause)));
+        return processCount(databaseAdapter.rawQuery(builder.countWhere(whereClause)));
     }
 
     protected int processCount(Cursor cursor) {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/SingleParentChildStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/SingleParentChildStoreImpl.java
@@ -61,6 +61,6 @@ class SingleParentChildStoreImpl<P extends ObjectWithUidInterface, C> implements
                 .appendKeyStringValue(childProjection.parentColumn, p.uid())
                 .build();
         String selectStatement = statementBuilder.selectWhere(whereClause);
-        return cursorExecutor.getObjects(databaseAdapter.query(selectStatement));
+        return cursorExecutor.getObjects(databaseAdapter.rawQuery(selectStatement));
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryComboUidsSeeker.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryComboUidsSeeker.java
@@ -66,7 +66,7 @@ class CategoryComboUidsSeeker {
         String query = new MultipleTableQueryBuilder()
                 .generateQuery(DataSetTableInfo.Columns.CATEGORY_COMBO, tableNames).build();
 
-        Cursor cursor = databaseAdapter.query(query);
+        Cursor cursor = databaseAdapter.rawQuery(query);
         Set<String> categoryCombos = new HashSet<>();
         try {
             if (cursor.getCount() > 0) {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventStoreImpl.java
@@ -140,12 +140,12 @@ public final class EventStoreImpl extends IdentifiableDeletableDataObjectStoreIm
                     " FROM " + EventTableInfo.TABLE_INFO.name() + whereStatement + ") b " +
                 "ON a." + IdentifiableColumns.UID + " = b." + Columns.ENROLLMENT;
 
-        return processCount(databaseAdapter.query(query));
+        return processCount(databaseAdapter.rawQuery(query));
     }
 
     private List<Event> eventListFromQuery(String query) {
         List<Event> eventList = new ArrayList<>();
-        Cursor cursor = databaseAdapter.query(query);
+        Cursor cursor = databaseAdapter.rawQuery(query);
         addObjectsToCollection(cursor, eventList);
         return eventList;
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerImpl.java
@@ -113,7 +113,7 @@ public final class ForeignKeyCleanerImpl implements ForeignKeyCleaner {
 
     private ForeignKeyViolation getForeignKeyViolation(String foreignKeyIdNumber, String fromTable, String toTable,
                                                        String rowId) {
-        Cursor listCursor = databaseAdapter.query("PRAGMA foreign_key_list(" + fromTable + ");");
+        Cursor listCursor = databaseAdapter.rawQuery("PRAGMA foreign_key_list(" + fromTable + ");");
 
         ForeignKeyViolation foreignKeyViolation = null;
 
@@ -142,7 +142,7 @@ public final class ForeignKeyCleanerImpl implements ForeignKeyCleaner {
         String fromColumn = listCursor.getString(3);
         String selectStatement = "SELECT * FROM " + fromTable + " WHERE ROWID = " + rowId + ";";
 
-        try (Cursor objectCursor = databaseAdapter.query(selectStatement)) {
+        try (Cursor objectCursor = databaseAdapter.rawQuery(selectStatement)) {
             if (objectCursor.getCount() > 0) {
                 objectCursor.moveToFirst();
 
@@ -201,7 +201,7 @@ public final class ForeignKeyCleanerImpl implements ForeignKeyCleaner {
     }
 
     private Cursor getForeignKeyErrorsCursor() {
-        Cursor cursor = databaseAdapter.query("PRAGMA foreign_key_check;");
+        Cursor cursor = databaseAdapter.rawQuery("PRAGMA foreign_key_check;");
         if (cursor.getCount() > 0) {
             cursor.moveToFirst();
             return cursor;

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreImpl.java
@@ -146,7 +146,7 @@ public final class RelationshipItemStoreImpl extends ObjectWithoutUidStoreImpl<R
                 "FROM " + RelationshipItemTableInfo.TABLE_INFO.name() +
                 " GROUP BY " + RelationshipItemTableInfo.Columns.RELATIONSHIP;
 
-        return this.databaseAdapter.query(query);
+        return this.databaseAdapter.rawQuery(query);
     }
 
     private String getItemElementColumn(RelationshipItem item) {

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreImpl.java
@@ -72,7 +72,7 @@ public final class RelationshipStoreImpl extends IdentifiableObjectStoreImpl<Rel
                 "WHERE " + whereClause + ";";
 
         List<Relationship> relationships = new ArrayList<>();
-        addObjectsToCollection(databaseAdapter.query(queryStatement), relationships);
+        addObjectsToCollection(databaseAdapter.rawQuery(queryStatement), relationships);
 
         return relationships;
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreImpl.java
@@ -127,7 +127,7 @@ public final class TrackedEntityAttributeValueStoreImpl
 
     private List<TrackedEntityAttributeValue> trackedEntityAttributeValueListFromQuery(String query) {
         List<TrackedEntityAttributeValue> trackedEntityAttributeValueList = new ArrayList<>();
-        Cursor cursor = databaseAdapter.query(query);
+        Cursor cursor = databaseAdapter.rawQuery(query);
         addObjectsToCollection(cursor, trackedEntityAttributeValueList);
         return trackedEntityAttributeValueList;
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreImpl.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueStoreImpl.java
@@ -134,7 +134,7 @@ public final class TrackedEntityDataValueStoreImpl extends ObjectWithoutUidStore
     private Map<String, List<TrackedEntityDataValue>> queryTrackedEntityDataValues(String queryStatement) {
 
         List<TrackedEntityDataValue> dataValueList = new ArrayList<>();
-        Cursor cursor = databaseAdapter.query(queryStatement);
+        Cursor cursor = databaseAdapter.rawQuery(queryStatement);
         addObjectsToCollection(cursor, dataValueList);
 
         Map<String, List<TrackedEntityDataValue>> dataValuesMap = new HashMap<>();

--- a/core/src/test/java/org/hisp/dhis/android/core/data/database/SqLiteDatabaseAdapterShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/data/database/SqLiteDatabaseAdapterShould.java
@@ -80,7 +80,7 @@ public class SqLiteDatabaseAdapterShould {
     @Test
     public void verify_query_on_readable_data_base_when_set_query_in_data_base_adapter() throws Exception {
         String sql = "SELECT * FROM TABLE";
-        sqLiteDatabaseAdapter.query(sql, (String[]) null);
+        sqLiteDatabaseAdapter.rawQuery(sql, (String[]) null);
         verify(readableDatabase).rawQuery(sql, null);
     }
 


### PR DESCRIPTION
This replaces directly usage of database in most of the tests. Access to database object is still available, so there are no breaking changes.