### PR TITLE
fix: [ANDROSDK-1936] refreshing expired cookie not being properly handled with API 41

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
@@ -40,7 +40,7 @@ internal class PasswordAndCookieAuthenticator(
 ) {
 
     companion object {
-        private const val LOGIN_ACTION = "login.action"
+        private val LOGIN_KEY_LIST = listOf("login.action", "dhis-web-login")
         const val LOCATION_KEY = "Location"
     }
 
@@ -66,7 +66,7 @@ internal class PasswordAndCookieAuthenticator(
 
     private fun hasAuthenticationFailed(res: Response): Boolean {
         val location = res.header(LOCATION_KEY)
-        return res.isRedirect && location != null && location.contains(LOGIN_ACTION)
+        return res.isRedirect && location != null && LOGIN_KEY_LIST.any { location.contains(it) }
     }
 
     private fun addPasswordHeader(builder: Request.Builder, credentials: Credentials): Request.Builder {


### PR DESCRIPTION
Related tasks [ANDROSDK-1936](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-1936) and [ANDROAPP-6610](https://dhis2.atlassian.net/browse/ANDROAPP-6610)

[ANDROSDK-1936]: https://dhis2.atlassian.net/browse/ANDROSDK-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROAPP-6610]: https://dhis2.atlassian.net/browse/ANDROAPP-6610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ