### PR TITLE
fix: [ANDROSDK-1930] Remove header with Connection: close

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/HttpServiceClient.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/HttpServiceClient.kt
@@ -82,7 +82,6 @@ class HttpServiceClient(
         requestBuilder.headers.forEach { (key, value) ->
             header(key, value)
         }
-        header("Connection", "close")
         if (requestBuilder.isAbsoluteUrl) {
             header(IsAbsouteUrlHeader, true)
         }


### PR DESCRIPTION
Solves [ANDROSDK-1930](https://dhis2.atlassian.net/browse/ANDROSDK-1930)

Removes the explicit http header `Connection: close`. As of HTTP1.1, the default value is `keep-alive`, so the header has simply been removed.

The error mapper has been modified to catch the EOF exception as a SERVER_CONNECTION_ERROR, which is considered as an offline error and allows the use of login offline. This is a workaround for an unexpected behavior in the combination of the mockserver and ktor.

[ANDROSDK-1930]: https://dhis2.atlassian.net/browse/ANDROSDK-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ