### PR TITLE
fix: [ANDROSDK-1731-DEFECT] Wrap TEI query call in old tracker endpoints 

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
@@ -179,6 +179,7 @@ object D2Manager {
             throw NoSuchFieldException("No testing Server Url")
         }
         d2DIComponent.credentialsSecureStore().set(Credentials(username, testingServerUrl!!, password, null))
+        d2DIComponent.userIdInMemoryStore().set(username)
     }
 
     private fun wantToImportDBForExternalTesting(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallFactory.kt
@@ -130,39 +130,37 @@ internal class TrackedEntityInstanceQueryCallFactory @Inject constructor(
     private suspend fun getTrackedEntityQuery(query: TrackedEntityInstanceQueryOnline): List<TrackedEntityInstance> {
         val uidsStr = query.uids?.joinToString(";")
 
-        val searchGridCall = trackedEntityService.query(
-            trackedEntityInstance = uidsStr,
-            orgUnit = getOrgunits(query.orgUnits),
-            orgUnitMode = query.orgUnitMode?.toString(),
-            program = query.program,
-            programStage = query.programStage,
-            programStartDate = query.programStartDate.simpleDateFormat(),
-            programEndDate = query.programEndDate.simpleDateFormat(),
-            enrollmentStatus = query.enrollmentStatus?.toString(),
-            programIncidentStartDate = query.incidentStartDate.simpleDateFormat(),
-            programIncidentEndDate = query.incidentEndDate.simpleDateFormat(),
-            followUp = query.followUp,
-            eventStartDate = query.eventStartDate.simpleDateFormat(),
-            eventEndDate = query.eventEndDate.simpleDateFormat(),
-            eventStatus = getEventStatus(query),
-            trackedEntityType = query.trackedEntityType,
-            query = query.query,
-            filter = toAPIFilterFormat(query.attributeFilter, upper = true),
-            assignedUserMode = query.assignedUserMode?.toString(),
-            lastUpdatedStartDate = query.lastUpdatedStartDate.simpleDateFormat(),
-            lastUpdatedEndDate = query.lastUpdatedEndDate.simpleDateFormat(),
-            order = query.order,
-            paging = query.paging,
-            pageSize = query.pageSize,
-            page = query.page,
-        )
-
         return try {
             coroutineAPICallExecutor.wrap(
                 storeError = false,
                 errorCatcher = TrackedEntityInstanceQueryErrorCatcher()
             ) {
-                searchGridCall
+                trackedEntityService.query(
+                    trackedEntityInstance = uidsStr,
+                    orgUnit = getOrgunits(query.orgUnits),
+                    orgUnitMode = query.orgUnitMode?.toString(),
+                    program = query.program,
+                    programStage = query.programStage,
+                    programStartDate = query.programStartDate.simpleDateFormat(),
+                    programEndDate = query.programEndDate.simpleDateFormat(),
+                    enrollmentStatus = query.enrollmentStatus?.toString(),
+                    programIncidentStartDate = query.incidentStartDate.simpleDateFormat(),
+                    programIncidentEndDate = query.incidentEndDate.simpleDateFormat(),
+                    followUp = query.followUp,
+                    eventStartDate = query.eventStartDate.simpleDateFormat(),
+                    eventEndDate = query.eventEndDate.simpleDateFormat(),
+                    eventStatus = getEventStatus(query),
+                    trackedEntityType = query.trackedEntityType,
+                    query = query.query,
+                    filter = toAPIFilterFormat(query.attributeFilter, upper = true),
+                    assignedUserMode = query.assignedUserMode?.toString(),
+                    lastUpdatedStartDate = query.lastUpdatedStartDate.simpleDateFormat(),
+                    lastUpdatedEndDate = query.lastUpdatedEndDate.simpleDateFormat(),
+                    order = query.order,
+                    paging = query.paging,
+                    pageSize = query.pageSize,
+                    page = query.page,
+                )
             }.getOrThrow().let { mapper.transform(it) }
         } catch (pe: ParseException) {
             throw D2Error.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/api/executors/internal/CoroutineAPICallExecutorMock.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/api/executors/internal/CoroutineAPICallExecutorMock.kt
@@ -43,12 +43,18 @@ internal class CoroutineAPICallExecutorMock : CoroutineAPICallExecutor {
         return try {
             Result.Success(block.invoke())
         } catch (e: Throwable) {
-            Result.Failure(
-                D2Error.builder()
-                    .errorCode(D2ErrorCode.UNEXPECTED)
-                    .errorDescription("Unexpected error")
-                    .build()
-            )
+            when (e) {
+                is D2Error ->
+                    Result.Failure(e)
+
+                else ->
+                    Result.Failure(
+                        D2Error.builder()
+                            .errorCode(D2ErrorCode.UNEXPECTED)
+                            .errorDescription("Unexpected error")
+                            .build()
+                    )
+            }
         }
     }
 


### PR DESCRIPTION
Wraps query to old tracker endpoint in coroutine error handler