### PR TITLE
feat: [ANDROSDK-1805] Adapt to changes in tracker payload (v41)

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/payload/internal/TrackerPager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/payload/internal/TrackerPager.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.api.payload.internal
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+internal data class TrackerPager(
+    @JsonProperty val page: Int,
+    @JsonProperty val pageSize: Int,
+)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/payload/internal/TrackerPayload.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/payload/internal/TrackerPayload.kt
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.api.payload.internal
+
+import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+
+internal data class TrackerPayload<T>(
+    @JsonProperty private val pager: TrackerPager?,
+    @JsonProperty private val page: Int?,
+    @JsonProperty private val pageSize: Int?,
+    @JsonIgnore private var items: List<T> = emptyList(),
+) {
+
+    @JsonAnySetter
+    @Suppress("unused")
+    private fun processItems(key: String?, values: List<T>) {
+        items = values
+    }
+
+    fun pager(): TrackerPager? {
+        return pager
+            ?: if (page != null && pageSize != null) {
+                TrackerPager(page = page, pageSize = pageSize)
+            } else {
+                null
+            }
+    }
+
+    fun items(): List<T> {
+        return items
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/NewEventEndpointCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/NewEventEndpointCallFactory.kt
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.android.core.event.internal
 
-import org.hisp.dhis.android.core.arch.api.payload.internal.NTIPayload
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.NewTrackerImporterEvent
 import org.hisp.dhis.android.core.event.NewTrackerImporterEventTransformer
@@ -67,8 +67,8 @@ internal class NewEventEndpointCallFactory(
         ).let { mapPayload(it) }
     }
 
-    private fun mapPayload(payload: NTIPayload<NewTrackerImporterEvent>): Payload<Event> {
-        val newItems = payload.instances.map { t -> NewTrackerImporterEventTransformer.deTransform(t) }
+    private fun mapPayload(payload: TrackerPayload<NewTrackerImporterEvent>): Payload<Event> {
+        val newItems = payload.items().map { t -> NewTrackerImporterEventTransformer.deTransform(t) }
         return Payload(newItems)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackedEntityEndpointCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackedEntityEndpointCallFactory.kt
@@ -28,8 +28,8 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
-import org.hisp.dhis.android.core.arch.api.payload.internal.NTIPayload
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
 import org.hisp.dhis.android.core.event.NewTrackerImporterEvent
 import org.hisp.dhis.android.core.event.internal.NewEventFields
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
@@ -169,7 +169,7 @@ internal class NewTrackedEntityEndpointCallFactory(
                 updatedBefore = query.lastUpdatedEndDate.simpleDateFormat(),
                 includeDeleted = query.includeDeleted,
             )
-        }.getOrThrow().instances
+        }.getOrThrow().items()
     }
 
     private suspend fun getTrackedEntityQuery(query: TrackedEntityInstanceQueryOnline): List<TrackedEntityInstance> {
@@ -227,8 +227,8 @@ internal class NewTrackedEntityEndpointCallFactory(
         )
     }
 
-    private fun mapPayload(payload: NTIPayload<NewTrackerImporterTrackedEntity>): Payload<TrackedEntityInstance> {
-        val newItems = payload.instances.map { t -> NewTrackerImporterTrackedEntityTransformer.deTransform(t) }
+    private fun mapPayload(payload: TrackerPayload<NewTrackerImporterTrackedEntity>): Payload<TrackedEntityInstance> {
+        val newItems = payload.items().map { t -> NewTrackerImporterTrackedEntityTransformer.deTransform(t) }
         return Payload(newItems)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerExporterService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerExporterService.kt
@@ -29,7 +29,7 @@ package org.hisp.dhis.android.core.tracker.exporter
 
 import org.hisp.dhis.android.core.arch.api.fields.internal.Fields
 import org.hisp.dhis.android.core.arch.api.filters.internal.Which
-import org.hisp.dhis.android.core.arch.api.payload.internal.NTIPayload
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
 import org.hisp.dhis.android.core.enrollment.NewTrackerImporterEnrollment
 import org.hisp.dhis.android.core.event.NewTrackerImporterEvent
 import org.hisp.dhis.android.core.trackedentity.NewTrackerImporterTrackedEntity
@@ -75,7 +75,7 @@ internal interface TrackerExporterService {
         @Query(PAGE) page: Int,
         @Query(PAGE_SIZE) pageSize: Int,
         @Query(INCLUDE_DELETED) includeDeleted: Boolean = false,
-    ): NTIPayload<NewTrackerImporterTrackedEntity>
+    ): TrackerPayload<NewTrackerImporterTrackedEntity>
 
     @GET("$ENROLLMENTS/{$ENROLLMENT}")
     suspend fun getEnrollmentSingle(
@@ -112,14 +112,14 @@ internal interface TrackerExporterService {
         @Query(UPDATED_BEFORE) updatedBefore: String? = null,
         @Query(INCLUDE_DELETED) includeDeleted: Boolean,
         @Query(EVENT) eventUid: String? = null,
-    ): NTIPayload<NewTrackerImporterEvent>
+    ): TrackerPayload<NewTrackerImporterEvent>
 
     @GET(EVENTS)
     suspend fun getEventSingle(
         @Query(FIELDS) @Which fields: Fields<NewTrackerImporterEvent>,
         @Query(EVENT) eventUid: String,
         @Query(OU_MODE) orgUnitMode: String,
-    ): NTIPayload<NewTrackerImporterEvent>
+    ): TrackerPayload<NewTrackerImporterEvent>
 
     companion object {
         const val TRACKED_ENTITY_INSTANCES = "tracker/trackedEntities"

--- a/core/src/sharedTest/resources/event/new_tracker_importer_events_greater_equal_v41.json
+++ b/core/src/sharedTest/resources/event/new_tracker_importer_events_greater_equal_v41.json
@@ -1,0 +1,35 @@
+{
+  "pager": {
+    "page": 1,
+    "pageSize": 50
+  },
+  "page": 1,
+  "pageSize": 50,
+  "events": [
+    {
+      "attributeOptionCombo": "bRowv6yZOF2",
+      "programStage": "dBwrot7S420",
+      "orgUnit": "DiszpKrYNg8",
+      "scheduledAt": "2017-01-28T00:00:00.000",
+      "program": "lxAQ7Zs9VYR",
+      "event": "single1",
+      "status": "COMPLETED",
+      "occurredAt": "2018-02-27T00:00:00.000",
+      "dataValues": [
+        ]
+    },
+    {
+      "attributeOptionCombo": "bRowv6yZOF2",
+      "programStage": "dBwrot7S420",
+      "orgUnit": "DiszpKrYNg8",
+      "scheduledAt": "2018-02-28T00:00:00.000",
+      "trackedEntityInstance": "nWrB0TfWlvh",
+      "program": "lxAQ7Zs9VYR",
+      "event": "single2",
+      "status": "ACTIVE",
+      "occurredAt": "2017-02-27T00:00:00.000",
+      "dataValues": [
+      ]
+    }
+  ]
+}

--- a/core/src/sharedTest/resources/event/new_tracker_importer_events_lower_v41.json
+++ b/core/src/sharedTest/resources/event/new_tracker_importer_events_lower_v41.json
@@ -1,0 +1,31 @@
+{
+  "page": 1,
+  "pageSize": 50,
+  "instances": [
+    {
+      "attributeOptionCombo": "bRowv6yZOF2",
+      "programStage": "dBwrot7S420",
+      "orgUnit": "DiszpKrYNg8",
+      "scheduledAt": "2017-01-28T00:00:00.000",
+      "program": "lxAQ7Zs9VYR",
+      "event": "single1",
+      "status": "COMPLETED",
+      "occurredAt": "2018-02-27T00:00:00.000",
+      "dataValues": [
+        ]
+    },
+    {
+      "attributeOptionCombo": "bRowv6yZOF2",
+      "programStage": "dBwrot7S420",
+      "orgUnit": "DiszpKrYNg8",
+      "scheduledAt": "2018-02-28T00:00:00.000",
+      "trackedEntityInstance": "nWrB0TfWlvh",
+      "program": "lxAQ7Zs9VYR",
+      "event": "single2",
+      "status": "ACTIVE",
+      "occurredAt": "2017-02-27T00:00:00.000",
+      "dataValues": [
+      ]
+    }
+  ]
+}

--- a/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities_greater_equal_v41.json
+++ b/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities_greater_equal_v41.json
@@ -1,0 +1,34 @@
+{
+  "pager": {
+    "page": 1,
+    "pageSize": 50
+  },
+  "page": 1,
+  "pageSize": 50,
+  "trackedEntities": [
+    {
+      "trackedEntityType": "nEenWmSyUEp",
+      "orgUnit": "DiszpKrYNg8",
+      "trackedEntity": "nWrB0TfWlvh",
+      "deleted": false,
+      "attributes": [
+        {
+          "attribute": "cejWyOfXge6",
+          "value": "4081507"
+        }
+      ]
+    },
+    {
+      "trackedEntityType": "nEenWmSyUEp",
+      "orgUnit": "DiszpKrYNg8",
+      "trackedEntity": "nWrB0TfWlvD",
+      "deleted": false,
+      "attributes": [
+        {
+          "attribute": "cejWyOfXge6",
+          "value": "654321"
+        }
+      ]
+    }
+  ]
+}

--- a/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities_lower_v41.json
+++ b/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities_lower_v41.json
@@ -1,0 +1,30 @@
+{
+  "page": 1,
+  "pageSize": 50,
+  "instances": [
+    {
+      "trackedEntityType": "nEenWmSyUEp",
+      "orgUnit": "DiszpKrYNg8",
+      "trackedEntity": "nWrB0TfWlvh",
+      "deleted": false,
+      "attributes": [
+        {
+          "attribute": "cejWyOfXge6",
+          "value": "4081507"
+        }
+      ]
+    },
+    {
+      "trackedEntityType": "nEenWmSyUEp",
+      "orgUnit": "DiszpKrYNg8",
+      "trackedEntity": "nWrB0TfWlvD",
+      "deleted": false,
+      "attributes": [
+        {
+          "attribute": "cejWyOfXge6",
+          "value": "654321"
+        }
+      ]
+    }
+  ]
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadGreaterEqualV41Should.kt
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.event
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
+import org.hisp.dhis.android.core.common.BaseObjectShould
+import org.hisp.dhis.android.core.common.ObjectShould
+import org.junit.Test
+
+class NewTrackerImporterEventPayloadGreaterEqualV41Should :
+    BaseObjectShould("event/new_tracker_importer_events_greater_equal_v41.json"),
+    ObjectShould {
+
+    @Test
+    override fun map_from_json_string() {
+        val eventPayload = objectMapper.readValue(
+            jsonStream,
+            object : TypeReference<TrackerPayload<NewTrackerImporterEvent>>() {},
+        )
+
+        assertThat(eventPayload.pager()?.page).isEqualTo(1)
+        assertThat(eventPayload.pager()?.pageSize).isEqualTo(50)
+        assertThat(eventPayload.items().size).isEqualTo(2)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadLowerV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadLowerV41Should.kt
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.event
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
+import org.hisp.dhis.android.core.common.BaseObjectShould
+import org.hisp.dhis.android.core.common.ObjectShould
+import org.junit.Test
+
+class NewTrackerImporterEventPayloadLowerV41Should :
+    BaseObjectShould("event/new_tracker_importer_events_lower_v41.json"),
+    ObjectShould {
+
+    @Test
+    override fun map_from_json_string() {
+        val eventPayload = objectMapper.readValue(
+            jsonStream,
+            object : TypeReference<TrackerPayload<NewTrackerImporterEvent>>() {},
+        )
+
+        assertThat(eventPayload.pager()?.page).isEqualTo(1)
+        assertThat(eventPayload.pager()?.pageSize).isEqualTo(50)
+        assertThat(eventPayload.items().size).isEqualTo(2)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2004-2022, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.trackedentity
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
+import org.hisp.dhis.android.core.common.BaseObjectShould
+import org.hisp.dhis.android.core.common.ObjectShould
+import org.junit.Test
+
+class NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should :
+    BaseObjectShould("trackedentity/new_tracker_importer_tracked_entities_greater_equal_v41.json"),
+    ObjectShould {
+
+    @Test
+    override fun map_from_json_string() {
+        val trackedEntityPayload = objectMapper.readValue(
+            jsonStream,
+            object : TypeReference<TrackerPayload<NewTrackerImporterTrackedEntity>>() {},
+        )
+
+        assertThat(trackedEntityPayload.pager()?.page).isEqualTo(1)
+        assertThat(trackedEntityPayload.pager()?.pageSize).isEqualTo(50)
+        assertThat(trackedEntityPayload.items().size).isEqualTo(2)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadLowerV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadLowerV41Should.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2022, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,10 +25,28 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.arch.api.payload.internal
+package org.hisp.dhis.android.core.trackedentity
 
-data class NTIPayload<T>(
-    val page: Int,
-    val pageSize: Int,
-    val instances: List<T>,
-)
+import com.fasterxml.jackson.core.type.TypeReference
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.api.payload.internal.TrackerPayload
+import org.hisp.dhis.android.core.common.BaseObjectShould
+import org.hisp.dhis.android.core.common.ObjectShould
+import org.junit.Test
+
+class NewTrackerImporterTrackedEntityPayloadLowerV41Should :
+    BaseObjectShould("trackedentity/new_tracker_importer_tracked_entities_lower_v41.json"),
+    ObjectShould {
+
+    @Test
+    override fun map_from_json_string() {
+        val trackedEntityPayload = objectMapper.readValue(
+            jsonStream,
+            object : TypeReference<TrackerPayload<NewTrackerImporterTrackedEntity>>() {},
+        )
+
+        assertThat(trackedEntityPayload.pager()?.page).isEqualTo(1)
+        assertThat(trackedEntityPayload.pager()?.pageSize).isEqualTo(50)
+        assertThat(trackedEntityPayload.items().size).isEqualTo(2)
+    }
+}


### PR DESCRIPTION
Solves [ANDROSDK-1805](https://dhis2.atlassian.net/browse/ANDROSDK-1805)

New `TrackerPayload` class to accommodate both kinds of payload (<41 and >= 41). It uses the annotation @JsonAnyGetter to deserialize the item list, no matter the property name (in the same way it is done for metadata). Changes in pager are managed as well.

[ANDROSDK-1805]: https://dhis2.atlassian.net/browse/ANDROSDK-1805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ