### PR TITLE
fix: [DISABLE-CONCURRENT-BUILDS] Disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label "ec2-android"
     }
 
+    options {
+        disableConcurrentBuilds(abortPrevious: true)
+    }
+
     stages{
         stage('Change to JAVA 17') {
             steps {


### PR DESCRIPTION
Abort previous builds for the same pipeline. This configuration is already set in the Android Capture App