### PR TITLE
[BUMP-1.10.0] Bump to 1.10.0-SNAPSHOT; enable v41

### DIFF
--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -29,8 +29,8 @@
 # Properties which are consumed by plugins/gradle-mvn-push.gradle plugin.
 # They are used for publishing artifact to snapshot repository.
 
-VERSION_NAME=1.9.1-SNAPSHOT
-VERSION_CODE=291
+VERSION_NAME=1.10.0-SNAPSHOT
+VERSION_CODE=292
 
 GROUP=org.hisp.dhis
 

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/DHISVersion.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/DHISVersion.kt
@@ -40,7 +40,7 @@ enum class DHISVersion(internal val prefix: String, internal val supported: Bool
     V2_38("2.38"),
     V2_39("2.39"),
     V2_40("2.40"),
-    V2_41("2.41", false),
+    V2_41("2.41"),
     ;
 
     companion object {

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/DHISVersion.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/DHISVersion.kt
@@ -46,7 +46,7 @@ enum class DHISVersion(internal val prefix: String, internal val supported: Bool
     companion object {
         @JvmStatic
         fun getValue(versionStr: String): DHISVersion? {
-            return values().find { versionStr.startsWith(it.prefix).and(it.supported) }
+            return entries.find { versionStr.startsWith(it.prefix).and(it.supported) }
         }
 
         @JvmStatic
@@ -56,7 +56,7 @@ enum class DHISVersion(internal val prefix: String, internal val supported: Bool
 
         @JvmStatic
         fun allowedVersionsAsStr(): Array<String> {
-            return values().filter { it.supported }
+            return entries.filter { it.supported }
                 .map { it.prefix }
                 .toTypedArray()
         }

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/DHISVersionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/DHISVersionShould.kt
@@ -28,19 +28,22 @@
 
 package org.hisp.dhis.android.core.systeminfo.internal
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
 import org.junit.Test
 
 class DHISVersionShould {
     @Test
     fun return_null_for_unsupported_versions() {
-        val supportedVersions = listOf("2.29", "2.41")
-        DHISVersion.values()
-            .filter { supportedVersions.contains(it.prefix) }
+        DHISVersion.entries
             .forEach {
-                Truth.assertThat(DHISVersion.getValue(it.prefix + ".0")).isNull()
-                Truth.assertThat(DHISVersion.getValue(it.prefix + ".9")).isNull()
+                if (it.supported) {
+                    assertThat(DHISVersion.getValue(it.prefix + ".0")).isNotNull()
+                    assertThat(DHISVersion.getValue(it.prefix + ".9")).isNotNull()
+                } else {
+                    assertThat(DHISVersion.getValue(it.prefix + ".0")).isNull()
+                    assertThat(DHISVersion.getValue(it.prefix + ".9")).isNull()
+                }
             }
     }
 }


### PR DESCRIPTION
This PR changes the version to 1.10.0-SNAPSHOT and enables connections to DHIS2 v41. This PR makes "develop" branch ready for 1.10.0 development.

A new branch `1.9.1-rc` has been created for the patch release.