### PR TITLE
fix: [androsdk-1297] Avoid to call EventFilterCall if version is not greater than 2.31

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoModuleMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoModuleMockIntegrationShould.java
@@ -41,7 +41,7 @@ public class SystemInfoModuleMockIntegrationShould extends BaseMockIntegrationTe
     @Test
     public void allow_access_to_system_info_user() {
         SystemInfo systemInfo = d2.systemInfoModule().systemInfo().blockingGet();
-        assertThat(systemInfo.version()).isEqualTo("2.30");
+        assertThat(systemInfo.version()).isEqualTo("2.35");
         assertThat(systemInfo.systemName()).isEqualTo("DHIS 2 Demo - Sierra Leone");
     }
 }

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/systeminfo/SystemInfoSamples.java
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/systeminfo/SystemInfoSamples.java
@@ -41,7 +41,7 @@ public class SystemInfoSamples {
                 .id(1L)
                 .serverDate(getDate("2017-11-29T11:27:46.935"))
                 .dateFormat("yyyy-mm-dd")
-                .version("2.30")
+                .version("2.35")
                 .contextPath("https://play.dhis2.org/android-current")
                 .systemName("DHIS 2 Demo - Sierra Leone")
                 .build();

--- a/core/src/sharedTest/resources/systeminfo/system_info.json
+++ b/core/src/sharedTest/resources/systeminfo/system_info.json
@@ -7,7 +7,7 @@
   "lastAnalyticsTableSuccess": "2017-11-29T03:32:45.861",
   "intervalSinceLastAnalyticsTableSuccess": "7 h, 55 m, 1 s",
   "lastAnalyticsTableRuntime": "7 m, 40 s",
-  "version": "2.30",
+  "version": "2.35",
   "revision": "585e4bd",
   "buildTime": "2017-10-12T06:22:05.000",
   "jasperReportsVersion": "6.3.1",


### PR DESCRIPTION
Solves [ANDROSDK-1297](https://jira.dhis2.org/browse/ANDROSDK-1297).