### PR TITLE
fix: [ANDROSDK-1746] Reserved value is not returned if server is exhausted

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -321,7 +321,9 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
                     storeError,
                 )
             }
-        } catch (ignored: Exception) {}
+        } catch (ignored: Exception) {
+            // Ignored
+        }
     }
 
     private suspend fun downloadValues(

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -297,29 +297,31 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         minNumberOfValuesToHave: Int?,
         storeError: Boolean,
     ) = coroutineScope {
-        // Using local date. It's not worth it to make a system info call
-        store.deleteExpired(Date())
-        val fillUpTo = getFillUpToValue(minNumberOfValuesToHave, attribute)
-        val pattern = trackedEntityAttributeStore.selectByUid(attribute)!!.pattern()
-        val remainingValues = store.count(
-            attribute,
-            if (isOrgunitDependent(pattern)) getUidOrNull(organisationUnit) else null,
-            pattern,
-        )
-
-        // If number of values is explicitly specified, we use that value as threshold.
-        val minNumberToTryFill = minNumberOfValuesToHave ?: (fillUpTo!! * FACTOR_TO_REFILL).toInt()
-
-        if (remainingValues < minNumberToTryFill) {
-            val numberToReserve = fillUpTo!! - remainingValues
-            downloadValues(
+        try {
+            // Using local date. It's not worth it to make a system info call
+            store.deleteExpired(Date())
+            val fillUpTo = getFillUpToValue(minNumberOfValuesToHave, attribute)
+            val pattern = trackedEntityAttributeStore.selectByUid(attribute)!!.pattern()
+            val remainingValues = store.count(
                 attribute,
-                organisationUnit,
-                numberToReserve,
+                if (isOrgunitDependent(pattern)) getUidOrNull(organisationUnit) else null,
                 pattern,
-                storeError,
             )
-        }
+
+            // If number of values is explicitly specified, we use that value as threshold.
+            val minNumberToTryFill = minNumberOfValuesToHave ?: (fillUpTo!! * FACTOR_TO_REFILL).toInt()
+
+            if (remainingValues < minNumberToTryFill) {
+                val numberToReserve = fillUpTo!! - remainingValues
+                downloadValues(
+                    attribute,
+                    organisationUnit,
+                    numberToReserve,
+                    pattern,
+                    storeError,
+                )
+            }
+        } catch (ignored: Exception) {}
     }
 
     private suspend fun downloadValues(


### PR DESCRIPTION
fix:
- TrackedEntityAttributeReservedValueManager was refactor from Java/RxJava to Kotlin/Coroutines, some RxJava's code "onErrorComplete" was mistakenly skipped, so it was needed to add a `try/catch` ignoring the errors