### PR TITLE
chore: [ANDROSDK-2079] add db mappers to usecase, user, validation and visualization

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/adapters/custom/internal/TrackerVisualizationDimensionRepetitionColumnAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/adapters/custom/internal/TrackerVisualizationDimensionRepetitionColumnAdapter.kt
@@ -30,7 +30,7 @@ package org.hisp.dhis.android.core.arch.db.adapters.custom.internal
 import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.visualization.TrackerVisualizationDimensionRepetition
 import org.hisp.dhis.android.persistence.visualization.TrackerVisualizationDimensionRepetitionDB
-import org.hisp.dhis.android.persistence.visualization.TrackerVisualizationDimensionRepetitionDB.Companion.toDB
+import org.hisp.dhis.android.persistence.visualization.TrackerVisualizationDimensionRepetitionDB.Companion.toDBSerializable
 
 internal class TrackerVisualizationDimensionRepetitionColumnAdapter :
     JSONObjectColumnAdapter<TrackerVisualizationDimensionRepetition>() {
@@ -50,7 +50,7 @@ internal class TrackerVisualizationDimensionRepetitionColumnAdapter :
             return o?.let {
                 KotlinxJsonParser.instance.encodeToString(
                     TrackerVisualizationDimensionRepetitionDB.serializer(),
-                    it.toDB(),
+                    it.toDBSerializable(),
                 )
             }
         }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerArrayDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerArrayDB.kt
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.common
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+
+internal object IntegerArrayDB {
+    fun toDomain(value: String?): List<Int> {
+        return if (value == null || value == "") {
+            emptyList()
+        } else {
+            try {
+                return KotlinxJsonParser.instance.decodeFromString(ListSerializer(Int.serializer()), value)
+            } catch (e: SerializationException) {
+                throw SerializationException("Couldn't deserialize integer array")
+            }
+        }
+    }
+
+    fun toDB(value: List<Int>?): String {
+        try {
+            return KotlinxJsonParser.instance.encodeToString(
+                ListSerializer(Int.serializer()), value ?: emptyList()
+            )
+        } catch (e: SerializationException) {
+            throw SerializationException("Couldn't serialize integer array")
+        }
+    }
+
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerArrayDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerArrayDB.kt
@@ -49,11 +49,11 @@ internal object IntegerArrayDB {
     fun toDB(value: List<Int>?): String {
         try {
             return KotlinxJsonParser.instance.encodeToString(
-                ListSerializer(Int.serializer()), value ?: emptyList()
+                ListSerializer(Int.serializer()),
+                value ?: emptyList(),
             )
         } catch (e: SerializationException) {
             throw SerializationException("Couldn't serialize integer array")
         }
     }
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerListDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerListDB.kt
@@ -35,7 +35,7 @@ import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 
 @JvmInline
 internal value class IntegerListDB(
-    val value: String
+    val value: String,
 ) {
     fun toDomain(): List<Int> {
         return if (value == "") {
@@ -56,7 +56,7 @@ internal fun <T : List<Int>> T.toDB(): IntegerListDB {
             KotlinxJsonParser.instance.encodeToString(
                 ListSerializer(Int.serializer()),
                 this,
-            )
+            ),
         )
     } catch (e: SerializationException) {
         throw SerializationException("Couldn't serialize integer array")

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerListDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/IntegerListDB.kt
@@ -33,9 +33,12 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 
-internal object IntegerArrayDB {
-    fun toDomain(value: String?): List<Int> {
-        return if (value == null || value == "") {
+@JvmInline
+internal value class IntegerListDB(
+    val value: String
+) {
+    fun toDomain(): List<Int> {
+        return if (value == "") {
             emptyList()
         } else {
             try {
@@ -45,15 +48,17 @@ internal object IntegerArrayDB {
             }
         }
     }
+}
 
-    fun toDB(value: List<Int>?): String {
-        try {
-            return KotlinxJsonParser.instance.encodeToString(
+internal fun <T : List<Int>> T.toDB(): IntegerListDB {
+    try {
+        return IntegerListDB(
+            KotlinxJsonParser.instance.encodeToString(
                 ListSerializer(Int.serializer()),
-                value ?: emptyList(),
+                this,
             )
-        } catch (e: SerializationException) {
-            throw SerializationException("Couldn't serialize integer array")
-        }
+        )
+    } catch (e: SerializationException) {
+        throw SerializationException("Couldn't serialize integer array")
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDB.kt
@@ -56,4 +56,3 @@ internal fun InternalStockUseCase.toDB(): StockUseCaseDB {
         stockOnHand = stockOnHand(),
     )
 }
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDB.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.usecase.stock.InternalStockUseCase
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
 @Entity(
@@ -33,9 +34,10 @@ internal data class StockUseCaseDB(
     val programType: String?,
     val description: String?,
     val stockOnHand: String?,
-) {
-    fun toDomain(): InternalStockUseCase {
+) : EntityDB<InternalStockUseCase> {
+    override fun toDomain(): InternalStockUseCase {
         return InternalStockUseCase.builder()
+            .id(id?.toLong())
             .uid(uid)
             .itemCode(itemCode)
             .itemDescription(itemDescription)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDB.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.usecase.stock.InternalStockUseCase
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
 @Entity(
@@ -32,4 +33,27 @@ internal data class StockUseCaseDB(
     val programType: String?,
     val description: String?,
     val stockOnHand: String?,
-)
+) {
+    fun toDomain(): InternalStockUseCase {
+        return InternalStockUseCase.builder()
+            .uid(uid)
+            .itemCode(itemCode)
+            .itemDescription(itemDescription)
+            .programType(programType)
+            .description(description)
+            .stockOnHand(stockOnHand)
+            .build()
+    }
+}
+
+internal fun InternalStockUseCase.toDB(): StockUseCaseDB {
+    return StockUseCaseDB(
+        uid = uid(),
+        itemCode = itemCode(),
+        itemDescription = itemDescription(),
+        programType = programType(),
+        description = description(),
+        stockOnHand = stockOnHand(),
+    )
+}
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionDB.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.usecase.stock.InternalStockUseCaseTransaction
 
 @Entity(
     tableName = "StockUseCaseTransaction",
@@ -32,4 +33,29 @@ internal data class StockUseCaseTransactionDB(
     val stockDistributed: String?,
     val stockDiscarded: String?,
     val stockCount: String?,
-)
+) {
+    fun toDomain(): InternalStockUseCaseTransaction {
+        return InternalStockUseCaseTransaction.builder()
+            .programUid(programUid)
+            .sortOrder(sortOrder)
+            .transactionType(transactionType)
+            .distributedTo(distributedTo)
+            .stockDistributed(stockDistributed)
+            .stockDiscarded(stockDiscarded)
+            .stockCount(stockCount)
+            .build()
+    }
+}
+
+internal fun InternalStockUseCaseTransaction.toDB(): StockUseCaseTransactionDB {
+    return StockUseCaseTransactionDB(
+        programUid = programUid()!!,
+        sortOrder = sortOrder(),
+        transactionType = transactionType(),
+        distributedTo = distributedTo(),
+        stockDistributed = stockDistributed(),
+        stockDiscarded = stockDiscarded(),
+        stockCount = stockCount(),
+    )
+}
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionDB.kt
@@ -58,4 +58,3 @@ internal fun InternalStockUseCaseTransaction.toDB(): StockUseCaseTransactionDB {
         stockCount = stockCount(),
     )
 }
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthenticatedUserDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthenticatedUserDB.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.AuthenticatedUser
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "AuthenticatedUser",
@@ -28,9 +29,11 @@ internal data class AuthenticatedUserDB(
     val id: Int? = 0,
     val user: String,
     val hash: String?,
-) {
-    fun toDomain(): AuthenticatedUser {
+) : EntityDB<AuthenticatedUser> {
+
+    override fun toDomain(): AuthenticatedUser {
         return AuthenticatedUser.builder()
+            .id(id?.toLong())
             .hash(hash)
             .user(user)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthenticatedUserDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthenticatedUserDB.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.user.AuthenticatedUser
 
 @Entity(
     tableName = "AuthenticatedUser",
@@ -27,4 +28,18 @@ internal data class AuthenticatedUserDB(
     val id: Int? = 0,
     val user: String,
     val hash: String?,
-)
+) {
+    fun toDomain(): AuthenticatedUser {
+        return AuthenticatedUser.builder()
+            .hash(hash)
+            .user(user)
+            .build()
+    }
+}
+
+internal fun AuthenticatedUser.toDB(): AuthenticatedUserDB {
+    return AuthenticatedUserDB(
+        user = user()!!,
+        hash = hash(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDB.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.Authority
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(tableName = "Authority")
 internal data class AuthorityDB(
@@ -11,9 +12,11 @@ internal data class AuthorityDB(
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
     val name: String?,
-) {
-    fun toDomain(): Authority {
+) : EntityDB<Authority> {
+
+    override fun toDomain(): Authority {
         return Authority.builder()
+            .id(id?.toLong())
             .name(name)
             .build()
     }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDB.kt
@@ -3,7 +3,6 @@ package org.hisp.dhis.android.persistence.user
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import org.hisp.dhis.android.core.user.AuthenticatedUser
 import org.hisp.dhis.android.core.user.Authority
 
 @Entity(tableName = "Authority")
@@ -25,4 +24,3 @@ internal fun Authority.toDB(): AuthorityDB {
         name = name(),
     )
 }
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDB.kt
@@ -3,6 +3,8 @@ package org.hisp.dhis.android.persistence.user
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.user.AuthenticatedUser
+import org.hisp.dhis.android.core.user.Authority
 
 @Entity(tableName = "Authority")
 internal data class AuthorityDB(
@@ -10,4 +12,17 @@ internal data class AuthorityDB(
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
     val name: String?,
-)
+) {
+    fun toDomain(): Authority {
+        return Authority.builder()
+            .name(name)
+            .build()
+    }
+}
+
+internal fun Authority.toDB(): AuthorityDB {
+    return AuthorityDB(
+        name = name(),
+    )
+}
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
@@ -6,9 +6,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "User",
@@ -43,29 +43,24 @@ internal data class UserDB(
 ) : EntityDB<User>, BaseIdentifiableObjectDB {
 
     override fun toDomain(): User {
-        return User.builder()
-            .id(id?.toLong())
-            .uid(uid)
-            .code(code)
-            .name(name)
-            .displayName(displayName)
-            .created(created.toJavaDate())
-            .lastUpdated(lastUpdated.toJavaDate())
-            .birthday(birthday)
-            .education(education)
-            .gender(gender)
-            .jobTitle(jobTitle)
-            .surname(surname)
-            .firstName(firstName)
-            .introduction(introduction)
-            .employer(employer)
-            .interests(interests)
-            .languages(languages)
-            .email(email)
-            .phoneNumber(phoneNumber)
-            .nationality(nationality)
-            .username(username)
-            .build()
+        return User.builder().apply {
+            applyBaseIdentifiableFields(this@UserDB)
+            id(id?.toLong())
+            birthday(birthday)
+            education(education)
+            gender(gender)
+            jobTitle(jobTitle)
+            surname(surname)
+            firstName(firstName)
+            introduction(introduction)
+            employer(employer)
+            interests(interests)
+            languages(languages)
+            email(email)
+            phoneNumber(phoneNumber)
+            nationality(nationality)
+            username(username)
+        }.build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
@@ -4,6 +4,9 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.user.User
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
 
 @Entity(
     tableName = "User",
@@ -35,4 +38,56 @@ internal data class UserDB(
     val phoneNumber: String?,
     val nationality: String?,
     val username: String?,
-)
+) {
+    fun toDomain(): User {
+        return User.builder()
+            .uid(uid)
+            .code(code)
+            .name(name)
+            .displayName(displayName)
+            .created(created.toJavaDate())
+            .lastUpdated(lastUpdated.toJavaDate())
+            .birthday(birthday)
+            .education(education)
+            .gender(gender)
+            .jobTitle(jobTitle)
+            .surname(surname)
+            .firstName(firstName)
+            .introduction(introduction)
+            .employer(employer)
+            .interests(interests)
+            .languages(languages)
+            .email(email)
+            .phoneNumber(phoneNumber)
+            .nationality(nationality)
+            .username(username)
+            .build()
+    }
+}
+
+internal fun User.toDB(): UserDB {
+    return UserDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+        birthday = birthday(),
+        education = education(),
+        gender = gender(),
+        jobTitle = jobTitle(),
+        surname = surname(),
+        firstName = firstName(),
+        introduction = introduction(),
+        employer = employer(),
+        interests = interests(),
+        languages = languages(),
+        email = email(),
+        phoneNumber = phoneNumber(),
+        nationality = nationality(),
+        username = username(),
+    )
+}
+
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
@@ -89,5 +89,3 @@ internal fun User.toDB(): UserDB {
         username = username(),
     )
 }
-
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDB.kt
@@ -7,6 +7,8 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "User",
@@ -18,12 +20,12 @@ internal data class UserDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val birthday: String?,
     val education: String?,
     val gender: String?,
@@ -38,9 +40,11 @@ internal data class UserDB(
     val phoneNumber: String?,
     val nationality: String?,
     val username: String?,
-) {
-    fun toDomain(): User {
+) : EntityDB<User>, BaseIdentifiableObjectDB {
+
+    override fun toDomain(): User {
         return User.builder()
+            .id(id?.toLong())
             .uid(uid)
             .code(code)
             .name(name)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
@@ -7,6 +7,8 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.UserGroup
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "UserGroup",
@@ -18,15 +20,17 @@ internal data class UserGroupDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
-) {
-    fun toDomain(): UserGroup {
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
+) : EntityDB<UserGroup>, BaseIdentifiableObjectDB {
+
+    override fun toDomain(): UserGroup {
         return UserGroup.builder()
+            .id(id?.toLong())
             .uid(uid)
             .code(code)
             .name(name)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
@@ -4,6 +4,10 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.user.Authority
+import org.hisp.dhis.android.core.user.UserGroup
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
 
 @Entity(
     tableName = "UserGroup",
@@ -21,4 +25,28 @@ internal data class UserGroupDB(
     val displayName: String?,
     val created: String?,
     val lastUpdated: String?,
-)
+) {
+    fun toDomain(): UserGroup {
+        return UserGroup.builder()
+            .uid(uid)
+            .code(code)
+            .name(name)
+            .displayName(displayName)
+            .created(created.toJavaDate())
+            .lastUpdated(lastUpdated.toJavaDate())
+            .build()
+    }
+}
+
+internal fun UserGroup.toDB(): UserGroupDB {
+    return UserGroupDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+    )
+}
+
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
@@ -6,9 +6,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.UserGroup
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "UserGroup",
@@ -29,15 +29,10 @@ internal data class UserGroupDB(
 ) : EntityDB<UserGroup>, BaseIdentifiableObjectDB {
 
     override fun toDomain(): UserGroup {
-        return UserGroup.builder()
-            .id(id?.toLong())
-            .uid(uid)
-            .code(code)
-            .name(name)
-            .displayName(displayName)
-            .created(created.toJavaDate())
-            .lastUpdated(lastUpdated.toJavaDate())
-            .build()
+        return UserGroup.builder().apply {
+            applyBaseIdentifiableFields(this@UserGroupDB)
+            id(id?.toLong())
+        }.build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDB.kt
@@ -4,7 +4,6 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import org.hisp.dhis.android.core.user.Authority
 import org.hisp.dhis.android.core.user.UserGroup
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
@@ -48,5 +47,3 @@ internal fun UserGroup.toDB(): UserGroupDB {
         lastUpdated = lastUpdated().dateFormat(),
     )
 }
-
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
@@ -53,5 +53,3 @@ internal fun UserOrganisationUnitLink.toDB(): UserOrganisationUnitDB {
         userAssigned = userAssigned(),
     )
 }
-
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.user.UserOrganisationUnitLink
 
 @Entity(
     tableName = "UserOrganisationUnit",
@@ -29,6 +30,28 @@ internal data class UserOrganisationUnitDB(
     val user: String,
     val organisationUnit: String,
     val organisationUnitScope: String,
-    val root: Int?,
-    val userAssigned: Int?,
-)
+    val root: Boolean?,
+    val userAssigned: Boolean?,
+) {
+    fun toDomain(): UserOrganisationUnitLink {
+        return UserOrganisationUnitLink.builder()
+            .user(user)
+            .organisationUnit(organisationUnit)
+            .organisationUnitScope(organisationUnitScope)
+            .root(root)
+            .userAssigned(userAssigned)
+            .build()
+    }
+}
+
+internal fun UserOrganisationUnitLink.toDB(): UserOrganisationUnitDB {
+    return UserOrganisationUnitDB(
+        user = user(),
+        organisationUnit = organisationUnit(),
+        organisationUnitScope = organisationUnitScope(),
+        root = root(),
+        userAssigned = userAssigned(),
+    )
+}
+
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLink
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "UserOrganisationUnit",
@@ -32,9 +33,11 @@ internal data class UserOrganisationUnitDB(
     val organisationUnitScope: String,
     val root: Boolean?,
     val userAssigned: Boolean?,
-) {
-    fun toDomain(): UserOrganisationUnitLink {
+) : EntityDB<UserOrganisationUnitLink> {
+
+    override fun toDomain(): UserOrganisationUnitLink {
         return UserOrganisationUnitLink.builder()
+            .id(id?.toLong())
             .user(user)
             .organisationUnit(organisationUnit)
             .organisationUnitScope(organisationUnitScope)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
@@ -6,9 +6,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.UserRole
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "UserRole",
@@ -29,15 +29,10 @@ internal data class UserRoleDB(
 ) : EntityDB<UserRole>, BaseIdentifiableObjectDB {
 
     override fun toDomain(): UserRole {
-        return UserRole.builder()
-            .id(id?.toLong())
-            .uid(uid)
-            .code(code)
-            .name(name)
-            .displayName(displayName)
-            .created(created.toJavaDate())
-            .lastUpdated(lastUpdated.toJavaDate())
-            .build()
+        return UserRole.builder().apply {
+            applyBaseIdentifiableFields(this@UserRoleDB)
+            id(id?.toLong())
+        }.build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
@@ -45,6 +45,5 @@ internal fun UserRole.toDB(): UserRoleDB {
         displayName = displayName(),
         created = created().dateFormat(),
         lastUpdated = lastUpdated().dateFormat(),
-
-        )
+    )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
@@ -7,6 +7,8 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.user.UserRole
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "UserRole",
@@ -18,15 +20,17 @@ internal data class UserRoleDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
-) {
-    fun toDomain(): UserRole {
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
+) : EntityDB<UserRole>, BaseIdentifiableObjectDB {
+
+    override fun toDomain(): UserRole {
         return UserRole.builder()
+            .id(id?.toLong())
             .uid(uid)
             .code(code)
             .name(name)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDB.kt
@@ -4,6 +4,9 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.user.UserRole
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
 
 @Entity(
     tableName = "UserRole",
@@ -21,4 +24,27 @@ internal data class UserRoleDB(
     val displayName: String?,
     val created: String?,
     val lastUpdated: String?,
-)
+) {
+    fun toDomain(): UserRole {
+        return UserRole.builder()
+            .uid(uid)
+            .code(code)
+            .name(name)
+            .displayName(displayName)
+            .created(created.toJavaDate())
+            .lastUpdated(lastUpdated.toJavaDate())
+            .build()
+    }
+}
+
+internal fun UserRole.toDB(): UserRoleDB {
+    return UserRoleDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+
+        )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.validation.DataSetValidationRuleLink
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataset.DataSetDB
 
 @Entity(
@@ -38,9 +39,10 @@ internal data class DataSetValidationRuleLinkDB(
     val id: Int? = 0,
     val dataSet: String,
     val validationRule: String,
-) {
-    fun toDomain(): DataSetValidationRuleLink {
+) : EntityDB<DataSetValidationRuleLink> {
+    override fun toDomain(): DataSetValidationRuleLink {
         return DataSetValidationRuleLink.builder()
+            .id(id?.toLong())
             .dataSet(dataSet)
             .validationRule(validationRule)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
@@ -40,6 +40,7 @@ internal data class DataSetValidationRuleLinkDB(
     val dataSet: String,
     val validationRule: String,
 ) : EntityDB<DataSetValidationRuleLink> {
+
     override fun toDomain(): DataSetValidationRuleLink {
         return DataSetValidationRuleLink.builder()
             .id(id?.toLong())

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.validation.DataSetValidationRuleLink
 import org.hisp.dhis.android.persistence.dataset.DataSetDB
 
 @Entity(
@@ -37,4 +38,18 @@ internal data class DataSetValidationRuleLinkDB(
     val id: Int? = 0,
     val dataSet: String,
     val validationRule: String,
-)
+) {
+    fun toDomain(): DataSetValidationRuleLink {
+        return DataSetValidationRuleLink.builder()
+            .dataSet(dataSet)
+            .validationRule(validationRule)
+            .build()
+    }
+}
+
+internal fun DataSetValidationRuleLink.toDB(): DataSetValidationRuleLinkDB {
+    return DataSetValidationRuleLinkDB(
+        dataSet = dataSet()!!,
+        validationRule = validationRule()!!,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
@@ -6,7 +6,6 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.core.validation.MissingValueStrategy
 import org.hisp.dhis.android.core.validation.ValidationRule
 import org.hisp.dhis.android.core.validation.ValidationRuleExpression
@@ -15,6 +14,7 @@ import org.hisp.dhis.android.core.validation.ValidationRuleOperator
 import org.hisp.dhis.android.persistence.common.BaseNameableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.IntegerListDB
+import org.hisp.dhis.android.persistence.common.applyBaseNameableFields
 import org.hisp.dhis.android.persistence.common.toDB
 
 @Entity(
@@ -50,40 +50,32 @@ internal data class ValidationRuleDB(
     val rightSideMissingValueStrategy: String?,
     val organisationUnitLevels: IntegerListDB?,
 ) : EntityDB<ValidationRule>, BaseNameableObjectDB {
+
     override fun toDomain(): ValidationRule {
-        return ValidationRule.builder()
-            .id(id?.toLong())
-            .uid(uid)
-            .code(code)
-            .name(name)
-            .displayName(displayName)
-            .created(created?.toJavaDate())
-            .lastUpdated(lastUpdated?.toJavaDate())
-            .shortName(shortName)
-            .displayShortName(displayShortName)
-            .description(description)
-            .displayDescription(displayDescription)
-            .instruction(instruction)
-            .importance(importance?.let { ValidationRuleImportance.valueOf(it) })
-            .operator(operator?.let { ValidationRuleOperator.valueOf(it) })
-            .periodType(periodType?.let { PeriodType.valueOf(it) })
-            .skipFormValidation(skipFormValidation)
-            .leftSide(
+        return ValidationRule.builder().apply {
+            applyBaseNameableFields(this@ValidationRuleDB)
+            id(id?.toLong())
+            instruction(instruction)
+            importance(importance?.let { ValidationRuleImportance.valueOf(it) })
+            operator(operator?.let { ValidationRuleOperator.valueOf(it) })
+            periodType(periodType?.let { PeriodType.valueOf(it) })
+            skipFormValidation(skipFormValidation)
+            leftSide(
                 ValidationRuleExpression.builder()
                     .expression(leftSideExpression)
                     .description(leftSideDescription)
                     .missingValueStrategy(leftSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
                     .build(),
             )
-            .rightSide(
+            rightSide(
                 ValidationRuleExpression.builder()
                     .expression(rightSideExpression)
                     .description(rightSideDescription)
                     .missingValueStrategy(rightSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
                     .build(),
             )
-            .organisationUnitLevels(organisationUnitLevels?.toDomain())
-            .build()
+            organisationUnitLevels(organisationUnitLevels?.toDomain())
+        }.build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
@@ -69,14 +69,14 @@ internal data class ValidationRuleDB(
                     .expression(leftSideExpression)
                     .description(leftSideDescription)
                     .missingValueStrategy(leftSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
-                    .build()
+                    .build(),
             )
             .rightSide(
                 ValidationRuleExpression.builder()
                     .expression(rightSideExpression)
                     .description(rightSideDescription)
                     .missingValueStrategy(rightSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
-                    .build()
+                    .build(),
             )
             .organisationUnitLevels(IntegerArrayDB.toDomain(organisationUnitLevels))
             .build()
@@ -106,6 +106,6 @@ internal fun ValidationRule.toDB(): ValidationRuleDB {
         rightSideExpression = rightSide().expression(),
         rightSideDescription = rightSide().description(),
         rightSideMissingValueStrategy = rightSide().missingValueStrategy()?.name,
-        organisationUnitLevels = IntegerArrayDB.toDB(organisationUnitLevels())
+        organisationUnitLevels = IntegerArrayDB.toDB(organisationUnitLevels()),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
@@ -12,7 +12,9 @@ import org.hisp.dhis.android.core.validation.ValidationRule
 import org.hisp.dhis.android.core.validation.ValidationRuleExpression
 import org.hisp.dhis.android.core.validation.ValidationRuleImportance
 import org.hisp.dhis.android.core.validation.ValidationRuleOperator
-import org.hisp.dhis.android.persistence.common.IntegerArrayDB
+import org.hisp.dhis.android.persistence.common.BaseNameableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.IntegerArrayDBMapper
 
 @Entity(
     tableName = "ValidationRule",
@@ -24,16 +26,16 @@ internal data class ValidationRuleDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
-    val shortName: String?,
-    val displayShortName: String?,
-    val description: String?,
-    val displayDescription: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
+    override val shortName: String?,
+    override val displayShortName: String?,
+    override val description: String?,
+    override val displayDescription: String?,
     val instruction: String?,
     val importance: String?,
     val operator: String?,
@@ -46,9 +48,10 @@ internal data class ValidationRuleDB(
     val rightSideDescription: String?,
     val rightSideMissingValueStrategy: String?,
     val organisationUnitLevels: String?,
-) {
-    fun toDomain(): ValidationRule {
+) : EntityDB<ValidationRule>, BaseNameableObjectDB {
+    override fun toDomain(): ValidationRule {
         return ValidationRule.builder()
+            .id(id?.toLong())
             .uid(uid)
             .code(code)
             .name(name)
@@ -78,7 +81,7 @@ internal data class ValidationRuleDB(
                     .missingValueStrategy(rightSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
                     .build(),
             )
-            .organisationUnitLevels(IntegerArrayDB.toDomain(organisationUnitLevels))
+            .organisationUnitLevels(IntegerArrayDBMapper.toDomain(organisationUnitLevels))
             .build()
     }
 }
@@ -106,6 +109,6 @@ internal fun ValidationRule.toDB(): ValidationRuleDB {
         rightSideExpression = rightSide().expression(),
         rightSideDescription = rightSide().description(),
         rightSideMissingValueStrategy = rightSide().missingValueStrategy()?.name,
-        organisationUnitLevels = IntegerArrayDB.toDB(organisationUnitLevels()),
+        organisationUnitLevels = IntegerArrayDBMapper.toDB(organisationUnitLevels()),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
@@ -14,7 +14,8 @@ import org.hisp.dhis.android.core.validation.ValidationRuleImportance
 import org.hisp.dhis.android.core.validation.ValidationRuleOperator
 import org.hisp.dhis.android.persistence.common.BaseNameableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
-import org.hisp.dhis.android.persistence.common.IntegerArrayDBMapper
+import org.hisp.dhis.android.persistence.common.IntegerListDB
+import org.hisp.dhis.android.persistence.common.toDB
 
 @Entity(
     tableName = "ValidationRule",
@@ -47,7 +48,7 @@ internal data class ValidationRuleDB(
     val rightSideExpression: String?,
     val rightSideDescription: String?,
     val rightSideMissingValueStrategy: String?,
-    val organisationUnitLevels: String?,
+    val organisationUnitLevels: IntegerListDB?,
 ) : EntityDB<ValidationRule>, BaseNameableObjectDB {
     override fun toDomain(): ValidationRule {
         return ValidationRule.builder()
@@ -81,7 +82,7 @@ internal data class ValidationRuleDB(
                     .missingValueStrategy(rightSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
                     .build(),
             )
-            .organisationUnitLevels(IntegerArrayDBMapper.toDomain(organisationUnitLevels))
+            .organisationUnitLevels(organisationUnitLevels?.toDomain())
             .build()
     }
 }
@@ -109,6 +110,6 @@ internal fun ValidationRule.toDB(): ValidationRuleDB {
         rightSideExpression = rightSide().expression(),
         rightSideDescription = rightSide().description(),
         rightSideMissingValueStrategy = rightSide().missingValueStrategy()?.name,
-        organisationUnitLevels = IntegerArrayDBMapper.toDB(organisationUnitLevels()),
+        organisationUnitLevels = organisationUnitLevels()?.toDB(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
@@ -4,6 +4,17 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.validation.MissingValueStrategy
+import org.hisp.dhis.android.core.validation.ValidationRule
+import org.hisp.dhis.android.core.validation.ValidationRuleExpression
+import org.hisp.dhis.android.core.validation.ValidationRuleImportance
+import org.hisp.dhis.android.core.validation.ValidationRuleOperator
 
 @Entity(
     tableName = "ValidationRule",
@@ -29,7 +40,7 @@ internal data class ValidationRuleDB(
     val importance: String?,
     val operator: String?,
     val periodType: String?,
-    val skipFormValidation: Int?,
+    val skipFormValidation: Boolean?,
     val leftSideExpression: String?,
     val leftSideDescription: String?,
     val leftSideMissingValueStrategy: String?,
@@ -37,4 +48,73 @@ internal data class ValidationRuleDB(
     val rightSideDescription: String?,
     val rightSideMissingValueStrategy: String?,
     val organisationUnitLevels: String?,
-)
+) {
+    fun toDomain(): ValidationRule {
+        return ValidationRule.builder()
+            .uid(uid)
+            .code(code)
+            .name(name)
+            .displayName(displayName)
+            .created(created?.toJavaDate())
+            .lastUpdated(lastUpdated?.toJavaDate())
+            .shortName(shortName)
+            .displayShortName(displayShortName)
+            .description(description)
+            .displayDescription(displayDescription)
+            .instruction(instruction)
+            .importance(importance?.let { ValidationRuleImportance.valueOf(it) })
+            .operator(operator?.let { ValidationRuleOperator.valueOf(it) })
+            .periodType(periodType?.let { PeriodType.valueOf(it) })
+            .skipFormValidation(skipFormValidation)
+            .leftSide(
+                ValidationRuleExpression.builder()
+                    .expression(leftSideExpression)
+                    .description(leftSideDescription)
+                    .missingValueStrategy(leftSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
+                    .build()
+            )
+            .rightSide(
+                ValidationRuleExpression.builder()
+                    .expression(rightSideExpression)
+                    .description(rightSideDescription)
+                    .missingValueStrategy(rightSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
+                    .build()
+            )
+            .organisationUnitLevels(
+                organisationUnitLevels?.let {
+                    KotlinxJsonParser.instance.decodeFromString(ListSerializer(Int.serializer()), it)
+                } ?: emptyList()
+            )
+            .build()
+    }
+}
+
+internal fun ValidationRule.toDB(): ValidationRuleDB {
+    return ValidationRuleDB(
+        uid = uid()!!,
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        shortName = shortName(),
+        displayShortName = displayShortName(),
+        description = description(),
+        displayDescription = displayDescription(),
+        instruction = instruction(),
+        importance = importance()?.name,
+        operator = operator()?.name,
+        periodType = periodType()?.name,
+        skipFormValidation = skipFormValidation(),
+        leftSideExpression = leftSide().expression(),
+        leftSideDescription = leftSide().description(),
+        leftSideMissingValueStrategy = leftSide().missingValueStrategy()?.name,
+        rightSideExpression = rightSide().expression(),
+        rightSideDescription = rightSide().description(),
+        rightSideMissingValueStrategy = rightSide().missingValueStrategy()?.name,
+        organisationUnitLevels = KotlinxJsonParser.instance.encodeToString(
+            ListSerializer(Int.serializer()),
+            organisationUnitLevels() ?: emptyList()
+        )
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDB.kt
@@ -4,9 +4,6 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.serializer
-import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
@@ -15,6 +12,7 @@ import org.hisp.dhis.android.core.validation.ValidationRule
 import org.hisp.dhis.android.core.validation.ValidationRuleExpression
 import org.hisp.dhis.android.core.validation.ValidationRuleImportance
 import org.hisp.dhis.android.core.validation.ValidationRuleOperator
+import org.hisp.dhis.android.persistence.common.IntegerArrayDB
 
 @Entity(
     tableName = "ValidationRule",
@@ -80,11 +78,7 @@ internal data class ValidationRuleDB(
                     .missingValueStrategy(rightSideMissingValueStrategy?.let { MissingValueStrategy.valueOf(it) })
                     .build()
             )
-            .organisationUnitLevels(
-                organisationUnitLevels?.let {
-                    KotlinxJsonParser.instance.decodeFromString(ListSerializer(Int.serializer()), it)
-                } ?: emptyList()
-            )
+            .organisationUnitLevels(IntegerArrayDB.toDomain(organisationUnitLevels))
             .build()
     }
 }
@@ -112,9 +106,6 @@ internal fun ValidationRule.toDB(): ValidationRuleDB {
         rightSideExpression = rightSide().expression(),
         rightSideDescription = rightSide().description(),
         rightSideMissingValueStrategy = rightSide().missingValueStrategy()?.name,
-        organisationUnitLevels = KotlinxJsonParser.instance.encodeToString(
-            ListSerializer(Int.serializer()),
-            organisationUnitLevels() ?: emptyList()
-        )
+        organisationUnitLevels = IntegerArrayDB.toDB(organisationUnitLevels())
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/RepetitionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/RepetitionDB.kt
@@ -28,24 +28,30 @@
 
 package org.hisp.dhis.android.persistence.visualization
 
-import kotlinx.serialization.Serializable
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.visualization.TrackerVisualizationDimensionRepetition
+import org.hisp.dhis.android.persistence.visualization.TrackerVisualizationDimensionRepetitionDB.Companion.toDBSerializable
 
-@Serializable
-internal data class TrackerVisualizationDimensionRepetitionDB(
-    val indexes: List<Int>?,
+@JvmInline
+internal value class RepetitionDB(
+    val value: String,
 ) {
     fun toDomain(): TrackerVisualizationDimensionRepetition {
-        return TrackerVisualizationDimensionRepetition.builder()
-            .indexes(indexes)
-            .build()
-    }
-
-    companion object {
-        fun TrackerVisualizationDimensionRepetition.toDBSerializable(): TrackerVisualizationDimensionRepetitionDB {
-            return TrackerVisualizationDimensionRepetitionDB(
-                indexes = this.indexes(),
-            )
+        return value.let {
+            KotlinxJsonParser.instance.decodeFromString<TrackerVisualizationDimensionRepetitionDB>(
+                it,
+            ).toDomain()
         }
     }
+}
+
+internal fun TrackerVisualizationDimensionRepetition.toDB(): RepetitionDB {
+    return RepetitionDB(
+        this.let {
+            KotlinxJsonParser.instance.encodeToString(
+                TrackerVisualizationDimensionRepetitionDB.serializer(),
+                it.toDBSerializable(),
+            )
+        },
+    )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
@@ -5,6 +5,12 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.visualization.TrackerVisualization
+import org.hisp.dhis.android.core.visualization.TrackerVisualizationOutputType
+import org.hisp.dhis.android.core.visualization.TrackerVisualizationType
 import org.hisp.dhis.android.persistence.program.ProgramDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityTypeDB
@@ -58,4 +64,41 @@ internal data class TrackerVisualizationDB(
     val program: String?,
     val programStage: String?,
     val trackedEntityType: String?,
-)
+) {
+    fun toDomain(): TrackerVisualization {
+        return TrackerVisualization.builder()
+            .uid(uid)
+            .code(code)
+            .name(name)
+            .displayName(displayName)
+            .created(created.toJavaDate())
+            .lastUpdated(lastUpdated.toJavaDate())
+            .description(description)
+            .displayDescription(displayDescription)
+            .type(type?.let { TrackerVisualizationType.valueOf(it) })
+            .outputType(outputType?.let { TrackerVisualizationOutputType.valueOf(it) })
+            .program(ObjectWithUid.create(program))
+            .programStage(ObjectWithUid.create(programStage))
+            .trackedEntityType(ObjectWithUid.create(trackedEntityType))
+            .build()
+    }
+}
+
+internal fun TrackerVisualization.toDB(): TrackerVisualizationDB {
+    return TrackerVisualizationDB(
+        uid = this.uid(),
+        code = this.code(),
+        name = this.name(),
+        displayName = this.displayName(),
+        created = this.created().dateFormat(),
+        lastUpdated = this.lastUpdated().dateFormat(),
+        description = this.description(),
+        displayDescription = this.displayDescription(),
+        type = this.type()?.name,
+        outputType = this.outputType()?.name,
+        program = this.program()?.uid(),
+        programStage = this.programStage()?.uid(),
+        trackedEntityType = this.trackedEntityType()?.uid(),
+    )
+}
+

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
@@ -101,4 +101,3 @@ internal fun TrackerVisualization.toDB(): TrackerVisualizationDB {
         trackedEntityType = this.trackedEntityType()?.uid(),
     )
 }
-

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
@@ -7,12 +7,12 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.core.visualization.TrackerVisualization
 import org.hisp.dhis.android.core.visualization.TrackerVisualizationOutputType
 import org.hisp.dhis.android.core.visualization.TrackerVisualizationType
 import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 import org.hisp.dhis.android.persistence.program.ProgramDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityTypeDB
@@ -68,22 +68,17 @@ internal data class TrackerVisualizationDB(
     val trackedEntityType: String?,
 ) : EntityDB<TrackerVisualization>, BaseIdentifiableObjectDB {
     override fun toDomain(): TrackerVisualization {
-        return TrackerVisualization.builder()
-            .id(id?.toLong())
-            .uid(uid)
-            .code(code)
-            .name(name)
-            .displayName(displayName)
-            .created(created.toJavaDate())
-            .lastUpdated(lastUpdated.toJavaDate())
-            .description(description)
-            .displayDescription(displayDescription)
-            .type(type?.let { TrackerVisualizationType.valueOf(it) })
-            .outputType(outputType?.let { TrackerVisualizationOutputType.valueOf(it) })
-            .program(ObjectWithUid.create(program))
-            .programStage(ObjectWithUid.create(programStage))
-            .trackedEntityType(ObjectWithUid.create(trackedEntityType))
-            .build()
+        return TrackerVisualization.builder().apply {
+            applyBaseIdentifiableFields(this@TrackerVisualizationDB)
+            id(id?.toLong())
+            description(description)
+            displayDescription(displayDescription)
+            type(type?.let { TrackerVisualizationType.valueOf(it) })
+            outputType(outputType?.let { TrackerVisualizationOutputType.valueOf(it) })
+            program(ObjectWithUid.create(program))
+            programStage(ObjectWithUid.create(programStage))
+            trackedEntityType(ObjectWithUid.create(trackedEntityType))
+        }.build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDB.kt
@@ -11,6 +11,8 @@ import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.core.visualization.TrackerVisualization
 import org.hisp.dhis.android.core.visualization.TrackerVisualizationOutputType
 import org.hisp.dhis.android.core.visualization.TrackerVisualizationType
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityTypeDB
@@ -51,12 +53,12 @@ internal data class TrackerVisualizationDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val description: String?,
     val displayDescription: String?,
     val type: String?,
@@ -64,9 +66,10 @@ internal data class TrackerVisualizationDB(
     val program: String?,
     val programStage: String?,
     val trackedEntityType: String?,
-) {
-    fun toDomain(): TrackerVisualization {
+) : EntityDB<TrackerVisualization>, BaseIdentifiableObjectDB {
+    override fun toDomain(): TrackerVisualization {
         return TrackerVisualization.builder()
+            .id(id?.toLong())
             .uid(uid)
             .code(code)
             .name(name)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
@@ -4,6 +4,18 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.AggregationType
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.visualization.DigitGroupSeparator
+import org.hisp.dhis.android.core.visualization.DisplayDensity
+import org.hisp.dhis.android.core.visualization.HideEmptyItemStrategy
+import org.hisp.dhis.android.core.visualization.LegendStrategy
+import org.hisp.dhis.android.core.visualization.LegendStyle
+import org.hisp.dhis.android.core.visualization.Visualization
+import org.hisp.dhis.android.core.visualization.VisualizationLegend
+import org.hisp.dhis.android.core.visualization.VisualizationType
 
 @Entity(
     tableName = "Visualization",
@@ -29,21 +41,21 @@ internal data class VisualizationDB(
     val subtitle: String?,
     val displaySubtitle: String?,
     val type: String?,
-    val hideTitle: Int?,
-    val hideSubtitle: Int?,
-    val hideEmptyColumns: Int?,
-    val hideEmptyRows: Int?,
+    val hideTitle: Boolean?,
+    val hideSubtitle: Boolean?,
+    val hideEmptyColumns: Boolean?,
+    val hideEmptyRows: Boolean?,
     val hideEmptyRowItems: String?,
-    val hideLegend: Int?,
-    val showHierarchy: Int?,
-    val rowTotals: Int?,
-    val rowSubTotals: Int?,
-    val colTotals: Int?,
-    val colSubTotals: Int?,
-    val showDimensionLabels: Int?,
-    val percentStackedValues: Int?,
-    val noSpaceBetweenColumns: Int?,
-    val skipRounding: Int?,
+    val hideLegend: Boolean?,
+    val showHierarchy: Boolean?,
+    val rowTotals: Boolean?,
+    val rowSubTotals: Boolean?,
+    val colTotals: Boolean?,
+    val colSubTotals: Boolean?,
+    val showDimensionLabels: Boolean?,
+    val percentStackedValues: Boolean?,
+    val noSpaceBetweenColumns: Boolean?,
+    val skipRounding: Boolean?,
     val displayDensity: String?,
     val digitGroupSeparator: String?,
     val legendShowKey: String?,
@@ -51,4 +63,92 @@ internal data class VisualizationDB(
     val legendSetId: String?,
     val legendStrategy: String?,
     val aggregationType: String?,
-)
+) {
+    fun toDomain(): Visualization {
+        return Visualization.builder()
+            .uid(uid)
+            .code(code)
+            .name(name)
+            .displayName(displayName)
+            .created(created?.toJavaDate())
+            .lastUpdated(lastUpdated?.toJavaDate())
+            .description(description)
+            .displayDescription(displayDescription)
+            .displayFormName(displayFormName)
+            .title(title)
+            .displayTitle(displayTitle)
+            .subtitle(subtitle)
+            .displaySubtitle(displaySubtitle)
+            .type(type?.let { VisualizationType.valueOf(it) })
+            .hideTitle(hideTitle)
+            .hideSubtitle(hideSubtitle)
+            .hideEmptyColumns(hideEmptyColumns)
+            .hideEmptyRows(hideEmptyRows)
+            .hideEmptyRowItems(hideEmptyRowItems?.let { HideEmptyItemStrategy.valueOf(it) })
+            .hideLegend(hideLegend)
+            .showHierarchy(showHierarchy)
+            .rowTotals(rowTotals)
+            .rowSubTotals(rowSubTotals)
+            .colTotals(colTotals)
+            .colSubTotals(colSubTotals)
+            .showDimensionLabels(showDimensionLabels)
+            .percentStackedValues(percentStackedValues)
+            .noSpaceBetweenColumns(noSpaceBetweenColumns)
+            .skipRounding(skipRounding)
+            .legend(
+                if (sequenceOf(legendShowKey, legendStyle, legendSetId, legendStrategy).any { it != null }) {
+                    VisualizationLegend.builder()
+                        .showKey(legendShowKey == "1")
+                        .style(legendStyle?.let { LegendStyle.valueOf(it) })
+                        .set(legendSetId?.let { ObjectWithUid.create(it) })
+                        .strategy(legendStrategy?.let { LegendStrategy.valueOf(it) })
+                        .build()
+                } else null
+            )
+            .displayDensity(displayDensity?.let { DisplayDensity.valueOf(it) })
+            .digitGroupSeparator(digitGroupSeparator?.let { DigitGroupSeparator.valueOf(it) })
+            .aggregationType(aggregationType?.let { AggregationType.valueOf(it) })
+            .build()
+    }
+}
+
+internal fun Visualization.toDB(): VisualizationDB {
+    return VisualizationDB(
+        uid = uid()!!,
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        description = description(),
+        displayDescription = displayDescription(),
+        displayFormName = displayFormName(),
+        title = title(),
+        displayTitle = displayTitle(),
+        subtitle = subtitle(),
+        displaySubtitle = displaySubtitle(),
+        type = type()?.name,
+        hideTitle = hideTitle(),
+        hideSubtitle = hideSubtitle(),
+        hideEmptyColumns = hideEmptyColumns(),
+        hideEmptyRows = hideEmptyRows(),
+        hideEmptyRowItems = hideEmptyRowItems()?.name,
+        hideLegend = hideLegend(),
+        showHierarchy = showHierarchy(),
+        rowTotals = rowTotals(),
+        rowSubTotals = rowSubTotals(),
+        colTotals = colTotals(),
+        colSubTotals = colSubTotals(),
+        showDimensionLabels = showDimensionLabels(),
+        percentStackedValues = percentStackedValues(),
+        noSpaceBetweenColumns = noSpaceBetweenColumns(),
+        skipRounding = skipRounding(),
+        displayDensity = displayDensity()?.name,
+        digitGroupSeparator = digitGroupSeparator()?.name,
+        legendShowKey = legend()?.showKey()?.let { if (it) "1" else "0" },
+        legendStyle = legend()?.style()?.name,
+        legendSetId = legend()?.set()?.uid(),
+        legendStrategy = legend()?.strategy()?.name,
+        aggregationType = aggregationType()?.name,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
@@ -7,7 +7,6 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.common.AggregationType
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.core.visualization.DigitGroupSeparator
 import org.hisp.dhis.android.core.visualization.DisplayDensity
 import org.hisp.dhis.android.core.visualization.HideEmptyItemStrategy
@@ -18,6 +17,7 @@ import org.hisp.dhis.android.core.visualization.VisualizationLegend
 import org.hisp.dhis.android.core.visualization.VisualizationType
 import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "Visualization",
@@ -67,38 +67,33 @@ internal data class VisualizationDB(
     val aggregationType: String?,
 ) : EntityDB<Visualization>, BaseIdentifiableObjectDB {
     override fun toDomain(): Visualization {
-        return Visualization.builder()
-            .id(id?.toLong())
-            .uid(uid)
-            .code(code)
-            .name(name)
-            .displayName(displayName)
-            .created(created?.toJavaDate())
-            .lastUpdated(lastUpdated?.toJavaDate())
-            .description(description)
-            .displayDescription(displayDescription)
-            .displayFormName(displayFormName)
-            .title(title)
-            .displayTitle(displayTitle)
-            .subtitle(subtitle)
-            .displaySubtitle(displaySubtitle)
-            .type(type?.let { VisualizationType.valueOf(it) })
-            .hideTitle(hideTitle)
-            .hideSubtitle(hideSubtitle)
-            .hideEmptyColumns(hideEmptyColumns)
-            .hideEmptyRows(hideEmptyRows)
-            .hideEmptyRowItems(hideEmptyRowItems?.let { HideEmptyItemStrategy.valueOf(it) })
-            .hideLegend(hideLegend)
-            .showHierarchy(showHierarchy)
-            .rowTotals(rowTotals)
-            .rowSubTotals(rowSubTotals)
-            .colTotals(colTotals)
-            .colSubTotals(colSubTotals)
-            .showDimensionLabels(showDimensionLabels)
-            .percentStackedValues(percentStackedValues)
-            .noSpaceBetweenColumns(noSpaceBetweenColumns)
-            .skipRounding(skipRounding)
-            .legend(
+        return Visualization.builder().apply {
+            applyBaseIdentifiableFields(this@VisualizationDB)
+            id(id?.toLong())
+            description(description)
+            displayDescription(displayDescription)
+            displayFormName(displayFormName)
+            title(title)
+            displayTitle(displayTitle)
+            subtitle(subtitle)
+            displaySubtitle(displaySubtitle)
+            type(type?.let { VisualizationType.valueOf(it) })
+            hideTitle(hideTitle)
+            hideSubtitle(hideSubtitle)
+            hideEmptyColumns(hideEmptyColumns)
+            hideEmptyRows(hideEmptyRows)
+            hideEmptyRowItems(hideEmptyRowItems?.let { HideEmptyItemStrategy.valueOf(it) })
+            hideLegend(hideLegend)
+            showHierarchy(showHierarchy)
+            rowTotals(rowTotals)
+            rowSubTotals(rowSubTotals)
+            colTotals(colTotals)
+            colSubTotals(colSubTotals)
+            showDimensionLabels(showDimensionLabels)
+            percentStackedValues(percentStackedValues)
+            noSpaceBetweenColumns(noSpaceBetweenColumns)
+            skipRounding(skipRounding)
+            legend(
                 if (sequenceOf(legendShowKey, legendStyle, legendSetId, legendStrategy).any { it != null }) {
                     VisualizationLegend.builder()
                         .showKey(legendShowKey == "1")
@@ -110,10 +105,10 @@ internal data class VisualizationDB(
                     null
                 },
             )
-            .displayDensity(displayDensity?.let { DisplayDensity.valueOf(it) })
-            .digitGroupSeparator(digitGroupSeparator?.let { DigitGroupSeparator.valueOf(it) })
-            .aggregationType(aggregationType?.let { AggregationType.valueOf(it) })
-            .build()
+            displayDensity(displayDensity?.let { DisplayDensity.valueOf(it) })
+            digitGroupSeparator(digitGroupSeparator?.let { DigitGroupSeparator.valueOf(it) })
+            aggregationType(aggregationType?.let { AggregationType.valueOf(it) })
+        }.build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
@@ -16,6 +16,8 @@ import org.hisp.dhis.android.core.visualization.LegendStyle
 import org.hisp.dhis.android.core.visualization.Visualization
 import org.hisp.dhis.android.core.visualization.VisualizationLegend
 import org.hisp.dhis.android.core.visualization.VisualizationType
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "Visualization",
@@ -27,12 +29,12 @@ internal data class VisualizationDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val description: String?,
     val displayDescription: String?,
     val displayFormName: String?,
@@ -63,9 +65,10 @@ internal data class VisualizationDB(
     val legendSetId: String?,
     val legendStrategy: String?,
     val aggregationType: String?,
-) {
-    fun toDomain(): Visualization {
+) : EntityDB<Visualization>, BaseIdentifiableObjectDB {
+    override fun toDomain(): Visualization {
         return Visualization.builder()
+            .id(id?.toLong())
             .uid(uid)
             .code(code)
             .name(name)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDB.kt
@@ -103,7 +103,9 @@ internal data class VisualizationDB(
                         .set(legendSetId?.let { ObjectWithUid.create(it) })
                         .strategy(legendStrategy?.let { LegendStrategy.valueOf(it) })
                         .build()
-                } else null
+                } else {
+                    null
+                },
             )
             .displayDensity(displayDensity?.let { DisplayDensity.valueOf(it) })
             .digitGroupSeparator(digitGroupSeparator?.let { DigitGroupSeparator.valueOf(it) })

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
@@ -35,6 +35,7 @@ internal data class VisualizationDimensionItemDB(
 ) {
     fun toDomain(): VisualizationDimensionItem {
         return VisualizationDimensionItem.builder()
+            .id(id?.toLong())
             .visualization(visualization)
             .position(LayoutPosition.valueOf(position))
             .dimension(dimension)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
@@ -7,6 +7,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.visualization.LayoutPosition
 import org.hisp.dhis.android.core.visualization.VisualizationDimensionItem
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "VisualizationDimensionItem",
@@ -32,8 +33,8 @@ internal data class VisualizationDimensionItemDB(
     val dimension: String,
     val dimensionItem: String?,
     val dimensionItemType: String?,
-) {
-    fun toDomain(): VisualizationDimensionItem {
+) : EntityDB<VisualizationDimensionItem> {
+    override fun toDomain(): VisualizationDimensionItem {
         return VisualizationDimensionItem.builder()
             .id(id?.toLong())
             .visualization(visualization)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
@@ -50,6 +50,6 @@ internal fun VisualizationDimensionItem.toDB(): VisualizationDimensionItemDB {
         position = position()!!.name,
         dimension = dimension()!!,
         dimensionItem = dimensionItem(),
-        dimensionItemType = dimensionItemType()
+        dimensionItemType = dimensionItemType(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
@@ -5,6 +5,8 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.visualization.LayoutPosition
+import org.hisp.dhis.android.core.visualization.VisualizationDimensionItem
 
 @Entity(
     tableName = "VisualizationDimensionItem",
@@ -30,4 +32,24 @@ internal data class VisualizationDimensionItemDB(
     val dimension: String,
     val dimensionItem: String?,
     val dimensionItemType: String?,
-)
+) {
+    fun toDomain(): VisualizationDimensionItem {
+        return VisualizationDimensionItem.builder()
+            .visualization(visualization)
+            .position(LayoutPosition.valueOf(position))
+            .dimension(dimension)
+            .dimensionItem(dimensionItem)
+            .dimensionItemType(dimensionItemType)
+            .build()
+    }
+}
+
+internal fun VisualizationDimensionItem.toDB(): VisualizationDimensionItemDB {
+    return VisualizationDimensionItemDB(
+        visualization = visualization()!!,
+        position = position()!!.name,
+        dimension = dimension()!!,
+        dimensionItem = dimensionItem(),
+        dimensionItemType = dimensionItemType()
+    )
+}


### PR DESCRIPTION
This is subtask Part 2 from [ANDROSDK-2076](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2076)

In this PR, toDoamin and toDB mappers have been added to the entities from the following packages: usecase, user, validation and visualization. Additionally, value classes and supporting classes have been added to manage non primitive type columns (ObjectWithUidListDB and IntegerListDB)

Related task [ANDROSDK-2079](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2079)


[ANDROSDK-2076]: https://dhis2.atlassian.net/browse/ANDROSDK-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROSDK-2079]: https://dhis2.atlassian.net/browse/ANDROSDK-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ