### PR TITLE
fix: [ANDROAPP-4326] Crash secureStorage

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
@@ -185,7 +185,11 @@ public final class AndroidSecureStore implements SecureStore {
                 | IllegalBlockSizeException | BadPaddingException e) {
             deleteKeyStoreEntry(ks, ALIAS);
             String valueToDisplay = value != null ? value : "null";
-            throw new RuntimeException("Couldn't get value from AndroidSecureStore for key: " + key + "and value: " + valueToDisplay, e);
+            String errorMessage = String.format(
+                    "Couldn't get value from AndroidSecureStore for key: %s and value: %s",
+                    key,
+                    valueToDisplay);
+            throw new RuntimeException(errorMessage, e);
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
@@ -170,11 +170,13 @@ public final class AndroidSecureStore implements SecureStore {
 
     public String getData(@NonNull String key) {
         KeyStore ks = null;
+        PrivateKey privateKey;
+        String value = null;
         try {
             ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID_KEYSTORE);
             ks.load(null);
-            PrivateKey privateKey = (PrivateKey) ks.getKey(ALIAS, null);
-            String value = preferences.getString(key, null);
+            privateKey = (PrivateKey) ks.getKey(ALIAS, null);
+            value = preferences.getString(key, null);
 
             return value == null ? null :
                     new String(decrypt(privateKey, value), CHARSET);
@@ -182,7 +184,8 @@ public final class AndroidSecureStore implements SecureStore {
                 | UnrecoverableEntryException | InvalidKeyException | NoSuchPaddingException
                 | IllegalBlockSizeException | BadPaddingException e) {
             deleteKeyStoreEntry(ks, ALIAS);
-            throw new RuntimeException("Couldn't get value from AndroidSecureStore for key: " + key, e);
+            String valueToDisplay = value != null ? value : "null";
+            throw new RuntimeException("Couldn't get value from AndroidSecureStore for key: " + key + "and value: " + valueToDisplay, e);
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
@@ -184,7 +184,7 @@ public final class AndroidSecureStore implements SecureStore {
                 | UnrecoverableEntryException | InvalidKeyException | NoSuchPaddingException
                 | IllegalBlockSizeException | BadPaddingException e) {
             deleteKeyStoreEntry(ks, ALIAS);
-            String valueToDisplay = value == null ? "null" : value  ;
+            String valueToDisplay = value == null ? "null" : value;
             String errorMessage = String.format(
                     "Couldn't get value from AndroidSecureStore for key: %s and value: %s",
                     key,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.java
@@ -184,7 +184,7 @@ public final class AndroidSecureStore implements SecureStore {
                 | UnrecoverableEntryException | InvalidKeyException | NoSuchPaddingException
                 | IllegalBlockSizeException | BadPaddingException e) {
             deleteKeyStoreEntry(ks, ALIAS);
-            String valueToDisplay = value != null ? value : "null";
+            String valueToDisplay = value == null ? "null" : value  ;
             String errorMessage = String.format(
                     "Couldn't get value from AndroidSecureStore for key: %s and value: %s",
                     key,


### PR DESCRIPTION
There is a crash in the secure storage related to the decrypt method. Added extra information to the exception being thrown.

[android app jira issue ](https://jira.dhis2.org/browse/ANDROAPP-4326)
[android sdk jira issue ](https://jira.dhis2.org/browse/ANDROSDK-1442)