### PR TITLE
feat: [ANDROSDK-2048] Add support for 'in' filter in tracker search queries

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3018,8 +3018,9 @@ public final class org/hisp/dhis/android/core/arch/repositories/filters/internal
 	public final fun eq (Ljava/lang/Object;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 }
 
-public final class org/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector {
+public final class org/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector {
 	public final fun eq (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
+	public final fun in (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun like (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 }
 
@@ -14023,12 +14024,12 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 public abstract class org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators {
 	public final fun allowOnlineCache ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public final fun byAssignedUserMode ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
-	public final fun byAttribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector;
-	public final fun byDataValue (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector;
+	public final fun byAttribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector;
+	public final fun byDataValue (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector;
 	public final fun byEnrollmentStatus ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byEventDate ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/PeriodFilterConnector;
 	public final fun byEventStatus ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
-	public final fun byFilter (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector;
+	public final fun byFilter (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector;
 	public final fun byFollowUp ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/BoolFilterConnector;
 	public final fun byIncidentDate ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/PeriodFilterConnector;
 	public final fun byIncludeDeleted ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
@@ -14039,7 +14040,7 @@ public abstract class org/hisp/dhis/android/core/trackedentity/search/TrackedEnt
 	public final fun byProgramDate ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/PeriodFilterConnector;
 	public final fun byProgramStage ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public final fun byProgramStageWorkingList ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
-	public final fun byQuery ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector;
+	public final fun byQuery ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector;
 	public final fun byStates ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byTrackedEntities ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byTrackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallRealIntegrationShould.kt
@@ -144,6 +144,16 @@ class TrackedEntityInstanceQueryCallRealIntegrationShould : BaseRealIntegrationT
     }
 
     // @Test
+    fun query_multiple_tracked_entity_instances_using_in_filter() {
+        login()
+        val queryResponse = repository.onlineOnly()
+            .byFilter("w75KJ2mc4zz").`in`(listOf("Tom", "Evelyn", "John"))
+            .blockingGet()
+
+        assertThat(queryResponse).isNotEmpty()
+    }
+
+    // @Test
     fun throw_exception_for_too_long_list_of_org_units() {
         login()
         val orgUnits = listOf(

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -195,4 +195,13 @@ class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould :
 
         assertThat(trackedEntityInstances.size).isEqualTo(1)
     }
+
+    @Test
+    fun find_by_in_filter() {
+        val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstanceQuery()
+            .offlineOnly()
+            .byFilter("cejWyOfXge6").`in`(listOf("654321", "4081507"))
+            .blockingGet()
+        assertThat(trackedEntityInstances.size).isEqualTo(2)
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould.kt
@@ -204,4 +204,15 @@ class TrackedEntityInstanceQueryCollectionRepositoryMockIntegrationShould :
             .blockingGet()
         assertThat(trackedEntityInstances.size).isEqualTo(2)
     }
+
+    @Test
+    fun find_by_in_data_value() {
+        val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstanceQuery()
+            .offlineOnly()
+            .byProgram().eq("IpHINAT79UW")
+            .byDataValue("g9eOBujte1U").`in`(listOf("false"))
+            .blockingGet()
+
+        assertThat(trackedEntityInstances.size).isEqualTo(1)
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -100,4 +100,14 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
         assertThat(trackedEntity!!.attributeValues!![0].attribute).isEqualTo("cejWyOfXge6")
         assertThat(trackedEntity.attributeValues!![1].attribute).isEqualTo("aejWyOfXge6")
     }
+
+    @Test
+    fun find_by_in_data_value() {
+        val trackedEntityInstances = d2.trackedEntityModule().trackedEntitySearch()
+            .byProgram().eq("IpHINAT79UW")
+            .byDataValue("g9eOBujte1U").`in`(listOf("false"))
+            .blockingGet()
+
+        assertThat(trackedEntityInstances.size).isEqualTo(1)
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeInItemFilterConnector.kt
@@ -32,7 +32,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOpe
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem
 import org.hisp.dhis.android.core.common.FilterOperatorsHelper
 
-class EqLikeItemFilterConnector<R : BaseRepository> internal constructor(
+class EqLikeInItemFilterConnector<R : BaseRepository> internal constructor(
     private val key: String,
     private val repositoryFactory: ScopedRepositoryFilterFactory<R, RepositoryScopeFilterItem>,
 ) {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/EqLikeItemFilterConnector.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.arch.repositories.filters.internal
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOperator
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem
+import org.hisp.dhis.android.core.common.FilterOperatorsHelper
 
 class EqLikeItemFilterConnector<R : BaseRepository> internal constructor(
     private val key: String,
@@ -44,6 +45,12 @@ class EqLikeItemFilterConnector<R : BaseRepository> internal constructor(
     fun like(value: String): R {
         val item = RepositoryScopeFilterItem.builder()
             .key(key).operator(FilterItemOperator.LIKE).value(value).build()
+        return repositoryFactory.updated(item)
+    }
+
+    fun `in`(values: Collection<String>): R {
+        val item = RepositoryScopeFilterItem.builder()
+            .key(key).operator(FilterItemOperator.IN).value(FilterOperatorsHelper.listToStr(values)).build()
         return repositoryFactory.updated(item)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ScopedFilterConnectorFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ScopedFilterConnectorFactory.kt
@@ -51,11 +51,11 @@ internal class ScopedFilterConnectorFactory<R : BaseRepository, S : BaseScope>(
         return BoolFilterConnector { bool: Boolean -> repositoryFactory.updated(baseScopeFactory.updated(bool)) }
     }
 
-    fun eqLikeItemC(
+    fun eqLikeInItemC(
         key: String,
         baseScopeFactory: BaseScopeFactory<S, RepositoryScopeFilterItem>,
-    ): EqLikeItemFilterConnector<R> {
-        return EqLikeItemFilterConnector(key) { item: RepositoryScopeFilterItem ->
+    ): EqLikeInItemFilterConnector<R> {
+        return EqLikeInItemFilterConnector(key) { item: RepositoryScopeFilterItem ->
             repositoryFactory.updated(
                 baseScopeFactory.updated(item),
             )

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
@@ -31,7 +31,7 @@ package org.hisp.dhis.android.core.trackedentity.search
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BoolFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EqFilterConnector
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.EqLikeItemFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.EqLikeInItemFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.PeriodFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
@@ -112,7 +112,7 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
     }
 
     @Deprecated(message = "Use byFilter()", replaceWith = ReplaceWith("byFilter(attributeId)"))
-    fun byAttribute(attributeId: String): EqLikeItemFilterConnector<R> {
+    fun byAttribute(attributeId: String): EqLikeInItemFilterConnector<R> {
         return byFilter(attributeId)
     }
 
@@ -129,8 +129,8 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
      * @param attributeId Attribute uid to use in the filter
      * @return Repository connector
      */
-    fun byFilter(attributeId: String): EqLikeItemFilterConnector<R> {
-        return connectorFactory.eqLikeItemC(attributeId) { filterItem: RepositoryScopeFilterItem ->
+    fun byFilter(attributeId: String): EqLikeInItemFilterConnector<R> {
+        return connectorFactory.eqLikeInItemC(attributeId) { filterItem: RepositoryScopeFilterItem ->
             scopeHelper.addFilter(scope, filterItem)
         }
     }
@@ -139,8 +139,8 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
         message = "This property is ignored for online queries and will be ignored in offline queries soon. " +
             "Please use byFilter to achieve a similar functionality.",
     )
-    fun byQuery(): EqLikeItemFilterConnector<R> {
-        return connectorFactory.eqLikeItemC("") { filterItem: RepositoryScopeFilterItem ->
+    fun byQuery(): EqLikeInItemFilterConnector<R> {
+        return connectorFactory.eqLikeInItemC("") { filterItem: RepositoryScopeFilterItem ->
             scope.toBuilder().query(filterItem).build()
         }
     }
@@ -152,8 +152,8 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
      * @param dataElement DataElement uid to use in the filter
      * @return Repository connector
      */
-    fun byDataValue(dataElement: String): EqLikeItemFilterConnector<R> {
-        return connectorFactory.eqLikeItemC(dataElement) { filterItem: RepositoryScopeFilterItem ->
+    fun byDataValue(dataElement: String): EqLikeInItemFilterConnector<R> {
+        return connectorFactory.eqLikeInItemC(dataElement) { filterItem: RepositoryScopeFilterItem ->
             scope.toBuilder().dataValue(scope.dataValue() + filterItem).build()
         }
     }


### PR DESCRIPTION
This PR introduces **support for filtering tracker entities using a list of values via the** `in` **operator**, enabling more flexible query conditions for attributes and data values. This enhancement supports both online and offline modes and is a prerequisite for the custom intents solution.

#### Key Changes:
- Introduced `EqLikeInItemFilterConnector` to support `in` operator.
- Updated `TrackedEntitySearchOperators.byFilter()` and  `TrackedEntitySearchOperators.byDataValue()` to allow filtering by multiple values using `.in()`.
- Added integration tests for offline and online querying by `in` filter on attributes and data values.