### PR TITLE
feat: [DC-1376] Add missing program indicator variables and functions

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
@@ -61,6 +61,9 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEv
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.program
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.programStage1
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.programStage2
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipTypeFrom
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipTypeTo
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipType
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.trackedEntityType
 import org.hisp.dhis.android.core.category.internal.*
 import org.hisp.dhis.android.core.common.RelativeOrganisationUnit
@@ -78,6 +81,7 @@ import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStor
 import org.hisp.dhis.android.core.period.internal.PeriodStoreImpl
 import org.hisp.dhis.android.core.program.internal.ProgramStageStore
 import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.core.relationship.internal.*
 import org.hisp.dhis.android.core.trackedentity.internal.*
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.junit.After
@@ -116,6 +120,9 @@ internal open class BaseEvaluatorIntegrationShould : BaseMockIntegrationTestEmpt
 
     protected val indicatorTypeStore = IndicatorTypeStore.create(databaseAdapter)
     protected val indicatorStore = IndicatorStore.create(databaseAdapter)
+
+    protected val relationshipTypeStore = RelationshipTypeStore.create(databaseAdapter)
+    protected val relationshipConstraintStore = RelationshipConstraintStore.create(databaseAdapter)
 
     protected val constantStore = ConstantStore.create(databaseAdapter)
 
@@ -206,6 +213,10 @@ internal open class BaseEvaluatorIntegrationShould : BaseMockIntegrationTestEmpt
         programStageStore.insert(programStage1)
         programStageStore.insert(programStage2)
 
+        relationshipTypeStore.insert(relationshipType)
+        relationshipConstraintStore.insert(relationshipTypeFrom)
+        relationshipConstraintStore.insert(relationshipTypeTo)
+
         constantStore.insert(constant1)
     }
 
@@ -230,6 +241,8 @@ internal open class BaseEvaluatorIntegrationShould : BaseMockIntegrationTestEmpt
         programStore.delete()
         indicatorTypeStore.delete()
         indicatorStore.delete()
+        relationshipTypeStore.delete()
+        relationshipConstraintStore.delete()
         constantStore.delete()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
@@ -68,6 +68,8 @@ import org.hisp.dhis.android.core.common.RelativePeriod
 import org.hisp.dhis.android.core.constant.internal.ConstantStore
 import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
+import org.hisp.dhis.android.core.event.internal.EventStoreImpl
 import org.hisp.dhis.android.core.indicator.internal.IndicatorStore
 import org.hisp.dhis.android.core.indicator.internal.IndicatorTypeStore
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitGroupStore
@@ -76,16 +78,22 @@ import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStor
 import org.hisp.dhis.android.core.period.internal.PeriodStoreImpl
 import org.hisp.dhis.android.core.program.internal.ProgramStageStore
 import org.hisp.dhis.android.core.program.internal.ProgramStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStore
+import org.hisp.dhis.android.core.trackedentity.internal.*
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.junit.After
 import org.junit.Before
 
 internal open class BaseEvaluatorIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
 
-    // Stores
+    // Data stores
     protected val dataValueStore = DataValueStore.create(databaseAdapter)
+    protected val eventStore = EventStoreImpl.create(databaseAdapter)
+    protected val enrollmentStore = EnrollmentStoreImpl.create(databaseAdapter)
+    protected val trackedEntityStore = TrackedEntityInstanceStoreImpl.create(databaseAdapter)
+    protected val trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl.create(databaseAdapter)
+    protected val trackedEntityAttributeValueStore = TrackedEntityAttributeValueStoreImpl.create(databaseAdapter)
+
+    // Metadata stores
     protected val categoryStore = CategoryStore.create(databaseAdapter)
     protected val categoryOptionStore = CategoryOptionStore.create(databaseAdapter)
     protected val categoryCategoryOptionStore = CategoryCategoryOptionLinkStore.create(databaseAdapter)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
@@ -61,9 +61,9 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEv
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.program
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.programStage1
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.programStage2
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipType
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipTypeFrom
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipTypeTo
-import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipType
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.trackedEntityType
 import org.hisp.dhis.android.core.category.internal.*
 import org.hisp.dhis.android.core.common.RelativeOrganisationUnit

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorSamples.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorSamples.kt
@@ -44,6 +44,9 @@ import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.ProgramStage
+import org.hisp.dhis.android.core.relationship.RelationshipConstraint
+import org.hisp.dhis.android.core.relationship.RelationshipConstraintType
+import org.hisp.dhis.android.core.relationship.RelationshipType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType
@@ -283,5 +286,21 @@ object BaseEvaluatorSamples {
         .uid(generator.generate())
         .displayName("Five")
         .value(5.0)
+        .build()
+
+    val relationshipType = RelationshipType.builder()
+        .uid(generator.generate())
+        .name("Relationship type")
+        .bidirectional(false)
+        .build()
+
+    val relationshipTypeFrom = RelationshipConstraint.builder()
+        .relationshipType(ObjectWithUid.create(relationshipType.uid()))
+        .constraintType(RelationshipConstraintType.FROM)
+        .trackedEntityType(ObjectWithUid.create(trackedEntityType.uid()))
+        .build()
+
+    val relationshipTypeTo = relationshipTypeFrom.toBuilder()
+        .constraintType(RelationshipConstraintType.TO)
         .build()
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorSamples.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorSamples.kt
@@ -275,6 +275,8 @@ object BaseEvaluatorSamples {
 
     val secondNovember2019 = DateUtils.DATE_FORMAT.parse("2019-11-02T00:00:00.000")
 
+    val tenthNovember2019 = DateUtils.DATE_FORMAT.parse("2019-11-10T00:00:00.000")
+
     val secondDecember2020 = DateUtils.DATE_FORMAT.parse("2020-12-02T00:00:00.000")
 
     val constant1 = Constant.builder()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorEvaluatorIntegrationShould.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitGroupStore
 import org.hisp.dhis.android.core.parser.internal.service.ExpressionService
 import org.hisp.dhis.android.core.program.internal.ProgramStageStore
+import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLExecutor
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
@@ -52,6 +53,7 @@ internal class IndicatorEvaluatorIntegrationShould : IndicatorEvaluatorIntegrati
     private val programIndicatorEvaluator = ProgramIndicatorSQLEvaluator(
         programIndicatorExecutor
     )
+    private val eventDataItemEvaluator = EventDataItemSQLEvaluator(databaseAdapter)
 
     private val expressionService = ExpressionService(
         DataElementStore.create(databaseAdapter),
@@ -63,10 +65,13 @@ internal class IndicatorEvaluatorIntegrationShould : IndicatorEvaluatorIntegrati
     private val indicatorEngine = IndicatorEngine(
         indicatorTypeStore,
         DataElementStore.create(databaseAdapter),
+        TrackedEntityAttributeStore.create(databaseAdapter),
         CategoryOptionComboStoreImpl.create(databaseAdapter),
+        ProgramStore.create(databaseAdapter),
         d2.programModule().programIndicators(),
         dataElementEvaluator,
         programIndicatorEvaluator,
+        eventDataItemEvaluator,
         ConstantStore.create(databaseAdapter),
         expressionService
     )

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorSQLEvaluatorIntegrationShould.kt
@@ -31,6 +31,7 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.indica
 import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStoreImpl
 import org.hisp.dhis.android.core.constant.internal.ConstantStore
 import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
+import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLExecutor
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
@@ -49,14 +50,18 @@ internal class IndicatorSQLEvaluatorIntegrationShould : IndicatorEvaluatorIntegr
     private val programIndicatorEvaluator = ProgramIndicatorSQLEvaluator(
         programIndicatorExecutor
     )
+    private val eventDataItemEvaluator = EventDataItemSQLEvaluator(databaseAdapter)
 
     private val indicatorEngine = IndicatorSQLEngine(
         indicatorTypeStore,
         DataElementStore.create(databaseAdapter),
+        TrackedEntityAttributeStore.create(databaseAdapter),
         CategoryOptionComboStoreImpl.create(databaseAdapter),
+        ProgramStore.create(databaseAdapter),
         d2.programModule().programIndicators(),
         dataElementEvaluator,
         programIndicatorEvaluator,
+        eventDataItemEvaluator,
         ConstantStore.create(databaseAdapter),
         databaseAdapter
     )

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseTrackerDataIntegrationHelper.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseTrackerDataIntegrationHelper.kt
@@ -39,6 +39,9 @@ import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.event.internal.EventStoreImpl
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.internal.ProgramIndicatorStore
+import org.hisp.dhis.android.core.relationship.*
+import org.hisp.dhis.android.core.relationship.internal.RelationshipItemStoreImpl
+import org.hisp.dhis.android.core.relationship.internal.RelationshipStoreImpl
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
@@ -179,6 +182,23 @@ open class BaseTrackerDataIntegrationHelper(private val databaseAdapter: Databas
         val trackedEntityAttributeValue = TrackedEntityAttributeValue.builder()
             .value(value).trackedEntityAttribute(attributeUid).trackedEntityInstance(teiUid).build()
         TrackedEntityAttributeValueStoreImpl.create(databaseAdapter).updateOrInsertWhere(trackedEntityAttributeValue)
+    }
+
+    fun createRelationship(typeUid: String, fromTei: String, toTei: String) {
+        val relationship = RelationshipHelper.teiToTeiRelationship(fromTei, toTei, typeUid)
+
+        RelationshipStoreImpl.create(databaseAdapter).insert(relationship)
+        RelationshipItemStoreImpl.create(databaseAdapter).let {
+            val r = ObjectWithUid.create(relationship.uid())
+            it.insert(relationship.from()!!.toBuilder()
+                .relationshipItemType(RelationshipConstraintType.FROM)
+                .relationship(r)
+                .build())
+            it.insert(relationship.to()!!.toBuilder()
+                .relationshipItemType(RelationshipConstraintType.TO)
+                .relationship(r)
+                .build())
+        }
     }
 
     companion object {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseTrackerDataIntegrationHelper.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseTrackerDataIntegrationHelper.kt
@@ -190,14 +190,18 @@ open class BaseTrackerDataIntegrationHelper(private val databaseAdapter: Databas
         RelationshipStoreImpl.create(databaseAdapter).insert(relationship)
         RelationshipItemStoreImpl.create(databaseAdapter).let {
             val r = ObjectWithUid.create(relationship.uid())
-            it.insert(relationship.from()!!.toBuilder()
-                .relationshipItemType(RelationshipConstraintType.FROM)
-                .relationship(r)
-                .build())
-            it.insert(relationship.to()!!.toBuilder()
-                .relationshipItemType(RelationshipConstraintType.TO)
-                .relationship(r)
-                .build())
+            it.insert(
+                relationship.from()!!.toBuilder()
+                    .relationshipItemType(RelationshipConstraintType.FROM)
+                    .relationship(r)
+                    .build()
+            )
+            it.insert(
+                relationship.to()!!.toBuilder()
+                    .relationshipItemType(RelationshipConstraintType.TO)
+                    .relationship(r)
+                    .build()
+            )
         }
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseTrackerDataIntegrationHelper.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseTrackerDataIntegrationHelper.kt
@@ -67,11 +67,13 @@ open class BaseTrackerDataIntegrationHelper(private val databaseAdapter: Databas
         orgunitUid: String,
         enrollmentDate: Date? = null,
         incidentDate: Date? = null,
+        created: Date? = null,
+        lastUpdated: Date? = null,
         status: EnrollmentStatus? = EnrollmentStatus.ACTIVE
     ) {
         val enrollment = Enrollment.builder().uid(enrollmentUid).organisationUnit(orgunitUid).program(programUid)
             .enrollmentDate(enrollmentDate).incidentDate(incidentDate).trackedEntityInstance(teiUid)
-            .status(status).build()
+            .created(created).lastUpdated(lastUpdated).status(status).build()
         EnrollmentStoreImpl.create(databaseAdapter).insert(enrollment)
     }
 
@@ -83,10 +85,11 @@ open class BaseTrackerDataIntegrationHelper(private val databaseAdapter: Databas
         orgunitUid: String,
         deleted: Boolean = false,
         eventDate: Date?,
+        created: Date? = null,
         lastUpdated: Date? = null,
         status: EventStatus? = EventStatus.ACTIVE
     ) {
-        val event = Event.builder().uid(eventUid).enrollment(enrollmentUid).lastUpdated(lastUpdated)
+        val event = Event.builder().uid(eventUid).enrollment(enrollmentUid).created(created).lastUpdated(lastUpdated)
             .program(programUid).programStage(programStageUid).organisationUnit(orgunitUid)
             .eventDate(eventDate).deleted(deleted).status(status).build()
         EventStoreImpl.create(databaseAdapter).insert(event)
@@ -100,6 +103,7 @@ open class BaseTrackerDataIntegrationHelper(private val databaseAdapter: Databas
         orgunitUid: String,
         deleted: Boolean = false,
         eventDate: Date? = null,
+        created: Date? = null,
         lastUpdated: Date? = null,
         status: EventStatus? = EventStatus.ACTIVE
     ) {
@@ -110,8 +114,9 @@ open class BaseTrackerDataIntegrationHelper(private val databaseAdapter: Databas
             enrollmentUid = enrollmentUid,
             orgunitUid = orgunitUid,
             deleted = deleted,
-            eventDate = eventDate,
+            created = created,
             lastUpdated = lastUpdated,
+            eventDate = eventDate,
             status = status
         )
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/ProgramIndicatorSQLExecutorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/ProgramIndicatorSQLExecutorIntegrationShould.kt
@@ -354,7 +354,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "d2:monthsBetween(${`var`("enrollment_date")}, " +
-                            "PS_EVENTDATE:${programStage2.uid()})",
+                        "PS_EVENTDATE:${programStage2.uid()})",
                     analyticsType = AnalyticsType.ENROLLMENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -443,7 +443,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "d2:countIfCondition(${de(programStage1.uid(), dataElement1.uid())}, " +
-                            "'< ${de(programStage1.uid(), dataElement2.uid())}')",
+                        "'< ${de(programStage1.uid(), dataElement2.uid())}')",
                     analyticsType = AnalyticsType.EVENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -524,7 +524,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "firstNonNull(${de(programStage1.uid(), dataElement1.uid())}, " +
-                            "${de(programStage1.uid(), dataElement2.uid())})",
+                        "${de(programStage1.uid(), dataElement2.uid())})",
                     analyticsType = AnalyticsType.EVENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -647,7 +647,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
         helper.insertTrackedEntityDataValue(event1, dataElement1.uid(), "-3")
 
         val expression = "${de(programStage1.uid(), dataElement1.uid())} + " +
-                "${de(programStage1.uid(), dataElement2.uid())} + ${att(attribute1.uid())}"
+            "${de(programStage1.uid(), dataElement2.uid())} + ${att(attribute1.uid())}"
 
         assertThat(
             programIndicatorEvaluator.getProgramIndicatorValue(
@@ -749,7 +749,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "d2:zpvc(${de(programStage1.uid(), dataElement1.uid())}, " +
-                            "${de(programStage1.uid(), dataElement2.uid())}, ${att(attribute1.uid())})",
+                        "${de(programStage1.uid(), dataElement2.uid())}, ${att(attribute1.uid())})",
                     analyticsType = AnalyticsType.EVENT,
                     aggregationType = AggregationType.SUM
                 )

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/ProgramIndicatorSQLExecutorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/ProgramIndicatorSQLExecutorIntegrationShould.kt
@@ -353,7 +353,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "d2:monthsBetween(${`var`("enrollment_date")}, " +
-                        "PS_EVENTDATE:${programStage2.uid()})",
+                            "PS_EVENTDATE:${programStage2.uid()})",
                     analyticsType = AnalyticsType.ENROLLMENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -442,7 +442,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "d2:countIfCondition(${de(programStage1.uid(), dataElement1.uid())}, " +
-                        "'< ${de(programStage1.uid(), dataElement2.uid())}')",
+                            "'< ${de(programStage1.uid(), dataElement2.uid())}')",
                     analyticsType = AnalyticsType.EVENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -523,7 +523,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "firstNonNull(${de(programStage1.uid(), dataElement1.uid())}, " +
-                        "${de(programStage1.uid(), dataElement2.uid())})",
+                            "${de(programStage1.uid(), dataElement2.uid())})",
                     analyticsType = AnalyticsType.EVENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -646,7 +646,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
         helper.insertTrackedEntityDataValue(event1, dataElement1.uid(), "-3")
 
         val expression = "${de(programStage1.uid(), dataElement1.uid())} + " +
-            "${de(programStage1.uid(), dataElement2.uid())} + ${att(attribute1.uid())}"
+                "${de(programStage1.uid(), dataElement2.uid())} + ${att(attribute1.uid())}"
 
         assertThat(
             programIndicatorEvaluator.getProgramIndicatorValue(
@@ -748,7 +748,7 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = "d2:zpvc(${de(programStage1.uid(), dataElement1.uid())}, " +
-                        "${de(programStage1.uid(), dataElement2.uid())}, ${att(attribute1.uid())})",
+                            "${de(programStage1.uid(), dataElement2.uid())}, ${att(attribute1.uid())})",
                     analyticsType = AnalyticsType.EVENT,
                     aggregationType = AggregationType.SUM
                 )
@@ -988,24 +988,32 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             eventDate = tenthNovember2019
         )
 
-        assertThat(evaluateTeiCount(
-            filter = "d2:daysBetween(${`var`("analytics_period_start")}, ${`var`("event_date")}) < 15",
-            listOf(periodNov))
+        assertThat(
+            evaluateTeiCount(
+                filter = "d2:daysBetween(${`var`("analytics_period_start")}, ${`var`("event_date")}) < 15",
+                listOf(periodNov)
+            )
         ).isEqualTo("1")
 
-        assertThat(evaluateTeiCount(
-            filter = "d2:daysBetween(${`var`("analytics_period_start")}, ${`var`("event_date")}) < 5",
-            listOf(periodNov))
+        assertThat(
+            evaluateTeiCount(
+                filter = "d2:daysBetween(${`var`("analytics_period_start")}, ${`var`("event_date")}) < 5",
+                listOf(periodNov)
+            )
         ).isEqualTo("0")
 
-        assertThat(evaluateTeiCount(
-            filter = "d2:daysBetween(${`var`("event_date")}, ${`var`("analytics_period_end")}) < 5",
-            listOf(periodNov))
+        assertThat(
+            evaluateTeiCount(
+                filter = "d2:daysBetween(${`var`("event_date")}, ${`var`("analytics_period_end")}) < 5",
+                listOf(periodNov)
+            )
         ).isEqualTo("0")
 
-        assertThat(evaluateTeiCount(
-            filter = "d2:daysBetween(${`var`("event_date")}, ${`var`("analytics_period_end")}) < 24",
-            listOf(periodNov))
+        assertThat(
+            evaluateTeiCount(
+                filter = "d2:daysBetween(${`var`("event_date")}, ${`var`("analytics_period_end")}) < 24",
+                listOf(periodNov)
+            )
         ).isEqualTo("1")
     }
 
@@ -1025,19 +1033,60 @@ internal class ProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorInteg
             eventDate = firstNovember2019
         )
 
-        assertThat(programIndicatorEvaluator.getProgramIndicatorValue(
+        assertThat(
+            programIndicatorEvaluator.getProgramIndicatorValue(
                 setProgramIndicator(
                     expression = `var`("org_unit_count"),
                     analyticsType = AnalyticsType.ENROLLMENT,
                     aggregationType = AggregationType.COUNT
-        ))).isEqualTo("1")
+                )
+            )
+        ).isEqualTo("1")
 
-        assertThat(programIndicatorEvaluator.getProgramIndicatorValue(
-            setProgramIndicator(
-                expression = `var`("org_unit_count"),
-                analyticsType = AnalyticsType.EVENT,
-                aggregationType = AggregationType.COUNT
-            ))).isEqualTo("2")
+        assertThat(
+            programIndicatorEvaluator.getProgramIndicatorValue(
+                setProgramIndicator(
+                    expression = `var`("org_unit_count"),
+                    analyticsType = AnalyticsType.EVENT,
+                    aggregationType = AggregationType.COUNT
+                )
+            )
+        ).isEqualTo("2")
+    }
+
+    @Test
+    fun should_evaluate_creation_and_sync_date_variables() {
+        helper.createTrackedEntity(trackedEntity1.uid(), orgunitChild1.uid(), trackedEntityType.uid())
+        val enrollment1 = generator.generate()
+        helper.createEnrollment(
+            trackedEntity1.uid(), enrollment1, program.uid(), orgunitChild1.uid(),
+            created = firstNovember2019, lastUpdated = secondNovember2019
+        )
+        val event1 = generator.generate()
+        helper.createTrackerEvent(
+            event1, enrollment1, program.uid(), programStage1.uid(), orgunitChild1.uid(),
+            created = firstNovember2019, lastUpdated = tenthNovember2019
+        )
+
+        assertThat(
+            programIndicatorEvaluator.getProgramIndicatorValue(
+                setProgramIndicator(
+                    expression = "d2:daysBetween(${`var`("creation_date")}, ${`var`("sync_date")})",
+                    analyticsType = AnalyticsType.ENROLLMENT,
+                    aggregationType = AggregationType.SUM
+                )
+            )
+        ).isEqualTo("1")
+
+        assertThat(
+            programIndicatorEvaluator.getProgramIndicatorValue(
+                setProgramIndicator(
+                    expression = "d2:daysBetween(${`var`("creation_date")}, ${`var`("sync_date")})",
+                    analyticsType = AnalyticsType.EVENT,
+                    aggregationType = AggregationType.SUM
+                )
+            )
+        ).isEqualTo("9")
     }
 
     private fun evaluateTeiCount(filter: String, periods: List<Period>? = null): String? {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsModel.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsModel.kt
@@ -53,7 +53,7 @@ sealed class MetadataItem(val id: String, val displayName: String) {
     class ProgramIndicatorItem(val item: ProgramIndicator) : MetadataItem(item.uid(), item.displayName()!!)
     class EventDataElementItem(val item: DataElement, val program: Program) :
         MetadataItem("${program.uid()}.${item.uid()}", "${program.displayName()} ${item.displayName()}")
-    class EventAttributeItem(val item: TrackedEntityAttribute, program: Program) :
+    class EventAttributeItem(val item: TrackedEntityAttribute, val program: Program) :
         MetadataItem("${program.uid()}.${item.uid()}", "${program.displayName()} ${item.displayName()}")
 
     class CategoryItem(val item: Category) : MetadataItem(item.uid(), item.displayName()!!)

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsServiceEvaluationItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsServiceEvaluationItem.kt
@@ -34,4 +34,8 @@ import org.hisp.dhis.android.core.analytics.aggregated.DimensionItem
 internal data class AnalyticsServiceEvaluationItem(
     val dimensionItems: List<AbsoluteDimensionItem>,
     val filters: List<DimensionItem>
-)
+) {
+    val allDimensionItems: List<DimensionItem> by lazy {
+        (dimensionItems + filters).map { it as DimensionItem }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsServiceMetadataHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsServiceMetadataHelper.kt
@@ -93,8 +93,7 @@ internal class AnalyticsServiceMetadataHelper @Inject constructor(
     private fun getMetadata(evaluationItem: AnalyticsServiceEvaluationItem): Map<String, MetadataItem> {
         val metadata: MutableMap<String, MetadataItem> = mutableMapOf()
 
-        (evaluationItem.dimensionItems + evaluationItem.filters)
-            .map { it as DimensionItem }
+        evaluationItem.allDimensionItems
             .forEach { item ->
                 if (!metadata.containsKey(item.id)) {
                     val metadataItems = when (item) {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsDimensionHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsDimensionHelper.kt
@@ -36,8 +36,7 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsService
 internal object AnalyticsDimensionHelper {
 
     fun getItemsByDimension(evaluationItem: AnalyticsServiceEvaluationItem): Map<Dimension, List<DimensionItem>> {
-        return (evaluationItem.dimensionItems + evaluationItem.filters)
-            .map { it as DimensionItem }
+        return evaluationItem.allDimensionItems
             .groupBy { it.dimension }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorEvaluator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorEvaluator.kt
@@ -68,8 +68,7 @@ internal class IndicatorEvaluator @Inject constructor(
         evaluationItem: AnalyticsServiceEvaluationItem,
         metadata: Map<String, MetadataItem>
     ): Indicator {
-        val indicatorItem = (evaluationItem.dimensionItems + evaluationItem.filters)
-            .map { it as DimensionItem }
+        val indicatorItem = evaluationItem.allDimensionItems
             .find { it is DimensionItem.DataItem.IndicatorItem }
             ?: throw AnalyticsException.InvalidArguments("Invalid arguments: no indicator dimension provided.")
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorEvaluatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/IndicatorEvaluatorHelper.kt
@@ -39,8 +39,7 @@ internal object IndicatorEvaluatorHelper {
         evaluationItem: AnalyticsServiceEvaluationItem,
         metadata: Map<String, MetadataItem>
     ): Indicator {
-        val indicatorItem = (evaluationItem.dimensionItems + evaluationItem.filters)
-            .map { it as DimensionItem }
+        val indicatorItem = evaluationItem.allDimensionItems
             .find { it is DimensionItem.DataItem.IndicatorItem }
             ?: throw AnalyticsException.InvalidArguments("Invalid arguments: no indicator dimension provided.")
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ProgramIndicatorEvaluatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ProgramIndicatorEvaluatorHelper.kt
@@ -45,8 +45,7 @@ internal object ProgramIndicatorEvaluatorHelper {
         evaluationItem: AnalyticsServiceEvaluationItem,
         metadata: Map<String, MetadataItem>
     ): ProgramIndicator {
-        val programIndicatorItem = (evaluationItem.dimensionItems + evaluationItem.filters)
-            .map { it as DimensionItem }
+        val programIndicatorItem = evaluationItem.allDimensionItems
             .find { it is DimensionItem.DataItem.ProgramIndicatorItem }
             ?: throw AnalyticsException.InvalidArguments("Invalid arguments: no program indicator dimension provided.")
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ProgramIndicatorSQLEvaluator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ProgramIndicatorSQLEvaluator.kt
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator
 
+import org.hisp.dhis.android.core.analytics.aggregated.DimensionItem
 import javax.inject.Inject
 import org.hisp.dhis.android.core.analytics.aggregated.MetadataItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsServiceEvaluationItem
@@ -60,7 +61,8 @@ internal class ProgramIndicatorSQLEvaluator @Inject constructor(
     ): ProgramIndicatorSQLParams {
         val programIndicator = ProgramIndicatorEvaluatorHelper.getProgramIndicator(evaluationItem, metadata)
         val contextWhereClause = getContextWhereClause(programIndicator, evaluationItem, metadata)
-        val periods = AnalyticsEvaluatorHelper.getReportingPeriods(evaluationItem.allDimensionItems, metadata)
+        val periodItems = evaluationItem.allDimensionItems.filterIsInstance<DimensionItem.PeriodItem>()
+        val periods = AnalyticsEvaluatorHelper.getReportingPeriods(periodItems, metadata)
 
         return ProgramIndicatorSQLParams(
             programIndicator = programIndicator,

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorContext.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorContext.kt
@@ -35,13 +35,18 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStor
 import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
 import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.program.ProgramIndicatorCollectionRepository
+import org.hisp.dhis.android.core.program.internal.ProgramStoreInterface
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 
 internal data class IndicatorContext(
     val dataElementStore: IdentifiableObjectStore<DataElement>,
+    val trackedEntityAttributeStore: IdentifiableObjectStore<TrackedEntityAttribute>,
     val categoryOptionComboStore: CategoryOptionComboStore,
+    val programStore: ProgramStoreInterface,
     val programIndicatorRepository: ProgramIndicatorCollectionRepository,
     val dataElementEvaluator: AnalyticsEvaluator,
     val programIndicatorEvaluator: AnalyticsEvaluator,
+    val eventDataItemEvaluator: AnalyticsEvaluator,
     val evaluationItem: AnalyticsServiceEvaluationItem,
     val contextMetadata: Map<String, MetadataItem>
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorEngine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorEngine.kt
@@ -31,6 +31,7 @@ import javax.inject.Inject
 import org.hisp.dhis.android.core.analytics.aggregated.MetadataItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsServiceEvaluationItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.DataElementSQLEvaluator
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.EventDataItemSQLEvaluator
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.ProgramIndicatorSQLEvaluator
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.mapByUid
@@ -44,14 +45,19 @@ import org.hisp.dhis.android.core.parser.internal.expression.CommonParser
 import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
 import org.hisp.dhis.android.core.parser.internal.service.ExpressionService
 import org.hisp.dhis.android.core.program.ProgramIndicatorCollectionRepository
+import org.hisp.dhis.android.core.program.internal.ProgramStoreInterface
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 
 internal class IndicatorEngine @Inject constructor(
     private val indicatorTypeStore: IdentifiableObjectStore<IndicatorType>,
     private val dataElementStore: IdentifiableObjectStore<DataElement>,
+    private val trackedEntityAttributeStore: IdentifiableObjectStore<TrackedEntityAttribute>,
     private val categoryOptionComboStore: CategoryOptionComboStore,
+    private val programStore: ProgramStoreInterface,
     private val programIndicatorRepository: ProgramIndicatorCollectionRepository,
     private val dataElementEvaluator: DataElementSQLEvaluator,
     private val programIndicatorEvaluator: ProgramIndicatorSQLEvaluator,
+    private val eventDataItemEvaluator: EventDataItemSQLEvaluator,
     private val constantStore: IdentifiableObjectStore<Constant>,
     private val expressionService: ExpressionService
 ) {
@@ -63,10 +69,13 @@ internal class IndicatorEngine @Inject constructor(
     ): String? {
         val indicatorContext = IndicatorContext(
             dataElementStore = dataElementStore,
+            trackedEntityAttributeStore = trackedEntityAttributeStore,
             categoryOptionComboStore = categoryOptionComboStore,
+            programStore = programStore,
             programIndicatorRepository = programIndicatorRepository,
             dataElementEvaluator = dataElementEvaluator,
             programIndicatorEvaluator = programIndicatorEvaluator,
+            eventDataItemEvaluator = eventDataItemEvaluator,
             evaluationItem = contextEvaluationItem,
             contextMetadata = contextMetadata
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorEngine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorEngine.kt
@@ -48,6 +48,7 @@ import org.hisp.dhis.android.core.program.ProgramIndicatorCollectionRepository
 import org.hisp.dhis.android.core.program.internal.ProgramStoreInterface
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 
+@Suppress("LongParameterList")
 internal class IndicatorEngine @Inject constructor(
     private val indicatorTypeStore: IdentifiableObjectStore<IndicatorType>,
     private val dataElementStore: IdentifiableObjectStore<DataElement>,

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorParserUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorParserUtils.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.core.analytics.aggregated.DimensionItem
 import org.hisp.dhis.android.core.analytics.aggregated.MetadataItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsServiceEvaluationItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.indicatorengine.dataitem.DataElementItem
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.indicatorengine.dataitem.ProgramAttributeItem
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.indicatorengine.dataitem.ProgramDataElementItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.indicatorengine.dataitem.ProgramIndicatorItem
 import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
 import org.hisp.dhis.android.core.period.Period
@@ -95,10 +97,13 @@ internal object IndicatorParserUtils {
             ExpressionParser.D2_COUNT_IF_CONDITION to D2CountIfCondition(),
             ExpressionParser.D2_COUNT_IF_VALUE to D2CountIfValue(),
             ExpressionParser.D2_HAS_VALUE to D2HasValue(),
-            ExpressionParser.D2_CONDITION to D2Condition(), // Data items
+            ExpressionParser.D2_CONDITION to D2Condition(),
 
+            // Data items
             ExpressionParser.HASH_BRACE to DataElementItem(),
-            ExpressionParser.I_BRACE to ProgramIndicatorItem()
+            ExpressionParser.I_BRACE to ProgramIndicatorItem(),
+            ExpressionParser.D_BRACE to ProgramDataElementItem(),
+            ExpressionParser.A_BRACE to ProgramAttributeItem()
         )
 
     fun getDays(

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorParserUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorParserUtils.kt
@@ -110,8 +110,7 @@ internal object IndicatorParserUtils {
         contextEvaluationItem: AnalyticsServiceEvaluationItem,
         contextMetadata: Map<String, MetadataItem>
     ): Int? {
-        val periods = (contextEvaluationItem.dimensionItems + contextEvaluationItem.filters)
-            .map { it as DimensionItem }
+        val periods = contextEvaluationItem.allDimensionItems
             .mapNotNull { item ->
                 when (item) {
                     is DimensionItem.PeriodItem.Absolute -> {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorSQLEngine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorSQLEngine.kt
@@ -31,6 +31,7 @@ import javax.inject.Inject
 import org.hisp.dhis.android.core.analytics.aggregated.MetadataItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsServiceEvaluationItem
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.DataElementSQLEvaluator
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.EventDataItemSQLEvaluator
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.ProgramIndicatorSQLEvaluator
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
@@ -44,14 +45,19 @@ import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVis
 import org.hisp.dhis.android.core.parser.internal.expression.CommonParser
 import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
 import org.hisp.dhis.android.core.program.ProgramIndicatorCollectionRepository
+import org.hisp.dhis.android.core.program.internal.ProgramStoreInterface
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 
 internal class IndicatorSQLEngine @Inject constructor(
     private val indicatorTypeStore: IdentifiableObjectStore<IndicatorType>,
     private val dataElementStore: IdentifiableObjectStore<DataElement>,
+    private val trackedEntityAttributeStore: IdentifiableObjectStore<TrackedEntityAttribute>,
     private val categoryOptionComboStore: CategoryOptionComboStore,
+    private val programStore: ProgramStoreInterface,
     private val programIndicatorRepository: ProgramIndicatorCollectionRepository,
     private val dataElementEvaluator: DataElementSQLEvaluator,
     private val programIndicatorEvaluator: ProgramIndicatorSQLEvaluator,
+    private val eventDataItemEvaluator: EventDataItemSQLEvaluator,
     private val constantStore: IdentifiableObjectStore<Constant>,
     private val databaseAdapter: DatabaseAdapter
 ) {
@@ -77,10 +83,13 @@ internal class IndicatorSQLEngine @Inject constructor(
     ): String {
         val indicatorContext = IndicatorContext(
             dataElementStore = dataElementStore,
+            trackedEntityAttributeStore = trackedEntityAttributeStore,
             categoryOptionComboStore = categoryOptionComboStore,
+            programStore = programStore,
             programIndicatorRepository = programIndicatorRepository,
             dataElementEvaluator = dataElementEvaluator,
             programIndicatorEvaluator = programIndicatorEvaluator,
+            eventDataItemEvaluator = eventDataItemEvaluator,
             evaluationItem = contextEvaluationItem,
             contextMetadata = contextMetadata
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorSQLEngine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/IndicatorSQLEngine.kt
@@ -48,6 +48,7 @@ import org.hisp.dhis.android.core.program.ProgramIndicatorCollectionRepository
 import org.hisp.dhis.android.core.program.internal.ProgramStoreInterface
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 
+@Suppress("LongParameterList")
 internal class IndicatorSQLEngine @Inject constructor(
     private val indicatorTypeStore: IdentifiableObjectStore<IndicatorType>,
     private val dataElementStore: IdentifiableObjectStore<DataElement>,

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.indicatorengine.dataitem
+
+import org.hisp.dhis.android.core.analytics.AnalyticsException
+import org.hisp.dhis.android.core.analytics.aggregated.AbsoluteDimensionItem
+import org.hisp.dhis.android.core.analytics.aggregated.DimensionItem
+import org.hisp.dhis.android.core.analytics.aggregated.MetadataItem
+import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsServiceEvaluationItem
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.AnalyticsEvaluator
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.dataelement.DataElementOperand
+import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
+import org.hisp.dhis.android.core.parser.internal.expression.ExpressionItem
+import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
+
+internal interface IndicatorDataItem : ExpressionItem {
+
+    override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
+        return getEvaluationItem(ctx, visitor)?.let { evaluationItem ->
+            getMetadataEntry(evaluationItem, visitor)?.let { metadataEntry ->
+                getEvaluator(visitor).evaluate(
+                    evaluationItem = evaluationItem,
+                    metadata = visitor.indicatorContext.contextMetadata + metadataEntry
+                )
+            }
+        } ?: ParserUtils.DOUBLE_VALUE_IF_NULL
+    }
+
+    override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
+        return getEvaluationItem(ctx, visitor)?.let { evaluationItem ->
+            getMetadataEntry(evaluationItem, visitor)?.let { metadataEntry ->
+                getEvaluator(visitor).getSql(
+                    evaluationItem = evaluationItem,
+                    metadata = visitor.indicatorContext.contextMetadata + metadataEntry
+                )?.let { "($it)" }
+            }
+        }
+    }
+
+    fun getEvaluator(visitor: CommonExpressionVisitor): AnalyticsEvaluator
+
+    fun getDataItem(ctx: ExprContext, visitor: CommonExpressionVisitor): AbsoluteDimensionItem?
+
+    private fun getEvaluationItem(
+        ctx: ExprContext,
+        visitor: CommonExpressionVisitor
+    ): AnalyticsServiceEvaluationItem? {
+        return getDataItem(ctx, visitor)?.let { dataItem ->
+            AnalyticsServiceEvaluationItem(
+                dimensionItems = listOf(dataItem),
+                filters = visitor.indicatorContext.evaluationItem.filters +
+                    visitor.indicatorContext.evaluationItem.dimensionItems.map { it as DimensionItem }
+            )
+        }
+    }
+
+    private fun getMetadataEntry(
+        evaluationItem: AnalyticsServiceEvaluationItem,
+        visitor: CommonExpressionVisitor
+    ): Pair<String, MetadataItem>? {
+        return when (val dataItem = evaluationItem.dimensionItems.first()) {
+            is DimensionItem.DataItem.DataElementOperandItem -> {
+                val dataElement = visitor.indicatorContext.dataElementStore.selectByUid(dataItem.dataElement)
+                val coc = visitor.indicatorContext.categoryOptionComboStore.selectByUid(dataItem.categoryOptionCombo)
+
+                if (dataElement == null || coc == null) {
+                    throw AnalyticsException.InvalidDataElementOperand(dataItem.id)
+                }
+
+                val dataElementOperandId = dataItem.id
+                val dataElementOperand = DataElementOperand.builder()
+                    .uid(dataItem.id)
+                    .dataElement(ObjectWithUid.create(dataItem.dataElement))
+                    .categoryOptionCombo(ObjectWithUid.create(dataItem.categoryOptionCombo))
+                    .build()
+
+                dataElementOperandId to MetadataItem.DataElementOperandItem(
+                    dataElementOperand,
+                    dataElement.displayName()!!,
+                    coc.displayName()
+                )
+            }
+            is DimensionItem.DataItem.DataElementItem -> {
+                val dataElement =
+                    visitor.indicatorContext.dataElementStore.selectByUid(dataItem.uid)
+                        ?: throw AnalyticsException.InvalidDataElement(dataItem.uid)
+
+                dataItem.uid to MetadataItem.DataElementItem(dataElement)
+            }
+            is DimensionItem.DataItem.ProgramIndicatorItem -> {
+                val programIndicator = visitor.indicatorContext.programIndicatorRepository
+                    .withAnalyticsPeriodBoundaries()
+                    .uid(dataItem.uid)
+                    .blockingGet()
+                    ?: throw AnalyticsException.InvalidProgramIndicator(dataItem.uid)
+
+                dataItem.uid to MetadataItem.ProgramIndicatorItem(programIndicator)
+            }
+            is DimensionItem.DataItem.EventDataItem.DataElement -> {
+                val program = visitor.indicatorContext.programStore.selectByUid(dataItem.program)
+                    ?: throw AnalyticsException.InvalidProgram(dataItem.program)
+
+                val dataElement = visitor.indicatorContext.dataElementStore.selectByUid(dataItem.dataElement)
+                    ?: throw AnalyticsException.InvalidDataElement(dataItem.dataElement)
+
+                val metadataItem = MetadataItem.EventDataElementItem(dataElement, program)
+                metadataItem.id to metadataItem
+            }
+            is DimensionItem.DataItem.EventDataItem.Attribute -> {
+                val program = visitor.indicatorContext.programStore.selectByUid(dataItem.program)
+                    ?: throw AnalyticsException.InvalidProgram(dataItem.program)
+
+                val attribute = visitor.indicatorContext.trackedEntityAttributeStore.selectByUid(dataItem.attribute)
+                    ?: throw AnalyticsException.InvalidTrackedEntityAttribute(dataItem.attribute)
+
+                val metadataItem = MetadataItem.EventAttributeItem(attribute, program)
+                metadataItem.id to metadataItem
+            }
+            else ->
+                null
+        }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
@@ -75,8 +75,7 @@ internal interface IndicatorDataItem : ExpressionItem {
         return getDataItem(ctx, visitor)?.let { dataItem ->
             AnalyticsServiceEvaluationItem(
                 dimensionItems = listOf(dataItem),
-                filters = visitor.indicatorContext.evaluationItem.filters +
-                    visitor.indicatorContext.evaluationItem.dimensionItems.map { it as DimensionItem }
+                filters = visitor.indicatorContext.evaluationItem.allDimensionItems
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
@@ -81,6 +81,7 @@ internal interface IndicatorDataItem : ExpressionItem {
         }
     }
 
+    @Suppress("ThrowsCount")
     private fun getMetadataEntry(
         evaluationItem: AnalyticsServiceEvaluationItem,
         visitor: CommonExpressionVisitor

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/ProgramAttributeItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/ProgramAttributeItem.kt
@@ -33,23 +33,20 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.Analyt
 import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 
-internal class DataElementItem : IndicatorDataItem {
+internal class ProgramAttributeItem : IndicatorDataItem {
 
     override fun getDataItem(ctx: ExprContext, visitor: CommonExpressionVisitor): AbsoluteDimensionItem? {
-        val dataElementUid = ctx.uid0?.text
-        val categoryOptionComboUid = ctx.uid1?.text
+        val programUid = ctx.uid0?.text
+        val attributeUid = ctx.uid1?.text
 
-        return when {
-            dataElementUid != null && categoryOptionComboUid != null ->
-                DimensionItem.DataItem.DataElementOperandItem(dataElementUid, categoryOptionComboUid)
-            dataElementUid != null ->
-                DimensionItem.DataItem.DataElementItem(dataElementUid)
-            else ->
-                null
+        return if (programUid != null && attributeUid != null) {
+            DimensionItem.DataItem.EventDataItem.Attribute(programUid, attributeUid)
+        } else {
+            null
         }
     }
 
     override fun getEvaluator(visitor: CommonExpressionVisitor): AnalyticsEvaluator {
-        return visitor.indicatorContext.dataElementEvaluator
+        return visitor.indicatorContext.eventDataItemEvaluator
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/ProgramDataElementItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/ProgramDataElementItem.kt
@@ -33,23 +33,20 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.Analyt
 import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 
-internal class DataElementItem : IndicatorDataItem {
+internal class ProgramDataElementItem : IndicatorDataItem {
 
     override fun getDataItem(ctx: ExprContext, visitor: CommonExpressionVisitor): AbsoluteDimensionItem? {
-        val dataElementUid = ctx.uid0?.text
-        val categoryOptionComboUid = ctx.uid1?.text
+        val programUid = ctx.uid0?.text
+        val dataElementUid = ctx.uid1?.text
 
-        return when {
-            dataElementUid != null && categoryOptionComboUid != null ->
-                DimensionItem.DataItem.DataElementOperandItem(dataElementUid, categoryOptionComboUid)
-            dataElementUid != null ->
-                DimensionItem.DataItem.DataElementItem(dataElementUid)
-            else ->
-                null
+        return if (programUid != null && dataElementUid != null) {
+            DimensionItem.DataItem.EventDataItem.DataElement(programUid, dataElementUid)
+        } else {
+            null
         }
     }
 
     override fun getEvaluator(visitor: CommonExpressionVisitor): AnalyticsEvaluator {
-        return visitor.indicatorContext.dataElementEvaluator
+        return visitor.indicatorContext.eventDataItemEvaluator
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorParserUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorParserUtils.kt
@@ -74,12 +74,10 @@ internal object ProgramIndicatorParserUtils {
         ExpressionParser.D2_COUNT_IF_VALUE to D2CountIfValue(),
         ExpressionParser.D2_DAYS_BETWEEN to D2DaysBetween(),
         ExpressionParser.D2_HAS_VALUE to D2HasValue(),
-        // TODO D2_MAX_VALUE
         ExpressionParser.D2_MINUTES_BETWEEN to D2MinutesBetween(),
-        // TODO D2_MIN_VALUE
         ExpressionParser.D2_MONTHS_BETWEEN to D2MonthsBetween(),
         ExpressionParser.D2_OIZP to D2Oizp(),
-        // TODO RELATIONSHIP_COUNT
+        ExpressionParser.D2_RELATIONSHIP_COUNT to D2RelationshipCount(),
         ExpressionParser.D2_WEEKS_BETWEEN to D2WeeksBetween(),
         ExpressionParser.D2_YEARS_BETWEEN to D2YearsBetween(),
         ExpressionParser.D2_ZING to D2Zing(),

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorSQLParams.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorSQLParams.kt
@@ -30,7 +30,8 @@ package org.hisp.dhis.android.core.program.programindicatorengine.internal
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.program.ProgramIndicator
 
-internal data class ProgramIndicatorSQLContext(
+internal data class ProgramIndicatorSQLParams(
     val programIndicator: ProgramIndicator,
-    val periods: List<Period>?
+    val contextWhereClause: String? = null,
+    val periods: List<Period>? = null
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/function/D2RelationshipCount.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/function/D2RelationshipCount.kt
@@ -51,18 +51,18 @@ internal class D2RelationshipCount : ExpressionItem {
         val queries = getQueries(visitor.programIndicatorSQLContext.programIndicator)
 
         return "(SELECT COUNT(*) " +
-                "FROM ${RelationshipItemTableInfo.TABLE_INFO.name()} $riAlias " +
-                "INNER JOIN ${RelationshipTableInfo.TABLE_INFO.name()} $rAlias " +
-                "ON $riAlias.${RelationshipItemTableInfo.Columns.RELATIONSHIP} = " +
-                "$rAlias.${RelationshipTableInfo.Columns.UID} " +
-                "WHERE " +
-                "($riAlias.${RelationshipItemTableInfo.Columns.TRACKED_ENTITY_INSTANCE} ${queries.teiQuery} " +
-                "OR $riAlias.${RelationshipItemTableInfo.Columns.ENROLLMENT} ${queries.enrollmentQuery} " +
-                "OR $riAlias.${RelationshipItemTableInfo.Columns.EVENT} ${queries.eventQuery}) " +
-                "AND ($rAlias.${RelationshipTableInfo.Columns.DELETED} = 0 OR " +
-                "$rAlias.${RelationshipTableInfo.Columns.DELETED} IS NULL) " +
-                (rTypeUid?.let { "AND $rAlias.${RelationshipTableInfo.Columns.RELATIONSHIP_TYPE} = $it" } ?: "") +
-                ")"
+            "FROM ${RelationshipItemTableInfo.TABLE_INFO.name()} $riAlias " +
+            "INNER JOIN ${RelationshipTableInfo.TABLE_INFO.name()} $rAlias " +
+            "ON $riAlias.${RelationshipItemTableInfo.Columns.RELATIONSHIP} = " +
+            "$rAlias.${RelationshipTableInfo.Columns.UID} " +
+            "WHERE " +
+            "($riAlias.${RelationshipItemTableInfo.Columns.TRACKED_ENTITY_INSTANCE} ${queries.teiQuery} " +
+            "OR $riAlias.${RelationshipItemTableInfo.Columns.ENROLLMENT} ${queries.enrollmentQuery} " +
+            "OR $riAlias.${RelationshipItemTableInfo.Columns.EVENT} ${queries.eventQuery}) " +
+            "AND ($rAlias.${RelationshipTableInfo.Columns.DELETED} = 0 OR " +
+            "$rAlias.${RelationshipTableInfo.Columns.DELETED} IS NULL) " +
+            (rTypeUid?.let { "AND $rAlias.${RelationshipTableInfo.Columns.RELATIONSHIP_TYPE} = $it" } ?: "") +
+            ")"
     }
 
     private fun getQueries(programIndicator: ProgramIndicator): RelationshipCountQueries {
@@ -70,8 +70,8 @@ internal class D2RelationshipCount : ExpressionItem {
             AnalyticsType.EVENT ->
                 RelationshipCountQueries(
                     teiQuery = "IN (SELECT ${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE} " +
-                            "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
-                            "WHERE ${EnrollmentTableInfo.Columns.UID} = $event.${EventTableInfo.Columns.ENROLLMENT})",
+                        "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
+                        "WHERE ${EnrollmentTableInfo.Columns.UID} = $event.${EventTableInfo.Columns.ENROLLMENT})",
                     enrollmentQuery = "= $event.${EventTableInfo.Columns.ENROLLMENT}",
                     eventQuery = "= $event.${EventTableInfo.Columns.UID}"
                 )
@@ -80,9 +80,9 @@ internal class D2RelationshipCount : ExpressionItem {
                     teiQuery = "= $enrollment.${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE}",
                     enrollmentQuery = "= $enrollment.${EnrollmentTableInfo.Columns.UID}",
                     eventQuery = "IN (SELECT ${EventTableInfo.Columns.UID} " +
-                            "FROM ${EventTableInfo.TABLE_INFO.name()} " +
-                            "WHERE ${EventTableInfo.Columns.ENROLLMENT} = " +
-                            "$enrollment.${EnrollmentTableInfo.Columns.UID})"
+                        "FROM ${EventTableInfo.TABLE_INFO.name()} " +
+                        "WHERE ${EventTableInfo.Columns.ENROLLMENT} = " +
+                        "$enrollment.${EnrollmentTableInfo.Columns.UID})"
                 )
         }
     }
@@ -93,4 +93,3 @@ internal class D2RelationshipCount : ExpressionItem {
         val eventQuery: String
     )
 }
-

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/function/D2RelationshipCount.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/function/D2RelationshipCount.kt
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.program.programindicatorengine.internal.function
+
+import org.hisp.dhis.android.core.common.AnalyticsType
+import org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo
+import org.hisp.dhis.android.core.event.EventTableInfo
+import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
+import org.hisp.dhis.android.core.parser.internal.expression.ExpressionItem
+import org.hisp.dhis.android.core.program.ProgramIndicator
+import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLUtils.enrollment
+import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLUtils.event
+import org.hisp.dhis.android.core.relationship.RelationshipItemTableInfo
+import org.hisp.dhis.android.core.relationship.RelationshipTableInfo
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
+
+internal class D2RelationshipCount : ExpressionItem {
+
+    private val riAlias = "ri"
+    private val rAlias = "r"
+
+    override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {
+
+        val rTypeUid = ctx.uid0?.text
+
+        val queries = getQueries(visitor.programIndicatorSQLContext.programIndicator)
+
+        return "(SELECT COUNT(*) " +
+                "FROM ${RelationshipItemTableInfo.TABLE_INFO.name()} $riAlias " +
+                "INNER JOIN ${RelationshipTableInfo.TABLE_INFO.name()} $rAlias " +
+                "ON $riAlias.${RelationshipItemTableInfo.Columns.RELATIONSHIP} = " +
+                "$rAlias.${RelationshipTableInfo.Columns.UID} " +
+                "WHERE " +
+                "($riAlias.${RelationshipItemTableInfo.Columns.TRACKED_ENTITY_INSTANCE} ${queries.teiQuery} " +
+                "OR $riAlias.${RelationshipItemTableInfo.Columns.ENROLLMENT} ${queries.enrollmentQuery} " +
+                "OR $riAlias.${RelationshipItemTableInfo.Columns.EVENT} ${queries.eventQuery}) " +
+                "AND ($rAlias.${RelationshipTableInfo.Columns.DELETED} = 0 OR " +
+                "$rAlias.${RelationshipTableInfo.Columns.DELETED} IS NULL) " +
+                (rTypeUid?.let { "AND $rAlias.${RelationshipTableInfo.Columns.RELATIONSHIP_TYPE} = $it" } ?: "") +
+                ")"
+    }
+
+    private fun getQueries(programIndicator: ProgramIndicator): RelationshipCountQueries {
+        return when (programIndicator.analyticsType()) {
+            AnalyticsType.EVENT ->
+                RelationshipCountQueries(
+                    teiQuery = "IN (SELECT ${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE} " +
+                            "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
+                            "WHERE ${EnrollmentTableInfo.Columns.UID} = $event.${EventTableInfo.Columns.ENROLLMENT})",
+                    enrollmentQuery = "= $event.${EventTableInfo.Columns.ENROLLMENT}",
+                    eventQuery = "= $event.${EventTableInfo.Columns.UID}"
+                )
+            AnalyticsType.ENROLLMENT, null ->
+                RelationshipCountQueries(
+                    teiQuery = "= $enrollment.${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE}",
+                    enrollmentQuery = "= $enrollment.${EnrollmentTableInfo.Columns.UID}",
+                    eventQuery = "IN (SELECT ${EventTableInfo.Columns.UID} " +
+                            "FROM ${EventTableInfo.TABLE_INFO.name()} " +
+                            "WHERE ${EventTableInfo.Columns.ENROLLMENT} = " +
+                            "$enrollment.${EnrollmentTableInfo.Columns.UID})"
+                )
+        }
+    }
+
+    internal data class RelationshipCountQueries(
+        val teiQuery: String,
+        val enrollmentQuery: String,
+        val eventQuery: String
+    )
+}
+

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/ProgramVariableItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/ProgramVariableItem.kt
@@ -61,6 +61,8 @@ internal class ProgramVariableItem : ProgramExpressionItem() {
 
     companion object {
         private val PROGRAM_VARIABLES = mapOf(
+            ExpressionParser.V_ANALYTICS_PERIOD_END to VAnalyticsEndDate(),
+            ExpressionParser.V_ANALYTICS_PERIOD_START to VAnalyticsStartDate(),
             ExpressionParser.V_CREATION_DATE to VCreationDate(),
             ExpressionParser.V_CURRENT_DATE to VCurrentDate(),
             ExpressionParser.V_COMPLETED_DATE to VCompletedDate(),

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/ProgramVariableItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/ProgramVariableItem.kt
@@ -75,6 +75,7 @@ internal class ProgramVariableItem : ProgramExpressionItem() {
             ExpressionParser.V_EVENT_DATE to VEventDate(),
             ExpressionParser.V_EXECUTION_DATE to VEventDate(),
             ExpressionParser.V_INCIDENT_DATE to VIncidentDate(),
+            ExpressionParser.V_ORG_UNIT_COUNT to VOrgUnitCount(),
             ExpressionParser.V_TEI_COUNT to VTeiCount(),
             ExpressionParser.V_VALUE_COUNT to VValueCount(),
             ExpressionParser.V_ZERO_POS_VALUE_COUNT to VZeroPosValueCount(),

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/ProgramVariableItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/ProgramVariableItem.kt
@@ -76,6 +76,7 @@ internal class ProgramVariableItem : ProgramExpressionItem() {
             ExpressionParser.V_EXECUTION_DATE to VEventDate(),
             ExpressionParser.V_INCIDENT_DATE to VIncidentDate(),
             ExpressionParser.V_ORG_UNIT_COUNT to VOrgUnitCount(),
+            ExpressionParser.V_SYNC_DATE to VSyncDate(),
             ExpressionParser.V_TEI_COUNT to VTeiCount(),
             ExpressionParser.V_VALUE_COUNT to VValueCount(),
             ExpressionParser.V_ZERO_POS_VALUE_COUNT to VZeroPosValueCount(),

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VAnalyticsEndDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VAnalyticsEndDate.kt
@@ -25,12 +25,20 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.program.programindicatorengine.internal
+package org.hisp.dhis.android.core.program.programindicatorengine.internal.variable
 
-import org.hisp.dhis.android.core.period.Period
-import org.hisp.dhis.android.core.program.ProgramIndicator
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
+import org.hisp.dhis.android.core.parser.internal.expression.ExpressionItem
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 
-internal data class ProgramIndicatorSQLContext(
-    val programIndicator: ProgramIndicator,
-    val periods: List<Period>?
-)
+internal class VAnalyticsEndDate : ExpressionItem {
+
+    override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {
+        val startDate = visitor.programIndicatorSQLContext.periods
+            ?.mapNotNull { it.endDate() }
+            ?.maxByOrNull { it.time }
+
+        return startDate?.let { "'${DateUtils.SIMPLE_DATE_FORMAT.format(it)}'" } ?: "date('now')"
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VAnalyticsStartDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VAnalyticsStartDate.kt
@@ -25,12 +25,20 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.program.programindicatorengine.internal
+package org.hisp.dhis.android.core.program.programindicatorengine.internal.variable
 
-import org.hisp.dhis.android.core.period.Period
-import org.hisp.dhis.android.core.program.ProgramIndicator
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
+import org.hisp.dhis.android.core.parser.internal.expression.ExpressionItem
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 
-internal data class ProgramIndicatorSQLContext(
-    val programIndicator: ProgramIndicator,
-    val periods: List<Period>?
-)
+internal class VAnalyticsStartDate : ExpressionItem {
+
+    override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {
+        val startDate = visitor.programIndicatorSQLContext.periods
+            ?.mapNotNull { it.startDate() }
+            ?.minByOrNull { it.time }
+
+        return startDate?.let { "'${DateUtils.SIMPLE_DATE_FORMAT.format(it)}'" } ?: "date('now')"
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VCompletedDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VCompletedDate.kt
@@ -42,8 +42,7 @@ internal class VCompletedDate : ProgramExpressionItem() {
         val enrollment = visitor.programIndicatorContext.enrollment
 
         return if (enrollment == null) {
-            val singleEvent = getLatestEvent(visitor)
-            if (singleEvent == null) null else ParserUtils.getMediumDateString(singleEvent.completedDate())
+            getLatestEvent(visitor)?.let { ParserUtils.getMediumDateString(it.completedDate()) }
         } else {
             ParserUtils.getMediumDateString(enrollment.completedDate())
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VCreationDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VCreationDate.kt
@@ -42,8 +42,7 @@ internal class VCreationDate : ProgramExpressionItem() {
         val enrollment = visitor.programIndicatorContext.enrollment
 
         return if (enrollment == null) {
-            val singleEvent = getLatestEvent(visitor)
-            if (singleEvent == null) null else ParserUtils.getMediumDateString(singleEvent.created())
+            getLatestEvent(visitor)?.let { ParserUtils.getMediumDateString(it.created()) }
         } else {
             ParserUtils.getMediumDateString(enrollment.created())
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VDueDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VDueDate.kt
@@ -39,9 +39,7 @@ import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 internal class VDueDate : ProgramExpressionItem() {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        val singleEvent = getLatestEvent(visitor)
-
-        return if (singleEvent == null) null else ParserUtils.getMediumDateString(singleEvent.dueDate())
+        return getLatestEvent(visitor)?.let { ParserUtils.getMediumDateString(it.dueDate()) }
     }
 
     override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VEnrollmentDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VEnrollmentDate.kt
@@ -40,9 +40,9 @@ import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 internal class VEnrollmentDate : ExpressionItem {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        val enrollment = visitor.programIndicatorContext.enrollment
-
-        return if (enrollment == null) null else ParserUtils.getMediumDateString(enrollment.enrollmentDate())
+        return visitor.programIndicatorContext.enrollment?.let {
+            ParserUtils.getMediumDateString(it.enrollmentDate())
+        }
     }
 
     override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VEnrollmentStatus.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VEnrollmentStatus.kt
@@ -39,9 +39,7 @@ import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 internal class VEnrollmentStatus : ExpressionItem {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        val enrollment = visitor.programIndicatorContext.enrollment
-
-        return enrollment?.status()?.name
+        return visitor.programIndicatorContext.enrollment?.status()?.name
     }
 
     override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VIncidentDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VIncidentDate.kt
@@ -40,9 +40,9 @@ import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 internal class VIncidentDate : ExpressionItem {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        val enrollment = visitor.programIndicatorContext.enrollment
-
-        return if (enrollment == null) null else ParserUtils.getMediumDateString(enrollment.incidentDate())
+        return visitor.programIndicatorContext.enrollment?.let {
+            ParserUtils.getMediumDateString(it.incidentDate())
+        }
     }
 
     override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VProgramStageId.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VProgramStageId.kt
@@ -37,9 +37,7 @@ import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 internal class VProgramStageId : ProgramExpressionItem() {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        val event = getLatestEvent(visitor)
-
-        return event?.programStage()
+        return getLatestEvent(visitor)?.programStage()
     }
 
     override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VProgramStageName.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VProgramStageName.kt
@@ -39,9 +39,7 @@ import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 internal class VProgramStageName : ProgramExpressionItem() {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        val event = getLatestEvent(visitor)
-
-        return event?.programStage()?.let {
+        return getLatestEvent(visitor)?.programStage()?.let {
             visitor.programStageStore.selectByUid(it)?.name()
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VSyncDate.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/variable/VSyncDate.kt
@@ -28,28 +28,32 @@
 package org.hisp.dhis.android.core.program.programindicatorengine.internal.variable
 
 import org.hisp.dhis.android.core.common.AnalyticsType
-import org.hisp.dhis.android.core.event.EventTableInfo
+import org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo
 import org.hisp.dhis.android.core.parser.internal.expression.CommonExpressionVisitor
 import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
 import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramExpressionItem
-import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLUtils
+import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLUtils.enrollment
 import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLUtils.event
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 
-internal class VEventDate : ProgramExpressionItem() {
+internal class VSyncDate : ProgramExpressionItem() {
 
     override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
-        return getLatestEvent(visitor)?.let { ParserUtils.getMediumDateString(it.eventDate()) }
+        val enrollment = visitor.programIndicatorContext.enrollment
+
+        return if (enrollment == null) {
+            getLatestEvent(visitor)?.let { ParserUtils.getMediumDateString(it.lastUpdated()) }
+        } else {
+            ParserUtils.getMediumDateString(enrollment.lastUpdated())
+        }
     }
 
     override fun getSql(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {
         return when (visitor.programIndicatorSQLContext.programIndicator.analyticsType()) {
             AnalyticsType.EVENT ->
-                "$event.${EventTableInfo.Columns.EVENT_DATE}"
+                "$event.${EnrollmentTableInfo.Columns.LAST_UPDATED}"
             AnalyticsType.ENROLLMENT, null ->
-                ProgramIndicatorSQLUtils.getEventColumnForEnrollmentWhereClause(
-                    column = EventTableInfo.Columns.EVENT_DATE
-                )
+                "$enrollment.${EnrollmentTableInfo.Columns.LAST_UPDATED}"
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintStore.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintStore.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.android.core.arch.helpers.UidsHelper;
 import org.hisp.dhis.android.core.relationship.RelationshipConstraint;
 import org.hisp.dhis.android.core.relationship.RelationshipConstraintTableInfo;
 
-final class RelationshipConstraintStore {
+public final class RelationshipConstraintStore {
 
     private static final StatementBinder<RelationshipConstraint> BINDER = (o, w) -> {
         w.bind(1, UidsHelper.getUidOrNull(o.relationshipType()));
@@ -60,7 +60,7 @@ final class RelationshipConstraintStore {
 
     private RelationshipConstraintStore() {}
 
-    static ObjectWithoutUidStore<RelationshipConstraint> create(DatabaseAdapter databaseAdapter) {
+    public static ObjectWithoutUidStore<RelationshipConstraint> create(DatabaseAdapter databaseAdapter) {
         return StoreFactory.objectWithoutUidStore(databaseAdapter, RelationshipConstraintTableInfo.TABLE_INFO,
                 BINDER, WHERE_UPDATE_BINDER, WHERE_DELETE_BINDER, RelationshipConstraint::create);
     }

--- a/docs/content/developer/analytics.md
+++ b/docs/content/developer/analytics.md
@@ -424,7 +424,7 @@ ProgramIndicator analytic boundaries are not supported at the moment. ProgramInd
 |                           |D2Modulus              | No        | No            |
 |                           |D2MonthsBetween        | Yes       | Yes           |
 |                           |D2Oizp                 | Yes       | Yes           |
-|                           |D2RelationshipCount    | Yes       | No            |
+|                           |D2RelationshipCount    | Yes       | Yes           |
 |                           |D2Right                | No        | No            |
 |                           |D2Round                | No        | No            |
 |                           |D2Split                | No        | No            |

--- a/docs/content/developer/analytics.md
+++ b/docs/content/developer/analytics.md
@@ -452,8 +452,8 @@ ProgramIndicator analytic boundaries are not supported at the moment. ProgramInd
 |                           |stddevSamp             | Yes       | No            |
 |                           |sum                    | Yes       | No            |
 |                           |variance               | Yes       | No            |
-|**Variables:**             |AnalyticsPeriodEnd     | Yes       | No            |
-|                           |AnalyticsPeriodStart   | Yes       | No            |
+|**Variables:**             |AnalyticsPeriodEnd     | Yes       | Yes           |
+|                           |AnalyticsPeriodStart   | Yes       | Yes           |
 |                           |CreationDate           | Yes       | Yes           |
 |                           |CurrentDate            | Yes       | Yes           |
 |                           |CompletedDate          | Yes       | Yes           |

--- a/docs/content/developer/analytics.md
+++ b/docs/content/developer/analytics.md
@@ -466,10 +466,10 @@ ProgramIndicator analytic boundaries are not supported at the moment. ProgramInd
 |                           |ExecutionDate          | Yes       | Yes           |
 |                           |EventDate              | Yes       | Yes           |
 |                           |IncidentDate           | Yes       | Yes           |
-|                           |OrgunitCount           | Yes       | No            |
+|                           |OrgunitCount           | Yes       | Yes           |
 |                           |ProgramStageId         | Yes       | Yes           |
 |                           |ProgramStageName       | Yes       | Yes           |
-|                           |SyncDate               | Yes       | No            |
+|                           |SyncDate               | Yes       | Yes           |
 |                           |TeiCount               | Yes       | Yes           |
 |                           |ValueCount             | Yes       | Yes           |
 |                           |ZeroPosValueCount      | Yes       | Yes           |

--- a/docs/content/developer/analytics.md
+++ b/docs/content/developer/analytics.md
@@ -355,8 +355,8 @@ This table shows the functionality supported by the Indicator dimension item com
 |                   |Log10                  | Yes       | No            |
 |**Dimensions:**    |Constant               | Yes       | Yes           |
 |                   |DataElement            | Yes       | Yes           |
-|                   |ProgramAttribute       | Yes       | No            |
-|                   |ProgramDataElement     | Yes       | No            |
+|                   |ProgramAttribute       | Yes       | Yes           |
+|                   |ProgramDataElement     | Yes       | Yes           |
 |                   |ProgramIndicator       | Yes       | Yes           |
 |                   |OrgUnitGroup           | Yes       | No            |
 |                   |ReportingRate          | Yes       | No            |


### PR DESCRIPTION
Solves [ANDROSDK-1376](https://jira.dhis2.org/browse/ANDROSDK-1376).

Added support for:
- Variables: analytics_period_end, analytics_period_start, org_unit_count, sync_date.
- Functions: d2:relationshipCount()
- Indicators: programDataElement, programAttribute