### PR TITLE
fix: [androsdk-1064] Delete not necessary id property for geometry object

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/common/Geometry.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/Geometry.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.android.core.arch.json.internal.StringJsonElementSerializer
 
 @AutoValue
 @JsonDeserialize(builder = AutoValue_Geometry.Builder.class)
-public abstract class Geometry extends BaseObject {
+public abstract class Geometry {
 
     @Nullable
     @JsonProperty()
@@ -74,7 +74,7 @@ public abstract class Geometry extends BaseObject {
 
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")
-    public abstract static class Builder extends BaseObject.Builder<Builder> {
+    public abstract static class Builder {
 
         @JsonDeserialize(using = GeometryTypeDeserializer.class)
         public abstract Builder type(FeatureType type);


### PR DESCRIPTION
Solves [ANDROSDK-1064](https://jira.dhis2.org/browse/ANDROSDK-1064).