### PR TITLE
fix: [ANDROSDK-1669] Add support for missing aggregation types

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/DataElementSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/DataElementSQLEvaluatorIntegrationShould.kt
@@ -368,6 +368,20 @@ internal class DataElementSQLEvaluatorIntegrationShould : BaseEvaluatorIntegrati
         assertThat(
             evaluateAggregation(
                 periodId = period2019Q4.periodId()!!,
+                aggregator = AggregationType.FIRST_FIRST_ORG_UNIT,
+            ),
+        ).isEqualTo("8")
+
+        assertThat(
+            evaluateAggregation(
+                periodId = period202012.periodId()!!,
+                aggregator = AggregationType.FIRST_FIRST_ORG_UNIT,
+            ),
+        ).isEqualTo(null)
+
+        assertThat(
+            evaluateAggregation(
+                periodId = period2019Q4.periodId()!!,
                 aggregator = AggregationType.LAST,
             ),
         ).isEqualTo("13")
@@ -418,6 +432,20 @@ internal class DataElementSQLEvaluatorIntegrationShould : BaseEvaluatorIntegrati
             evaluateAggregation(
                 periodId = period202012.periodId()!!,
                 aggregator = AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT,
+            ),
+        ).isEqualTo(null)
+
+        assertThat(
+            evaluateAggregation(
+                periodId = period2019Q4.periodId()!!,
+                aggregator = AggregationType.LAST_LAST_ORG_UNIT,
+            ),
+        ).isEqualTo("5")
+
+        assertThat(
+            evaluateAggregation(
+                periodId = period202012.periodId()!!,
+                aggregator = AggregationType.LAST_LAST_ORG_UNIT,
             ),
         ).isEqualTo(null)
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/DataElementSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/DataElementSQLEvaluatorIntegrationShould.kt
@@ -44,6 +44,7 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEv
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.orgunitChild1
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.orgunitChild2
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.orgunitParent
+import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.period201910
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.period201911
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.period201912
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.period2019Q4
@@ -326,6 +327,7 @@ internal class DataElementSQLEvaluatorIntegrationShould : BaseEvaluatorIntegrati
 
     @Test
     fun should_aggregate_by_aggregation_types() {
+        createDataValue("1", orgunitUid = orgunitChild1.uid(), periodId = period201910.periodId()!!)
         createDataValue("3", orgunitUid = orgunitChild1.uid(), periodId = period201911.periodId()!!)
         createDataValue("5", orgunitUid = orgunitChild1.uid(), periodId = period201912.periodId()!!)
         createDataValue("8", orgunitUid = orgunitChild2.uid(), periodId = period201911.periodId()!!)
@@ -335,42 +337,42 @@ internal class DataElementSQLEvaluatorIntegrationShould : BaseEvaluatorIntegrati
                 periodId = period2019Q4.periodId()!!,
                 aggregator = AggregationType.AVERAGE_SUM_ORG_UNIT,
             ),
-        ).isEqualTo("12")
+        ).isEqualTo("11")
 
         assertThat(
             evaluateAggregation(
                 periodId = period2019Q4.periodId()!!,
                 aggregator = AggregationType.FIRST,
             ),
-        ).isEqualTo("11")
+        ).isEqualTo("9")
 
         assertThat(
             evaluateAggregation(
                 periodId = period202012.periodId()!!,
                 aggregator = AggregationType.FIRST,
             ),
-        ).isEqualTo("11")
+        ).isEqualTo("9")
 
         assertThat(
             evaluateAggregation(
                 periodId = period2019Q4.periodId()!!,
                 aggregator = AggregationType.FIRST_AVERAGE_ORG_UNIT,
             ),
-        ).isEqualTo("5.5")
+        ).isEqualTo("4.5")
 
         assertThat(
             evaluateAggregation(
                 periodId = period202012.periodId()!!,
                 aggregator = AggregationType.FIRST_AVERAGE_ORG_UNIT,
             ),
-        ).isEqualTo("5.5")
+        ).isEqualTo("4.5")
 
         assertThat(
             evaluateAggregation(
                 periodId = period2019Q4.periodId()!!,
                 aggregator = AggregationType.FIRST_FIRST_ORG_UNIT,
             ),
-        ).isEqualTo("8")
+        ).isEqualTo("1")
 
         assertThat(
             evaluateAggregation(
@@ -461,7 +463,7 @@ internal class DataElementSQLEvaluatorIntegrationShould : BaseEvaluatorIntegrati
                 periodId = period2019Q4.periodId()!!,
                 aggregator = AggregationType.MIN_SUM_ORG_UNIT,
             ),
-        ).isEqualTo("11")
+        ).isEqualTo("9")
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/DataElementSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/DataElementSQLEvaluatorIntegrationShould.kt
@@ -420,6 +420,20 @@ internal class DataElementSQLEvaluatorIntegrationShould : BaseEvaluatorIntegrati
                 aggregator = AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT,
             ),
         ).isEqualTo(null)
+
+        assertThat(
+            evaluateAggregation(
+                periodId = period2019Q4.periodId()!!,
+                aggregator = AggregationType.MAX_SUM_ORG_UNIT,
+            ),
+        ).isEqualTo("13")
+
+        assertThat(
+            evaluateAggregation(
+                periodId = period2019Q4.periodId()!!,
+                aggregator = AggregationType.MIN_SUM_ORG_UNIT,
+            ),
+        ).isEqualTo("11")
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/EventDataItemSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/EventDataItemSQLEvaluatorIntegrationShould.kt
@@ -229,6 +229,10 @@ internal class EventDataItemSQLEvaluatorIntegrationShould : BaseEvaluatorIntegra
         ).isEqualTo("4")
 
         assertThat(
+            evaluateEventAttribute(atAggregation = AggregationType.FIRST_FIRST_ORG_UNIT),
+        ).isEqualTo("5")
+
+        assertThat(
             evaluateEventAttribute(atAggregation = AggregationType.LAST, pe = period2019Q4),
         ).isEqualTo("8")
 
@@ -259,6 +263,10 @@ internal class EventDataItemSQLEvaluatorIntegrationShould : BaseEvaluatorIntegra
         assertThat(
             evaluateEventAttribute(atAggregation = AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT, pe = period202001),
         ).isEqualTo(null)
+
+        assertThat(
+            evaluateEventAttribute(atAggregation = AggregationType.LAST_LAST_ORG_UNIT),
+        ).isEqualTo("3")
 
         assertThat(
             evaluateEventAttribute(atAggregation = AggregationType.MAX_SUM_ORG_UNIT, pe = period2019Q4),

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/EventDataItemSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/EventDataItemSQLEvaluatorIntegrationShould.kt
@@ -178,6 +178,14 @@ internal class EventDataItemSQLEvaluatorIntegrationShould : BaseEvaluatorIntegra
                 pe = period202001,
             ),
         ).isEqualTo(null)
+
+        assertThat(
+            evaluateEventDataElement(deAggregation = AggregationType.MAX_SUM_ORG_UNIT, pe = period2019Q4),
+        ).isEqualTo("30")
+
+        assertThat(
+            evaluateEventDataElement(deAggregation = AggregationType.MIN_SUM_ORG_UNIT, pe = period2019Q4),
+        ).isEqualTo("30")
     }
 
     @Test
@@ -251,6 +259,14 @@ internal class EventDataItemSQLEvaluatorIntegrationShould : BaseEvaluatorIntegra
         assertThat(
             evaluateEventAttribute(atAggregation = AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT, pe = period202001),
         ).isEqualTo(null)
+
+        assertThat(
+            evaluateEventAttribute(atAggregation = AggregationType.MAX_SUM_ORG_UNIT, pe = period2019Q4),
+        ).isEqualTo("8")
+
+        assertThat(
+            evaluateEventAttribute(atAggregation = AggregationType.MIN_SUM_ORG_UNIT, pe = period2019Q4),
+        ).isEqualTo("8")
     }
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ValuePosition.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ValuePosition.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2024, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,33 +25,10 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.common
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
-import org.hisp.dhis.android.core.util.SqlAggregator
+package org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator
 
-enum class AggregationType(val sql: String?) {
-    SUM(SqlAggregator.SUM),
-    AVERAGE(SqlAggregator.AVG),
-    AVERAGE_SUM_ORG_UNIT(SqlAggregator.AVG),
-    LAST(null),
-    LAST_AVERAGE_ORG_UNIT(null),
-    LAST_LAST_ORG_UNIT(null),
-    LAST_IN_PERIOD(null),
-    LAST_IN_PERIOD_AVERAGE_ORG_UNIT(null),
-    FIRST(null),
-    FIRST_AVERAGE_ORG_UNIT(null),
-    FIRST_FIRST_ORG_UNIT(null),
-    COUNT(SqlAggregator.COUNT),
-    STDDEV(null),
-    VARIANCE(null),
-    MIN(SqlAggregator.MIN),
-    MAX(SqlAggregator.MAX),
-    MIN_SUM_ORG_UNIT(null),
-    MAX_SUM_ORG_UNIT(null),
-    NONE(null),
-    CUSTOM(null),
-
-    @JsonEnumDefaultValue
-    DEFAULT(null),
+internal enum class ValuePosition(val aggregator: String) {
+    FIRST("MIN"),
+    LAST("MAX"),
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/util/SqlUtils.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/util/SqlUtils.kt
@@ -45,3 +45,11 @@ internal object SqlUtils {
         }
     }
 }
+
+internal object SqlAggregator {
+    const val SUM = "SUM"
+    const val COUNT = "COUNT"
+    const val MAX = "MAX"
+    const val MIN = "MIN"
+    const val AVG = "AVG"
+}

--- a/docs/content/developer/analytics.md
+++ b/docs/content/developer/analytics.md
@@ -494,10 +494,10 @@ This table shows the functionality supported by the ProgramIndicator dimension i
 | LAST_AVERAGE_ORG_UNIT           | Yes         |
 | LAST_IN_PERIOD                  | Yes         |
 | LAST_IN_PERIOD_AVERAGE_ORG_UNIT | Yes         |
-| LAST_LAST_ORG_UNIT              |             |
+| LAST_LAST_ORG_UNIT              | Yes         |
 | FIRST                           | Yes         |
 | FIRST_AVERAGE_ORG_UNIT          | Yes         |
-| FIRST_FIRST_ORG_UNIT            |             |
+| FIRST_FIRST_ORG_UNIT            | Yes         |
 | COUNT                           | Yes         |
 | STDDEV                          | No          |
 | VARIANCE                        | No          |

--- a/docs/content/developer/analytics.md
+++ b/docs/content/developer/analytics.md
@@ -494,13 +494,17 @@ This table shows the functionality supported by the ProgramIndicator dimension i
 | LAST_AVERAGE_ORG_UNIT           | Yes         |
 | LAST_IN_PERIOD                  | Yes         |
 | LAST_IN_PERIOD_AVERAGE_ORG_UNIT | Yes         |
+| LAST_LAST_ORG_UNIT              |             |
 | FIRST                           | Yes         |
 | FIRST_AVERAGE_ORG_UNIT          | Yes         |
+| FIRST_FIRST_ORG_UNIT            |             |
 | COUNT                           | Yes         |
 | STDDEV                          | No          |
 | VARIANCE                        | No          |
 | MIN                             | Yes         |
+| MIN_SUM_ORG_UNIT                | Yes         |
 | MAX                             | Yes         |
+| MAX_SUM_ORG_UNIT                | Yes         |
 | NONE                            | No          |
 | CUSTOM                          | No          |
 | DEFAULT                         | No          |


### PR DESCRIPTION
Add support for:
- FIRST_FIRST_ORG_UNIT
- LAST_LAST_ORG_UNIT
- MAX_SUM_ORG_UNIT
- MIN_SUM_ORG_UNIT

Solves [ANDROSDK-1669](https://dhis2.atlassian.net/browse/ANDROSDK-1669)

[ANDROSDK-1669]: https://dhis2.atlassian.net/browse/ANDROSDK-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ