### PR TITLE
fix: [ANDROSDK-1782] Support search by trackedEntity in TEI search

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -127,6 +127,15 @@ class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould :
     }
 
     @Test
+    fun find_by_uid() {
+        val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstanceQuery()
+            .byTrackedEntities().eq("nWrB0TfWlvh")
+            .blockingGet()
+
+        assertThat(trackedEntityInstances.size).isEqualTo(1)
+    }
+
+    @Test
     fun exclude_uids() {
         val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstanceQuery()
             .excludeUids().`in`("nWrB0TfWlvh")

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -81,6 +81,16 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
     }
 
     @Test
+    fun should_return_header_in_object_repository() {
+        val trackedEntity = d2.trackedEntityModule().trackedEntitySearch()
+            .byProgram().eq("IpHINAT79UW")
+            .uid("nWrB0TfWlvh")
+            .blockingGet()
+
+        assertThat(trackedEntity?.header).isEqualTo("4081507, befryEfXge5")
+    }
+
+    @Test
     fun should_return_ordered_attributes() {
         val trackedEntity = d2.trackedEntityModule().trackedEntitySearch()
             .uid("nWrB0TfWlvh")

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -199,7 +199,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
     }
 
     override fun uid(uid: String?): ReadOnlyObjectRepository<TrackedEntityInstance> {
-        return objectRepository(
+        return byTrackedEntities().eq(uid).objectRepository(
             object : Transformer<List<TrackedEntityInstance>, TrackedEntityInstance?> {
                 override fun transform(o: List<TrackedEntityInstance>): TrackedEntityInstance? {
                     return o.find { uid == it.uid() }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -167,7 +167,7 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     }
 
     override fun uid(uid: String?): ReadOnlyObjectRepository<TrackedEntitySearchItem> {
-        return objectRepository(
+        return byTrackedEntities().eq(uid).objectRepository(
             object : Transformer<List<TrackedEntitySearchItem>, TrackedEntitySearchItem?> {
                 override fun transform(o: List<TrackedEntitySearchItem>): TrackedEntitySearchItem? {
                     return o.find { uid == it.uid() }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
@@ -346,6 +346,17 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
     }
 
     /**
+     * Filter by trackedEntity uid
+     *
+     * @return Repository connector
+     */
+    fun byTrackedEntities(): ListFilterConnector<R, String> {
+        return connectorFactory.listConnector { list: List<String> ->
+            scope.toBuilder().uids(list).build()
+        }
+    }
+
+    /**
      * Whether to allow or not cached results for online queries. Its value is 'false' by default.
      *
      * @return Repository connector


### PR DESCRIPTION
Solves [ANDROSDK-1782](https://dhis2.atlassian.net/browse/ANDROSDK-1782).

Adds support to filter by trackedEntity uid in TEI search. It improves the performance of `.uid()` method. This method evaluated all the TEIs before filtering by uid. Now, it filters by uid in first place and then evaluates the TEI (header, attributes, etc)

[ANDROSDK-1782]: https://dhis2.atlassian.net/browse/ANDROSDK-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ