### PR TITLE
fix: [ANDROSDK-1933] add creation date to new relationship

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
@@ -122,6 +122,7 @@ class RelationshipCollectionRepository internal constructor(
                     r.toBuilder()
                         .syncState(State.TO_POST)
                         .created(clockProvider.clock.now().toJavaDate())
+                        .lastUpdated(clockProvider.clock.now().toJavaDate())
                         .deleted(false)
                         .build()
                 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.relationship
 import io.reactivex.Single
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
+import org.hisp.dhis.android.core.arch.helpers.DateUtils.toJavaDate
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadWriteWithUidCollectionRepository
@@ -47,6 +48,7 @@ import org.hisp.dhis.android.core.common.internal.TrackerDataManager
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory.clockProvider
 import org.hisp.dhis.android.core.relationship.internal.RelationshipHandler
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemChildrenAppender
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemElementStoreSelector
@@ -119,6 +121,7 @@ class RelationshipCollectionRepository internal constructor(
                 relationshipHandler.handle(relationshipWithUid) { r: Relationship ->
                     r.toBuilder()
                         .syncState(State.TO_POST)
+                        .created(clockProvider.clock.now().toJavaDate())
                         .deleted(false)
                         .build()
                 }


### PR DESCRIPTION
related task: [ANDROSDK-1933](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-1933)

It has been tested using local maven publication that the creation date is now visible when adding a new relationship.

[ANDROSDK-1933]: https://dhis2.atlassian.net/browse/ANDROSDK-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ