### PR TITLE
feat: [ANDROSDK-1859] Add gradle task to install pre-commit and prepare-commit-msg scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             steps {
                 script {
                     echo 'Running Check style and quality'
-                    sh './runChecks.sh'
+                    sh './gradlew runChecks'
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,11 @@ tasks.register("clean", Delete::class) {
 
 tasks.register("installGitHooks") {
     group = "git hooks"
-    description = "Installs the pre-commit git hook."
+
+    doFirst {
+        val hooks = project.fileTree("scripts/hooks").files.map { it.name }
+        description = "Installs the following git hooks: ${hooks.joinToString(", ")}."
+    }
 
     doLast {
         val hooksDir = File(rootDir, ".git/hooks")
@@ -66,13 +70,16 @@ tasks.register("installGitHooks") {
             hooksDir.mkdirs()
         }
 
-        val preCommitHook = File(rootDir, "scripts/hooks/pre-commit")
-        val destination = File(hooksDir, "pre-commit")
+        val hooks = project.fileTree("scripts/hooks")
 
-        preCommitHook.copyTo(destination, overwrite = true)
-        destination.setExecutable(true)
+        hooks.forEach { file ->
+            val destination = File(hooksDir, file.name)
+            file.copyTo(destination, overwrite = true)
+            destination.setExecutable(true)
+            println("Installed hook: ${file.name}")
+        }
 
-        println("Pre-commit hook installed successfully.")
+        println("All hooks installed successfully.")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,36 +52,7 @@ allprojects {
     }
 }
 
-tasks.register("clean", Delete::class) {
-    delete(rootProject.layout.buildDirectory)
-}
-
-tasks.register("installGitHooks") {
-    group = "git hooks"
-
-    doFirst {
-        val hooks = project.fileTree("scripts/hooks").files.map { it.name }
-        description = "Installs the following git hooks: ${hooks.joinToString(", ")}."
-    }
-
-    doLast {
-        val hooksDir = File(rootDir, ".git/hooks")
-        if (!hooksDir.exists()) {
-            hooksDir.mkdirs()
-        }
-
-        val hooks = project.fileTree("scripts/hooks")
-
-        hooks.forEach { file ->
-            val destination = File(hooksDir, file.name)
-            file.copyTo(destination, overwrite = true)
-            destination.setExecutable(true)
-            println("Installed hook: ${file.name}")
-        }
-
-        println("All hooks installed successfully.")
-    }
-}
+apply(from = "tasks.gradle.kts")
 
 subprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,25 @@ tasks.register("clean", Delete::class) {
     delete(rootProject.layout.buildDirectory)
 }
 
+tasks.register("installGitHooks") {
+    group = "git hooks"
+    description = "Installs the pre-commit git hook."
+
+    doLast {
+        val hooksDir = File(rootDir, ".git/hooks")
+        if (!hooksDir.exists()) {
+            hooksDir.mkdirs()
+        }
+
+        val preCommitHook = File(rootDir, "scripts/hooks/pre-commit")
+        val destination = File(hooksDir, "pre-commit")
+
+        preCommitHook.copyTo(destination, overwrite = true)
+        destination.setExecutable(true)
+
+        println("Pre-commit hook installed successfully.")
+    }
+}
 
 subprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")

--- a/runChecks.sh
+++ b/runChecks.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -xe
-
-# You can run it from any directory.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PROJECT_DIR=$DIR/
-
-# This will: compile the project, run lint, package apk and check the code quality.
-"$PROJECT_DIR"/gradlew clean ktlintCheck detekt checkstyleDebug pmdDebug lintDebug --project-dir core

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+#
+#  Copyright (c) 2004-2024, University of Oslo
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation
+#  and/or other materials provided with the distribution.
+#  Neither the name of the HISP project nor the names of its contributors may
+#  be used to endorse or promote products derived from this software without
+#  specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+#  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+#  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+#  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+echo "Formatting code with ktlint"
+./gradlew ktlintFormat --daemon
+if [ $? -ne 0 ]; then
+    echo "ktlintFormat failed. Commit aborted."
+    exit 1
+fi
+
+echo "Running detekt for static code analysis"
+./gradlew detekt --daemon
+if [ $? -ne 0 ]; then
+    echo "detekt analysis failed. Commit aborted."
+    exit 1
+fi
+
+exit 0

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -29,15 +29,13 @@
 #
 
 echo "Formatting code with ktlint"
-./gradlew ktlintFormat --daemon
-if [ $? -ne 0 ]; then
+if ! ./gradlew ktlintFormat --daemon; then
     echo "ktlintFormat failed. Commit aborted."
     exit 1
 fi
 
 echo "Running detekt for static code analysis"
-./gradlew detekt --daemon
-if [ $? -ne 0 ]; then
+if ! ./gradlew detekt --daemon; then
     echo "detekt analysis failed. Commit aborted."
     exit 1
 fi

--- a/scripts/hooks/prepare-commit-msg
+++ b/scripts/hooks/prepare-commit-msg
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+#
+#  Copyright (c) 2004-2024, University of Oslo
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#
+#  Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation
+#  and/or other materials provided with the distribution.
+#  Neither the name of the HISP project nor the names of its contributors may
+#  be used to endorse or promote products derived from this software without
+#  specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+#  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+#  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+#  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#  This script ensures that Git commit messages include the current branch name (in uppercase) at the beginning,
+#  unless the branch is excluded (e.g., `master` or `develop`) or already mentioned in the commit message.
+
+if [ -z "$EXCLUDED_BRANCHES" ]; then
+  EXCLUDED_BRANCHES=(master develop)
+fi
+
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
+CURRENT_BRANCH="${CURRENT_BRANCH##*/}"
+CURRENT_BRANCH=$(echo "$CURRENT_BRANCH" | tr '[:lower:]' '[:upper:]')
+BRANCH_EXCLUDED=$(printf "%s\n" "${EXCLUDED_BRANCHES[@]}" | grep -c "^$CURRENT_BRANCH$")
+BRANCH_IN_COMMIT=$(grep -c "\[$CURRENT_BRANCH\]" "$1")
+
+if [ -n "$CURRENT_BRANCH" ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
+  sed -i.bak -e "1s/^/[$CURRENT_BRANCH] /" "$1"
+fi

--- a/tasks.gradle.kts
+++ b/tasks.gradle.kts
@@ -1,0 +1,44 @@
+tasks.register("installGitHooks") {
+    group = "git hooks"
+
+    doFirst {
+        val hooks = project.fileTree("scripts/hooks").files.map { it.name }
+        description = "Installs the following git hooks: ${hooks.joinToString(", ")}."
+    }
+
+    doLast {
+        val hooksDir = File(rootDir, ".git/hooks")
+        if (!hooksDir.exists()) {
+            hooksDir.mkdirs()
+        }
+
+        val hooks = project.fileTree("scripts/hooks")
+
+        hooks.forEach { file ->
+            val destination = File(hooksDir, file.name)
+            file.copyTo(destination, overwrite = true)
+            destination.setExecutable(true)
+            println("Installed hook: ${file.name}")
+        }
+
+        println("All hooks installed successfully.")
+    }
+}
+
+tasks.register("clean", Delete::class) {
+    delete(rootProject.layout.buildDirectory)
+}
+
+tasks.register("runChecks") {
+    group = "verification"
+    description = "Cleans the project, runs lint checks, and code quality checks."
+
+    dependsOn(
+        ":core:clean",
+        ":core:ktlintCheck",
+        ":core:detekt",
+        ":core:checkstyleDebug",
+        ":core:pmdDebug",
+        ":core:lintDebug"
+    )
+}


### PR DESCRIPTION
### Install git hooks task
To add the `pre-commit` and `prepare-commit-msg` script to your `.git/hooks` directory just run the gradle task `installGitHooks` with gradlew.

### Pre-commit script
The pre-commit script runs kotlintFormat and detekt before commiting.

To avoid run the pre-commit if you don't need it you can add `--no-verify` at the end of your commit:

`git commit -m "Your commit message" --no-verify
`

### Prepare-commit-msg script
This script ensures that Git commit messages include the current branch name (in uppercase) at the beginning, unless the branch is excluded (e.g., `master` or `develop`) or already mentioned in the commit message.

### Refactor
The gradle tasks are refactored outside the `build.gradle.kts` to `tasks.gradle.kts` and the `runChecks.sh` have been refactored to a gradle task.