### PR TITLE
chore: [ANDROSDK-2093] add mappers to entities in maintenance, map, note, options 

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/adapters/custom/internal/MapLayerImagerProviderAreaListColumnAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/adapters/custom/internal/MapLayerImagerProviderAreaListColumnAdapter.kt
@@ -27,11 +27,9 @@
  */
 package org.hisp.dhis.android.core.arch.db.adapters.custom.internal
 
-import kotlinx.serialization.builtins.ListSerializer
-import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.map.layer.MapLayerImageryProviderArea
 import org.hisp.dhis.android.persistence.map.MapLayerImageryProviderAreaDB
-import org.hisp.dhis.android.persistence.map.MapLayerImageryProviderAreaDB.Companion.toDB
+import org.hisp.dhis.android.persistence.map.toDB
 
 internal class MapLayerImagerProviderAreaListColumnAdapter :
     JSONObjectListColumnAdapter<MapLayerImageryProviderArea>() {
@@ -40,22 +38,12 @@ internal class MapLayerImagerProviderAreaListColumnAdapter :
         MapLayerImagerProviderAreaListColumnAdapter.serialize(o)
 
     override fun deserialize(str: String): List<MapLayerImageryProviderArea> {
-        val dao = KotlinxJsonParser.instance.decodeFromString(
-            ListSerializer(MapLayerImageryProviderAreaDB.serializer()),
-            str,
-        )
-        return dao.map { it.toDomain() }
+        return MapLayerImageryProviderAreaDB(str).toDomain()
     }
 
     companion object {
         fun serialize(o: List<MapLayerImageryProviderArea>?): String? {
-            return o?.let {
-                val dao = it.map { it.toDB() }
-                return KotlinxJsonParser.instance.encodeToString(
-                    ListSerializer(MapLayerImageryProviderAreaDB.serializer()),
-                    dao,
-                )
-            }
+            return o?.let { it.toDB().value }
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueDB.kt
@@ -101,6 +101,8 @@ internal data class DataValueDB(
             lastUpdated?.let { lastUpdated(it.toJavaDate()!!) }
             comment(comment)
             followUp(followUp)
+            syncState?.let { syncState(it.toDomain()) }
+            deleted(deleted)
         }.build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
@@ -3,6 +3,12 @@ package org.hisp.dhis.android.persistence.maintenance
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(tableName = "D2Error")
 internal data class D2ErrorDB(
@@ -17,4 +23,28 @@ internal data class D2ErrorDB(
     val errorDescription: String?,
     val httpErrorCode: Int?,
     val created: String?,
-)
+) : EntityDB<D2Error> {
+    override fun toDomain(): D2Error {
+        return D2Error.builder().apply {
+            url(url)
+            errorComponent?.let { errorComponent(D2ErrorComponent.valueOf(it)) }
+            errorCode?.let { errorCode(D2ErrorCode.valueOf(it)) }
+            errorDescription(errorDescription)
+            httpErrorCode(httpErrorCode)
+            created(created.toJavaDate())
+        }.build()
+    }
+}
+
+internal fun D2Error.toDB(): D2ErrorDB {
+    return D2ErrorDB(
+        resourceType = null,
+        uid = null,
+        url = url(),
+        errorComponent = errorComponent()?.name,
+        errorCode = errorCode().name,
+        errorDescription = errorDescription(),
+        httpErrorCode = httpErrorCode(),
+        created = created().dateFormat()
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
@@ -47,6 +47,6 @@ internal fun D2Error.toDB(): D2ErrorDB {
         errorCode = errorCode().name,
         errorDescription = errorDescription(),
         httpErrorCode = httpErrorCode(),
-        created = created().dateFormat()
+        created = created().dateFormat(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
@@ -24,8 +24,10 @@ internal data class D2ErrorDB(
     val httpErrorCode: Int?,
     val created: String?,
 ) : EntityDB<D2Error> {
+
     override fun toDomain(): D2Error {
         return D2Error.builder().apply {
+            id(id?.toLong())
             url(url)
             errorComponent?.let { errorComponent(D2ErrorComponent.valueOf(it)) }
             errorCode?.let { errorCode(D2ErrorCode.valueOf(it)) }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDB.kt
@@ -22,8 +22,10 @@ internal data class ForeignKeyViolationDB(
     val fromObjectRow: String?,
     val created: String?,
 ) : EntityDB<ForeignKeyViolation> {
+
     override fun toDomain(): ForeignKeyViolation {
         return ForeignKeyViolation.builder()
+            .id(id?.toLong())
             .fromTable(fromTable)
             .fromColumn(fromColumn)
             .toTable(toTable)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDB.kt
@@ -6,6 +6,7 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolation
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(tableName = "ForeignKeyViolation")
 internal data class ForeignKeyViolationDB(
@@ -20,8 +21,8 @@ internal data class ForeignKeyViolationDB(
     val fromObjectUid: String?,
     val fromObjectRow: String?,
     val created: String?,
-) {
-    fun toDomain(): ForeignKeyViolation {
+) : EntityDB<ForeignKeyViolation> {
+    override fun toDomain(): ForeignKeyViolation {
         return ForeignKeyViolation.builder()
             .fromTable(fromTable)
             .fromColumn(fromColumn)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDB.kt
@@ -3,6 +3,9 @@ package org.hisp.dhis.android.persistence.maintenance
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.maintenance.ForeignKeyViolation
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
 
 @Entity(tableName = "ForeignKeyViolation")
 internal data class ForeignKeyViolationDB(
@@ -17,4 +20,30 @@ internal data class ForeignKeyViolationDB(
     val fromObjectUid: String?,
     val fromObjectRow: String?,
     val created: String?,
-)
+) {
+    fun toDomain(): ForeignKeyViolation {
+        return ForeignKeyViolation.builder()
+            .fromTable(fromTable)
+            .fromColumn(fromColumn)
+            .toTable(toTable)
+            .toColumn(toColumn)
+            .notFoundValue(notFoundValue)
+            .fromObjectUid(fromObjectUid)
+            .fromObjectRow(fromObjectRow)
+            .created(created.toJavaDate())
+            .build()
+    }
+}
+
+internal fun ForeignKeyViolation.toDB(): ForeignKeyViolationDB {
+    return ForeignKeyViolationDB(
+        fromTable = fromTable(),
+        fromColumn = fromColumn(),
+        toTable = toTable(),
+        toColumn = toColumn(),
+        notFoundValue = notFoundValue(),
+        fromObjectUid = fromObjectUid(),
+        fromObjectRow = fromObjectRow(),
+        created = created().dateFormat(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
@@ -34,8 +34,10 @@ internal data class MapLayerDB(
     val imageFormat: String?,
     val layers: String?,
 ) : EntityDB<MapLayer> {
+
     override fun toDomain(): MapLayer {
         return MapLayer.builder().apply {
+            id(id?.toLong())
             uid(uid)
             name(name)
             displayName(displayName)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
@@ -4,6 +4,12 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.map.layer.ImageFormat
+import org.hisp.dhis.android.core.map.layer.MapLayer
+import org.hisp.dhis.android.core.map.layer.MapLayerPosition
+import org.hisp.dhis.android.core.map.layer.MapService
+import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.toDB
 
 @Entity(
     tableName = "MapLayer",
@@ -12,20 +18,54 @@ import androidx.room.PrimaryKey
     ],
 )
 internal data class MapLayerDB(
-    @PrimaryKey(autoGenerate = true)
-    @ColumnInfo(name = "_id")
-    val id: Int? = 0,
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "_id") val id: Int? = 0,
     val uid: String,
     val name: String,
     val displayName: String,
-    val external: Int?,
+    val external: Boolean?,
     val mapLayerPosition: String,
     val style: String?,
     val imageUrl: String,
-    val subdomains: String?,
+    val subdomains: StringListDB?,
     val subdomainPlaceholder: String?,
     val code: String?,
     val mapService: String?,
     val imageFormat: String?,
     val layers: String?,
-)
+) {
+    fun toDomain(): MapLayer {
+        return MapLayer.builder().apply {
+            uid(uid)
+            name(name)
+            displayName(displayName)
+            external(external)
+            mapLayerPosition(MapLayerPosition.valueOf(mapLayerPosition))
+            style(style)
+            imageUrl(imageUrl)
+            subdomains(subdomains?.toDomain())
+            subdomainPlaceholder(subdomainPlaceholder)
+            code(code)
+            mapService?.let { mapService(MapService.valueOf(it)) }
+            imageFormat?.let { imageFormat(ImageFormat.valueOf(it)) }
+            layers(layers)
+        }.build()
+    }
+}
+
+internal fun MapLayer.toDB(): MapLayerDB {
+    return MapLayerDB(
+        uid = uid(),
+        name = name(),
+        displayName = displayName(),
+        external = external(),
+        mapLayerPosition = mapLayerPosition().name,
+        style = style(),
+        imageUrl = imageUrl(),
+        subdomains = subdomains()?.toDB(),
+        subdomainPlaceholder = subdomainPlaceholder(),
+        code = code(),
+        mapService = mapService()?.name,
+        imageFormat = imageFormat()?.name,
+        layers = layers(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
@@ -8,6 +8,7 @@ import org.hisp.dhis.android.core.map.layer.ImageFormat
 import org.hisp.dhis.android.core.map.layer.MapLayer
 import org.hisp.dhis.android.core.map.layer.MapLayerPosition
 import org.hisp.dhis.android.core.map.layer.MapService
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.StringListDB
 import org.hisp.dhis.android.persistence.common.toDB
 
@@ -32,8 +33,8 @@ internal data class MapLayerDB(
     val mapService: String?,
     val imageFormat: String?,
     val layers: String?,
-) {
-    fun toDomain(): MapLayer {
+) : EntityDB<MapLayer> {
+    override fun toDomain(): MapLayer {
         return MapLayer.builder().apply {
             uid(uid)
             name(name)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderAreaDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderAreaDB.kt
@@ -36,7 +36,7 @@ import org.hisp.dhis.android.persistence.map.MapLayerImageryProviderAreaDBSerial
 
 @JvmInline
 internal value class MapLayerImageryProviderAreaDB(
-    val value: String?
+    val value: String?,
 ) {
     fun toDomain(): List<MapLayerImageryProviderArea> {
         return if (value == null) {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
@@ -33,12 +33,12 @@ internal data class MapLayerImageryProviderDB(
 ) : EntityDB<MapLayerImageryProvider> {
 
     override fun toDomain(): MapLayerImageryProvider {
-        return MapLayerImageryProvider.builder().apply {
-            id(id?.toLong())
-            mapLayer(mapLayer)
-            attribution(attribution)
-            coverageAreas(coverageAreas?.toDomain())
-        }.build()
+        return MapLayerImageryProvider.builder()
+            .id(id?.toLong())
+            .mapLayer(mapLayer)
+            .attribution(attribution)
+            .coverageAreas(coverageAreas?.toDomain())
+            .build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
@@ -5,6 +5,8 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.map.layer.MapLayerImageryProvider
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "MapLayerImageryProvider",
@@ -27,5 +29,21 @@ internal data class MapLayerImageryProviderDB(
     val id: Int? = 0,
     val mapLayer: String,
     val attribution: String,
-    val coverageAreas: String?,
-)
+    val coverageAreas: MapLayerImageryProviderAreaDB?,
+) : EntityDB<MapLayerImageryProvider> {
+    override fun toDomain(): MapLayerImageryProvider {
+        return MapLayerImageryProvider.builder().apply {
+            mapLayer(mapLayer)
+            attribution(attribution)
+            coverageAreas(coverageAreas?.toDomain())
+        }.build()
+    }
+}
+
+internal fun MapLayerImageryProvider.toDB(): MapLayerImageryProviderDB {
+    return MapLayerImageryProviderDB(
+        mapLayer = mapLayer(),
+        attribution = attribution(),
+        coverageAreas = coverageAreas()?.toDB(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
@@ -31,8 +31,10 @@ internal data class MapLayerImageryProviderDB(
     val attribution: String,
     val coverageAreas: MapLayerImageryProviderAreaDB?,
 ) : EntityDB<MapLayerImageryProvider> {
+
     override fun toDomain(): MapLayerImageryProvider {
         return MapLayerImageryProvider.builder().apply {
+            id(id?.toLong())
             mapLayer(mapLayer)
             attribution(attribution)
             coverageAreas(coverageAreas?.toDomain())

--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDB.kt
@@ -52,8 +52,10 @@ internal data class NoteDB(
     override val syncState: SyncStateDB?,
     override val deleted: Boolean?,
 ) : EntityDB<Note>, DeletableObjectDB, DataObjectDB {
+
     override fun toDomain(): Note {
         return Note.builder().apply {
+            id(id?.toLong())
             uid(uid)
             noteType?.let { noteType(Note.NoteType.valueOf(it)) }
             event(event)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDB.kt
@@ -5,6 +5,12 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.note.Note
+import org.hisp.dhis.android.persistence.common.DataObjectDB
+import org.hisp.dhis.android.persistence.common.DeletableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.SyncStateDB
+import org.hisp.dhis.android.persistence.common.toDB
 import org.hisp.dhis.android.persistence.enrollment.EnrollmentDB
 import org.hisp.dhis.android.persistence.event.EventDB
 
@@ -43,6 +49,34 @@ internal data class NoteDB(
     val storedBy: String?,
     val storedDate: String?,
     val uid: String?,
-    val syncState: String?,
-    val deleted: Int?,
-)
+    override val syncState: SyncStateDB?,
+    override val deleted: Boolean?,
+) : EntityDB<Note>, DeletableObjectDB, DataObjectDB {
+    override fun toDomain(): Note {
+        return Note.builder().apply {
+            uid(uid)
+            noteType?.let { noteType(Note.NoteType.valueOf(it)) }
+            event(event)
+            enrollment(enrollment)
+            value(value)
+            storedBy(storedBy)
+            storedDate(storedDate)
+            syncState?.let { syncState(it.toDomain()) }
+            deleted(deleted)
+        }.build()
+    }
+}
+
+internal fun Note.toDB(): NoteDB {
+    return NoteDB(
+        uid = uid(),
+        noteType = noteType()?.name,
+        event = event(),
+        enrollment = enrollment(),
+        value = value(),
+        storedBy = storedBy(),
+        storedDate = storedDate(),
+        syncState = syncState()?.toDB(),
+        deleted = deleted(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDB.kt
@@ -48,13 +48,13 @@ internal data class OptionDB(
 ) : EntityDB<Option>, BaseIdentifiableObjectDB, ObjectWithStyleDB {
 
     override fun toDomain(): Option {
-        return Option.builder().apply {
-            applyBaseIdentifiableFields(this@OptionDB)
-            applyStyleFields(this@OptionDB)
-            id(id?.toLong())
-            optionSet(ObjectWithUid.create(optionSet))
-            sortOrder(sortOrder)
-        }.build()
+        return Option.builder()
+            .applyBaseIdentifiableFields(this@OptionDB)
+            .applyStyleFields(this@OptionDB)
+            .id(id?.toLong())
+            .optionSet(ObjectWithUid.create(optionSet))
+            .sortOrder(sortOrder)
+            .build()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDB.kt
@@ -5,6 +5,14 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.option.Option
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.ObjectWithStyleDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
+import org.hisp.dhis.android.persistence.common.applyStyleFields
 
 @Entity(
     tableName = "Option",
@@ -27,14 +35,40 @@ internal data class OptionDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val optionSet: String,
     val sortOrder: Int?,
-    val color: String?,
-    val icon: String?,
-)
+    override val color: String?,
+    override val icon: String?,
+) : EntityDB<Option>, BaseIdentifiableObjectDB, ObjectWithStyleDB {
+
+    override fun toDomain(): Option {
+        return Option.builder().apply {
+            applyBaseIdentifiableFields(this@OptionDB)
+            applyStyleFields(this@OptionDB)
+            id(id?.toLong())
+            optionSet(ObjectWithUid.create(optionSet))
+            sortOrder(sortOrder)
+        }.build()
+    }
+}
+
+internal fun Option.toDB(): OptionDB {
+    return OptionDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+        optionSet = optionSet()!!.uid(),
+        sortOrder = sortOrder(),
+        color = style().color(),
+        icon = style().icon(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupDB.kt
@@ -5,6 +5,12 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.option.OptionGroup
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "OptionGroup",
@@ -26,11 +32,32 @@ internal data class OptionGroupDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val optionSet: String,
-)
+) : EntityDB<OptionGroup>, BaseIdentifiableObjectDB {
+
+    override fun toDomain(): OptionGroup {
+        return OptionGroup.builder()
+            .applyBaseIdentifiableFields(this@OptionGroupDB)
+            .id(id?.toLong())
+            .optionSet(ObjectWithUid.create(optionSet))
+            .build()
+    }
+}
+
+internal fun OptionGroup.toDB(): OptionGroupDB {
+    return OptionGroupDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+        optionSet = optionSet()!!.uid(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDB.kt
@@ -5,6 +5,8 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.option.OptionGroupOptionLink
+import org.hisp.dhis.android.persistence.common.EntityDB
 
 @Entity(
     tableName = "OptionGroupOptionLink",
@@ -36,4 +38,20 @@ internal data class OptionGroupOptionLinkDB(
     val id: Int? = 0,
     val optionGroup: String,
     val option: String,
-)
+) : EntityDB<OptionGroupOptionLink> {
+
+    override fun toDomain(): OptionGroupOptionLink {
+        return OptionGroupOptionLink.builder()
+            .id(id?.toLong())
+            .optionGroup(optionGroup)
+            .option(option)
+            .build()
+    }
+}
+
+internal fun OptionGroupOptionLink.toDB(): OptionGroupOptionLinkDB {
+    return OptionGroupOptionLinkDB(
+        optionGroup = optionGroup()!!,
+        option = option()!!,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetDB.kt
@@ -4,6 +4,12 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.option.OptionSet
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "OptionSet",
@@ -15,12 +21,35 @@ internal data class OptionSetDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val version: Int?,
     val valueType: String?,
-)
+) : EntityDB<OptionSet>, BaseIdentifiableObjectDB {
+
+    override fun toDomain(): OptionSet {
+        return OptionSet.builder().apply {
+            applyBaseIdentifiableFields(this@OptionSetDB)
+            id(id?.toLong())
+            version(version)
+            valueType?.let { valueType(ValueType.valueOf(it)) }
+        }.build()
+    }
+}
+
+internal fun OptionSet.toDB(): OptionSetDB {
+    return OptionSetDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+        version = version(),
+        valueType = valueType()?.name,
+    )
+}


### PR DESCRIPTION
This is subtask Part 10 from [ANDROSDK-2076](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2076)

this PR, toDoamin and toDB mappers have been added to the next entities:

D2ErrorDB.kt
ForeignKeyViolationDB.kt
MapLayerDB.kt
MapLayerImageryProviderAreaDB.kt
MapLayerImageryProviderDB.kt
NoteDB.kt
OptionDB.kt
OptionGroupDB.kt
OptionGroupOptionLinkDB.kt
OptionSetDB.kt

Related task [ANDROSDK-2093](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2093)

[ANDROSDK-2076]: https://dhis2.atlassian.net/browse/ANDROSDK-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROSDK-2093]: https://dhis2.atlassian.net/browse/ANDROSDK-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ