### PR TITLE
refactor: [ANDROSDK-1714] Remove unnecessary @RunWith in tests

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/repositories/collection/PagingMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/repositories/collection/PagingMockIntegrationShould.kt
@@ -43,7 +43,6 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class PagingMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @get:Rule

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/repositories/collection/PagingMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/repositories/collection/PagingMockIntegrationShould.kt
@@ -36,12 +36,10 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.category.CategoryOption
 import org.hisp.dhis.android.core.category.internal.CategoryOptionStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.junit.runner.RunWith
 
 class PagingMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboUidsSeekerMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.core.category.internal
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class CategoryComboUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboUidsSeekerMockIntegrationShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class CategoryComboUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun seek_category_combos_uids() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorUidsSeekerMockIntegrationShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class IndicatorUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun seek_programIndicator_uids() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorUidsSeekerMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.core.indicator.internal
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class IndicatorUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetUidsSeekerMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.core.legendset.internal
 
 import com.google.common.truth.Truth
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class LegendSetUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetUidsSeekerMockIntegrationShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class LegendSetUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorUidsSeekerMockIntegrationShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class ProgramIndicatorUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun seek_programIndicator_uids() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorUidsSeekerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorUidsSeekerMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.core.program.internal
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class ProgramIndicatorUidsSeekerMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoModuleMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoModuleMockIntegrationShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class SystemInfoModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun allow_access_to_system_info_user() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoModuleMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/SystemInfoModuleMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.core.systeminfo
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class SystemInfoModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
@@ -43,7 +43,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class TrackedEntityInstanceLocalQueryHelperMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     private val trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(databaseAdapter)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
@@ -39,9 +39,7 @@ import org.hisp.dhis.android.core.period.internal.CalendarProviderFactory
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class TrackedEntityInstanceLocalQueryHelperMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -38,7 +38,6 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @get:Rule

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -32,11 +32,9 @@ import androidx.paging.PagedList
 import com.jraska.livedata.TestObserver
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.junit.runner.RunWith
 
 class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/utils/runner/D2JunitTestListener.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/utils/runner/D2JunitTestListener.kt
@@ -45,5 +45,7 @@ class D2JunitTestListener : RunListener() {
         TestDatabaseAdapterFactory.tearDown()
         tearDown()
         DatabaseRemover.removeAllDatabases()
+        Log.i("D2JunitTestListener", "Test run database clearing finished")
+
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/utils/runner/D2JunitTestListener.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/utils/runner/D2JunitTestListener.kt
@@ -46,6 +46,5 @@ class D2JunitTestListener : RunListener() {
         tearDown()
         DatabaseRemover.removeAllDatabases()
         Log.i("D2JunitTestListener", "Test run database clearing finished")
-
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryCollectionRepositoryMockIntegrationShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class CategoryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryCollectionRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.category
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class CategoryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryComboCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryComboCollectionRepositoryMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.testapp.category
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class CategoryComboCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryComboCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryComboCollectionRepositoryMockIntegrationShould.kt
@@ -34,8 +34,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class CategoryComboCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class CategoryComboCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     private val beforeDate = "2007-12-24T12:24:25.203"
     private val inBetweenDate = "2016-04-16T18:04:34.745"
     private val afterDate = "2017-12-24T12:24:25.203"

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryModuleMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryModuleMockIntegrationShould.kt
@@ -37,7 +37,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun allow_access_to_combos_without_children() {
@@ -96,7 +95,8 @@ class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
 
     @Test
     fun allow_access_to_combo_by_uid_with_sorted_categories() {
-        val combo = d2.categoryModule().categoryCombos().withCategories().uid("m2jTvAj5kkm").blockingGet()!!
+        val combo =
+            d2.categoryModule().categoryCombos().withCategories().uid("m2jTvAj5kkm").blockingGet()!!
         assertThat(combo.uid()).isEqualTo("m2jTvAj5kkm")
         assertThat(combo.code()).isEqualTo("BIRTHS")
         assertThat(combo.name()).isEqualTo("Births")
@@ -139,7 +139,8 @@ class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
 
     @Test
     fun allow_access_to_category_by_uid_with_sorted_category_options() {
-        val category = d2.categoryModule().categories().withCategoryOptions().uid("KfdsGBcoiCa").blockingGet()!!
+        val category = d2.categoryModule().categories().withCategoryOptions().uid("KfdsGBcoiCa")
+            .blockingGet()!!
         assertThat(category.uid()).isEqualTo("KfdsGBcoiCa")
         assertThat(category.name()).isEqualTo("Births attended by")
         assertThat(category.dataDimensionType()).isEqualTo("DISAGGREGATION")
@@ -169,7 +170,8 @@ class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
 
     @Test
     fun allow_access_to_category_option_combos_with_category_options() {
-        val categoryOptionCombos = d2.categoryModule().categoryOptionCombos().withCategoryOptions().blockingGet()
+        val categoryOptionCombos =
+            d2.categoryModule().categoryOptionCombos().withCategoryOptions().blockingGet()
         assertThat(categoryOptionCombos.size).isEqualTo(3)
 
         for (categoryOptionCombo in categoryOptionCombos) {
@@ -179,7 +181,8 @@ class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
 
     @Test
     fun allow_access_to_category_option_combo_by_uid_without_children() {
-        val categoryOptionCombo = d2.categoryModule().categoryOptionCombos().uid("Gmbgme7z9BF").blockingGet()!!
+        val categoryOptionCombo =
+            d2.categoryModule().categoryOptionCombos().uid("Gmbgme7z9BF").blockingGet()!!
         assertThat(categoryOptionCombo.uid()).isEqualTo("Gmbgme7z9BF")
         assertThat(categoryOptionCombo.name()).isEqualTo("Trained TBA, At PHU")
     }
@@ -213,7 +216,8 @@ class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
 
     @Test
     fun allow_access_to_category_combo_by_uid_without_children() {
-        val categoryOption = d2.categoryModule().categoryOptions().uid("apsOixVZlf1").blockingGet()!!
+        val categoryOption =
+            d2.categoryModule().categoryOptions().uid("apsOixVZlf1").blockingGet()!!
         assertThat(categoryOption.uid()).isEqualTo("apsOixVZlf1")
         assertThat(categoryOption.name()).isEqualTo("Female")
         assertThat(categoryOption.code()).isEqualTo("FMLE")

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryModuleMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryModuleMockIntegrationShould.kt
@@ -33,9 +33,7 @@ import org.hisp.dhis.android.core.category.CategoryCombo
 import org.hisp.dhis.android.core.category.CategoryComboInternalAccessor
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class CategoryModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionComboCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionComboCollectionRepositoryMockIntegrationShould.kt
@@ -33,8 +33,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class CategoryOptionComboCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class CategoryOptionComboCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
         val categoryOptionCombos = d2.categoryModule().categoryOptionCombos()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionComboCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionComboCollectionRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.category
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class CategoryOptionComboCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionRepositoryMockIntegrationShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class CategoryOptionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionRepositoryMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.testapp.category
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class CategoryOptionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceCollectionRepositoryMockIntegrationShould.kt
@@ -35,8 +35,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class DataSetInstanceCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class DataSetInstanceCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
         val dataSetInstances = d2.dataSetModule().dataSetInstances()
@@ -75,7 +75,8 @@ class DataSetInstanceCollectionRepositoryMockIntegrationShould : BaseMockIntegra
     @Test
     fun filter_by_period_start_date() {
         val dataSetInstances = d2.dataSetModule().dataSetInstances()
-            .byPeriodStartDate().after(DateUtils.SIMPLE_DATE_FORMAT.parse("2019-06-15T00:00:00.000"))
+            .byPeriodStartDate()
+            .after(DateUtils.SIMPLE_DATE_FORMAT.parse("2019-06-15T00:00:00.000"))
             .blockingGet()
 
         assertThat(dataSetInstances.size).isEqualTo(3)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceCollectionRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataSetInstanceCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould.kt
@@ -35,8 +35,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class DataSetInstanceSummaryCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
 
     @Test
     fun find_all() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreCollectionRepositoryMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.testapp.datastore
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataStoreCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreCollectionRepositoryMockIntegrationShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class DataStoreCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreObjectRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datastore.internal.DataStoreEntryStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataStoreObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreObjectRepositoryMockIntegrationShould.kt
@@ -35,7 +35,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class DataStoreObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueCollectionRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataValueCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueCollectionRepositoryMockIntegrationShould.kt
@@ -35,7 +35,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class DataValueCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueConflictCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueConflictCollectionRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.imports.ImportStatus
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataValueConflictCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueConflictCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueConflictCollectionRepositoryMockIntegrationShould.kt
@@ -35,8 +35,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class DataValueConflictCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class DataValueConflictCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
 
     @Test
     fun find_all() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueObjectRepositoryMockIntegrationShould.kt
@@ -36,7 +36,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueObjectRepositoryMockIntegrationShould.kt
@@ -32,9 +32,7 @@ import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datavalue.DataValueObjectRepository
 import org.hisp.dhis.android.core.datavalue.internal.DataValueStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/expressiondimensionitem/ExpressionDimensionItemCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/expressiondimensionitem/ExpressionDimensionItemCollectionRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.expressiondimensionitem
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class ExpressionDimensionItemCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/expressiondimensionitem/ExpressionDimensionItemCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/expressiondimensionitem/ExpressionDimensionItemCollectionRepositoryMockIntegrationShould.kt
@@ -33,8 +33,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class ExpressionDimensionItemCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class ExpressionDimensionItemCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
         val items = d2.expressionDimensionItemModule().expressionDimensionItems()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceCollectionRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class FileResourceCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceCollectionRepositoryMockIntegrationShould.kt
@@ -35,8 +35,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class FileResourceCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class FileResourceCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
         val fileResources = d2.fileResourceModule().fileResources()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/indicator/IndicatorCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/indicator/IndicatorCollectionRepositoryMockIntegrationShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.testapp.indicator
 
 import com.google.common.truth.Truth
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class IndicatorCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
@@ -74,7 +72,7 @@ class IndicatorCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTe
             .byNumerator()
             .eq(
                 "#{fbfJHSPpUQD.pq2XI5kz2BY}+#{fbfJHSPpUQD.PT59n8BQbqM}" +
-                        "-#{Jtf34kNZhzP.pq2XI5kz2BY}-#{Jtf34kNZhzP.PT59n8BQbqM}",
+                    "-#{Jtf34kNZhzP.pq2XI5kz2BY}-#{Jtf34kNZhzP.PT59n8BQbqM}",
             )
             .blockingGet()
         Truth.assertThat(indicators.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/indicator/IndicatorCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/indicator/IndicatorCollectionRepositoryMockIntegrationShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class IndicatorCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
@@ -75,7 +74,7 @@ class IndicatorCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTe
             .byNumerator()
             .eq(
                 "#{fbfJHSPpUQD.pq2XI5kz2BY}+#{fbfJHSPpUQD.PT59n8BQbqM}" +
-                    "-#{Jtf34kNZhzP.pq2XI5kz2BY}-#{Jtf34kNZhzP.PT59n8BQbqM}",
+                        "-#{Jtf34kNZhzP.pq2XI5kz2BY}-#{Jtf34kNZhzP.PT59n8BQbqM}",
             )
             .blockingGet()
         Truth.assertThat(indicators.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/option/OptionServiceShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/option/OptionServiceShould.kt
@@ -30,9 +30,7 @@ package org.hisp.dhis.android.testapp.option
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class OptionServiceShould : BaseMockIntegrationTestFullDispatcher() {
 
@@ -60,7 +58,7 @@ class OptionServiceShould : BaseMockIntegrationTestFullDispatcher() {
         val options = d2.optionModule().optionService()
             .blockingSearchForOptions(
                 optionSetUid = "VQ2lai3OfVG",
-                optionToHideUids = listOf("Y1ILwhy5VDY")
+                optionToHideUids = listOf("Y1ILwhy5VDY"),
             )
 
         assertThat(options.size).isEqualTo(1)
@@ -72,7 +70,7 @@ class OptionServiceShould : BaseMockIntegrationTestFullDispatcher() {
         val options = d2.optionModule().optionService()
             .blockingSearchForOptions(
                 optionSetUid = "VQ2lai3OfVG",
-                optionToShowUids = listOf("Y1ILwhy5VDY")
+                optionToShowUids = listOf("Y1ILwhy5VDY"),
             )
 
         assertThat(options.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/option/OptionServiceShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/option/OptionServiceShould.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class OptionServiceShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test
@@ -59,7 +58,10 @@ class OptionServiceShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_option_with_hide_uids() {
         val options = d2.optionModule().optionService()
-            .blockingSearchForOptions(optionSetUid = "VQ2lai3OfVG", optionToHideUids = listOf("Y1ILwhy5VDY"))
+            .blockingSearchForOptions(
+                optionSetUid = "VQ2lai3OfVG",
+                optionToHideUids = listOf("Y1ILwhy5VDY")
+            )
 
         assertThat(options.size).isEqualTo(1)
         assertThat(options[0].uid()).isEqualTo("egT1YqFWsVk")
@@ -68,7 +70,10 @@ class OptionServiceShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_option_with_show_uids() {
         val options = d2.optionModule().optionService()
-            .blockingSearchForOptions(optionSetUid = "VQ2lai3OfVG", optionToShowUids = listOf("Y1ILwhy5VDY"))
+            .blockingSearchForOptions(
+                optionSetUid = "VQ2lai3OfVG",
+                optionToShowUids = listOf("Y1ILwhy5VDY")
+            )
 
         assertThat(options.size).isEqualTo(1)
         assertThat(options[0].uid()).isEqualTo("Y1ILwhy5VDY")

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramStageWorkingListCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramStageWorkingListCollectionRepositoryMockIntegrationShould.kt
@@ -37,8 +37,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class ProgramStageWorkingListCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class ProgramStageWorkingListCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
         val lists = d2.programModule().programStageWorkingLists()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramStageWorkingListCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramStageWorkingListCollectionRepositoryMockIntegrationShould.kt
@@ -33,9 +33,7 @@ import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class ProgramStageWorkingListCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.settings
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {
@@ -46,7 +44,7 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
 
         assertThat(analyticsDhisVisualizationsSetting.home().size).isEqualTo(2)
         assertThat(
-            analyticsDhisVisualizationsSetting.home().first().visualizations().first().name()
+            analyticsDhisVisualizationsSetting.home().first().visualizations().first().name(),
         ).isNotEmpty()
 
         assertThat(analyticsDhisVisualizationsSetting.program().size).isEqualTo(1)
@@ -64,7 +62,7 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
         assertThat(programSettings?.size).isEqualTo(1)
         assertThat(programSettings?.first()?.visualizations()?.size).isEqualTo(2)
         assertThat(
-            programSettings?.first()?.visualizations()?.first()?.uid()
+            programSettings?.first()?.visualizations()?.first()?.uid(),
         ).isEqualTo("PYBH8ZaAQnC")
     }
 
@@ -79,7 +77,7 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
         assertThat(programSettings?.size).isEqualTo(1)
         assertThat(programSettings?.first()?.visualizations()?.size).isEqualTo(1)
         assertThat(
-            programSettings?.first()?.visualizations()?.first()?.uid()
+            programSettings?.first()?.visualizations()?.first()?.uid(),
         ).isEqualTo("FAFa11yFeFe")
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {
 
@@ -46,7 +45,9 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
             .blockingGet()
 
         assertThat(analyticsDhisVisualizationsSetting.home().size).isEqualTo(2)
-        assertThat(analyticsDhisVisualizationsSetting.home().first().visualizations().first().name()).isNotEmpty()
+        assertThat(
+            analyticsDhisVisualizationsSetting.home().first().visualizations().first().name()
+        ).isNotEmpty()
 
         assertThat(analyticsDhisVisualizationsSetting.program().size).isEqualTo(1)
         assertThat(analyticsDhisVisualizationsSetting.dataSet().size).isEqualTo(1)
@@ -62,7 +63,9 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
 
         assertThat(programSettings?.size).isEqualTo(1)
         assertThat(programSettings?.first()?.visualizations()?.size).isEqualTo(2)
-        assertThat(programSettings?.first()?.visualizations()?.first()?.uid()).isEqualTo("PYBH8ZaAQnC")
+        assertThat(
+            programSettings?.first()?.visualizations()?.first()?.uid()
+        ).isEqualTo("PYBH8ZaAQnC")
     }
 
     @Test
@@ -75,6 +78,8 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
 
         assertThat(programSettings?.size).isEqualTo(1)
         assertThat(programSettings?.first()?.visualizations()?.size).isEqualTo(1)
-        assertThat(programSettings?.first()?.visualizations()?.first()?.uid()).isEqualTo("FAFa11yFeFe")
+        assertThat(
+            programSettings?.first()?.visualizations()?.first()?.uid()
+        ).isEqualTo("FAFa11yFeFe")
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AppearanceSettingsObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AppearanceSettingsObjectRepositoryMockIntegrationShould.kt
@@ -32,9 +32,7 @@ import org.hisp.dhis.android.core.settings.DataSetFilter
 import org.hisp.dhis.android.core.settings.HomeFilter
 import org.hisp.dhis.android.core.settings.ProgramFilter
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class AppearanceSettingsObjectRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AppearanceSettingsObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AppearanceSettingsObjectRepositoryMockIntegrationShould.kt
@@ -36,8 +36,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class AppearanceSettingsObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class AppearanceSettingsObjectRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_appearance_settings() {
         val appearanceSettings = d2.settingModule().appearanceSettings().blockingGet()!!
@@ -54,14 +54,16 @@ class AppearanceSettingsObjectRepositoryMockIntegrationShould : BaseMockIntegrat
 
     @Test
     fun should_return_only_dataSetFilters_for_specific_uid() {
-        val specificFilters = d2.settingModule().appearanceSettings().getDataSetFiltersByUid(program3)
+        val specificFilters =
+            d2.settingModule().appearanceSettings().getDataSetFiltersByUid(program3)
         assertThat(specificFilters?.size).isEqualTo(5)
         assertThat(specificFilters!![DataSetFilter.SYNC_STATUS]!!.uid()).isEqualTo(program3)
     }
 
     @Test
     fun should_return_only_programFilters_for_specific_uid() {
-        val specificFilters = d2.settingModule().appearanceSettings().getProgramFiltersByUid(program1)
+        val specificFilters =
+            d2.settingModule().appearanceSettings().getProgramFiltersByUid(program1)
         assertThat(specificFilters?.size).isEqualTo(7)
         assertThat(specificFilters!![ProgramFilter.ENROLLMENT_STATUS]!!.uid()).isEqualTo(program1)
     }
@@ -91,7 +93,8 @@ class AppearanceSettingsObjectRepositoryMockIntegrationShould : BaseMockIntegrat
 
     @Test
     fun should_return_completion_spinner_settings_for_specific_uid() {
-        val completionSpinner = d2.settingModule().appearanceSettings().getCompletionSpinnerByUid(program1)
+        val completionSpinner =
+            d2.settingModule().appearanceSettings().getCompletionSpinnerByUid(program1)
         assertThat(completionSpinner?.uid()).isEqualTo(program1)
         assertThat(completionSpinner?.visible()).isEqualTo(true)
     }
@@ -101,10 +104,12 @@ class AppearanceSettingsObjectRepositoryMockIntegrationShould : BaseMockIntegrat
         val setting = d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting()
         assertThat(setting?.disableReferrals()).isEqualTo(true)
 
-        val program1Setting = d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program1)
+        val program1Setting =
+            d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program1)
         assertThat(program1Setting?.disableReferrals()).isEqualTo(true)
 
-        val program2Setting = d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program2)
+        val program2Setting =
+            d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program2)
         assertThat(program2Setting?.disableReferrals()).isEqualTo(false)
     }
 
@@ -113,10 +118,12 @@ class AppearanceSettingsObjectRepositoryMockIntegrationShould : BaseMockIntegrat
         val setting = d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting()
         assertThat(setting?.disableCollapsibleSections()).isEqualTo(false)
 
-        val program1Setting = d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program1)
+        val program1Setting =
+            d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program1)
         assertThat(program1Setting?.disableCollapsibleSections()).isEqualTo(false)
 
-        val program2Setting = d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program2)
+        val program2Setting =
+            d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program2)
         assertThat(program2Setting?.disableCollapsibleSections()).isEqualTo(true)
     }
 
@@ -125,10 +132,12 @@ class AppearanceSettingsObjectRepositoryMockIntegrationShould : BaseMockIntegrat
         val setting = d2.settingModule().appearanceSettings().getGlobalProgramConfigurationSetting()
         assertThat(setting?.itemHeader()?.programIndicator()).isNull()
 
-        val program1Setting = d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program1)
+        val program1Setting =
+            d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program1)
         assertThat(program1Setting?.itemHeader()?.programIndicator()).isEqualTo("kALwOyvVvdT")
 
-        val program2Setting = d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program2)
+        val program2Setting =
+            d2.settingModule().appearanceSettings().getProgramConfigurationByUid(program2)
         assertThat(program2Setting?.itemHeader()?.programIndicator()).isNull()
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -35,8 +35,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_query() {
         val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstanceQuery()
@@ -169,12 +169,14 @@ class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould : Base
 
         // Transfer ownership
         val teiUid = originalOu.blockingGet()[0].uid()
-        d2.trackedEntityModule().ownershipManager().blockingTransfer(teiUid, "IpHINAT79UW", "g8upMTyEZGZ")
+        d2.trackedEntityModule().ownershipManager()
+            .blockingTransfer(teiUid, "IpHINAT79UW", "g8upMTyEZGZ")
         assertThat(originalOu.blockingCount()).isEqualTo(1)
         assertThat(transferredOu.blockingCount()).isEqualTo(1)
 
         // Undo change
-        d2.trackedEntityModule().ownershipManager().blockingTransfer(teiUid, "IpHINAT79UW", "DiszpKrYNg8")
+        d2.trackedEntityModule().ownershipManager()
+            .blockingTransfer(teiUid, "IpHINAT79UW", "DiszpKrYNg8")
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -31,9 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.trackedentity.search
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -33,8 +33,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class TrackedEntitySearchCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_query() {
         val trackedEntityInstances = d2.trackedEntityModule().trackedEntitySearch()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/TrackerConflictHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/TrackerConflictHelperMockIntegrationShould.kt
@@ -37,7 +37,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test
@@ -49,7 +48,7 @@ class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDi
         assertThat(trackerImportConflict.displayDescription())
             .isEqualTo(
                 "The Antenatal care visit - Program rules demo event was not found in the server." +
-                    " (Event: event1)",
+                        " (Event: event1)",
             )
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/TrackerConflictHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/TrackerConflictHelperMockIntegrationShould.kt
@@ -33,9 +33,7 @@ import org.hisp.dhis.android.core.tracker.importer.internal.JobValidationError
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerConflictHelper
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterObjectType
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
@@ -48,7 +46,7 @@ class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDi
         assertThat(trackerImportConflict.displayDescription())
             .isEqualTo(
                 "The Antenatal care visit - Program rules demo event was not found in the server." +
-                        " (Event: event1)",
+                    " (Event: event1)",
             )
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserCredentialsObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserCredentialsObjectRepositoryMockIntegrationShould.kt
@@ -33,8 +33,8 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class UserCredentialsObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class UserCredentialsObjectRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_user() {
         val userCredentials = d2.userModule().userCredentials().blockingGet()!!

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserCredentialsObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserCredentialsObjectRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.user
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class UserCredentialsObjectRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserObjectRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.user
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class UserObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/UserObjectRepositoryMockIntegrationShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class UserObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_user() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/visualization/VisualizationCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/visualization/VisualizationCollectionRepositoryMockIntegrationShould.kt
@@ -29,11 +29,9 @@ package org.hisp.dhis.android.testapp.visualization
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.hisp.dhis.android.core.visualization.HideEmptyItemStrategy
 import org.hisp.dhis.android.core.visualization.VisualizationType
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class VisualizationCollectionRepositoryMockIntegrationShould :
     BaseMockIntegrationTestFullDispatcher() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/visualization/VisualizationCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/visualization/VisualizationCollectionRepositoryMockIntegrationShould.kt
@@ -35,8 +35,8 @@ import org.hisp.dhis.android.core.visualization.VisualizationType
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
-class VisualizationCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+class VisualizationCollectionRepositoryMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_all() {
         val visualizations = d2.visualizationModule().visualizations()


### PR DESCRIPTION
- Custom runner removed in Tests based on BaseMockIntegrationTestFullDispatcher and using @RunWith(D2JunitRunner::class)