### PR TITLE
fix: [ANDROSDK-1893] Apply right priority in the evaluation of limitByOrgunit 

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
@@ -84,31 +84,29 @@ internal class TrackerQueryFactoryCommonHelper(
         }
     }
 
-    @Suppress("ReturnCount")
-    fun hasLimitByOrgUnit(
+    private fun hasLimitByOrgUnit(
         params: ProgramDataDownloadParams,
         programSettings: ProgramSettings?,
         programUid: String?,
     ): Boolean {
-        if (params.limitByOrgunit() != null) {
-            return params.limitByOrgunit()!!
+        val specificProgramScope = programSettings?.specificSettings()?.get(programUid)?.settingDownload()
+        val globalScope = programSettings?.globalSettings()?.settingDownload()
+
+        return when {
+            params.limitByOrgunit() != null && isUserDefinedProgram(params, programUid) ->
+                params.limitByOrgunit()!!
+
+            specificProgramScope != null ->
+                specificProgramScope == LimitScope.PER_ORG_UNIT
+
+            params.limitByOrgunit() != null ->
+                params.limitByOrgunit()!!
+
+            globalScope != null ->
+                globalScope == LimitScope.PER_OU_AND_PROGRAM || globalScope == LimitScope.PER_ORG_UNIT
+
+            else -> false
         }
-        if (programSettings != null) {
-            val specificSetting = programSettings.specificSettings()[programUid]
-            if (specificSetting != null) {
-                val scope = specificSetting.settingDownload()
-                if (scope != null) {
-                    return scope == LimitScope.PER_ORG_UNIT
-                }
-            }
-            if (programSettings.globalSettings() != null) {
-                val scope = programSettings.globalSettings()!!.settingDownload()
-                if (scope != null) {
-                    return scope == LimitScope.PER_OU_AND_PROGRAM || scope == LimitScope.PER_ORG_UNIT
-                }
-            }
-        }
-        return false
     }
 
     fun getLimit(


### PR DESCRIPTION
Solves [ANDROSDK-1893](https://dhis2.atlassian.net/browse/ANDROSDK-1893)

This PR fixes the priority to determine the value of limitByOrgunit. The specific settings for a particular program was not respected when the application provided an explicit value for limitByOrgunit. The specific setting must be respected unless the application provides a explicit program id as well (check jira issue description).

[ANDROSDK-1893]: https://dhis2.atlassian.net/browse/ANDROSDK-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ