### PR TITLE
fix: [androsdk-1291] Fix remaining reserved values count

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.java
@@ -317,7 +317,10 @@ public final class TrackedEntityAttributeReservedValueManager {
             Integer fillUpTo = getFillUpToValue(minNumberOfValuesToHave);
 
             String pattern = trackedEntityAttributeStore.selectByUid(attribute).pattern();
-            int remainingValues = store.count(attribute, UidsHelper.getUidOrNull(organisationUnit), pattern);
+            int remainingValues = store.count(
+                    attribute,
+                    isOrgunitDependent(pattern) ? UidsHelper.getUidOrNull(organisationUnit) : null,
+                    pattern);
 
             // If number of values is explicitly specified, we use that value as threshold.
             int minNumberToTryFill = minNumberOfValuesToHave == null ?

--- a/runChecks.sh
+++ b/runChecks.sh
@@ -6,4 +6,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR=$DIR/
 
 # This will: compile the project, run lint, package apk and check the code quality.
-"$PROJECT_DIR"/gradlew clean checkstyleDebug pmdDebug lintDebug detekt
+"$PROJECT_DIR"/gradlew clean checkstyleDebug pmdDebug lintDebug


### PR DESCRIPTION
Solves [ANDROSDK-1291](https://jira.dhis2.org/browse/ANDROSDK-1291).
Now, no extra reserved values are downloaded when asking for a reserved value for enrollment outside of a org. unit pattern scope.