### PR TITLE
fix: [ANDROSDK-2068] Accept null values in Validation Rules functions 

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/parser/internal/service/dataitem/DimensionalItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/parser/internal/service/dataitem/DimensionalItem.kt
@@ -48,9 +48,9 @@ internal abstract class DimensionalItem : ExpressionItem {
         return DOUBLE_VALUE_IF_NULL
     }
 
-    override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {
+    override fun evaluate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any? {
         val value = visitor.itemValueMap[getId(ctx)]
-        return visitor.handleNulls(value, ValueType.NUMBER)!!
+        return visitor.handleNulls(value, ValueType.NUMBER)
     }
 
     override fun regenerate(ctx: ExprContext, visitor: CommonExpressionVisitor): Any {

--- a/core/src/test/java/org/hisp/dhis/android/core/parser/internal/expression/ExpressionServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/parser/internal/expression/ExpressionServiceShould.kt
@@ -298,6 +298,22 @@ class ExpressionServiceShould {
     }
 
     @Test
+    fun evaluate_missing_nested_operands() {
+        val expression = "firstNonNull(${de(dataElementId1)}, ${de(dataElementId2)})"
+        val valueMap: Map<DimensionalItemObject, Double> = mapOf(
+            DataElementOperandObject(dataElementId2, null) to 5.0,
+        )
+
+        val result = service.getExpressionValue(
+            expression,
+            ExpressionServiceContext(valueMap, constantMap, emptyMap()),
+            MissingValueStrategy.NEVER_SKIP,
+        ) as Double?
+
+        assertThat(result).isEqualTo(5.0)
+    }
+
+    @Test
     fun get_dataelement_ids() {
         val expression = de(dataElementId1) + " + " + de(dataElementId2)
         val dataElementOperands = service.getDataElementOperands(expression)

--- a/docs/content/developer/getting-started.md
+++ b/docs/content/developer/getting-started.md
@@ -6,7 +6,7 @@ Include dependency in build.gradle.
 
 ```gradle
 dependencies {
-    implementation "org.hisp.dhis:android-core:1.12.0"
+    implementation "org.hisp.dhis:android-core:1.12.1"
     ...
 }
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-dhis2AndroidSdkVersion = "1.12.0-SNAPSHOT"
-dhis2AndroidSdkCode = "297"
+dhis2AndroidSdkVersion = "1.12.1-SNAPSHOT"
+dhis2AndroidSdkCode = "298"
 
 gradle = "8.6.1"
 kotlin = "2.0.20"


### PR DESCRIPTION
Increases the version number to 1.12.1, which will generate the first snapshot release for this version.

Solves [ANDROSDK-2068](https://dhis2.atlassian.net/browse/ANDROSDK-2068). There was an unnecessary `!!` operator which throw a null pointer when a dataElement value was used inside a function and its value was null (check the added unit test, which was throwing a NullPointerException before).

[ANDROSDK-2068]: https://dhis2.atlassian.net/browse/ANDROSDK-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ