### PR TITLE
fix: [ANDROSDK-1651] Fix metadataSync when latestVersion returns a 404 D2 error

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/SettingModuleDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/SettingModuleDownloader.kt
@@ -50,7 +50,7 @@ internal class SettingModuleDownloader @Inject constructor(
             downloadFromSettingsApp().blockingAwait()
             userSettingsCall.download().blockingGet()
             systemSettingCall.download().blockingGet()
-            latestAppVersionCall.download(false).blockingGet()
+            latestAppVersionCall.getCompletable(false).blockingAwait()
         }
     }
 


### PR DESCRIPTION
The metadata synchronization used to throw a D2Error and stop if the call to catch the latestVersion responded with a 404, now it just logs the error and does not throw it.