### PR TITLE
chore: [DOKKA-GRADLE-WORKFLOW] Add reusable workflow

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -7,50 +7,11 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
-          cache: 'gradle'
-      - name: Change wrapper permission
-        run: chmod +x ./gradlew
-
-      - name: Build Java docs
-        run: ./gradlew :core:dokkaHtml -PremoveSnapshotSuffix
-
-      - name: Organize pages structure
-        run: |
-          mkdir _site && mkdir _site/api
-          cp -r core/build/dokka/html/* _site/api
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  api-docs:
+    uses: dhis2/workflows/.github/workflows/publish-dokka-to-github-pages.yml@9515eb8
+    with:
+      java_version: 17
+      gradle_args: "-PremoveSnapshotSuffix"
+      gradle_module: "core"
+      output_folder: "api"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.hisp.dhis/android-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.hisp.dhis/android-core)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dhis2_dhis2-android-sdk&metric=coverage&branch=master)](https://sonarcloud.io/summary/new_code?id=dhis2_dhis2-android-sdk&branch=master)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=dhis2_dhis2-android-sdk&metric=ncloc&branch=master)](https://sonarcloud.io/summary/new_code?id=dhis2_dhis2-android-sdk&branch=master)
+[![KDoc link](https://img.shields.io/badge/API_reference-KDoc-blue)](https://dhis2.github.io/dhis2-android-sdk/api/)
 
 ## Introduction
 


### PR DESCRIPTION
This PR replaces the Dokka publication workflow with a reusable workflow in the "dhis2/workflows" repository. This is just to verify that it works fine before applying this workflow to other repositories.

This PR targets "master" branch, but it won't generate a release.