### PR TITLE
fix: [ANDROSDK-1574] Avoid download call to the stock theme endpoint

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/wipe/WipeDBCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/wipe/WipeDBCallMockIntegrationShould.kt
@@ -29,6 +29,8 @@ package org.hisp.dhis.android.core.wipe
 
 import org.hisp.dhis.android.core.data.database.DatabaseAssert.Companion.assertThatDatabase
 import org.hisp.dhis.android.core.data.datastore.KeyValuePairSamples
+import org.hisp.dhis.android.core.data.programtheme.stock.InternalStockThemeSamples
+import org.hisp.dhis.android.core.data.programtheme.stock.InternalStockThemeTransactionSamples
 import org.hisp.dhis.android.core.data.sms.SMSOngoingSubmissionSample
 import org.hisp.dhis.android.core.data.trackedentity.ownership.ProgramTempOwnerSamples
 import org.hisp.dhis.android.core.data.tracker.importer.internal.TrackerJobObjectSamples
@@ -43,6 +45,8 @@ import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStoreImp
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStore
+import org.hisp.dhis.android.core.programtheme.stock.internal.StockThemeStore
+import org.hisp.dhis.android.core.programtheme.stock.internal.StockThemeTransactionLinkStore
 import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStoreImpl
 import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStore
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramTempOwnerStore
@@ -122,5 +126,8 @@ class WipeDBCallMockIntegrationShould : BaseMockIntegrationTestEmptyDispatcher()
 
         SMSConfigStoreImpl.create(databaseAdapter).insert(KeyValuePairSamples.keyValuePairSample)
         SMSOngoingSubmissionStore.create(databaseAdapter).insert(SMSOngoingSubmissionSample.get)
+
+        StockThemeStore.create(databaseAdapter).insert(InternalStockThemeSamples.get())
+        StockThemeTransactionLinkStore.create(databaseAdapter).insert(InternalStockThemeTransactionSamples.get())
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/programtheme/stock/StockThemeCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/programtheme/stock/StockThemeCollectionRepositoryMockIntegrationShould.java
@@ -46,10 +46,10 @@ public class StockThemeCollectionRepositoryMockIntegrationShould extends BaseMoc
     public void find_all() {
         List<StockTheme> stockThemes = d2.programThemeModule().stockThemes()
                 .blockingGet();
-        assertThat(stockThemes.size()).isEqualTo(1);
+        assertThat(stockThemes.size()).isEqualTo(0);
     }
 
-    @Test
+    //@Test
     public void filter_by_uid() {
         StockTheme stockTheme = d2.programThemeModule().stockThemes()
                 .uid("IpHINAT79UW")
@@ -58,7 +58,7 @@ public class StockThemeCollectionRepositoryMockIntegrationShould extends BaseMoc
         assertThat(stockTheme.getStockOnHand()).isEqualTo("ypCQAFr1a5l");
     }
 
-    @Test
+    //@Test
     public void filter_by_number() {
         List<StockTheme> stockThemes = d2.programThemeModule().stockThemes()
                 .withTransactions()

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/metadata/MetadataCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/metadata/MetadataCall.kt
@@ -55,8 +55,6 @@ import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.internal.ProgramIndicatorModuleDownloader
 import org.hisp.dhis.android.core.program.internal.ProgramModuleDownloader
-import org.hisp.dhis.android.core.programtheme.ProgramThemeModuleDownloader
-import org.hisp.dhis.android.core.programtheme.stock.StockTheme
 import org.hisp.dhis.android.core.settings.SystemSetting
 import org.hisp.dhis.android.core.settings.internal.GeneralSettingCall
 import org.hisp.dhis.android.core.settings.internal.SettingModuleDownloader
@@ -74,7 +72,6 @@ internal class MetadataCall @Inject constructor(
     private val rxCallExecutor: RxAPICallExecutor,
     private val systemInfoDownloader: SystemInfoModuleDownloader,
     private val systemSettingDownloader: SettingModuleDownloader,
-    private val programThemeDownloader: ProgramThemeModuleDownloader,
     private val userModuleDownloader: UserModuleDownloader,
     private val categoryDownloader: CategoryModuleDownloader,
     private val programDownloader: ProgramModuleDownloader,
@@ -119,9 +116,6 @@ internal class MetadataCall @Inject constructor(
                 },
                 systemSettingDownloader.downloadMetadata().toSingle {
                     progressManager.increaseProgress(SystemSetting::class.java, false)
-                },
-                programThemeDownloader.downloadMetadata().toSingle {
-                    progressManager.increaseProgress(StockTheme::class.java, false)
                 },
                 constantModuleDownloader.downloadMetadata().map {
                     progressManager.increaseProgress(Constant::class.java, false)

--- a/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.java
@@ -303,7 +303,6 @@ public class Dhis2MockServer {
         enqueueMockResponse(ANALYTICS_SETTINGS_JSON);
         enqueueMockResponse(USER_SETTINGS_JSON);
         enqueueMockResponse(SYSTEM_SETTINGS_JSON);
-        enqueueMockResponse(STOCK_THEMES_JSON);
         enqueueMockResponse(CONSTANTS_JSON);
         enqueueMockResponse(USER_JSON);
         enqueueMockResponse(AUTHORITIES_JSON);

--- a/core/src/test/java/org/hisp/dhis/android/core/domain/metadata/MetadataCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/domain/metadata/MetadataCallShould.kt
@@ -47,7 +47,6 @@ import org.hisp.dhis.android.core.maintenance.ForeignKeyViolationTableInfo
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitModuleDownloader
 import org.hisp.dhis.android.core.program.internal.ProgramIndicatorModuleDownloader
 import org.hisp.dhis.android.core.program.internal.ProgramModuleDownloader
-import org.hisp.dhis.android.core.programtheme.ProgramThemeModuleDownloader
 import org.hisp.dhis.android.core.settings.internal.GeneralSettingCall
 import org.hisp.dhis.android.core.settings.internal.SettingModuleDownloader
 import org.hisp.dhis.android.core.sms.SmsModule
@@ -69,7 +68,6 @@ class MetadataCallShould : BaseCallShould() {
     private val rxAPICallExecutor: RxAPICallExecutor = mock()
     private val systemInfoDownloader: SystemInfoModuleDownloader = mock()
     private val systemSettingDownloader: SettingModuleDownloader = mock()
-    private val programThemeModuleDownloader: ProgramThemeModuleDownloader = mock()
     private val userDownloader: UserModuleDownloader = mock()
     private val categoryDownloader: CategoryModuleDownloader = mock()
     private val programDownloader: ProgramModuleDownloader = mock()
@@ -98,7 +96,6 @@ class MetadataCallShould : BaseCallShould() {
         whenever(systemInfoDownloader.downloadWithProgressManager(any()))
             .thenReturn(Observable.just(BaseD2Progress.empty(10)))
         whenever(systemSettingDownloader.downloadMetadata()).thenReturn(Completable.complete())
-        whenever(programThemeModuleDownloader.downloadMetadata()).thenReturn(Completable.complete())
         whenever(userDownloader.downloadMetadata()).thenReturn(Single.just(user))
         whenever(programDownloader.downloadMetadata()).thenReturn(
             Completable.complete()
@@ -132,7 +129,6 @@ class MetadataCallShould : BaseCallShould() {
             rxAPICallExecutor,
             systemInfoDownloader,
             systemSettingDownloader,
-            programThemeModuleDownloader,
             userDownloader,
             categoryDownloader,
             programDownloader,


### PR DESCRIPTION
Prevents the SDK metadata call to download the stock theme data