### PR TITLE
chore: [ANDROSDK-1914] Remove uses of D2CallExecutor

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleanerShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.arch.call.executors.internal.D2CallExecutor
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.core.common.ObjectWithUid
-import org.hisp.dhis.android.core.common.Unit
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolation
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolationTableInfo
 import org.hisp.dhis.android.core.option.Option
@@ -92,7 +91,7 @@ class ForeignKeyCleanerShould : BaseMockIntegrationTestEmptyDispatcher() {
         val executor = D2CallExecutor.create(d2.databaseAdapter())
         val PROGRAM_RULE_UID = "program_rule_uid"
         val program = ObjectWithUid.create("nonexisent-program")
-        executor.executeD2CallTransactionally<Any?> {
+        executor.executeD2CallTransactionally<Unit> {
             ProgramRuleStoreImpl(d2.databaseAdapter()).insert(
                 ProgramRule.builder()
                     .uid(PROGRAM_RULE_UID).name("Rule").program(program).build(),
@@ -111,14 +110,13 @@ class ForeignKeyCleanerShould : BaseMockIntegrationTestEmptyDispatcher() {
             assertThat(rowsAffected).isEqualTo(1)
             assertThat(d2.programModule().programRules().blockingCount()).isEqualTo(0)
             assertThat(d2.programModule().programRuleActions().blockingCount()).isEqualTo(0)
-            null
         }
     }
 
     private fun addOptionForeignKeyViolation() {
         val executor = D2CallExecutor.create(d2.databaseAdapter())
 
-        executor.executeD2CallTransactionally<Any> {
+        executor.executeD2CallTransactionally<Unit> {
             val optionSet = ObjectWithUid.create("no_option_set")
             val option = Option.builder()
                 .uid("option_uid")
@@ -128,7 +126,6 @@ class ForeignKeyCleanerShould : BaseMockIntegrationTestEmptyDispatcher() {
                 OptionStoreImpl(d2.databaseAdapter())
             optionStore.insert(option)
             ForeignKeyCleanerImpl.create(d2.databaseAdapter()).cleanForeignKeyErrors()
-            Unit()
         }
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/BasePayloadGeneratorMockIntegration.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/BasePayloadGeneratorMockIntegration.kt
@@ -238,7 +238,7 @@ open class BasePayloadGeneratorMockIntegration : BaseMockIntegrationTestMetadata
     ) {
         val relationshipType = RelationshipTypeStoreImpl(databaseAdapter).selectFirst()
         val executor = D2CallExecutor.create(databaseAdapter)
-        executor.executeD2CallTransactionally<Any?> {
+        executor.executeD2CallTransactionally<Unit> {
             RelationshipStoreImpl(databaseAdapter).insert(
                 RelationshipSamples.get230(relationshipUid, from, to).toBuilder()
                     .relationshipType(relationshipType!!.uid())
@@ -258,7 +258,6 @@ open class BasePayloadGeneratorMockIntegration : BaseMockIntegrationTestMetadata
                     .build(),
             )
             ForeignKeyCleanerImpl.create(databaseAdapter).cleanForeignKeyErrors()
-            null
         }
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/localanalytics/dbgeneration/LocalAnalyticsDatabaseFiller.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/localanalytics/dbgeneration/LocalAnalyticsDatabaseFiller.kt
@@ -68,7 +68,7 @@ internal class LocalAnalyticsDatabaseFiller(private val d2: D2) {
     private val d2DIComponent = D2DIComponentAccessor.getD2DIComponent(d2)
 
     fun fillDatabase(metadataParams: LocalAnalyticsMetadataParams, dataParams: LocalAnalyticsDataParams) {
-        D2CallExecutor.create(da).executeD2CallTransactionally {
+        D2CallExecutor.create(da).executeD2CallTransactionally<Unit> {
             val metadata = fillMetadata(metadataParams)
             fillData(dataParams, metadata)
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutor.kt
@@ -34,7 +34,6 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStore
 import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStoreImpl
-import java.util.concurrent.Callable
 
 internal class D2CallExecutor(
     private val databaseAdapter: DatabaseAdapter,
@@ -45,7 +44,7 @@ internal class D2CallExecutor(
         .errorComponent(D2ErrorComponent.SDK)
 
     @Throws(D2Error::class)
-    fun <C> executeD2CallTransactionally(call: Callable<C>): C {
+    fun <C> executeD2CallTransactionally(call: () -> C): C {
         try {
             return innerExecuteD2CallTransactionally(call)
         } catch (d2E: D2Error) {
@@ -56,10 +55,10 @@ internal class D2CallExecutor(
 
     @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
-    private fun <C> innerExecuteD2CallTransactionally(call: Callable<C>): C {
+    private fun <C> innerExecuteD2CallTransactionally(call: () -> C): C {
         var transaction = databaseAdapter.beginNewTransaction()
         try {
-            var response = call.call()
+            var response = call()
             transaction.setSuccessful()
             return response
         } catch (d2E: D2Error) {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalNoResourceSyncCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalNoResourceSyncCallProcessor.kt
@@ -39,9 +39,8 @@ internal class TransactionalNoResourceSyncCallProcessor<O>(
     @Throws(D2Error::class)
     override fun process(objectList: List<O>) {
         if (objectList.isNotEmpty()) {
-            D2CallExecutor.create(databaseAdapter).executeD2CallTransactionally<Any?> {
+            D2CallExecutor.create(databaseAdapter).executeD2CallTransactionally<Unit> {
                 handler.handleMany(objectList)
-                null
             }
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalResourceSyncCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalResourceSyncCallProcessor.kt
@@ -41,10 +41,9 @@ internal class TransactionalResourceSyncCallProcessor<O>(
     @Throws(D2Error::class)
     override fun process(objectList: List<O>) {
         if (objectList.isNotEmpty()) {
-            create(data.databaseAdapter).executeD2CallTransactionally<Any?>({
+            create(data.databaseAdapter).executeD2CallTransactionally<Unit>({
                 handler.handleMany(objectList)
                 data.handleResource(resourceType)
-                null
             })
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeReservedValueCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeReservedValueCallProcessor.kt
@@ -62,7 +62,6 @@ internal class TrackedEntityAttributeReservedValueCallProcessor(
                             .build(),
                     )
                 }
-                null
             })
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AuthorityCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AuthorityCallProcessor.kt
@@ -43,9 +43,8 @@ internal class AuthorityCallProcessor(
         AuthorityStoreImpl(databaseAdapter).delete()
 
         if (objectList.isNotEmpty()) {
-            create(databaseAdapter).executeD2CallTransactionally<Any?>({
+            create(databaseAdapter).executeD2CallTransactionally<Unit>({
                 handler.handleMany(objectList)
-                null
             })
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/wipe/internal/WipeModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/wipe/internal/WipeModuleImpl.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.wipe.internal
 
 import org.hisp.dhis.android.core.arch.call.executors.internal.D2CallExecutor
-import org.hisp.dhis.android.core.common.Unit
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.koin.core.annotation.Singleton
 
@@ -39,26 +38,23 @@ internal class WipeModuleImpl(
 ) : WipeModule {
     @Throws(D2Error::class)
     override fun wipeEverything() {
-        return d2CallExecutor.executeD2CallTransactionally {
+        return d2CallExecutor.executeD2CallTransactionally<Unit> {
             wipeMetadataInternal()
             wipeDataInternal()
-            Unit()
         }
     }
 
     @Throws(D2Error::class)
     override fun wipeMetadata() {
-        return d2CallExecutor.executeD2CallTransactionally {
+        return d2CallExecutor.executeD2CallTransactionally<Unit> {
             wipeMetadataInternal()
-            Unit()
         }
     }
 
     @Throws(D2Error::class)
     override fun wipeData() {
-        return d2CallExecutor.executeD2CallTransactionally {
+        return d2CallExecutor.executeD2CallTransactionally<Unit> {
             wipeDataInternal()
-            Unit()
         }
     }
 


### PR DESCRIPTION
Related task: [ANDROSDK-1914](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/93?selectedIssue=ANDROSDK-1914)

[ANDROSDK-1914]: https://dhis2.atlassian.net/browse/ANDROSDK-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ