### PR TITLE
fix: [ANDROSDK-1885] Handle failed tracker job reports

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostNewMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostNewMockIntegrationShould.kt
@@ -38,10 +38,12 @@ class EventPostNewMockIntegrationShould : EventPostBaseMockIntegrationShould() {
     override val exporterVersion = TrackerExporterVersion.V2
     override val importConflictsFile1 = listOf(
         "imports/tracker-importer/job_response.json",
+        "imports/tracker-importer/job_response_completed.json",
         "imports/web_response_with_event_import_conflicts_new.json",
     )
     override val importConflictsFile2 = listOf(
         "imports/tracker-importer/job_response.json",
+        "imports/tracker-importer/job_response_completed.json",
         "imports/web_response_with_event_import_conflicts2_new.json",
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReport.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReport.kt
@@ -77,3 +77,8 @@ internal data class JobReport(
     val stats: JobImportCount?,
     val bundleReport: JobBundleReport?,
 )
+
+internal data class JobProgress(
+    val message: String,
+    val completed: Boolean,
+)

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterService.kt
@@ -53,4 +53,7 @@ internal interface TrackerImporterService {
 
     @GET("$JOBS_URL{jobId}/report")
     suspend fun getJobReport(@Path(JOB_ID) jobId: String): JobReport
+
+    @GET("$JOBS_URL{jobId}")
+    suspend fun getJob(@Path(JOB_ID) jobId: String): List<JobProgress>
 }

--- a/core/src/sharedTest/resources/imports/tracker-importer/job_response_completed.json
+++ b/core/src/sharedTest/resources/imports/tracker-importer/job_response_completed.json
@@ -1,0 +1,154 @@
+[
+  {
+    "uid": "c32aY1bLBYj",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.611",
+    "message": "Import complete with status OK, 0 created, 1 updated, 0 deleted, 0 ignored",
+    "completed": true,
+    "id": "c32aY1bLBYj"
+  },
+  {
+    "uid": "WFJWFAx79iu",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.605",
+    "message": "PostCommit",
+    "completed": false,
+    "id": "WFJWFAx79iu"
+  },
+  {
+    "uid": "SIsNOdqJSe2",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.600",
+    "message": "Commit Transaction",
+    "completed": false,
+    "id": "SIsNOdqJSe2"
+  },
+  {
+    "uid": "TcJDOkqTwkp",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.599",
+    "message": "Running Rule Engine Validation",
+    "completed": false,
+    "id": "TcJDOkqTwkp"
+  },
+  {
+    "uid": "PwbIfsKU09y",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.595",
+    "message": "Running Rule Engine",
+    "completed": false,
+    "id": "PwbIfsKU09y"
+  },
+  {
+    "uid": "qAL9LQdJzFG",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.595",
+    "message": "Running Validation",
+    "completed": false,
+    "id": "qAL9LQdJzFG"
+  },
+  {
+    "uid": "XOfVqNzq0l5",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.595",
+    "message": "Running PreProcess",
+    "completed": false,
+    "id": "XOfVqNzq0l5"
+  },
+  {
+    "uid": "lIPN2MSPkGD",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.595",
+    "message": "Calculating Payload Size",
+    "completed": false,
+    "id": "lIPN2MSPkGD"
+  },
+  {
+    "uid": "aj1OpMy7XgR",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.547",
+    "message": "Running PreHeat",
+    "completed": false,
+    "id": "aj1OpMy7XgR"
+  },
+  {
+    "uid": "PzenjavRZBp",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.546",
+    "message": "Loading file content",
+    "completed": false,
+    "id": "PzenjavRZBp"
+  },
+  {
+    "uid": "xezG4GkmW32",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.545",
+    "message": "Loading file resource",
+    "completed": false,
+    "id": "xezG4GkmW32"
+  },
+  {
+    "uid": "rsoyHRmBJFW",
+    "level": "INFO",
+    "category": "TRACKER_IMPORT_JOB",
+    "time": "2024-07-11T14:49:59.545",
+    "message": "Tracker import started",
+    "completed": false,
+    "dataType": "PARAMETERS",
+    "data": {
+      "userId": "DXyJmlo9rge",
+      "importMode": "COMMIT",
+      "idSchemes": {
+        "dataElementIdScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        },
+        "orgUnitIdScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        },
+        "programIdScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        },
+        "programStageIdScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        },
+        "idScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        },
+        "categoryOptionComboIdScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        },
+        "categoryOptionIdScheme": {
+          "idScheme": "UID",
+          "attributeUid": null
+        }
+      },
+      "importStrategy": "CREATE_AND_UPDATE",
+      "atomicMode": "OBJECT",
+      "flushMode": "AUTO",
+      "validationMode": "FULL",
+      "skipPatternValidation": false,
+      "skipSideEffects": false,
+      "skipRuleEngine": false,
+      "filename": null,
+      "reportMode": "ERRORS"
+    },
+    "id": "rsoyHRmBJFW"
+  }
+]


### PR DESCRIPTION
Solves [ANDROSDK-1885](https://dhis2.atlassian.net/browse/ANDROSDK-1885).

This PR changes the behavior of the importer. Now, the importer checks the job status instead of the job report. Once the job status tells the job is complete, it fetches the job report. If the job report does not exist (as in the reported issue), it finishes the execution.

Previously, the job status changed to complete with an error and the job report was never available. That is the reason why fetching the job report never succeeded and had to wait for ~3minutes to finish.

[ANDROSDK-1885]: https://dhis2.atlassian.net/browse/ANDROSDK-1885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ