### PR TITLE
fix: [JENKINS-PULL-REQUEST-ID-FIX] Set PULL_REQUEST to null on pushes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,9 +42,10 @@ pipeline {
         }
         stage('Sonarqube') {
             environment {
-                GIT_BRANCH = "$env.GIT_BRANCH"
+                GIT_BRANCH = "${env.GIT_BRANCH}"
                 GIT_BRANCH_DEST = "${env.CHANGE_TARGET == null ? env.GIT_BRANCH : env.CHANGE_TARGET}"
-                PULL_REQUEST = "$env.CHANGE_ID"
+                // Jenkinsfile considers empty value ('') as null
+                PULL_REQUEST = "${env.CHANGE_ID == null ? '' : env.CHANGE_ID }"
                 SONAR_TOKEN = credentials('android-sonarcloud-token')
             }
             steps {


### PR DESCRIPTION
Pull request id was not correctly parsed in Jenkinsfile. It was parsed as "null" string instead of a null value.