### PR TITLE
chore: [ANDROSDK-1867] use non deprecated ping endpoint

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/RequestBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/RequestBuilder.kt
@@ -59,6 +59,10 @@ class RequestBuilder(private val baseUrl: String) {
         this.isExternalRequest = isExternalRequest
     }
 
+    fun excludeCredentials() {
+        this.isExternalRequest = true
+    }
+
     fun authorizationHeader(header: String?) {
         this.authorizationHeader = header
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.systeminfo.internal
 
-import io.ktor.client.statement.bodyAsText
 import io.reactivex.Single
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.api.internal.HttpStatusCodes
@@ -57,7 +56,8 @@ class PingImpl internal constructor(
         try {
             val response = pingService.getPing()
             return if (
-                response.status.value in HttpStatusCodes.SUCCESS_MIN..HttpStatusCodes.SUCCESS_MAX) {
+                response.status.value in HttpStatusCodes.SUCCESS_MIN..HttpStatusCodes.SUCCESS_MAX
+            ) {
                 "pong"
             } else {
                 throw IOException("Ping to the server failed with status code: ${response.status.value}")

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -56,11 +56,8 @@ class PingImpl internal constructor(
     private suspend fun checkPing(): String {
         try {
             val response = pingService.getPing()
-            val responseBody = response.bodyAsText()
             return if (
-                response.status.value in HttpStatusCodes.SUCCESS_MIN..HttpStatusCodes.SUCCESS_MAX &&
-                responseBody == "pong"
-            ) {
+                response.status.value in HttpStatusCodes.SUCCESS_MIN..HttpStatusCodes.SUCCESS_MAX) {
                 "pong"
             } else {
                 throw IOException("Ping to the server failed with status code: ${response.status.value}")

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingService.kt
@@ -29,14 +29,26 @@ package org.hisp.dhis.android.core.systeminfo.internal
 
 import io.ktor.client.statement.HttpResponse
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
+import org.hisp.dhis.android.core.systeminfo.DHISVersion
+import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class PingService(private val client: HttpServiceClient) {
+internal class PingService(
+    private val client: HttpServiceClient,
+    private val versionManager: DHISVersionManager
+    ) {
     suspend fun getPing(): HttpResponse {
-        return client.get {
-            url("ping")
-            excludeCredentials()
+        return if (versionManager.isGreaterThan(DHISVersion.V2_36)) {
+            client.get {
+                url("ping")
+                excludeCredentials()
+            }
+        } else {
+            client.get {
+                url("system/ping")
+            }
         }
+
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingService.kt
@@ -35,7 +35,8 @@ import org.koin.core.annotation.Singleton
 internal class PingService(private val client: HttpServiceClient) {
     suspend fun getPing(): HttpResponse {
         return client.get {
-            url("system/ping")
+            url("ping")
+            excludeCredentials()
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingService.kt
@@ -36,10 +36,10 @@ import org.koin.core.annotation.Singleton
 @Singleton
 internal class PingService(
     private val client: HttpServiceClient,
-    private val versionManager: DHISVersionManager
-    ) {
+    private val dhisVersionManager: DHISVersionManager,
+) {
     suspend fun getPing(): HttpResponse {
-        return if (versionManager.isGreaterThan(DHISVersion.V2_36)) {
+        return if (dhisVersionManager.isGreaterThan(DHISVersion.V2_36)) {
             client.get {
                 url("ping")
                 excludeCredentials()
@@ -49,6 +49,5 @@ internal class PingService(
                 url("system/ping")
             }
         }
-
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
@@ -48,15 +48,14 @@ class PingImplShould {
 
     @Test
     fun get_should_return_success_when_ping_service_succeeds2() = runBlocking {
-        val expectedResponse = "pong"
-        val mockEngine = MockEngine { respond(content = expectedResponse) }
+        val mockEngine = MockEngine { respond(content = "") }
         val client = HttpClient(mockEngine)
         val httpServiceClient = HttpServiceClient(client)
         val pingService = PingService(httpServiceClient)
 
         val response = pingService.getPing()
         val result = response.bodyAsText()
-        assertThat(expectedResponse).isEqualTo(result)
+        assertThat("").isEqualTo(result)
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
@@ -48,6 +48,7 @@ class PingImplShould {
 
     @Test
     fun get_should_return_success_when_ping_service_succeeds2() = runBlocking {
+        val expectedResponse = ""
         val mockEngine = MockEngine { respond(content = "") }
         val client = HttpClient(mockEngine)
         val httpServiceClient = HttpServiceClient(client)
@@ -55,7 +56,7 @@ class PingImplShould {
 
         val response = pingService.getPing()
         val result = response.bodyAsText()
-        assertThat("").isEqualTo(result)
+        assertThat(expectedResponse).isEqualTo(result)
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
@@ -28,6 +28,9 @@
 package org.hisp.dhis.android.core.systeminfo.internal
 
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -37,14 +40,23 @@ import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.systeminfo.DHISVersion
+import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class PingImplShould {
+    private val dhisVersionManager: DHISVersionManager = mock()
+
+    @Before
+    fun setUp() {
+        whenever(dhisVersionManager.isGreaterThan(DHISVersion.V2_36)).doReturn(true)
+    }
 
     @Test
     fun get_should_return_success_when_ping_service_succeeds2() = runBlocking {
@@ -52,7 +64,7 @@ class PingImplShould {
         val mockEngine = MockEngine { respond(content = "") }
         val client = HttpClient(mockEngine)
         val httpServiceClient = HttpServiceClient(client)
-        val pingService = PingService(httpServiceClient)
+        val pingService = PingService(httpServiceClient, dhisVersionManager)
 
         val response = pingService.getPing()
         val result = response.bodyAsText()
@@ -69,7 +81,7 @@ class PingImplShould {
         }
         val client = HttpClient(mockEngine)
         val httpServiceClient = HttpServiceClient(client)
-        val pingService = PingService(httpServiceClient)
+        val pingService = PingService(httpServiceClient, dhisVersionManager)
         val pingImpl = PingImpl(pingService)
 
         try {


### PR DESCRIPTION
Related task: [ANDROSDK-1867](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/93?selectedIssue=ANDROSDK-1867)

[ANDROSDK-1867]: https://dhis2.atlassian.net/browse/ANDROSDK-1867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ