### PR TITLE
fix: [ANDOSDK-1825] Prevent isEventExpired failure on null eventDate

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDateUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDateUtils.kt
@@ -81,9 +81,11 @@ class EventDateUtils(
                 false
             }
 
+        val eventDateOrDueDate = event.eventDate() ?: event.dueDate()!!
+
         val expiredBecauseOfPeriod = programPeriodType?.let { periodType ->
             var nextPeriod = periodHelper
-                .blockingGetPeriodForPeriodTypeAndDate(periodType, event.eventDate()!!, 1).startDate()!!
+                .blockingGetPeriodForPeriodTypeAndDate(periodType, eventDateOrDueDate, 1).startDate()!!
             val currentDate: Date = getCalendar().time
             if (expiryDays > 0) {
                 val calendar: Calendar = getCalendar()

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDateUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDateUtils.kt
@@ -81,11 +81,11 @@ class EventDateUtils(
                 false
             }
 
-        val eventDateOrDueDate = event.eventDate() ?: event.dueDate()!!
+        val eventDateOrDueDate = event.eventDate() ?: event.dueDate()
 
         val expiredBecauseOfPeriod = programPeriodType?.let { periodType ->
             var nextPeriod = periodHelper
-                .blockingGetPeriodForPeriodTypeAndDate(periodType, eventDateOrDueDate, 1).startDate()!!
+                .blockingGetPeriodForPeriodTypeAndDate(periodType, eventDateOrDueDate!!, 1).startDate()!!
             val currentDate: Date = getCalendar().time
             if (expiryDays > 0) {
                 val calendar: Calendar = getCalendar()


### PR DESCRIPTION
Solves [ANDROSDK-1825](https://dhis2.atlassian.net/browse/ANDROSDK-1825).

[ANDROSDK-1825]: https://dhis2.atlassian.net/browse/ANDROSDK-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ