### PR TITLE
fix: [androsdk-1534] Update account manager to only emit on the delete account observable when the SDK itself deletes the account.

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/user/AccountDeletionReason.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/AccountDeletionReason.kt
@@ -28,20 +28,7 @@
 
 package org.hisp.dhis.android.core.user
 
-import io.reactivex.Observable
-import kotlin.jvm.Throws
-import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
-import org.hisp.dhis.android.core.maintenance.D2Error
-
-interface AccountManager {
-    fun getAccounts(): List<DatabaseAccount>
-
-    fun setMaxAccounts(maxAccounts: Int)
-
-    fun getMaxAccounts(): Int
-
-    @Throws(D2Error::class)
-    fun deleteCurrentAccount()
-
-    fun accountDeletionObservable(): Observable<AccountDeletionReason>
+enum class AccountDeletionReason {
+    ACCOUNT_DISABLED,
+    APPLICATION_REQUEST
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -81,13 +81,22 @@ internal class AccountManagerImpl @Inject constructor(
                 .errorComponent(D2ErrorComponent.SDK)
                 .build()
         } else {
-            deleteAccount(credentials)
+            deleteAccountAndEmit(credentials)
         }
     }
 
     @Throws(D2Error::class)
     fun deleteAccount(credentials: Credentials) {
+        deleteAccountInternal(credentials)
+    }
+
+    internal fun deleteAccountAndEmit(credentials: Credentials) {
         accountDeletionSubject.onNext(Unit)
+        deleteAccountInternal(credentials)
+    }
+
+    @Throws(D2Error::class)
+    private fun deleteAccountInternal(credentials: Credentials) {
         logOutCall.logOut().blockingAwait()
         val configuration = databasesConfigurationStore.get()
         val loggedAccount = DatabaseConfigurationHelper.getLoggedAccount(

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -75,14 +75,30 @@ internal class AccountManagerImpl @Inject constructor(
         val credentials = credentialsSecureStore.get()
 
         if (credentials == null) {
-            throw D2Error.builder()
-                .errorCode(D2ErrorCode.NO_AUTHENTICATED_USER)
-                .errorDescription("There is not any authenticated user")
-                .errorComponent(D2ErrorComponent.SDK)
-                .build()
+            throwNotAnyAuthenticatedUser()
+        } else {
+            deleteAccount(credentials)
+        }
+    }
+
+    @Throws(D2Error::class)
+    internal fun deleteCurrentAccountAndEmit() {
+        val credentials = credentialsSecureStore.get()
+
+        if (credentials == null) {
+            throwNotAnyAuthenticatedUser()
         } else {
             deleteAccountAndEmit(credentials)
         }
+    }
+
+    @Throws(D2Error::class)
+    private fun throwNotAnyAuthenticatedUser() {
+        throw D2Error.builder()
+            .errorCode(D2ErrorCode.NO_AUTHENTICATED_USER)
+            .errorDescription("There is not any authenticated user")
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
     }
 
     @Throws(D2Error::class)

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -45,6 +45,7 @@ import org.hisp.dhis.android.core.configuration.internal.ServerUrlParser
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.systeminfo.SystemInfo
+import org.hisp.dhis.android.core.user.AccountDeletionReason
 import org.hisp.dhis.android.core.user.AuthenticatedUser
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
@@ -107,7 +108,7 @@ internal class LogInCall @Inject internal constructor(
         return if (d2Error.errorCode() == D2ErrorCode.USER_ACCOUNT_DISABLED) {
             try {
                 if (credentials != null) {
-                    accountManager.deleteAccountAndEmit(credentials)
+                    accountManager.deleteAccountAndEmit(credentials, AccountDeletionReason.ACCOUNT_DISABLED)
                 }
                 d2Error
             } catch (e: Exception) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -107,7 +107,7 @@ internal class LogInCall @Inject internal constructor(
         return if (d2Error.errorCode() == D2ErrorCode.USER_ACCOUNT_DISABLED) {
             try {
                 if (credentials != null) {
-                    accountManager.deleteAccount(credentials)
+                    accountManager.deleteAccountAndEmit(credentials)
                 }
                 d2Error
             } catch (e: Exception) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcher.kt
@@ -51,7 +51,7 @@ internal class UserAccountDisabledErrorCatcher @Inject constructor(
 
     override fun catchError(response: Response<*>, errorBody: String): D2ErrorCode? {
         return try {
-            accountManager.deleteCurrentAccount()
+            accountManager.deleteCurrentAccountAndEmit()
             D2ErrorCode.USER_ACCOUNT_DISABLED
         } catch (e: Throwable) {
             D2ErrorCode.USER_ACCOUNT_DISABLED

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcher.kt
@@ -35,6 +35,7 @@ import org.hisp.dhis.android.core.arch.api.executors.internal.APICallErrorCatche
 import org.hisp.dhis.android.core.arch.api.executors.internal.APIErrorMapper
 import org.hisp.dhis.android.core.imports.internal.HttpMessageResponse
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.user.AccountDeletionReason
 import retrofit2.HttpException
 import retrofit2.Response
 
@@ -51,7 +52,7 @@ internal class UserAccountDisabledErrorCatcher @Inject constructor(
 
     override fun catchError(response: Response<*>, errorBody: String): D2ErrorCode? {
         return try {
-            accountManager.deleteCurrentAccountAndEmit()
+            accountManager.deleteCurrentAccountAndEmit(AccountDeletionReason.ACCOUNT_DISABLED)
             D2ErrorCode.USER_ACCOUNT_DISABLED
         } catch (e: Throwable) {
             D2ErrorCode.USER_ACCOUNT_DISABLED

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcherShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcherShould.kt
@@ -34,6 +34,7 @@ import com.nhaarman.mockitokotlin2.verify
 import okhttp3.ResponseBody
 import org.hisp.dhis.android.core.arch.json.internal.ObjectMapperFactory.objectMapper
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.user.AccountDeletionReason
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -64,6 +65,6 @@ class UserAccountDisabledErrorCatcherShould {
     @Test
     fun delete_database() {
         catcher.catchError(response, response.errorBody()!!.string())
-        verify(accountManager, times(1)).deleteCurrentAccountAndEmit()
+        verify(accountManager, times(1)).deleteCurrentAccountAndEmit(AccountDeletionReason.ACCOUNT_DISABLED)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcherShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcherShould.kt
@@ -64,6 +64,6 @@ class UserAccountDisabledErrorCatcherShould {
     @Test
     fun delete_database() {
         catcher.catchError(response, response.errorBody()!!.string())
-        verify(accountManager, times(1)).deleteCurrentAccount()
+        verify(accountManager, times(1)).deleteCurrentAccountAndEmit()
     }
 }


### PR DESCRIPTION
Solves [ANDROSDK-1534](https://jira.dhis2.org/browse/ANDROSDK-1534).