### PR TITLE
Update Debugging setup for Flipper

### DIFF
--- a/docs/content/developer/debugging.md
+++ b/docs/content/developer/debugging.md
@@ -15,7 +15,7 @@ Steps to install it and configure it:
 
 1. Ensure you have the Android SDK installed (you probably will if you are planning to debug an Android app)
 2. Download Flipper from [its website](https://fbflipper.com/)
-3. Modify your build.gradle to install Flipper dependencies.
+3. Check to ensure the flipper dependencies are included in /app/build.gradle to install Flipper dependencies.
 
     ```gradle
     dependencies {


### PR DESCRIPTION
The dependencies are already included in the APK source code. Also I updated the path since there is a build.gradle in the root directory as well as one under /app. The build.gradle in root specified to NOT place the dependencies there.