### PR TITLE
chore: [ANDROSDK-1983-2] Fix date format in DataValueDTO

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/network/datavalue/DataValueDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/datavalue/DataValueDTO.kt
@@ -77,8 +77,8 @@ internal data class DataValueDTO(
                 attributeOptionCombo = dataValue.attributeOptionCombo()!!,
                 value = dataValue.value(),
                 storedBy = dataValue.storedBy(),
-                created = dataValue.created()?.toString(),
-                lastUpdated = dataValue.lastUpdated()?.toString(),
+                created = dataValue.created()?.let { DateUtils.DATE_FORMAT.format(it) },
+                lastUpdated = dataValue.lastUpdated()?.let { DateUtils.DATE_FORMAT.format(it) },
                 comment = dataValue.comment(),
                 followup = dataValue.followUp(),
             )


### PR DESCRIPTION
Fix a defect in ANDROSDK-1983. The serialization of dates must be done using the method `DateUtils.DATE_FORMAT.parse()` (the opposite to the method used in deserialization). The method `toString()` prints the date in a friendly format, such as:

![image](https://github.com/user-attachments/assets/2ca6d981-c816-41cb-aa30-87ece48ee8fa)
