### PR TITLE
fix: [ANDROSDK-1818] Avoid query to versionManager before login in OpenID login

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -36,7 +36,6 @@ import org.hisp.dhis.android.core.arch.storage.internal.UserIdInMemoryStore
 import org.hisp.dhis.android.core.configuration.internal.ServerUrlParser
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
-import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoCall
 import org.hisp.dhis.android.core.user.AccountDeletionReason
 import org.hisp.dhis.android.core.user.AuthenticatedUser
@@ -58,7 +57,6 @@ internal class LogInCall(
     private val databaseManager: LogInDatabaseManager,
     private val exceptions: LogInExceptions,
     private val accountManager: AccountManagerImpl,
-    private val versionManager: DHISVersionManager,
     private val apiCallErrorCatcher: UserAuthenticateCallErrorCatcher,
 ) {
     suspend fun logIn(username: String?, password: String?, serverUrl: String?): User {
@@ -85,7 +83,7 @@ internal class LogInCall(
                 val user = coroutineAPICallExecutor.wrap(errorCatcher = apiCallErrorCatcher) {
                     userService.authenticate(
                         okhttp3.Credentials.basic(username, password!!),
-                        UserFields.allFieldsWithoutOrgUnit(null),
+                        UserFields.allFieldsWithoutOrgUnit,
                     )
                 }.getOrThrow()
                 loginOnline(user, credentials)
@@ -189,7 +187,7 @@ internal class LogInCall(
             val user = coroutineAPICallExecutor.wrap(errorCatcher = apiCallErrorCatcher) {
                 userService.authenticate(
                     "Bearer ${openIDConnectState.idToken}",
-                    UserFields.allFieldsWithoutOrgUnit(versionManager.getVersion()),
+                    UserFields.allFieldsWithoutOrgUnit,
                 )
             }.getOrThrow()
             credentials = getOpenIdConnectCredentials(user, trimmedServerUrl!!, openIDConnectState)

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserFields.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserFields.kt
@@ -115,9 +115,7 @@ object UserFields {
         }
     }
 
-    fun allFieldsWithoutOrgUnit(version: DHISVersion?): Fields<User> {
-        return getBaseFields(version).build()
-    }
+    val allFieldsWithoutOrgUnit: Fields<User> = getBaseFields(null).build()
 
     fun allFieldsWithOrgUnit(version: DHISVersion?): Fields<User> {
         return getBaseFields(version)

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -43,8 +43,6 @@ import org.hisp.dhis.android.core.configuration.internal.MultiUserDatabaseManage
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.settings.internal.GeneralSettingCall
-import org.hisp.dhis.android.core.systeminfo.DHISVersion
-import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.hisp.dhis.android.core.systeminfo.SystemInfo
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoCall
 import org.hisp.dhis.android.core.user.AuthenticatedUser
@@ -80,7 +78,6 @@ class LogInCallUnitShould : BaseCallShould() {
     private val multiUserDatabaseManager: MultiUserDatabaseManager = mock()
     private val generalSettingCall: GeneralSettingCall = mock()
     private val accountManager: AccountManagerImpl = mock()
-    private val versionManager: DHISVersionManager = mock()
 
     @Before
     @Throws(Exception::class)
@@ -107,8 +104,6 @@ class LogInCallUnitShould : BaseCallShould() {
         generalSettingCall.stub {
             onBlocking { isDatabaseEncrypted() }.doReturn(false)
         }
-
-        whenever(versionManager.getVersion()).thenReturn(DHISVersion.V2_39)
     }
 
     private suspend fun login() = instantiateCall(USERNAME, PASSWORD, serverUrl)
@@ -118,7 +113,7 @@ class LogInCallUnitShould : BaseCallShould() {
             coroutineAPICallExecutor, userService, credentialsSecureStore,
             userIdStore, userHandler, authenticatedUserStore, systemInfoCall, userStore,
             LogInDatabaseManager(multiUserDatabaseManager, generalSettingCall),
-            LogInExceptions(credentialsSecureStore), accountManager, versionManager, apiErrorCatcher,
+            LogInExceptions(credentialsSecureStore), accountManager, apiErrorCatcher,
         ).logIn(username, password, serverUrl)
     }
 


### PR DESCRIPTION
Solves [ANDROSDK-1818](https://dhis2.atlassian.net/browse/ANDROSDK-1818)

[ANDROSDK-1818]: https://dhis2.atlassian.net/browse/ANDROSDK-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ