### PR TITLE
chore: [ANDROSDK-2028] add slack integration 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,4 +129,26 @@ pipeline {
             }
         }
     }
+    post {
+        success {
+            sendNotification(env.GIT_BRANCH, '*Build Succeeded*\n', 'good')
+        }
+
+        failure {
+            sendNotification(env.GIT_BRANCH, '*Build Failed*\n', 'bad')
+        }
+    }
+}
+
+def sendNotification(String branch, String messagePrefix, String color){
+   slackSend channel: '#android-sdk-app-ci', color: color, message: messagePrefix+ custom_msg()
+}
+
+def custom_msg(){
+  def BUILD_URL= env.BUILD_URL
+  def JOB_NAME = env.JOB_NAME
+  def BUILD_ID = env.BUILD_ID
+  def BRANCH_NAME = env.GIT_BRANCH
+  def JENKINS_LOG= "*Job:* $JOB_NAME\n *Branch:* $BRANCH_NAME\n *Build Number:* $BUILD_NUMBER (<${BUILD_URL}|Open>)"
+  return JENKINS_LOG
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,10 +130,6 @@ pipeline {
         }
     }
     post {
-        success {
-            sendNotification(env.GIT_BRANCH, '*Build Succeeded*\n', 'good')
-        }
-
         failure {
             sendNotification(env.GIT_BRANCH, '*Build Failed*\n', 'bad')
         }
@@ -141,7 +137,7 @@ pipeline {
 }
 
 def sendNotification(String branch, String messagePrefix, String color){
-   slackSend channel: '#android-sdk-app-ci', color: color, message: messagePrefix+ custom_msg()
+   slackSend channel: '#android-sdk-dev', color: color, message: messagePrefix+ custom_msg()
 }
 
 def custom_msg(){

--- a/core/src/test/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepositoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepositoryShould.kt
@@ -97,6 +97,6 @@ class AnalyticsRepositoryShould {
         verify(analyticsService).evaluate(paramsCaptor.capture())
         val aggregationType = paramsCaptor.firstValue.aggregationType
 
-        assertThat(aggregationType).isEqualTo(AggregationType.MAX) // reverto AggregationType.LAST
+        assertThat(aggregationType).isEqualTo(AggregationType.LAST)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepositoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepositoryShould.kt
@@ -97,6 +97,6 @@ class AnalyticsRepositoryShould {
         verify(analyticsService).evaluate(paramsCaptor.capture())
         val aggregationType = paramsCaptor.firstValue.aggregationType
 
-        assertThat(aggregationType).isEqualTo(AggregationType.LAST)
+        assertThat(aggregationType).isEqualTo(AggregationType.MAX) // reverto AggregationType.LAST
     }
 }


### PR DESCRIPTION
It has been added a function to the jenkins file to allow pipeline logging into a slack channel. It can be decided if a message is only sent when the pipeline fails.

Related task: [ANDROSDK-2028](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2028)

[ANDROSDK-2028]: https://dhis2.atlassian.net/browse/ANDROSDK-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ