### PR TITLE
[ANDROSDK-1835] Fix crash on event expired method when event and due dates are null

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDateUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDateUtils.kt
@@ -81,19 +81,20 @@ class EventDateUtils(
                 false
             }
 
-        val eventDateOrDueDate = event.eventDate() ?: event.dueDate()
+        val expiredBecauseOfPeriod = (event.eventDate() ?: event.dueDate())?.let { eventDateOrDueDate ->
+            programPeriodType?.let { periodType ->
 
-        val expiredBecauseOfPeriod = programPeriodType?.let { periodType ->
-            var nextPeriod = periodHelper
-                .blockingGetPeriodForPeriodTypeAndDate(periodType, eventDateOrDueDate!!, 1).startDate()!!
-            val currentDate: Date = getCalendar().time
-            if (expiryDays > 0) {
-                val calendar: Calendar = getCalendar()
-                calendar.time = nextPeriod
-                calendar.add(Calendar.DAY_OF_YEAR, expiryDays)
-                nextPeriod = calendar.time
+                var nextPeriod = periodHelper
+                    .blockingGetPeriodForPeriodTypeAndDate(periodType, eventDateOrDueDate, 1).startDate()!!
+                val currentDate: Date = getCalendar().time
+                if (expiryDays > 0) {
+                    val calendar: Calendar = getCalendar()
+                    calendar.time = nextPeriod
+                    calendar.add(Calendar.DAY_OF_YEAR, expiryDays)
+                    nextPeriod = calendar.time
+                }
+                nextPeriod <= currentDate
             }
-            nextPeriod <= currentDate
         } ?: false
 
         return expiredBecauseOfCompletion || expiredBecauseOfPeriod

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventDateUtilsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventDateUtilsShould.kt
@@ -96,6 +96,15 @@ class EventDateUtilsShould {
         assertThat(eventDateUtils.isEventExpired(event, 0, null, 2)).isFalse()
     }
 
+    @Test
+    fun `Should return is not expired if no event or due date provided`() {
+        whenever(event.status()) doReturn EventStatus.ACTIVE
+        whenever(event.eventDate()) doReturn null
+        whenever(event.dueDate()) doReturn null
+
+        assertThat(eventDateUtils.isEventExpired(event, 0, null, 2)).isFalse()
+    }
+
     private fun getCalendar(): Calendar {
         val calendar = Calendar.getInstance()
         calendar[Calendar.YEAR] = 2020


### PR DESCRIPTION
Solves [ANDROSDK-1835](https://dhis2.atlassian.net/browse/ANDROSDK-1835).

[ANDROSDK-1835]: https://dhis2.atlassian.net/browse/ANDROSDK-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ