### PR TITLE
fix: [ANDROSDK-1784] Database access is locked when transaction opened in encrypted DB

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -67,7 +67,8 @@ val retrofit = "2.9.0"
 val okHttp = "4.10.0"
 val rxJava = "2.2.21"
 val rxAndroid = "2.1.1"
-val sqlCipher = "4.4.3"
+val sqlCipher = "4.5.5"
+val sqlLite = "2.2.0"
 val smsCompression = "0.2.0"
 val expressionParser = "1.0.33"
 
@@ -156,6 +157,7 @@ android {
 }
 
 dependencies {
+
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:$libraryDesugaring")
 
     // RxJava
@@ -200,7 +202,9 @@ dependencies {
     api("com.gabrielittner.auto.value:auto-value-cursor-annotations:$autoValueCursor")
     kapt("com.gabrielittner.auto.value:auto-value-cursor:$autoValueCursor")
 
-    api("net.zetetic:android-database-sqlcipher:$sqlCipher")
+    api("net.zetetic:sqlcipher-android:$sqlCipher")
+    // From SQLCipher 4.5.5, it depends on androidx.sqlite:sqlite
+    api("androidx.sqlite:sqlite:$sqlLite")
 
     api("com.squareup.okhttp3:mockwebserver:$okHttp")
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseAdapterFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseAdapterFactory.java
@@ -105,10 +105,13 @@ public class DatabaseAdapterFactory {
                                                boolean encrypt,
                                                int version) {
         if (encrypt) {
-            EncryptedDatabaseOpenHelper openHelper = instantiateOpenHelper(databaseName, encryptedOpenHelpers,
-                    v -> new EncryptedDatabaseOpenHelper(context, databaseName, version));
             String password = passwordManager.getPassword(databaseName);
-            return new EncryptedDatabaseAdapter(openHelper.getWritableDatabase(password), openHelper.getDatabaseName());
+
+            // We need the password to be set before instantiating the helper
+            EncryptedDatabaseOpenHelper openHelper = instantiateOpenHelper(databaseName, encryptedOpenHelpers,
+                    v -> new EncryptedDatabaseOpenHelper(context, databaseName, password, version));
+            // It seems that now SQLCipher (4.5.5) handles password internally if previously given
+            return new EncryptedDatabaseAdapter(openHelper.getWritableDatabase(), openHelper.getDatabaseName());
         } else {
             UnencryptedDatabaseOpenHelper openHelper = instantiateOpenHelper(databaseName, unencryptedOpenHelpers,
                     v -> new UnencryptedDatabaseOpenHelper(context, databaseName, version));

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseExport.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseExport.java
@@ -31,9 +31,10 @@ package org.hisp.dhis.android.core.arch.db.access.internal;
 import android.content.Context;
 import android.util.Log;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteDatabaseHook;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabaseHook;
 
+import org.hisp.dhis.android.core.common.internal.NativeLibraryLoader;
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount;
 import org.hisp.dhis.android.core.configuration.internal.DatabaseConfigurationHelper;
 import org.hisp.dhis.android.core.configuration.internal.DatabaseEncryptionPasswordManager;
@@ -76,10 +77,9 @@ public class DatabaseExport {
             File oldDatabaseFile = context.getDatabasePath(oldConfiguration.databaseName());
             File newDatabaseFile = context.getDatabasePath(newConfiguration.databaseName());
 
-
-            SQLiteDatabase.loadLibs(context);
+            NativeLibraryLoader.INSTANCE.loadSQLCipher();
             SQLiteDatabase oldDatabase = SQLiteDatabase.openOrCreateDatabase(oldDatabaseFile, oldPassword, null,
-                    oldHook);
+                    null, oldHook);
             oldDatabase.rawExecSQL(String.format(
                     "ATTACH DATABASE '%s' as alias KEY '%s';", newDatabaseFile.getAbsolutePath(), newPassword));
             if (newHook != null) {
@@ -91,7 +91,7 @@ public class DatabaseExport {
 
             int version = oldDatabase.getVersion();
             SQLiteDatabase newDatabase = SQLiteDatabase.openOrCreateDatabase(newDatabaseFile, newPassword, null,
-                    newHook);
+                    null, newHook);
             newDatabase.setVersion(version);
 
             newDatabase.close();

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/EncryptedDatabaseAdapter.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/EncryptedDatabaseAdapter.java
@@ -33,7 +33,7 @@ import android.database.Cursor;
 
 import androidx.annotation.NonNull;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter;
 import org.hisp.dhis.android.core.arch.db.access.Transaction;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/EncryptedDatabaseOpenHelper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/EncryptedDatabaseOpenHelper.java
@@ -45,7 +45,7 @@ class EncryptedDatabaseOpenHelper extends SQLiteOpenHelper {
     static final SQLiteDatabaseHook hook = new SQLiteDatabaseHook() {
         @Override
         public void preKey(SQLiteConnection connection) {
-
+            // Nothing to do here
         }
 
         @Override

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/EncryptedStatementWrapper.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/EncryptedStatementWrapper.java
@@ -28,7 +28,8 @@
 
 package org.hisp.dhis.android.core.arch.db.access.internal;
 
-import net.sqlcipher.database.SQLiteStatement;
+
+import net.zetetic.database.sqlcipher.SQLiteStatement;
 
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper;
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.kt
@@ -28,6 +28,9 @@
 package org.hisp.dhis.android.core.arch.helpers
 
 import android.content.Context
+import okio.Path
+import okio.Path.Companion.toOkioPath
+import okio.Path.Companion.toPath
 import org.hisp.dhis.android.core.D2Manager
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.configuration.internal.DatabaseNameGenerator
@@ -94,6 +97,10 @@ object FileResourceDirectoryHelper {
         if (!file.exists()) {
             file.mkdirs()
         }
+        val string = "/path/to/file"
+        val okioPath: Path = string.toPath()
+        okioPath.toFile()
+        file.toOkioPath()
         return file
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResourceDirectoryHelper.kt
@@ -28,9 +28,6 @@
 package org.hisp.dhis.android.core.arch.helpers
 
 import android.content.Context
-import okio.Path
-import okio.Path.Companion.toOkioPath
-import okio.Path.Companion.toPath
 import org.hisp.dhis.android.core.D2Manager
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.configuration.internal.DatabaseNameGenerator
@@ -97,10 +94,6 @@ object FileResourceDirectoryHelper {
         if (!file.exists()) {
             file.mkdirs()
         }
-        val string = "/path/to/file"
-        val okioPath: Path = string.toPath()
-        okioPath.toFile()
-        file.toOkioPath()
         return file
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/common/internal/NativeLibraryLoader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/internal/NativeLibraryLoader.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.common.internal
+
+import android.util.Log
+
+internal object NativeLibraryLoader {
+
+    private var isLibraryLoaded = false
+
+    fun loadSQLCipher() {
+        synchronized(this) {
+            if (!isLibraryLoaded) {
+                try {
+                    System.loadLibrary("sqlcipher")
+                    isLibraryLoaded = true
+                } catch (e: UnsatisfiedLinkError) {
+                    Log.e("NativeLibraryLoader", "Could not load SQLCipher library")
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserCall.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.user.internal
 
+import android.database.sqlite.SQLiteException
 import android.util.Log
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.call.internal.GenericCallData
@@ -57,7 +58,7 @@ internal class UserCall(
         try {
             userHandler.handle(user)
             transaction.setSuccessful()
-        } catch (constraintException: net.sqlcipher.SQLException) {
+        } catch (constraintException: SQLiteException) {
             // TODO review
             Log.d("CAll", "call: constraintException")
         } catch (constraintException: android.database.SQLException) {


### PR DESCRIPTION
fix:
- Update SQLCipher to 4.5.5 in order to allow parallel operations on a database