### PR TITLE
chore: [ANDROSDK-2087] add db mappers to trackedentity and tracker package Entities

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -13710,6 +13710,18 @@ public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEnti
 public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterCall$Companion {
 }
 
+public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync {
+	public fun <init> ()V
+	public static fun builder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	public static fun create (Landroid/database/Cursor;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;
+	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+}
+
+public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;
+}
+
 public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync : org/hisp/dhis/android/core/common/BaseObject {
 	public fun <init> ()V
 	public abstract fun downloadLimit ()Ljava/lang/Integer;

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync.java
@@ -35,22 +35,22 @@ import androidx.annotation.NonNull;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-abstract class TrackedEntityInstanceSync extends TrackerBaseSync {
+public abstract class TrackedEntityInstanceSync extends TrackerBaseSync {
 
     @NonNull
-    static TrackedEntityInstanceSync create(Cursor cursor) {
+    public static TrackedEntityInstanceSync create(Cursor cursor) {
         return AutoValue_TrackedEntityInstanceSync.createFromCursor(cursor);
     }
 
-    static Builder builder() {
+    public static Builder builder() {
         return new AutoValue_TrackedEntityInstanceSync.Builder();
     }
 
-    abstract Builder toBuilder();
+    public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    abstract static class Builder extends TrackerBaseSync.Builder<Builder> {
+    public abstract static class Builder extends TrackerBaseSync.Builder<Builder> {
 
-        abstract TrackedEntityInstanceSync build();
+        public abstract TrackedEntityInstanceSync build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/DateFilterPeriodDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/DateFilterPeriodDB.kt
@@ -29,14 +29,33 @@
 package org.hisp.dhis.android.persistence.common
 
 import kotlinx.serialization.Serializable
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.common.DateFilterPeriod
 import org.hisp.dhis.android.core.common.DatePeriodType
 import org.hisp.dhis.android.core.common.RelativePeriod
 import org.hisp.dhis.android.core.util.simpleDateFormat
 import org.hisp.dhis.android.core.util.toJavaSimpleDate
 
+@JvmInline
+internal value class DateFilterPeriodDB(
+    val value: String,
+) {
+    fun toDomain(): DateFilterPeriod {
+        return KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDBSerializable>(value).toDomain()
+    }
+}
+
+internal fun DateFilterPeriod.toDB(): DateFilterPeriodDB {
+    return DateFilterPeriodDB(
+        KotlinxJsonParser.instance.encodeToString(
+            DateFilterPeriodDBSerializable.serializer(),
+            this.toDBSerializable(),
+        ),
+    )
+}
+
 @Serializable
-internal data class DateFilterPeriodDB(
+private data class DateFilterPeriodDBSerializable(
     val startBuffer: Int?,
     val endBuffer: Int?,
     val startDate: String?,
@@ -56,8 +75,8 @@ internal data class DateFilterPeriodDB(
     }
 }
 
-internal fun DateFilterPeriod.toDB(): DateFilterPeriodDB {
-    return DateFilterPeriodDB(
+private fun DateFilterPeriod.toDBSerializable(): DateFilterPeriodDBSerializable {
+    return DateFilterPeriodDBSerializable(
         startBuffer = this.startBuffer(),
         endBuffer = this.endBuffer(),
         startDate = this.startDate()?.simpleDateFormat(),

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterOperatorsDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterOperatorsDB.kt
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.persistence.common
 
-import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.common.FilterOperators
 
 internal interface FilterOperatorsDB {
@@ -37,9 +36,9 @@ internal interface FilterOperatorsDB {
     val gt: String?
     val lt: String?
     val eq: String?
-    val inProperty: String?
+    val inProperty: StringSetDB?
     val like: String?
-    val dateFilter: String?
+    val dateFilter: DateFilterPeriodDB?
 }
 
 internal fun <T> T.applyFilterOperatorsFields(item: FilterOperatorsDB): T where
@@ -49,16 +48,8 @@ internal fun <T> T.applyFilterOperatorsFields(item: FilterOperatorsDB): T where
     gt(item.gt)
     lt(item.lt)
     eq(item.eq)
-    item.inProperty?.let {
-        `in`(
-            KotlinxJsonParser.instance.decodeFromString<Set<String>>(it),
-        )
-    }
+    item.inProperty?.let { `in`(it.toDomain()) }
     like(item.like)
-    item.dateFilter?.let {
-        dateFilter(
-            KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain(),
-        )
-    }
+    item.dateFilter?.let { dateFilter(it.toDomain()) }
     return this
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterPeriodDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterPeriodDB.kt
@@ -1,0 +1,25 @@
+package org.hisp.dhis.android.persistence.common
+
+import org.hisp.dhis.android.core.common.FilterPeriod
+
+internal data class FilterPeriodDB(
+    val periodFrom: Int?,
+    val periodTo: Int?,
+) : EntityDB<FilterPeriod?> {
+
+    override fun toDomain(): FilterPeriod? {
+        return if (periodFrom != null && periodTo != null) {
+            FilterPeriod.builder()
+                .periodFrom(periodFrom)
+                .periodTo(periodTo)
+                .build()
+        } else null
+    }
+}
+
+internal fun FilterPeriod?.toDB(): FilterPeriodDB {
+    return FilterPeriodDB(
+        periodFrom = this?.periodFrom(),
+        periodTo = this?.periodTo()
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterPeriodDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterPeriodDB.kt
@@ -13,13 +13,15 @@ internal data class FilterPeriodDB(
                 .periodFrom(periodFrom)
                 .periodTo(periodTo)
                 .build()
-        } else null
+        } else {
+            null
+        }
     }
 }
 
 internal fun FilterPeriod?.toDB(): FilterPeriodDB {
     return FilterPeriodDB(
         periodFrom = this?.periodFrom(),
-        periodTo = this?.periodTo()
+        periodTo = this?.periodTo(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterQueryCriteriaDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/FilterQueryCriteriaDB.kt
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.persistence.common
 
-import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.common.AssignedUserMode
 import org.hisp.dhis.android.core.common.FilterQueryCriteria
 import org.hisp.dhis.android.core.event.EventStatus
@@ -39,11 +38,11 @@ internal interface FilterQueryCriteriaDB {
     val organisationUnit: String?
     val ouMode: String?
     val assignedUserMode: String?
-    val order: String?
-    val displayColumnOrder: String?
+    val orderProperty: String?
+    val displayColumnOrder: StringListDB?
     val eventStatus: String?
-    val eventDate: String?
-    val lastUpdatedDate: String?
+    val eventDate: DateFilterPeriodDB?
+    val lastUpdatedDate: DateFilterPeriodDB?
 }
 
 internal fun <T> T.applyFilterQueryCriteriaFields(item: FilterQueryCriteriaDB): T where
@@ -52,22 +51,10 @@ internal fun <T> T.applyFilterQueryCriteriaFields(item: FilterQueryCriteriaDB): 
     organisationUnit(item.organisationUnit)
     item.ouMode?.let { ouMode(OrganisationUnitMode.valueOf(it)) }
     item.assignedUserMode?.let { assignedUserMode(AssignedUserMode.valueOf(it)) }
-    order(item.order)
-    item.displayColumnOrder?.let {
-        displayColumnOrder(
-            KotlinxJsonParser.instance.decodeFromString<List<String>>(it),
-        )
-    }
+    order(item.orderProperty)
+    item.displayColumnOrder?.let { displayColumnOrder(it.toDomain()) }
     item.eventStatus?.let { eventStatus(EventStatus.valueOf(it)) }
-    item.eventDate?.let {
-        eventDate(
-            KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain(),
-        )
-    }
-    item.lastUpdatedDate?.let {
-        lastUpdatedDate(
-            KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain(),
-        )
-    }
+    item.eventDate?.let { eventDate(it.toDomain()) }
+    item.lastUpdatedDate?.let { lastUpdatedDate(it.toDomain()) }
     return this
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/GeometryDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/GeometryDB.kt
@@ -8,7 +8,6 @@ internal data class GeometryDB(
     val geometryCoordinates: String?,
 ) : EntityDB<Geometry?> {
     override fun toDomain(): Geometry? {
-
         return if (geometryType != null && geometryCoordinates != null) {
             FeatureType.valueOfFeatureType(geometryType)?.let { type ->
                 Geometry.builder()
@@ -16,13 +15,15 @@ internal data class GeometryDB(
                     .coordinates(geometryCoordinates)
                     .build()
             }
-        } else null
+        } else {
+            null
+        }
     }
 }
 
 internal fun Geometry?.toDB(): GeometryDB {
     return GeometryDB(
         geometryType = this?.type()?.geometryType,
-        geometryCoordinates = this?.coordinates()
+        geometryCoordinates = this?.coordinates(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/GeometryDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/GeometryDB.kt
@@ -1,0 +1,28 @@
+package org.hisp.dhis.android.persistence.common
+
+import org.hisp.dhis.android.core.common.FeatureType
+import org.hisp.dhis.android.core.common.Geometry
+
+internal data class GeometryDB(
+    val geometryType: String?,
+    val geometryCoordinates: String?,
+) : EntityDB<Geometry?> {
+    override fun toDomain(): Geometry? {
+
+        return if (geometryType != null && geometryCoordinates != null) {
+            FeatureType.valueOfFeatureType(geometryType)?.let { type ->
+                Geometry.builder()
+                    .type(type)
+                    .coordinates(geometryCoordinates)
+                    .build()
+            }
+        } else null
+    }
+}
+
+internal fun Geometry?.toDB(): GeometryDB {
+    return GeometryDB(
+        geometryType = this?.type()?.geometryType,
+        geometryCoordinates = this?.coordinates()
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/EntityQueryCriteriaDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/EntityQueryCriteriaDB.kt
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.trackedentity
+
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+import org.hisp.dhis.android.core.common.AssignedUserMode
+import org.hisp.dhis.android.core.common.DateFilterPeriod
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
+import org.hisp.dhis.android.core.event.EventStatus
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
+import org.hisp.dhis.android.core.trackedentity.EntityQueryCriteria
+import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.toDB
+
+internal data class EntityQueryCriteriaDB(
+    val enrollmentStatus: String?,
+    val followUp: Boolean?,
+    val organisationUnit: String?,
+    val ouMode: String?,
+    val assignedUserMode: String?,
+    val orderProperty: String?,
+    val displayColumnOrder: StringListDB?,
+    val eventStatus: String?,
+    val eventDate: String?,
+    val lastUpdatedDate: String?,
+    val programStage: String?,
+    val trackedEntityInstances: StringListDB?,
+    val enrollmentIncidentDate: String?,
+    val enrollmentCreatedDate: String?,
+    val trackedEntityType: String?,
+) : EntityDB<EntityQueryCriteria> {
+    override fun toDomain(): EntityQueryCriteria {
+        return EntityQueryCriteria.builder()
+            .enrollmentStatus(enrollmentStatus?.let { EnrollmentStatus.valueOf(it) })
+            .followUp(followUp)
+            .organisationUnit(organisationUnit)
+            .ouMode(ouMode?.let { OrganisationUnitMode.valueOf(it) })
+            .assignedUserMode(assignedUserMode?.let { AssignedUserMode.valueOf(it) })
+            .order(orderProperty)
+            .displayColumnOrder(displayColumnOrder?.toDomain())
+            .eventStatus(eventStatus?.let { EventStatus.valueOf(it) })
+            .eventDate(eventDate?.let {
+                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
+            })
+            .lastUpdatedDate(lastUpdatedDate?.let {
+                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
+            })
+            .programStage(programStage)
+            .trackedEntityInstances(trackedEntityInstances?.toDomain())
+            .enrollmentIncidentDate(enrollmentIncidentDate?.let {
+                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
+            })
+            .enrollmentCreatedDate(enrollmentCreatedDate?.let {
+                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
+            })
+            .trackedEntityType(trackedEntityType)
+            .build()
+    }
+}
+
+internal fun EntityQueryCriteria.toDB(): EntityQueryCriteriaDB {
+    return EntityQueryCriteriaDB(
+        enrollmentStatus = enrollmentStatus()?.name,
+        followUp = followUp(),
+        organisationUnit = organisationUnit(),
+        ouMode = ouMode()?.name,
+        assignedUserMode = assignedUserMode()?.name,
+        orderProperty = order(),
+        displayColumnOrder = displayColumnOrder()?.toDB(),
+        eventStatus = eventStatus()?.name,
+        eventDate = eventDate()?.let {
+            KotlinxJsonParser.instance.encodeToString(
+                DateFilterPeriodDB.serializer(),
+                it.toDB(),
+            )
+        },
+        lastUpdatedDate = lastUpdatedDate()?.let {
+            KotlinxJsonParser.instance.encodeToString(
+                DateFilterPeriodDB.serializer(),
+                it.toDB(),
+            )
+        },
+        programStage = programStage(),
+        trackedEntityInstances = trackedEntityInstances()?.toDB(),
+        enrollmentIncidentDate = enrollmentIncidentDate()?.let {
+            KotlinxJsonParser.instance.encodeToString(
+                DateFilterPeriodDB.serializer(),
+                it.toDB(),
+            )
+        },
+        enrollmentCreatedDate = enrollmentCreatedDate()?.let {
+            KotlinxJsonParser.instance.encodeToString(
+                DateFilterPeriodDB.serializer(),
+                it.toDB(),
+            )
+        },
+        trackedEntityType = trackedEntityType()
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/EntityQueryCriteriaDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/EntityQueryCriteriaDB.kt
@@ -28,62 +28,43 @@
 
 package org.hisp.dhis.android.persistence.trackedentity
 
-import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
-import org.hisp.dhis.android.core.common.AssignedUserMode
-import org.hisp.dhis.android.core.common.DateFilterPeriod
-import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
-import org.hisp.dhis.android.core.event.EventStatus
-import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.trackedentity.EntityQueryCriteria
 import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.FilterQueryCriteriaDB
 import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.applyFilterQueryCriteriaFields
 import org.hisp.dhis.android.persistence.common.toDB
 
 internal data class EntityQueryCriteriaDB(
     val enrollmentStatus: String?,
-    val followUp: Boolean?,
-    val organisationUnit: String?,
-    val ouMode: String?,
-    val assignedUserMode: String?,
-    val orderProperty: String?,
-    val displayColumnOrder: StringListDB?,
-    val eventStatus: String?,
-    val eventDate: String?,
-    val lastUpdatedDate: String?,
+    override val followUp: Boolean?,
+    override val organisationUnit: String?,
+    override val ouMode: String?,
+    override val assignedUserMode: String?,
+    override val orderProperty: String?,
+    override val displayColumnOrder: StringListDB?,
+    override val eventStatus: String?,
+    override val eventDate: DateFilterPeriodDB?,
+    override val lastUpdatedDate: DateFilterPeriodDB?,
     val programStage: String?,
     val trackedEntityInstances: StringListDB?,
-    val enrollmentIncidentDate: String?,
-    val enrollmentCreatedDate: String?,
+    val enrollmentIncidentDate: DateFilterPeriodDB?,
+    val enrollmentCreatedDate: DateFilterPeriodDB?,
     val trackedEntityType: String?,
-) : EntityDB<EntityQueryCriteria> {
+) : EntityDB<EntityQueryCriteria>, FilterQueryCriteriaDB {
+
     override fun toDomain(): EntityQueryCriteria {
-        return EntityQueryCriteria.builder()
-            .enrollmentStatus(enrollmentStatus?.let { EnrollmentStatus.valueOf(it) })
-            .followUp(followUp)
-            .organisationUnit(organisationUnit)
-            .ouMode(ouMode?.let { OrganisationUnitMode.valueOf(it) })
-            .assignedUserMode(assignedUserMode?.let { AssignedUserMode.valueOf(it) })
-            .order(orderProperty)
-            .displayColumnOrder(displayColumnOrder?.toDomain())
-            .eventStatus(eventStatus?.let { EventStatus.valueOf(it) })
-            .eventDate(eventDate?.let {
-                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
-            })
-            .lastUpdatedDate(lastUpdatedDate?.let {
-                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
-            })
-            .programStage(programStage)
-            .trackedEntityInstances(trackedEntityInstances?.toDomain())
-            .enrollmentIncidentDate(enrollmentIncidentDate?.let {
-                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
-            })
-            .enrollmentCreatedDate(enrollmentCreatedDate?.let {
-                KotlinxJsonParser.instance.decodeFromString<DateFilterPeriodDB>(it).toDomain()
-            })
-            .trackedEntityType(trackedEntityType)
-            .build()
+        return EntityQueryCriteria.builder().apply {
+            applyFilterQueryCriteriaFields(this@EntityQueryCriteriaDB)
+            enrollmentStatus(enrollmentStatus?.let { EnrollmentStatus.valueOf(it) })
+            programStage(programStage)
+            trackedEntityInstances(trackedEntityInstances?.toDomain())
+            enrollmentIncidentDate(enrollmentIncidentDate?.let { it.toDomain() })
+            enrollmentCreatedDate(enrollmentCreatedDate?.let { it.toDomain() })
+            trackedEntityType(trackedEntityType)
+        }.build()
     }
 }
 
@@ -97,32 +78,12 @@ internal fun EntityQueryCriteria.toDB(): EntityQueryCriteriaDB {
         orderProperty = order(),
         displayColumnOrder = displayColumnOrder()?.toDB(),
         eventStatus = eventStatus()?.name,
-        eventDate = eventDate()?.let {
-            KotlinxJsonParser.instance.encodeToString(
-                DateFilterPeriodDB.serializer(),
-                it.toDB(),
-            )
-        },
-        lastUpdatedDate = lastUpdatedDate()?.let {
-            KotlinxJsonParser.instance.encodeToString(
-                DateFilterPeriodDB.serializer(),
-                it.toDB(),
-            )
-        },
+        eventDate = eventDate()?.let { it.toDB() },
+        lastUpdatedDate = lastUpdatedDate()?.let { it.toDB() },
         programStage = programStage(),
         trackedEntityInstances = trackedEntityInstances()?.toDB(),
-        enrollmentIncidentDate = enrollmentIncidentDate()?.let {
-            KotlinxJsonParser.instance.encodeToString(
-                DateFilterPeriodDB.serializer(),
-                it.toDB(),
-            )
-        },
-        enrollmentCreatedDate = enrollmentCreatedDate()?.let {
-            KotlinxJsonParser.instance.encodeToString(
-                DateFilterPeriodDB.serializer(),
-                it.toDB(),
-            )
-        },
-        trackedEntityType = trackedEntityType()
+        enrollmentIncidentDate = enrollmentIncidentDate()?.let { it.toDB() },
+        enrollmentCreatedDate = enrollmentCreatedDate()?.let { it.toDB() },
+        trackedEntityType = trackedEntityType(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramOwnerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramOwnerDB.kt
@@ -5,6 +5,9 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.State
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwner
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
@@ -48,4 +51,24 @@ internal data class ProgramOwnerDB(
     val trackedEntityInstance: String,
     val ownerOrgUnit: String,
     val syncState: String?,
-)
+) : EntityDB<ProgramOwner> {
+
+    override fun toDomain(): ProgramOwner {
+        return ProgramOwner.builder()
+            .id(id?.toLong())
+            .program(program)
+            .trackedEntityInstance(trackedEntityInstance)
+            .ownerOrgUnit(ownerOrgUnit)
+            .syncState(syncState?.let { State.valueOf(it) })
+            .build()
+    }
+}
+
+internal fun ProgramOwner.toDB(): ProgramOwnerDB {
+    return ProgramOwnerDB(
+        program = program(),
+        trackedEntityInstance = trackedEntityInstance(),
+        ownerOrgUnit = ownerOrgUnit(),
+        syncState = syncState()?.name,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramTempOwnerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramTempOwnerDB.kt
@@ -5,6 +5,10 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramTempOwner
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
 @Entity(
@@ -32,4 +36,26 @@ internal data class ProgramTempOwnerDB(
     val created: String,
     val validUntil: String,
     val reason: String,
-)
+) : EntityDB<ProgramTempOwner> {
+
+    override fun toDomain(): ProgramTempOwner {
+        return ProgramTempOwner.builder()
+            .id(id?.toLong())
+            .program(program)
+            .trackedEntityInstance(trackedEntityInstance)
+            .created(created.toJavaDate())
+            .validUntil(validUntil.toJavaDate())
+            .reason(reason)
+            .build()
+    }
+}
+
+internal fun ProgramTempOwner.toDB(): ProgramTempOwnerDB {
+    return ProgramTempOwnerDB(
+        program = program(),
+        trackedEntityInstance = trackedEntityInstance(),
+        created = created().dateFormat()!!,
+        validUntil = validUntil().dateFormat()!!,
+        reason = reason(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ReservedValueSettingDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ReservedValueSettingDB.kt
@@ -5,6 +5,8 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.trackedentity.ReservedValueSetting
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "ReservedValueSetting",
@@ -27,4 +29,20 @@ internal data class ReservedValueSettingDB(
     val id: Int? = 0,
     val uid: String?,
     val numberOfValuesToReserve: Int?,
-)
+) : EntityDB<ReservedValueSetting> {
+
+    override fun toDomain(): ReservedValueSetting {
+        return ReservedValueSetting.builder()
+            .id(id?.toLong())
+            .uid(uid)
+            .numberOfValuesToReserve(numberOfValuesToReserve)
+            .build()
+    }
+}
+
+internal fun ReservedValueSetting.toDB(): ReservedValueSettingDB {
+    return ReservedValueSettingDB(
+        uid = uid(),
+        numberOfValuesToReserve = numberOfValuesToReserve(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeDB.kt
@@ -5,6 +5,16 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.AggregationType
+import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseNameableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.ObjectWithStyleDB
+import org.hisp.dhis.android.persistence.common.ObjectWithUidDB
+import org.hisp.dhis.android.persistence.common.applyBaseNameableFields
+import org.hisp.dhis.android.persistence.common.applyStyleFields
 import org.hisp.dhis.android.persistence.option.OptionSetDB
 
 @Entity(
@@ -27,33 +37,93 @@ internal data class TrackedEntityAttributeDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
-    val shortName: String?,
-    val displayShortName: String?,
-    val description: String?,
-    val displayDescription: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
+    override val shortName: String?,
+    override val displayShortName: String?,
+    override val description: String?,
+    override val displayDescription: String?,
     val pattern: String?,
     val sortOrderInListNoProgram: Int?,
     val optionSet: String?,
     val valueType: String?,
     val expression: String?,
-    val programScope: Int?,
-    val displayInListNoProgram: Int?,
-    val generated: Int?,
-    val displayOnVisitSchedule: Int?,
-    val orgunitScope: Int?,
-    val uniqueProperty: Int?,
-    val inherit: Int?,
+    val programScope: Boolean?,
+    val displayInListNoProgram: Boolean?,
+    val generated: Boolean?,
+    val displayOnVisitSchedule: Boolean?,
+    val orgunitScope: Boolean?,
+    val uniqueProperty: Boolean?,
+    val inherit: Boolean?,
     val formName: String?,
     val fieldMask: String?,
-    val color: String?,
-    val icon: String?,
+    override val color: String?,
+    override val icon: String?,
     val displayFormName: String?,
     val aggregationType: String?,
-    val confidential: Int?,
-)
+    val confidential: Boolean?,
+) : EntityDB<TrackedEntityAttribute>, BaseNameableObjectDB, ObjectWithStyleDB {
+
+    override fun toDomain(): TrackedEntityAttribute {
+        return TrackedEntityAttribute.builder().apply {
+            applyBaseNameableFields(this@TrackedEntityAttributeDB)
+            applyStyleFields(this@TrackedEntityAttributeDB)
+            id(id?.toLong())
+            pattern(pattern)
+            sortOrderInListNoProgram(sortOrderInListNoProgram)
+            optionSet?.let { optionSet(ObjectWithUidDB(it).toDomain()) }
+            valueType(valueType?.let { ValueType.valueOf(it) })
+            expression(expression)
+            programScope(programScope)
+            displayInListNoProgram(displayInListNoProgram)
+            generated(generated)
+            displayOnVisitSchedule(displayOnVisitSchedule)
+            orgUnitScope(orgunitScope)
+            unique(uniqueProperty)
+            inherit(inherit)
+            formName(formName)
+            fieldMask(fieldMask)
+            displayFormName(displayFormName)
+            aggregationType(aggregationType?.let { AggregationType.valueOf(it) })
+            confidential(confidential)
+        }.build()
+    }
+}
+
+internal fun TrackedEntityAttribute.toDB(): TrackedEntityAttributeDB {
+    return TrackedEntityAttributeDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        shortName = shortName(),
+        displayShortName = displayShortName(),
+        description = description(),
+        displayDescription = displayDescription(),
+        pattern = pattern(),
+        sortOrderInListNoProgram = sortOrderInListNoProgram(),
+        optionSet = optionSet()?.uid(),
+        valueType = valueType()?.name,
+        expression = expression(),
+        programScope = programScope(),
+        displayInListNoProgram = programScope(),
+        generated = programScope(),
+        displayOnVisitSchedule = programScope(),
+        orgunitScope = programScope(),
+        uniqueProperty = programScope(),
+        inherit = programScope(),
+        formName = formName(),
+        fieldMask = fieldMask(),
+        color = style()?.color(),
+        icon = style()?.icon(),
+        displayFormName = displayFormName(),
+        aggregationType = aggregationType()?.name,
+        confidential = programScope(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkDB.kt
@@ -5,6 +5,8 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeLegendSetLink
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.legendset.LegendSetDB
 
 @Entity(
@@ -38,4 +40,22 @@ internal data class TrackedEntityAttributeLegendSetLinkDB(
     val trackedEntityAttribute: String,
     val legendSet: String,
     val sortOrder: Int?,
-)
+) : EntityDB<TrackedEntityAttributeLegendSetLink> {
+
+    override fun toDomain(): TrackedEntityAttributeLegendSetLink {
+        return TrackedEntityAttributeLegendSetLink.builder()
+            .id(id?.toLong())
+            .trackedEntityAttribute(trackedEntityAttribute)
+            .legendSet(legendSet)
+            .sortOrder(sortOrder)
+            .build()
+    }
+}
+
+internal fun TrackedEntityAttributeLegendSetLink.toDB(): TrackedEntityAttributeLegendSetLinkDB {
+    return TrackedEntityAttributeLegendSetLinkDB(
+        trackedEntityAttribute = trackedEntityAttribute(),
+        legendSet = legendSet(),
+        sortOrder = sortOrder(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueDB.kt
@@ -3,6 +3,10 @@ package org.hisp.dhis.android.persistence.trackedentity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeReservedValue
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(tableName = "TrackedEntityAttributeReservedValue")
 internal data class TrackedEntityAttributeReservedValueDB(
@@ -18,4 +22,34 @@ internal data class TrackedEntityAttributeReservedValueDB(
     val organisationUnit: String?,
     val temporalValidityDate: String?,
     val pattern: String?,
-)
+) : EntityDB<TrackedEntityAttributeReservedValue> {
+
+    override fun toDomain(): TrackedEntityAttributeReservedValue {
+        return TrackedEntityAttributeReservedValue.builder()
+            .id(id?.toLong())
+            .ownerObject(ownerObject)
+            .ownerUid(ownerUid)
+            .key(key)
+            .value(value)
+            .created(created?.toJavaDate())
+            .expiryDate(expiryDate?.toJavaDate())
+            .organisationUnit(organisationUnit)
+            .temporalValidityDate(temporalValidityDate?.toJavaDate())
+            .pattern(pattern)
+            .build()
+    }
+}
+
+internal fun TrackedEntityAttributeReservedValue.toDB(): TrackedEntityAttributeReservedValueDB {
+    return TrackedEntityAttributeReservedValueDB(
+        ownerObject = ownerObject(),
+        ownerUid = ownerUid(),
+        key = key(),
+        value = value(),
+        created = created()?.dateFormat(),
+        expiryDate = expiryDate()?.dateFormat(),
+        organisationUnit = organisationUnit(),
+        temporalValidityDate = temporalValidityDate()?.dateFormat(),
+        pattern = pattern(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDB.kt
@@ -5,6 +5,11 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.State
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "TrackedEntityAttributeValue",
@@ -40,4 +45,28 @@ internal data class TrackedEntityAttributeValueDB(
     val trackedEntityAttribute: String,
     val trackedEntityInstance: String,
     val syncState: String?,
-)
+) : EntityDB<TrackedEntityAttributeValue> {
+
+    override fun toDomain(): TrackedEntityAttributeValue {
+        return TrackedEntityAttributeValue.builder()
+            .id(id?.toLong())
+            .created(created?.toJavaDate())
+            .lastUpdated(lastUpdated?.toJavaDate())
+            .value(value)
+            .trackedEntityAttribute(trackedEntityAttribute)
+            .trackedEntityInstance(trackedEntityInstance)
+            .syncState(syncState?.let { State.valueOf(it) })
+            .build()
+    }
+}
+
+internal fun TrackedEntityAttributeValue.toDB(): TrackedEntityAttributeValueDB {
+    return TrackedEntityAttributeValueDB(
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        value = value(),
+        trackedEntityAttribute = trackedEntityAttribute()!!,
+        trackedEntityInstance = trackedEntityInstance()!!,
+        syncState = syncState()?.name,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityDataValueDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityDataValueDB.kt
@@ -5,6 +5,11 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.State
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
 import org.hisp.dhis.android.persistence.event.EventDB
 
@@ -42,6 +47,34 @@ internal data class TrackedEntityDataValueDB(
     val value: String?,
     val created: String?,
     val lastUpdated: String?,
-    val providedElsewhere: Int?,
+    val providedElsewhere: Boolean?,
     val syncState: String?,
-)
+) : EntityDB<TrackedEntityDataValue> {
+
+    override fun toDomain(): TrackedEntityDataValue {
+        return TrackedEntityDataValue.builder()
+            .id(id?.toLong())
+            .event(event)
+            .dataElement(dataElement)
+            .storedBy(storedBy)
+            .value(value)
+            .created(created?.toJavaDate())
+            .lastUpdated(lastUpdated?.toJavaDate())
+            .providedElsewhere(providedElsewhere)
+            .syncState(syncState?.let { State.valueOf(it) })
+            .build()
+    }
+}
+
+internal fun TrackedEntityDataValue.toDB(): TrackedEntityDataValueDB {
+    return TrackedEntityDataValueDB(
+        event = event()!!,
+        dataElement = dataElement()!!,
+        storedBy = storedBy(),
+        value = value(),
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        providedElsewhere = providedElsewhere(),
+        syncState = syncState()?.name,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceEventFilterDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceEventFilterDB.kt
@@ -5,6 +5,12 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.AssignedUserMode
+import org.hisp.dhis.android.core.event.EventStatus
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceEventFilter
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.FilterPeriodDB
+import org.hisp.dhis.android.persistence.common.toDB
 
 @Entity(
     tableName = "TrackedEntityInstanceEventFilter",
@@ -31,4 +37,26 @@ internal data class TrackedEntityInstanceEventFilterDB(
     val periodFrom: Int?,
     val periodTo: Int?,
     val assignedUserMode: String?,
-)
+) : EntityDB<TrackedEntityInstanceEventFilter> {
+    override fun toDomain(): TrackedEntityInstanceEventFilter {
+        return TrackedEntityInstanceEventFilter.builder()
+            .id(id?.toLong())
+            .trackedEntityInstanceFilter(trackedEntityInstanceFilter)
+            .programStage(programStage)
+            .eventStatus(eventStatus?.let { EventStatus.valueOf(it) })
+            .eventCreatedPeriod(FilterPeriodDB(periodFrom, periodTo).toDomain())
+            .assignedUserMode(assignedUserMode?.let { AssignedUserMode.valueOf(it) })
+            .build()
+    }
+}
+
+internal fun TrackedEntityInstanceEventFilter.toDB(): TrackedEntityInstanceEventFilterDB {
+    return TrackedEntityInstanceEventFilterDB(
+        trackedEntityInstanceFilter = trackedEntityInstanceFilter()!!,
+        programStage = programStage(),
+        eventStatus = eventStatus()?.name,
+        periodFrom = eventCreatedPeriod().toDB().periodFrom,
+        periodTo = eventCreatedPeriod().toDB().periodTo,
+        assignedUserMode = assignedUserMode()?.name,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceFilterDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceFilterDB.kt
@@ -5,6 +5,16 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.ObjectWithStyleDB
+import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
+import org.hisp.dhis.android.persistence.common.applyStyleFields
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
 @Entity(
@@ -27,30 +37,93 @@ internal data class TrackedEntityInstanceFilterDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
-    val color: String?,
-    val icon: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
+    override val color: String?,
+    override val icon: String?,
     val program: String,
     val description: String?,
     val sortOrder: Int?,
     val enrollmentStatus: String?,
-    val followUp: Int?,
+    val followUp: Boolean?,
     val organisationUnit: String?,
     val ouMode: String?,
     val assignedUserMode: String?,
     val orderProperty: String?,
-    val displayColumnOrder: String?,
+    val displayColumnOrder: StringListDB?,
     val eventStatus: String?,
-    val eventDate: String?,
-    val lastUpdatedDate: String?,
+    val eventDate: DateFilterPeriodDB?,
+    val lastUpdatedDate: DateFilterPeriodDB?,
     val programStage: String?,
-    val trackedEntityInstances: String?,
-    val enrollmentIncidentDate: String?,
-    val enrollmentCreatedDate: String?,
+    val trackedEntityInstances: StringListDB?,
+    val enrollmentIncidentDate: DateFilterPeriodDB?,
+    val enrollmentCreatedDate: DateFilterPeriodDB?,
     val trackedEntityType: String?,
-)
+) : EntityDB<TrackedEntityInstanceFilter>, BaseIdentifiableObjectDB, ObjectWithStyleDB {
+    override fun toDomain(): TrackedEntityInstanceFilter {
+        return TrackedEntityInstanceFilter.builder().apply {
+            applyBaseIdentifiableFields(this@TrackedEntityInstanceFilterDB)
+            applyStyleFields(this@TrackedEntityInstanceFilterDB)
+            id(id?.toLong())
+            program(ObjectWithUid.create(program))
+            description(description)
+            sortOrder(sortOrder)
+            entityQueryCriteria(
+                EntityQueryCriteriaDB(
+                    enrollmentStatus = enrollmentStatus,
+                    followUp = followUp,
+                    organisationUnit = organisationUnit,
+                    ouMode = ouMode,
+                    assignedUserMode = assignedUserMode,
+                    orderProperty = orderProperty,
+                    displayColumnOrder = displayColumnOrder,
+                    eventStatus = eventStatus,
+                    eventDate = eventDate,
+                    lastUpdatedDate = lastUpdatedDate,
+                    programStage = programStage,
+                    trackedEntityInstances = trackedEntityInstances,
+                    enrollmentIncidentDate = enrollmentIncidentDate,
+                    enrollmentCreatedDate = enrollmentCreatedDate,
+                    trackedEntityType = trackedEntityType,
+                ).toDomain(),
+            )
+        }.build()
+    }
+}
+
+internal fun TrackedEntityInstanceFilter.toDB(): TrackedEntityInstanceFilterDB {
+    val entityQueryCriteriaDB = entityQueryCriteria().toDB()
+
+    return TrackedEntityInstanceFilterDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        color = style()?.color(),
+        icon = style()?.icon(),
+        program = program()!!.uid(),
+        description = description(),
+        sortOrder = sortOrder(),
+        enrollmentStatus = entityQueryCriteriaDB.enrollmentStatus,
+        followUp = entityQueryCriteriaDB.followUp,
+        organisationUnit = entityQueryCriteriaDB.organisationUnit,
+        ouMode = entityQueryCriteriaDB.ouMode,
+        assignedUserMode = entityQueryCriteriaDB.assignedUserMode,
+        orderProperty = entityQueryCriteriaDB.orderProperty,
+        displayColumnOrder = entityQueryCriteriaDB.displayColumnOrder,
+        eventStatus = entityQueryCriteriaDB.eventStatus,
+        eventDate = entityQueryCriteriaDB.eventDate,
+        lastUpdatedDate = entityQueryCriteriaDB.lastUpdatedDate,
+        programStage = entityQueryCriteriaDB.programStage,
+        trackedEntityInstances = entityQueryCriteriaDB.trackedEntityInstances,
+        enrollmentIncidentDate = entityQueryCriteriaDB.enrollmentIncidentDate,
+        enrollmentCreatedDate = entityQueryCriteriaDB.enrollmentCreatedDate,
+        trackedEntityType = entityQueryCriteriaDB.trackedEntityType,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDB.kt
@@ -5,6 +5,10 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceSync
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
 @Entity(
@@ -30,4 +34,23 @@ internal data class TrackedEntityInstanceSyncDB(
     val organisationUnitIdsHash: Int?,
     val downloadLimit: Int,
     val lastUpdated: String,
-)
+) : EntityDB<TrackedEntityInstanceSync> {
+    override fun toDomain(): TrackedEntityInstanceSync {
+        return TrackedEntityInstanceSync.builder()
+            .id(id?.toLong())
+            .program(program)
+            .organisationUnitIdsHash(organisationUnitIdsHash!!)
+            .downloadLimit(downloadLimit)
+            .lastUpdated(lastUpdated.toJavaDate())
+            .build()
+    }
+}
+
+internal fun TrackedEntityInstanceSync.toDB(): TrackedEntityInstanceSyncDB {
+    return TrackedEntityInstanceSyncDB(
+        program = program(),
+        organisationUnitIdsHash = organisationUnitIdsHash(),
+        downloadLimit = downloadLimit(),
+        lastUpdated = lastUpdated().dateFormat()!!,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeDB.kt
@@ -5,6 +5,9 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeAttribute
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "TrackedEntityTypeAttribute",
@@ -35,8 +38,31 @@ internal data class TrackedEntityTypeAttributeDB(
     val id: Int? = 0,
     val trackedEntityType: String?,
     val trackedEntityAttribute: String?,
-    val displayInList: Int?,
-    val mandatory: Int?,
-    val searchable: Int?,
+    val displayInList: Boolean?,
+    val mandatory: Boolean?,
+    val searchable: Boolean?,
     val sortOrder: Int?,
-)
+) : EntityDB<TrackedEntityTypeAttribute> {
+    override fun toDomain(): TrackedEntityTypeAttribute {
+        return TrackedEntityTypeAttribute.builder()
+            .id(id?.toLong())
+            .trackedEntityType(ObjectWithUid.create(trackedEntityType))
+            .trackedEntityAttribute(trackedEntityAttribute?.let { ObjectWithUid.create(it) })
+            .displayInList(displayInList)
+            .mandatory(mandatory?.let { it })
+            .searchable(searchable)
+            .sortOrder(sortOrder)
+            .build()
+    }
+}
+
+internal fun TrackedEntityTypeAttribute.toDB(): TrackedEntityTypeAttributeDB {
+    return TrackedEntityTypeAttributeDB(
+        trackedEntityType = trackedEntityType().uid(),
+        trackedEntityAttribute = trackedEntityAttribute()?.uid(),
+        displayInList = displayInList(),
+        mandatory = mandatory(),
+        searchable = searchable(),
+        sortOrder = sortOrder(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDB.kt
@@ -3,6 +3,13 @@ package org.hisp.dhis.android.persistence.tracker
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterObjectType
+import org.hisp.dhis.android.core.tracker.importer.internal.TrackerJobObject
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.toDB
 
 @Entity(tableName = "TrackerJobObject")
 internal data class TrackerJobObjectDB(
@@ -13,5 +20,25 @@ internal data class TrackerJobObjectDB(
     val objectUid: String,
     val jobUid: String,
     val lastUpdated: String,
-    val fileResources: String?,
-)
+    val fileResources: StringListDB?,
+) : EntityDB<TrackerJobObject> {
+    override fun toDomain(): TrackerJobObject {
+        return TrackerJobObject.builder()
+            .trackerType(trackerType.let { TrackerImporterObjectType.valueOf(it) })
+            .objectUid(objectUid)
+            .jobUid(jobUid)
+            .lastUpdated(lastUpdated.toJavaDate())
+            .fileResources(fileResources?.toDomain())
+            .build()
+    }
+}
+
+internal fun TrackerJobObject.toDB(): TrackerJobObjectDB {
+    return TrackerJobObjectDB(
+        trackerType = trackerType().name,
+        objectUid = objectUid(),
+        jobUid = jobUid(),
+        lastUpdated = lastUpdated().dateFormat()!!,
+        fileResources = fileResources().toDB(),
+    )
+}


### PR DESCRIPTION
This is subtask Part 4 from [ANDROSDK-2076](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2076)

 this PR, toDoamin and toDB mappers have been added to the entities from the trackedentity  package: 

- EntityQueryCriteriaDB.kt
- ProgramOwnerDB.kt
- ProgramTempOwnerDB.kt
- ReservedValueSettingDB.kt
- TrackedEntityAttributeDB.kt
- TrackedEntityAttributeLegendSetLinkDB.kt
- TrackedEntityAttributeReservedValueDB.kt
- TrackedEntityAttributeValueDB.kt
- TrackedEntityDataValueDB.kt
- TrackedEntityInstanceDB.kt
- TrackedEntityInstanceEventFilterDB.kt
- TrackedEntityInstanceFilterDB.kt
- TrackedEntityInstanceSyncDB.kt
- TrackedEntityTypeAttributeDB.kt
- TrackedEntityTypeDB.kt

 Additionally, value classes and supporting classes have been added to manage non primitive type columns
 
 Related task [ANDROSDK-2087](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2087)

[ANDROSDK-2076]: https://dhis2.atlassian.net/browse/ANDROSDK-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROSDK-2087]: https://dhis2.atlassian.net/browse/ANDROSDK-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ