### PR TITLE
fix: [ANDROSDK-1924] Update lastest version algorithm to match logic in the APK Distribution app

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
@@ -29,9 +29,7 @@ package org.hisp.dhis.android.testapp.settings
 
 import com.google.common.truth.Truth
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
-import org.junit.runner.RunWith
 
 class LatestAppVersionObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
@@ -38,7 +38,7 @@ class LatestAppVersionObjectRepositoryMockIntegrationShould : BaseMockIntegratio
     @Test
     fun find_latest_app_version() {
         val latestAppVersion = d2.settingModule().latestAppVersion().blockingGet()
-        Truth.assertThat(latestAppVersion?.version()).isEqualTo("40.2")
+        Truth.assertThat(latestAppVersion?.version()).isEqualTo("40.3")
         Truth.assertThat(latestAppVersion?.downloadURL()).isEqualTo(
             "https://github.com/dhis2/dhis2-android-capture-app/releases/download/40.2/dhis2-40.2.apk",
         )

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(D2JunitRunner::class)
 class LatestAppVersionObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     fun find_latest_app_version() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/LatestAppVersionObjectRepositoryMockIntegrationShould.kt
@@ -40,7 +40,7 @@ class LatestAppVersionObjectRepositoryMockIntegrationShould : BaseMockIntegratio
         val latestAppVersion = d2.settingModule().latestAppVersion().blockingGet()
         Truth.assertThat(latestAppVersion?.version()).isEqualTo("40.3")
         Truth.assertThat(latestAppVersion?.downloadURL()).isEqualTo(
-            "https://github.com/dhis2/dhis2-android-capture-app/releases/download/40.2/dhis2-40.2.apk",
+            "https://github.com/dhis2/dhis2-android-capture-app/releases/download/40.3/dhis2-40.3.apk",
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCall.kt
@@ -46,22 +46,27 @@ internal class LatestAppVersionCall(
 
     override suspend fun tryFetch(storeError: Boolean): Result<LatestAppVersion, D2Error> {
         return coroutineAPICallExecutor.wrap(storeError = storeError) {
-            val userGroupUids = userModule.userGroups().blockingGetUids()
-
-            val versions = settingAppService.versions().items()
-
-            val filteredVersions = versions.filter { version ->
-                version.userGroups?.any { userGroupUid ->
-                    userGroupUids.contains(userGroupUid)
-                } ?: false
-            }
-
-            val version = filteredVersions.maxWithOrNull(versionComparator.comparator)
-                ?: versions.find { it.isDefault == true }
+            val version = resolveApkDistributionVersion()
 
             version?.let { LatestAppVersion.builder().version(it.version).downloadURL(it.downloadURL).build() }
                 ?: settingAppService.latestAppVersion()
         }
+    }
+
+    internal suspend fun resolveApkDistributionVersion(): ApkDistributionVersion? {
+        val userGroupUids = userModule.userGroups().blockingGetUids()
+
+        val versions = settingAppService.versions().items()
+
+        val filteredVersions = versions.filter { version ->
+            version.userGroups?.any { userGroupUid ->
+                userGroupUids.contains(userGroupUid)
+            } ?: false
+        }
+
+        val availableVersions = filteredVersions + versions.find { it.isDefault == true }!!
+
+        return availableVersions.maxWithOrNull(versionComparator.comparator)
     }
 
     override fun process(item: LatestAppVersion?) {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCall.kt
@@ -64,7 +64,9 @@ internal class LatestAppVersionCall(
             } ?: false
         }
 
-        val availableVersions = filteredVersions + versions.find { it.isDefault == true }!!
+        val defaultVersions = versions.filter { it.isDefault == true }
+
+        val availableVersions = filteredVersions + defaultVersions
 
         return availableVersions.maxWithOrNull(versionComparator.comparator)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCallShould.kt
@@ -141,7 +141,6 @@ class LatestAppVersionCallShould {
         assertThat("2.0.0").isEqualTo(result?.version)
     }
 
-
     @Test
     fun resolve_correct_apk_distribution_version_repeated_default() = runTest {
         mockUserGroups(listOf("uid1", "uid2"))
@@ -152,5 +151,4 @@ class LatestAppVersionCallShould {
         val result = latestAppVersionCall.resolveApkDistributionVersion()
         assertThat("1.1.1").isEqualTo(result?.version)
     }
-
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCallShould.kt
@@ -125,11 +125,11 @@ class LatestAppVersionCallShould {
     fun resolve_correct_apk_distribution_version_repeated() = runTest {
         mockUserGroups(listOf("uid1", "uid2"))
 
-        val version2_r = mockApkDistributionVersion(listOf("uid2"), false, "1.1.0")
-        mockVersions(listOf(version1, version2, version3, version2_r))
+        val version2_rep = mockApkDistributionVersion(listOf("uid2"), false, "1.1.1")
+        mockVersions(listOf(version1, version2, version3, version2_rep))
 
         val result = latestAppVersionCall.resolveApkDistributionVersion()
-        assertThat("1.1.0").isEqualTo(result?.version)
+        assertThat("1.1.1").isEqualTo(result?.version)
     }
 
     @Test
@@ -140,4 +140,17 @@ class LatestAppVersionCallShould {
         val result = latestAppVersionCall.resolveApkDistributionVersion()
         assertThat("2.0.0").isEqualTo(result?.version)
     }
+
+
+    @Test
+    fun resolve_correct_apk_distribution_version_repeated_default() = runTest {
+        mockUserGroups(listOf("uid1", "uid2"))
+
+        val version_rep_default = mockApkDistributionVersion(listOf("uid2"), true, "1.1.1")
+        mockVersions(listOf(version1, version2, version3, version_rep_default))
+
+        val result = latestAppVersionCall.resolveApkDistributionVersion()
+        assertThat("1.1.1").isEqualTo(result?.version)
+    }
+
 }


### PR DESCRIPTION
Related task: [ANDROSDK-1924](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/93?selectedIssue=ANDROSDK-1924)

[ANDROSDK-1924]: https://dhis2.atlassian.net/browse/ANDROSDK-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ