### PR TITLE
chore: [ANDROSDK-1666] Block old tracker endpoints for DHIS2 >= 2.42

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/TrackerPostParentCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/TrackerPostParentCallHelper.kt
@@ -40,28 +40,24 @@ internal class TrackerPostParentCallHelper(
 ) {
 
     fun useNewTrackerImporter(): Boolean {
-        return if (dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_38)) {
-            val explicitTrackerVersion = synchronizationSettingStore.selectFirst()?.trackerImporterVersion()
-            if (explicitTrackerVersion == null) {
-                dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_40)
-            } else {
-                explicitTrackerVersion == TrackerImporterVersion.V2
-            }
-        } else {
-            false
+        val explicitTrackerVersion = synchronizationSettingStore.selectFirst()?.trackerImporterVersion()
+        return when {
+            !dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_38) -> false
+            dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_42) -> true
+            explicitTrackerVersion == TrackerImporterVersion.V2 -> true
+            explicitTrackerVersion == null && dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_40) -> true
+            else -> false
         }
     }
 
     fun useNewTrackerExporter(): Boolean {
-        return if (dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_40)) {
-            val explicitTrackerVersion = synchronizationSettingStore.selectFirst()?.trackerExporterVersion()
-            if (explicitTrackerVersion == null) {
-                dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_40)
-            } else {
-                explicitTrackerVersion == TrackerExporterVersion.V2
-            }
-        } else {
-            false
+        val explicitTrackerVersion = synchronizationSettingStore.selectFirst()?.trackerExporterVersion()
+        return when {
+            !dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_40) -> false
+            dhisVersionManager.isGreaterOrEqualThan(DHISVersion.V2_42) -> true
+            explicitTrackerVersion == TrackerExporterVersion.V2 -> true
+            explicitTrackerVersion == null -> true
+            else -> false
         }
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/TrackerPostParentCallHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/TrackerPostParentCallHelperShould.kt
@@ -94,6 +94,13 @@ class TrackerPostParentCallHelperShould {
     }
 
     @Test
+    fun should_always_return_true_if_greater_or_equal_than_42_in_importer() {
+        whenever(systemInfo.version()).doReturn(DHISPatchVersion.V2_42_0.strValue)
+        whenever(syncSettings.trackerImporterVersion()).doReturn(TrackerImporterVersion.V1)
+        assertThat(helper.useNewTrackerImporter()).isTrue()
+    }
+
+    @Test
     fun should_return_true_if_explicitly_set_in_exporter() {
         whenever(systemInfo.version()).doReturn(DHISPatchVersion.V2_40_0.strValue)
         whenever(syncSettings.trackerExporterVersion()).doReturn(TrackerExporterVersion.V2)
@@ -112,5 +119,12 @@ class TrackerPostParentCallHelperShould {
         whenever(systemInfo.version()).doReturn(DHISPatchVersion.V2_39_0.strValue)
         whenever(syncSettings.trackerExporterVersion()).doReturn(TrackerExporterVersion.V2)
         assertThat(helper.useNewTrackerExporter()).isFalse()
+    }
+
+    @Test
+    fun should_always_return_true_if_greater_or_equal_than_42_in_exporter() {
+        whenever(systemInfo.version()).doReturn(DHISPatchVersion.V2_42_0.strValue)
+        whenever(syncSettings.trackerExporterVersion()).doReturn(TrackerExporterVersion.V1)
+        assertThat(helper.useNewTrackerExporter()).isTrue()
     }
 }


### PR DESCRIPTION
Related task [ANDROSDK-1666](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-1666)

[ANDROSDK-1666]: https://dhis2.atlassian.net/browse/ANDROSDK-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ