### PR TITLE
fix: [ANDROSDK-1166] Remove credentials in login when system info call fails

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAuthenticateCallFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAuthenticateCallFactory.java
@@ -169,11 +169,10 @@ public final class UserAuthenticateCallFactory {
             transaction.setSuccessful();
             return authenticatedUser;
         } catch (Exception e) {
+            // Credentials are stored and then removed in case of error since they are required to download system info
             credentialsSecureStore.remove();
             throw e;
-        }
-
-        finally {
+        } finally {
             transaction.end();
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAuthenticateCallFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAuthenticateCallFactory.java
@@ -165,9 +165,15 @@ public final class UserAuthenticateCallFactory {
             systemInfoRepository.download().blockingAwait();
 
             handleUser(authenticatedUser);
+
             transaction.setSuccessful();
             return authenticatedUser;
-        } finally {
+        } catch (Exception e) {
+            credentialsSecureStore.remove();
+            throw e;
+        }
+
+        finally {
             transaction.end();
         }
     }


### PR DESCRIPTION
Solves [ANDROSDK-1166](https://jira.dhis2.org/browse/ANDROSDK-1166).