### PR TITLE
fix: [ANDROSDK-1219] Escape ",", ";", ":" characters in queries' filters

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -160,7 +160,7 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
         fun toAPIFilterFormat(items: List<RepositoryScopeFilterItem>, upper: Boolean): List<String> {
             // Compatibility for the new Tracker (old Tracker will ignore this format)
             // Following characters need to be escaped escaped with a "/" for backend functionality
-            val charsToEscape  = "[;,:]".toRegex()
+            val charsToEscape = "[;,:]".toRegex()
 
             return items
                 .groupBy { it.key() }
@@ -168,7 +168,7 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
                     val clause = items.map { item ->
                         val operator = if (upper) item.operator().apiUpperOperator else item.operator().apiOperator
 
-                        ":" + operator + ":" + getAPIValue(item).replace(charsToEscape,  "/\$0" )
+                        ":" + operator + ":" + getAPIValue(item).replace(charsToEscape, "/\$0")
                     }
 
                     key + clause.joinToString(separator = "")

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -158,13 +158,17 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
 
     companion object {
         fun toAPIFilterFormat(items: List<RepositoryScopeFilterItem>, upper: Boolean): List<String> {
+            // Compatibility for the new Tracker (old Tracker will ignore this format)
+            // Following characters need to be escaped escaped with a "/" for backend functionality
+            val charsToEscape  = "[;,:]".toRegex()
+
             return items
                 .groupBy { it.key() }
                 .map { (key, items) ->
                     val clause = items.map { item ->
                         val operator = if (upper) item.operator().apiUpperOperator else item.operator().apiOperator
 
-                        ":" + operator + ":" + getAPIValue(item)
+                        ":" + operator + ":" + getAPIValue(item).replace(charsToEscape,  "/\$0" )
                     }
 
                     key + clause.joinToString(separator = "")

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -157,6 +157,7 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
     }
 
     companion object {
+
         fun toAPIFilterFormat(items: List<RepositoryScopeFilterItem>, upper: Boolean): List<String> {
             // Compatibility for the new Tracker (old Tracker will ignore this format)
             // Following characters need to be escaped escaped with a "/" for backend functionality
@@ -175,14 +176,19 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
         }
 
         private fun getAPIValue(item: RepositoryScopeFilterItem): String {
-            val charsToEscape = "[;,:]".toRegex()
 
             return if (item.operator() == FilterItemOperator.IN) {
-                val list = FilterOperatorsHelper.strToList(item.value()).map { it.replace(charsToEscape, "/\$0") }
+                val list = FilterOperatorsHelper.strToList(item.value()).map { escapeChars(it) }
                 list.joinToString(";")
             } else {
-                item.value().replace(charsToEscape, "/\$0")
+                escapeChars(item.value())
             }
+        }
+
+        private fun escapeChars(targetString: String): String {
+            val charsToEscape = "[;,:]".toRegex()
+            val escapingChar = "/\$0"
+            return targetString.replace(charsToEscape, escapingChar)
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -160,7 +160,6 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
         fun toAPIFilterFormat(items: List<RepositoryScopeFilterItem>, upper: Boolean): List<String> {
             // Compatibility for the new Tracker (old Tracker will ignore this format)
             // Following characters need to be escaped escaped with a "/" for backend functionality
-            val charsToEscape = "[;,:]".toRegex()
 
             return items
                 .groupBy { it.key() }
@@ -168,7 +167,7 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
                     val clause = items.map { item ->
                         val operator = if (upper) item.operator().apiUpperOperator else item.operator().apiOperator
 
-                        ":" + operator + ":" + getAPIValue(item).replace(charsToEscape, "/\$0")
+                        ":" + operator + ":" + getAPIValue(item)
                     }
 
                     key + clause.joinToString(separator = "")
@@ -176,11 +175,13 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
         }
 
         private fun getAPIValue(item: RepositoryScopeFilterItem): String {
+            val charsToEscape = "[;,:]".toRegex()
+
             return if (item.operator() == FilterItemOperator.IN) {
-                val list = FilterOperatorsHelper.strToList(item.value())
+                val list = FilterOperatorsHelper.strToList(item.value()).map { it.replace(charsToEscape, "/\$0") }
                 list.joinToString(";")
             } else {
-                item.value()
+                item.value().replace(charsToEscape, "/\$0")
             }
         }
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
@@ -97,17 +97,23 @@ class TrackedEntityInstanceQueryOnlineHelperShould {
         )
 
         val expectedList = listOf(
-            "filterItem1:in:nom/,app/;nom/:app/;nom/;app",
-            "filterItem2:like:nom/,app%%%<>%%%nom/:app%%%<>%%%nom/;app"
+            "filterItemIN:in:nom/,app;nom/:app;nom/;app",
+            "filterItemLIKE1:like:nom/,app",
+            "filterItemLIKE2:like:nom/:app",
+            "filterItemLIKE3:like:nom/;app",
         )
 
         val scope = queryBuilder
             .filter(
                 listOf(
                     RepositoryScopeFilterItem.builder()
-                        .key("filterItem1").operator(FilterItemOperator.IN).value(listToStr(list)).build(),
+                        .key("filterItemIN").operator(FilterItemOperator.IN).value(listToStr(list)).build(),
                     RepositoryScopeFilterItem.builder()
-                        .key("filterItem2").operator(FilterItemOperator.LIKE).value(listToStr(list)).build()
+                        .key("filterItemLIKE1").operator(FilterItemOperator.LIKE).value(list[0]).build(),
+                    RepositoryScopeFilterItem.builder()
+                        .key("filterItemLIKE2").operator(FilterItemOperator.LIKE).value(list[1]).build(),
+                    RepositoryScopeFilterItem.builder()
+                        .key("filterItemLIKE3").operator(FilterItemOperator.LIKE).value(list[2]).build()
                 )
             ).build()
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
@@ -115,5 +115,4 @@ class TrackedEntityInstanceQueryOnlineHelperShould {
 
         assertThat(formattedQueries).isEqualTo(expectedList)
     }
-
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
 import org.hisp.dhis.android.core.common.FilterOperatorsHelper.listToStr
 import org.hisp.dhis.android.core.period.internal.CalendarProviderFactory.calendarProvider
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryOnlineHelper.Companion.toAPIFilterFormat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -85,4 +86,34 @@ class TrackedEntityInstanceQueryOnlineHelperShould {
         assertThat(onlineQueries.size).isEqualTo(1)
         assertThat(onlineQueries[0].attributeFilter.size).isEqualTo(1)
     }
+
+    @Test
+    fun to_API_filter_format() {
+        // List of filters
+        val list = listOf(
+            "nom,app",
+            "nom:app",
+            "nom;app"
+        )
+
+        val expectedList = listOf(
+            "filterItem1:in:nom/,app/;nom/:app/;nom/;app",
+            "filterItem2:like:nom/,app%%%<>%%%nom/:app%%%<>%%%nom/;app"
+        )
+
+        val scope = queryBuilder
+            .filter(
+                listOf(
+                    RepositoryScopeFilterItem.builder()
+                        .key("filterItem1").operator(FilterItemOperator.IN).value(listToStr(list)).build(),
+                    RepositoryScopeFilterItem.builder()
+                        .key("filterItem2").operator(FilterItemOperator.LIKE).value(listToStr(list)).build()
+                )
+            ).build()
+
+        val formattedQueries = toAPIFilterFormat(scope.filter(), false)
+
+        assertThat(formattedQueries).isEqualTo(expectedList)
+    }
+
 }


### PR DESCRIPTION
fix:
- ",", ";", ":" characters in filters need to be escaped with "/". The backend is fixed this issue only for the new importer, versions 40.1, 41.0 and newer.



