### PR TITLE
fix: [ANDROSDK-1906] Continue fileResource download when error 

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/maintenance/D2ErrorCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/maintenance/D2ErrorCollectionRepositoryMockIntegrationShould.java
@@ -67,7 +67,7 @@ public class D2ErrorCollectionRepositoryMockIntegrationShould extends BaseMockIn
     public void filter_d2_error_by_d2_error_component() {
         List<D2Error> d2Errors = d2.maintenanceModule().d2Errors()
                 .byD2ErrorComponent().eq(D2ErrorComponent.Server).blockingGet();
-        assertThat(d2Errors.size()).isEqualTo(2);
+        assertThat(d2Errors.size()).isEqualTo(4);
     }
 
     @Test
@@ -105,6 +105,6 @@ public class D2ErrorCollectionRepositoryMockIntegrationShould extends BaseMockIn
         List<D2Error> d2Errors = d2.maintenanceModule().d2Errors()
                 .byCreated().inPeriods(Lists.newArrayList(todayPeriod)).blockingGet();
 
-        assertThat(d2Errors.size()).isEqualTo(3);
+        assertThat(d2Errors.size()).isEqualTo(5);
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/maintenance/MaintenanceMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/maintenance/MaintenanceMockIntegrationShould.java
@@ -83,6 +83,6 @@ public class MaintenanceMockIntegrationShould extends BaseMockIntegrationTestFul
     @Test
     public void allow_access_to_d2_errors() {
         List<D2Error> d2Errors = d2.maintenanceModule().d2Errors().blockingGet();
-        assertThat(d2Errors.size()).isEqualTo(3);
+        assertThat(d2Errors.size()).isEqualTo(5);
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould.java
@@ -51,7 +51,7 @@ public class TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShoul
     public void allow_access_to_all_tracked_entity_data_values() {
         List<TrackedEntityAttributeValue> trackedEntityAttributeValues =
                 d2.trackedEntityModule().trackedEntityAttributeValues().blockingGet();
-        assertThat(trackedEntityAttributeValues.size()).isEqualTo(3);
+        assertThat(trackedEntityAttributeValues.size()).isEqualTo(4);
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityInstanceCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityInstanceCollectionRepositoryMockIntegrationShould.java
@@ -72,8 +72,8 @@ public class TrackedEntityInstanceCollectionRepositoryMockIntegrationShould exte
         assertThat(tei.trackedEntityAttributeValues().size()).isEqualTo(2);
 
 
-        assertThat(tei.trackedEntityAttributeValues().get(0).trackedEntityAttribute()).isEqualTo("cejWyOfXge6");
-        assertThat(tei.trackedEntityAttributeValues().get(0).value()).isEqualTo("654321");
+        assertThat(tei.trackedEntityAttributeValues().get(0).trackedEntityAttribute()).isEqualTo("aejWyOfXge6");
+        assertThat(tei.trackedEntityAttributeValues().get(0).value()).isEqualTo("aefryrfXge5");
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityInstanceCollectionRepositoryMockIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityInstanceCollectionRepositoryMockIntegrationShould.java
@@ -69,7 +69,7 @@ public class TrackedEntityInstanceCollectionRepositoryMockIntegrationShould exte
         TrackedEntityInstance tei = d2.trackedEntityModule().trackedEntityInstances()
                 .withTrackedEntityAttributeValues().uid("nWrB0TfWlvD").blockingGet();
 
-        assertThat(tei.trackedEntityAttributeValues().size()).isEqualTo(1);
+        assertThat(tei.trackedEntityAttributeValues().size()).isEqualTo(2);
 
 
         assertThat(tei.trackedEntityAttributeValues().get(0).trackedEntityAttribute()).isEqualTo("cejWyOfXge6");

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -77,7 +77,7 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
             .blockingGet()
 
         assertThat(trackedEntityInstances[0].header).isEqualTo("4081507, befryEfXge5")
-        assertThat(trackedEntityInstances[1].header).isEqualTo("654321, ")
+        assertThat(trackedEntityInstances[1].header).isEqualTo("654321, aefryrfXge5")
     }
 
     @Test

--- a/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities.json
+++ b/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities.json
@@ -231,6 +231,12 @@
           "createdAt": "2018-01-10T13:40:28.000",
           "attribute": "cejWyOfXge6",
           "value": "654321"
+        },
+        {
+          "updatedAt": "2019-01-11T13:40:28.000",
+          "createdAt": "2019-01-11T13:40:28.000",
+          "attribute": "aejWyOfXge6",
+          "value": "aefryrfXge5"
         }
       ],
       "enrollments": [

--- a/core/src/sharedTest/resources/trackedentity/tracked_entity_instances.json
+++ b/core/src/sharedTest/resources/trackedentity/tracked_entity_instances.json
@@ -226,6 +226,12 @@
           "created": "2018-01-10T13:40:28.000",
           "attribute": "cejWyOfXge6",
           "value": "654321"
+        },
+        {
+          "lastUpdated": "2019-01-11T13:40:28.000",
+          "created": "2019-01-11T13:40:28.000",
+          "attribute": "aejWyOfXge6",
+          "value": "aefryrfXge5"
         }
       ],
       "enrollments": [


### PR DESCRIPTION
Solves [ANDROSDK-1906](https://dhis2.atlassian.net/browse/ANDROSDK-1906).

FileResource download was stopping if a file resource didn't exist in the server. This is something likely to happen in demo instances, it should happen in production instances.

[ANDROSDK-1906]: https://dhis2.atlassian.net/browse/ANDROSDK-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ