### PR TITLE
fix: [ANDROSDK-1787] Expired and closed editable status

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceServiceMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceServiceMockIntegrationShould.kt
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.testapp.dataset
+
+import com.google.common.truth.Truth
+import org.hisp.dhis.android.core.dataset.DataSetEditableStatus
+import org.hisp.dhis.android.core.dataset.DataSetNonEditableReason
+import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
+import org.junit.Test
+
+class DataSetInstanceServiceMockIntegrationShould :
+    BaseMockIntegrationTestFullDispatcher() {
+
+    @Test
+    fun do_not_allow_edit_expired_periods() {
+        val dataSetInstances = d2.dataSetModule().dataSetInstanceService()
+            .blockingGetEditableStatus(
+                "lyLU2wR22tC",
+                "201206",
+                "DiszpKrYNg8",
+                "bRowv6yZOF2",
+            )
+
+        Truth.assertThat(dataSetInstances).isInstanceOf(
+            DataSetEditableStatus.NonEditable(DataSetNonEditableReason.EXPIRED)::class.java,
+        )
+    }
+
+    @Test
+    fun do_not_allow_edit_closed_periods() {
+        val dataSetInstances = d2.dataSetModule().dataSetInstanceService()
+            .blockingGetEditableStatus(
+                "lyLU2wR22tC",
+                "202311",
+                "DiszpKrYNg8",
+                "bRowv6yZOF2",
+            )
+
+        Truth.assertThat(dataSetInstances).isInstanceOf(
+            DataSetEditableStatus.NonEditable(DataSetNonEditableReason.CLOSED)::class.java,
+        )
+    }
+}

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/organisationunit/OrganisationUnitCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/organisationunit/OrganisationUnitCollectionRepositoryMockIntegrationShould.java
@@ -76,7 +76,7 @@ public class OrganisationUnitCollectionRepositoryMockIntegrationShould extends B
     @Test
     public void filter_by_closed_date() throws ParseException {
         List<OrganisationUnit> organisationUnits = d2.organisationUnitModule().organisationUnits()
-                .byClosedDate().eq(BaseIdentifiableObject.parseDate("2018-05-22T15:21:48.516")).blockingGet();
+                .byClosedDate().eq(BaseIdentifiableObject.parseDate("2025-05-22T15:21:48.516")).blockingGet();
         assertThat(organisationUnits.size()).isEqualTo(1);
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -94,9 +94,9 @@ internal class DataSetInstanceServiceImpl(
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.ATTRIBUTE_OPTION_COMBO_NO_ASSIGN_TO_ORGUNIT)
             !blockingIsPeriodInOrgUnitRange(period, organisationUnitUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_IS_NOT_IN_ORGUNIT_RANGE)
-            dataSet?.let { !blockingIsExpired(dataSet, period) } ?: false ->
+            dataSet?.let { blockingIsExpired(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.EXPIRED)
-            dataSet?.let { !blockingIsClosed(dataSet, period) } ?: false ->
+            dataSet?.let { blockingIsClosed(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.CLOSED)
             else -> DataSetEditableStatus.Editable
         }

--- a/core/src/sharedTest/resources/category/category_options.json
+++ b/core/src/sharedTest/resources/category/category_options.json
@@ -12,6 +12,7 @@
       "name": "default name",
       "code": "default code",
       "id": "as6ygGvUGNg",
+      "endDate": "2024-06-12T20:37:48.666",
       "shortName": "default short name",
       "displayShortName": "default display short name",
       "description": "default description",

--- a/core/src/sharedTest/resources/organisationunit/organisation_units.json
+++ b/core/src/sharedTest/resources/organisationunit/organisation_units.json
@@ -36,7 +36,7 @@
       "level": 4,
       "created": "2012-02-17T15:54:39.987",
       "lastUpdated": "2017-05-22T15:21:48.516",
-      "closedDate": "2018-05-22T15:21:48.516",
+      "closedDate": "2025-05-22T15:21:48.516",
       "name": "Ngelehun CHC",
       "id": "DiszpKrYNg8",
       "shortName": "Ngelehun CHC",


### PR DESCRIPTION
fix:
- DataSetInstanceServiceImpl `blockingGetEditableStatus` expired and closed checks

test:
- New `DataSetInstanceServiceMockIntegrationShould` for `DataSetInstanceServiceImpl`: `blockingGetEditableStatus` expired and closed checks