### PR TITLE
fix: set credentials for UI Testing

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
@@ -53,7 +53,7 @@ object D2Manager {
     private var testingServerUrl: String? = null
     private var testingDatabaseName: String? = null
     private var testingUsername: String? = null
-    private lateinit var d2DIComponent : D2DIComponent
+    private lateinit var d2DIComponent: D2DIComponent
 
     /**
      * Returns the D2 instance, given that it has already been initialized using the
@@ -166,16 +166,16 @@ object D2Manager {
     }
 
     @VisibleForTesting
-    fun removeCredentials(){
+    fun removeCredentials() {
         d2DIComponent.credentialsSecureStore().remove()
     }
 
     @VisibleForTesting
-    fun setCredentials(username: String, password: String){
-        if (testingServerUrl.isNullOrEmpty()){
+    fun setCredentials(username: String, password: String) {
+        if (testingServerUrl.isNullOrEmpty()) {
             throw NoSuchFieldException("No testing Server Url")
         }
-        d2DIComponent.credentialsSecureStore().set(Credentials(username, testingServerUrl!!,password, null))
+        d2DIComponent.credentialsSecureStore().set(Credentials(username, testingServerUrl!!, password, null))
     }
 
     private fun wantToImportDBForExternalTesting(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
@@ -105,7 +105,6 @@ object D2Manager {
             val credentials = d2DIComponent.credentialsSecureStore().get()
 
             if (wantToImportDBForExternalTesting()) {
-           //     d2DIComponent.credentialsSecureStore().set(Credentials("Android", testingServerUrl!!,"Android123!", null))
                 multiUserDatabaseManager.loadDbForTesting(
                     testingServerUrl,
                     testingDatabaseName,


### PR DESCRIPTION
Hi Victor, during a jira issue we found out that setting an AndroidSecure Storage was not enough because the credentials were always null (not sure if this changed because of multi user) and we had to set them on D2Manager. Perhaps we're missing something? Let us know. 

This is needed for UI test that need to skip the login process.

Thanks