### PR TITLE
fix: [JDK-1.8-PATCH-RELEASE] Force JDK 1.8 in patch release (1.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out
 !.idea
 .idea/*
 !.idea/copyright
+!.idea/gradle.xml
 !.idea/scopes
 .idea/scopes/*
 !.idea/scopes/copyright.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,6 +6,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="1.8" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/core" />
+          </set>
+        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
Forces the use of JDK 1.8 in patch branch for 1.5. This is required by the version of gradle used in this branch.