### PR TITLE
fix: [ANDROSDK-1743-DEFECT] Not filter null values when returning attribute values

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper.kt
@@ -75,7 +75,7 @@ object TrackedEntitySearchItemHelper {
         attributes: List<SimpleTrackedEntityAttribute>,
         attributeValues: List<TrackedEntityAttributeValue>?,
     ): List<TrackedEntitySearchItemAttribute> {
-        return attributes.mapNotNull { attribute ->
+        return attributes.map { attribute ->
             from(attribute, attributeValues)
         }
     }
@@ -83,20 +83,19 @@ object TrackedEntitySearchItemHelper {
     private fun from(
         attribute: SimpleTrackedEntityAttribute,
         attributeValues: List<TrackedEntityAttributeValue>?,
-    ): TrackedEntitySearchItemAttribute? {
-        return attributeValues?.find { it.trackedEntityAttribute() == attribute.attribute }?.let { value ->
-            TrackedEntitySearchItemAttribute(
-                attribute = attribute.attribute,
-                displayName = attribute.displayName,
-                displayFormName = attribute.displayFormName ?: attribute.displayName,
-                value = value.value(),
-                created = value.created(),
-                lastUpdated = value.lastUpdated(),
-                valueType = attribute.valueType,
-                displayInList = attribute.displayInList,
-                optionSet = attribute.optionSet,
-            )
-        }
+    ): TrackedEntitySearchItemAttribute {
+        val value = attributeValues?.find { it.trackedEntityAttribute() == attribute.attribute }
+        return TrackedEntitySearchItemAttribute(
+            attribute = attribute.attribute,
+            displayName = attribute.displayName,
+            displayFormName = attribute.displayFormName ?: attribute.displayName,
+            value = value?.value(),
+            created = value?.created(),
+            lastUpdated = value?.lastUpdated(),
+            valueType = attribute.valueType,
+            displayInList = attribute.displayInList,
+            optionSet = attribute.optionSet,
+        )
     }
 
     private fun toTrackedEntityAttributeValue(a: TrackedEntitySearchItemAttribute): TrackedEntityAttributeValue {


### PR DESCRIPTION
Solves [ANDROSDK-1743](https://dhis2.atlassian.net/browse/ANDROSDK-1743).

[ANDROSDK-1743]: https://dhis2.atlassian.net/browse/ANDROSDK-1743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ