### PR TITLE
fix: [ANDROSDK-1189] Make D2Error errorComponent nullable

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2Error.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2Error.java
@@ -51,7 +51,7 @@ public abstract class D2Error extends Exception implements CoreObject {
     @Nullable
     public abstract String url();
 
-    @NonNull
+    @Nullable
     @ColumnAdapter(D2ErrorComponentColumnAdapter.class)
     public abstract D2ErrorComponent errorComponent();
 


### PR DESCRIPTION
Solves [ANDROSDK-1189](https://jira.dhis2.org/browse/ANDROSDK-1189)