### PR TITLE
ci: Add Bitrise yml and adapt deploy.sh script [ci skip]

### DIFF
--- a/.buildscript/deploy.sh
+++ b/.buildscript/deploy.sh
@@ -5,21 +5,18 @@
 # Adapted from https://coderwall.com/p/9b_lfq and
 # http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
-SLUG="dhis2/dhis2-android-sdk"
-JDK="oraclejdk8"
+SLUG="dhis2-android-sdk"
 MASTER_BRANCH="master"
 MASTERDEV_BRANCH="master-dev"
 
 set -e
 
-if [ "$TRAVIS_REPO_SLUG" != "$SLUG" ]; then
-  echo "Skipping snapshot deployment: wrong repository. Expected '$SLUG' but was '$TRAVIS_REPO_SLUG'."
-elif [ "$TRAVIS_JDK_VERSION" != "$JDK" ]; then
-  echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$TRAVIS_JDK_VERSION'."
-elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$BITRISEIO_GIT_REPOSITORY_SLUG" != "$SLUG" ]; then
+  echo "Skipping snapshot deployment: wrong repository. Expected '$SLUG' but was '$BITRISEIO_GIT_REPOSITORY_SLUG'."
+elif [ -n "$BITRISE_PULL_REQUEST" ]; then
   echo "Skipping snapshot deployment: was pull request."
-elif [ "$TRAVIS_BRANCH" != "$MASTER_BRANCH" ]; then
-  echo "Skipping snapshot deployment: wrong branch. Expected '$MASTER_BRANCH' or '$MASTERDEV_BRANCH' but was '$TRAVIS_BRANCH'."
+elif [ "$BITRISE_GIT_BRANCH" != "$MASTER_BRANCH" ]; then
+  echo "Skipping snapshot deployment: wrong branch. Expected '$MASTER_BRANCH' or '$MASTERDEV_BRANCH' but was '$BITRISE_GIT_BRANCH'."
 else
   echo "Deploying snapshot..."
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,149 @@
+---
+format_version: '8'
+default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
+project_type: android
+trigger_map:
+- push_branch: master
+  workflow: primary
+- push_branch: develop
+  workflow: deploy
+- pull_request_source_branch: '*'
+  workflow: primary
+workflows:
+  deploy:
+    description: >
+      ## How to get a signed APK
+
+
+      This workflow contains the **Sign APK** step. To sign your APK all you
+      have to do is to:
+
+
+      1. Click on **Code Signing** tab
+
+      1. Find the **ANDROID KEYSTORE FILE** section
+
+      1. Click or drop your file on the upload file field
+
+      1. Fill the displayed 3 input fields:
+       1. **Keystore password**
+       1. **Keystore alias**
+       1. **Private key password**
+      1. Click on **[Save metadata]** button
+
+
+      That's it! From now on, **Sign APK** step will receive your uploaded
+      files.
+
+
+      ## To run this workflow
+
+
+      If you want to run this workflow manually:
+
+
+      1. Open the app's build list page
+
+      2. Click on **[Start/Schedule a Build]** button
+
+      3. Select **deploy** in **Workflow** dropdown input
+
+      4. Click **[Start Build]** button
+
+
+      Or if you need this workflow to be started by a GIT event:
+
+
+      1. Click on **Triggers** tab
+
+      2. Setup your desired event (push/tag/pull) and select **deploy** workflow
+
+      3. Click on **[Done]** and then **[Save]** buttons
+
+
+      The next change in your repository that matches any of your trigger map
+      event will start **deploy** workflow.
+    steps:
+    - activate-ssh-key@4.0.3:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@4.0.17: {}
+    - cache-pull@2.1.1: {}
+    - script@1.1.5:
+        title: Do anything with Script step
+    - install-missing-android-tools@2.3.7:
+        inputs:
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+    - change-android-versioncode-and-versionname@1.1.1:
+        inputs:
+        - build_gradle_path: $PROJECT_LOCATION/$MODULE/build.gradle
+    - android-lint@0.9.6:
+        inputs:
+        - project_location: $PROJECT_LOCATION
+        - module: $MODULE
+        - variant: $VARIANT
+    - android-unit-test@1.0.0:
+        inputs:
+        - project_location: $PROJECT_LOCATION
+        - module: $MODULE
+        - variant: $VARIANT
+    - android-build@0.10.0:
+        inputs:
+        - project_location: $PROJECT_LOCATION
+        - module: $MODULE
+        - variant: $VARIANT
+    - sign-apk@1.4.1:
+        run_if: '{{getenv "BITRISEIO_ANDROID_KEYSTORE_URL" | ne ""}}'
+    - deploy-to-bitrise-io@1.9.2: {}
+    - cache-push@2.2.1: {}
+  primary:
+    steps:
+    - activate-ssh-key@4.0:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@4.0: {}
+    - cache-pull@2.1: {}
+    - install-missing-android-tools@2.3:
+        inputs:
+        - gradlew_path: $PROJECT_LOCATION/gradlew
+    - gradle-runner@1.9:
+        inputs:
+        - gradle_task: checkstyleDebug pmdDebug lintDebug detekt
+        - gradlew_path: ./gradlew
+        title: Checkstyle and others
+    - android-unit-test@1.0:
+        inputs:
+        - project_location: $PROJECT_LOCATION
+        - module: $MODULE
+        - variant: $VARIANT
+    - avd-manager@1.0.1: {}
+    - wait-for-android-emulator@1.0.4: {}
+    - gradle-runner@1.9:
+        title: Emulator Tests
+        inputs:
+        - gradle_task: connectedDebugAndroidTest
+        - gradlew_path: ./gradlew
+    - script@1:
+        title: PublishToNexus
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            cd .buildscript/
+            chmod+x deploy.sh
+            ./deploy.sh
+    - deploy-to-bitrise-io@1.10: {}
+    - cache-push@2.3: {}
+app:
+  envs:
+  - opts:
+      is_expand: false
+    PROJECT_LOCATION: .
+  - opts:
+      is_expand: false
+    MODULE: core
+  - opts:
+      is_expand: false
+    VARIANT: debug


### PR DESCRIPTION
Hello @vgarciabnz, I've run some builds and the job primary seems to run fine. A couple of things:
- I think lint is throwing an error in develop regarding build.gradle
- Test are running in pixel emulator API 26 (it can be change easilly)
- Build notification can be disable in step "deploy to bitrise.io"
- I think the script deploy does not need more. Bitrise by default is using JDK 8 in the docker image