### PR TITLE
fix: [ANDROSDK-1737-DEFECT] Update dokka; remove explicit sources in publish

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("io.gitlab.arturbosch.detekt") version "1.21.0"
-    id("org.jetbrains.dokka") version "1.7.20" apply false
+    id("org.jetbrains.dokka") version "1.8.20" apply false
 }
 
 apply(from = project.file("plugins/android-checkstyle.gradle"))

--- a/core/plugins/gradle-mvn-push.gradle
+++ b/core/plugins/gradle-mvn-push.gradle
@@ -62,6 +62,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 }
 
 tasks.named("dokkaJavadoc") {
+    dependsOn("kaptReleaseKotlin")
     outputDirectory = file("$buildDir/dokkaJavadoc")
 
     dokkaSourceSets {
@@ -79,11 +80,6 @@ task androidJavadocsJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-task androidSourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
-}
-
 afterEvaluate {
     publishing {
         publications {
@@ -92,7 +88,6 @@ afterEvaluate {
 
                 // Artifacts
                 artifact androidJavadocsJar
-                artifact androidSourcesJar
 
                 groupId = GROUP
                 artifactId = POM_ARTIFACT_ID


### PR DESCRIPTION
The update of Kotlin (1.9.0) and Gradle plugin had made Dokka task fail. 

- Update Dokka to a compatible version
- Remove explicit sources in Publish task. Source files seems to be automatically included in the publication.