### PR TITLE
fix: [ANDROSDK-1156] Use user defined limit and enrollment status only if global or program/event

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactory.java
@@ -124,10 +124,12 @@ class EventQueryBundleFactory {
                                                    String programUid,
                                                    String lastUpdated) {
         int limit = getLimit(params, programSettings, programUid);
+
+        if (limit == 0) {
+            return Collections.emptyList();
+        }
+
         String eventStartDate = getEventStartDate(programSettings, programUid);
-
-        List<EventQueryBundle> builders = new ArrayList<>();
-
         List<String> programs = Collections.singletonList(programUid);
         OrganisationUnitMode ouMode;
         List<String> orgUnits;
@@ -144,6 +146,8 @@ class EventQueryBundleFactory {
             ouMode = OrganisationUnitMode.DESCENDANTS;
             orgUnits = getRootCaptureOrgUnitUids();
         }
+
+        List<EventQueryBundle> builders = new ArrayList<>();
 
         if (hasLimitByOrgunit) {
             for (String orgUnitUid : orgUnits) {
@@ -162,10 +166,12 @@ class EventQueryBundleFactory {
                                                List<String> programList,
                                                String lastUpdated) {
         int limit = getLimit(params, programSettings, null);
+
+        if (limit == 0) {
+            return Collections.emptyList();
+        }
+
         String eventStartDate = getEventStartDate(programSettings, null);
-
-        List<EventQueryBundle> builders = new ArrayList<>();
-
         OrganisationUnitMode ouMode;
         List<String> orgUnits;
 
@@ -181,6 +187,8 @@ class EventQueryBundleFactory {
             ouMode = OrganisationUnitMode.DESCENDANTS;
             orgUnits = getRootCaptureOrgUnitUids();
         }
+
+        List<EventQueryBundle> builders = new ArrayList<>();
 
         if (hasLimitByOrgunit) {
             for (String orgUnitUid : orgUnits) {
@@ -284,7 +292,7 @@ class EventQueryBundleFactory {
     private int getLimit(ProgramDataDownloadParams params,
                          ProgramSettings programSettings,
                          String programUid) {
-        if (params.limit() != null) {
+        if (params.limit() != null && isGlobalOrUserDefinedProgram(params, programUid)) {
             return params.limit();
         }
 
@@ -326,5 +334,9 @@ class EventQueryBundleFactory {
 
     private boolean hasEventDateDownload(ProgramSetting programSetting) {
         return programSetting != null && programSetting.eventDateDownload() != null;
+    }
+
+    private boolean isGlobalOrUserDefinedProgram(ProgramDataDownloadParams params, String programUid) {
+        return programUid == null || programUid.equals(params.program());
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
@@ -285,7 +285,8 @@ class TrackedEntityInstanceQueryBuilderFactory {
     private int getLimit(ProgramDataDownloadParams params,
                          ProgramSettings programSettings,
                          String programUid) {
-        if (params.limit() != null) {
+
+        if (params.limit() != null && isGlobalOrUserDefinedProgram(params, programUid)) {
             return params.limit();
         }
 
@@ -307,7 +308,8 @@ class TrackedEntityInstanceQueryBuilderFactory {
     private EnrollmentStatus getProgramStatus(ProgramDataDownloadParams params,
                                               ProgramSettings programSettings,
                                               String programUid) {
-        if (params.programStatus() != null) {
+
+        if (params.programStatus() != null && isGlobalOrUserDefinedProgram(params, programUid)) {
             return enrollmentScopeToProgramStatus(params.programStatus());
         }
 
@@ -382,6 +384,10 @@ class TrackedEntityInstanceQueryBuilderFactory {
 
     private boolean hasUpdateDownload(ProgramSetting programSetting) {
         return programSetting != null && programSetting.updateDownload() != null;
+    }
+
+    private boolean isGlobalOrUserDefinedProgram(ProgramDataDownloadParams params, String programUid) {
+        return programUid == null || programUid.equals(params.program());
     }
 
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
@@ -125,13 +125,16 @@ class TrackedEntityInstanceQueryBuilderFactory {
                                                    String programUid,
                                                    String globalLastUpdated) {
         int limit = getLimit(params, programSettings, programUid);
+
+        if (limit == 0) {
+            return Collections.emptyList();
+        }
+
         EnrollmentStatus programStatus = getProgramStatus(params, programSettings, programUid);
         String programStartDate = getProgramStartDate(programSettings, programUid);
 
         String lastUpdated = globalLastUpdated == null && params.uids().isEmpty() ?
                 getInitialLastpdated(programSettings, programUid) : globalLastUpdated;
-
-        List<TeiQuery.Builder> builders = new ArrayList<>();
 
         OrganisationUnitMode ouMode;
         List<String> orgUnits;
@@ -148,6 +151,8 @@ class TrackedEntityInstanceQueryBuilderFactory {
             ouMode = OrganisationUnitMode.DESCENDANTS;
             orgUnits = getRootCaptureOrgUnitUids();
         }
+
+        List<TeiQuery.Builder> builders = new ArrayList<>();
 
         if (hasLimitByOrgunit) {
             for (String orgUnitUid : orgUnits) {
@@ -167,10 +172,12 @@ class TrackedEntityInstanceQueryBuilderFactory {
                                                String globalLastUpdated) {
         int limit = getLimit(params, programSettings, null);
 
+        if (limit == 0) {
+            return Collections.emptyList();
+        }
+
         String lastUpdated = globalLastUpdated == null && params.uids().isEmpty() ?
                 getInitialLastpdated(programSettings, null) : globalLastUpdated;
-
-        List<TeiQuery.Builder> builders = new ArrayList<>();
 
         OrganisationUnitMode ouMode;
         List<String> orgUnits;
@@ -187,6 +194,8 @@ class TrackedEntityInstanceQueryBuilderFactory {
             ouMode = OrganisationUnitMode.DESCENDANTS;
             orgUnits = getRootCaptureOrgUnitUids();
         }
+
+        List<TeiQuery.Builder> builders = new ArrayList<>();
 
         if (hasLimitByOrgunit) {
             for (String orgUnitUid : orgUnits) {
@@ -389,5 +398,4 @@ class TrackedEntityInstanceQueryBuilderFactory {
     private boolean isGlobalOrUserDefinedProgram(ProgramDataDownloadParams params, String programUid) {
         return programUid == null || programUid.equals(params.program());
     }
-
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.java
@@ -169,6 +169,29 @@ public class EventQueryBundleFactoryShould {
         }
     }
 
+    @Test
+    public void apply_user_defined_limit_only_to_global_if_no_program() {
+        ProgramDataDownloadParams params = ProgramDataDownloadParams.builder().limit(5000).build();
+
+        Map<String, ProgramSetting> specificSettings = new HashMap<>();
+        specificSettings.put(p1, ProgramSetting.builder().uid(p1).eventsDownload(100).build());
+
+        when(programSettings.specificSettings()).thenReturn(specificSettings);
+
+        List<EventQueryBundle> bundles = bundleFactory.getEventQueryBundles(params);
+
+        assertThat(bundles.size()).isEqualTo(2);
+
+        for (EventQueryBundle bundle : bundles) {
+            if (bundle.programList().size() == 1) {
+                assertThat(bundle.programList().get(0)).isEqualTo(p1);
+                assertThat(bundle.limit()).isEqualTo(100);
+            } else {
+                assertThat(bundle.limit()).isEqualTo(5000);
+            }
+        }
+    }
+
     private List<String> getProgramList() {
         List<String> programList = new ArrayList<>();
         programList.add(p1);

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactoryShould.java
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactoryShould.java
@@ -162,6 +162,31 @@ public class TrackedEntityInstanceQueryBuilderFactoryShould {
         }
     }
 
+    @Test
+    public void apply_user_defined_limit_only_to_global_if_no_program() {
+        ProgramDataDownloadParams params = ProgramDataDownloadParams.builder().limit(5000).build();
+
+        Map<String, ProgramSetting> specificSettings = new HashMap<>();
+        specificSettings.put(p1, ProgramSetting.builder().uid(p1).teiDownload(100).build());
+
+        when(programSettings.specificSettings()).thenReturn(specificSettings);
+
+        List<TeiQuery.Builder> builders = builderFactory.getTeiQueryBuilders(params);
+
+        assertThat(builders.size()).isEqualTo(2);
+
+        for (TeiQuery.Builder builder : builders) {
+            TeiQuery query = builder.build();
+
+            if (query.program() != null) {
+                assertThat(query.program()).isEqualTo(p1);
+                assertThat(query.limit()).isEqualTo(100);
+            } else {
+                assertThat(query.limit()).isEqualTo(5000);
+            }
+        }
+    }
+
     private List<String> getProgramList() {
         List<String> programList = new ArrayList<>();
         programList.add(p1);


### PR DESCRIPTION
Solves [ANDROSDK-1156](https://jira.dhis2.org/browse/ANDROSDK-1156)