### PR TITLE
bug: [ANDROSDK-2066] App is crashing when completion spinner parameters is not included in the appearance program config

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AppearanceSettingsHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AppearanceSettingsHelper.kt
@@ -91,10 +91,12 @@ internal object AppearanceSettingsHelper {
     @JvmStatic
     fun toCompletionSpinner(programConfiguration: ProgramConfigurationSetting?): CompletionSpinner? {
         return programConfiguration?.let {
-            CompletionSpinner.builder()
-                .uid(it.uid())
-                .visible(it.completionSpinner())
-                .build()
+            it.completionSpinner()?.let { completionSpinner ->
+                CompletionSpinner.builder()
+                    .uid(it.uid())
+                    .visible(completionSpinner)
+                    .build()
+            }
         }
     }
 }


### PR DESCRIPTION
The completion spinner parameter is mandatory inside program config setting, however, if for some reason it is not, the SDK was producing a hard crash that let the app to remain stuck during the start up process.

This change checks whether this parameter exists, and if not, a null for the whole object is returned instead of producing a runtime Null Pointer Exception.

Related task: [ANDROSDK-2066](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2066)



[ANDROSDK-2066]: https://dhis2.atlassian.net/browse/ANDROSDK-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ