### PR TITLE
feat: [ANDROSDK-2062] Disable App backup across all Android versions

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -29,7 +29,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <application android:networkSecurityConfig="@xml/network_security_configuration">
+    <application
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="false"
+        android:networkSecurityConfig="@xml/network_security_configuration">
         <activity
             android:name="net.openid.appauth.RedirectUriReceiverActivity"
             android:exported="false"

--- a/core/src/main/res/xml/data_extraction_rules.xml
+++ b/core/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2004-2025, University of Oslo
+  ~  All rights reserved.
+  ~
+  ~  Redistribution and use in source and binary forms, with or without
+  ~  modification, are permitted provided that the following conditions are met:
+  ~  Redistributions of source code must retain the above copyright notice, this
+  ~  list of conditions and the following disclaimer.
+  ~
+  ~  Redistributions in binary form must reproduce the above copyright notice,
+  ~  this list of conditions and the following disclaimer in the documentation
+  ~  and/or other materials provided with the distribution.
+  ~  Neither the name of the HISP project nor the names of its contributors may
+  ~  be used to endorse or promote products derived from this software without
+  ~  specific prior written permission.
+  ~
+  ~  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+        <exclude domain="device_root" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/instrumented-test-app/src/main/AndroidManifest.xml
+++ b/instrumented-test-app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
         android:icon="@android:drawable/sym_def_app_icon"
         android:label="@string/title"
         android:theme="@android:style/Theme.DeviceDefault"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="false"
         android:requestLegacyExternalStorage="true">
         <activity android:name=".TestLabActivity"
             android:exported="true">


### PR DESCRIPTION
Solves  [ANDROSDK-2062](https://dhis2.atlassian.net/browse/ANDROSDK-2062).

This pull request updates the backup configuration to ensure that no data from our app is backed up or restored, regardless of the Android version. The changes include:

- Setting `android:allowBackup="false"` to globally disable backup functionality.
- Configuring `android:fullBackupContent="false"` to explicitly prevent backups on devices running Android versions prior to 12.
- Adding the `android:dataExtractionRules` attribute for Android 12 and above, which points to a new XML resource that excludes all data domains (e.g., root, file, database, sharedpref, external).

[ANDROSDK-2062]: https://dhis2.atlassian.net/browse/ANDROSDK-2062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ