### PR TITLE
chore: [ANDROSDK-2092] add mappers to entities in enrollment, domain, event, expressionDimensionItem and fileResource packages

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6543,6 +6543,32 @@ public final class org/hisp/dhis/android/core/domain/aggregated/data/internal/Ag
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync : org/hisp/dhis/android/core/common/BaseObject {
+	public fun <init> ()V
+	public static fun builder ()Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public static fun create (Landroid/database/Cursor;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync;
+	public abstract fun dataElementsHash ()Ljava/lang/Integer;
+	public abstract fun dataSet ()Ljava/lang/String;
+	public abstract fun futurePeriods ()Ljava/lang/Integer;
+	public abstract fun lastUpdated ()Ljava/util/Date;
+	public abstract fun organisationUnitsHash ()Ljava/lang/Integer;
+	public abstract fun pastPeriods ()Ljava/lang/Integer;
+	public abstract fun periodType ()Lorg/hisp/dhis/android/core/period/PeriodType;
+	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+}
+
+public abstract class org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder : org/hisp/dhis/android/core/common/BaseObject$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync;
+	public abstract fun dataElementsHash (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public abstract fun dataSet (Ljava/lang/String;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public abstract fun futurePeriods (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public abstract fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public abstract fun organisationUnitsHash (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public abstract fun pastPeriods (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+	public abstract fun periodType (Lorg/hisp/dhis/android/core/period/PeriodType;)Lorg/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync$Builder;
+}
+
 public final class org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSyncTableInfo {
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 }
@@ -7072,6 +7098,18 @@ public class org/hisp/dhis/android/core/event/EventTableInfo$Columns : org/hisp/
 	public fun <init> ()V
 	public fun all ()[Ljava/lang/String;
 	public fun whereUpdate ()[Ljava/lang/String;
+}
+
+public abstract class org/hisp/dhis/android/core/event/internal/EventSync : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync {
+	public fun <init> ()V
+	public static fun builder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	public static fun create (Landroid/database/Cursor;)Lorg/hisp/dhis/android/core/event/internal/EventSync;
+	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+}
+
+public abstract class org/hisp/dhis/android/core/event/internal/EventSync$Builder : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lorg/hisp/dhis/android/core/event/internal/EventSync;
 }
 
 public final class org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository {

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataSync.java
@@ -43,59 +43,59 @@ import org.hisp.dhis.android.core.period.PeriodType;
 import java.util.Date;
 
 @AutoValue
-abstract class AggregatedDataSync extends BaseObject {
+public abstract class AggregatedDataSync extends BaseObject {
 
     @NonNull
-    abstract String dataSet();
-
-    @NonNull
-    @ColumnAdapter(PeriodTypeColumnAdapter.class)
-    abstract PeriodType periodType();
-
-    @NonNull
-    abstract Integer pastPeriods();
-
-    @NonNull
-    abstract Integer futurePeriods();
-
-    @NonNull
-    abstract Integer dataElementsHash();
-
-    @NonNull
-    abstract Integer organisationUnitsHash();
-
-    @NonNull
-    @ColumnAdapter(DbDateColumnAdapter.class)
-    abstract Date lastUpdated();
-
-    @NonNull
-    static AggregatedDataSync create(Cursor cursor) {
+    public static AggregatedDataSync create(Cursor cursor) {
         return AutoValue_AggregatedDataSync.createFromCursor(cursor);
     }
 
-    static Builder builder() {
+    public static Builder builder() {
         return new $$AutoValue_AggregatedDataSync.Builder();
     }
 
-    abstract Builder toBuilder();
+    @NonNull
+    public abstract String dataSet();
+
+    @NonNull
+    @ColumnAdapter(PeriodTypeColumnAdapter.class)
+    public abstract PeriodType periodType();
+
+    @NonNull
+    public abstract Integer pastPeriods();
+
+    @NonNull
+    public abstract Integer futurePeriods();
+
+    @NonNull
+    public abstract Integer dataElementsHash();
+
+    @NonNull
+    public abstract Integer organisationUnitsHash();
+
+    @NonNull
+    @ColumnAdapter(DbDateColumnAdapter.class)
+    public abstract Date lastUpdated();
+
+    public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    abstract static class Builder extends BaseObject.Builder<Builder> {
+    public abstract static class Builder extends BaseObject.Builder<Builder> {
 
-        abstract Builder dataSet(String dataSet);
+        public abstract Builder dataSet(String dataSet);
 
-        abstract Builder periodType(PeriodType periodType);
+        public abstract Builder periodType(PeriodType periodType);
 
-        abstract Builder pastPeriods(Integer pastPeriods);
+        public abstract Builder pastPeriods(Integer pastPeriods);
 
-        abstract Builder futurePeriods(Integer futurePeriods);
+        public abstract Builder futurePeriods(Integer futurePeriods);
 
-        abstract Builder dataElementsHash(Integer dataElementsHash);
+        public abstract Builder dataElementsHash(Integer dataElementsHash);
 
-        abstract Builder organisationUnitsHash(Integer organisationUnitHash);
+        public abstract Builder organisationUnitsHash(Integer organisationUnitHash);
 
-        abstract Builder lastUpdated(Date lastUpdated);
+        public abstract Builder lastUpdated(Date lastUpdated);
 
-        abstract AggregatedDataSync build();
+        public abstract AggregatedDataSync build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventSync.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventSync.java
@@ -37,21 +37,21 @@ import com.google.auto.value.AutoValue;
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerBaseSync;
 
 @AutoValue
-abstract class EventSync extends TrackerBaseSync {
+public abstract class EventSync extends TrackerBaseSync {
 
     @NonNull
-    static EventSync create(Cursor cursor) {
+    public static EventSync create(Cursor cursor) {
         return AutoValue_EventSync.createFromCursor(cursor);
     }
 
-    static Builder builder() {
+    public static Builder builder() {
         return new AutoValue_EventSync.Builder();
     }
 
-    abstract Builder toBuilder();
+    public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    abstract static class Builder extends TrackerBaseSync.Builder<Builder> {
-        abstract EventSync build();
+    public abstract static class Builder extends TrackerBaseSync.Builder<Builder> {
+        public abstract EventSync build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/domain/AggregatedDataSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/domain/AggregatedDataSyncDB.kt
@@ -5,6 +5,11 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.domain.aggregated.data.internal.AggregatedDataSync
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataset.DataSetDB
 
 @Entity(
@@ -33,4 +38,30 @@ internal data class AggregatedDataSyncDB(
     val dataElementsHash: Int,
     val organisationUnitsHash: Int,
     val lastUpdated: String,
-)
+) : EntityDB<AggregatedDataSync> {
+
+    override fun toDomain(): AggregatedDataSync {
+        return AggregatedDataSync.builder()
+            .id(id?.toLong())
+            .dataSet(dataSet)
+            .periodType(PeriodType.valueOf(periodType))
+            .pastPeriods(pastPeriods)
+            .futurePeriods(futurePeriods)
+            .dataElementsHash(dataElementsHash)
+            .organisationUnitsHash(organisationUnitsHash)
+            .lastUpdated(lastUpdated.toJavaDate())
+            .build()
+    }
+}
+
+internal fun AggregatedDataSync.toDB(): AggregatedDataSyncDB {
+    return AggregatedDataSyncDB(
+        dataSet = dataSet(),
+        periodType = periodType().name,
+        pastPeriods = pastPeriods(),
+        futurePeriods = futurePeriods(),
+        dataElementsHash = dataElementsHash(),
+        organisationUnitsHash = organisationUnitsHash(),
+        lastUpdated = lastUpdated().dateFormat()!!,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDB.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.util.dateFormat
@@ -146,6 +145,6 @@ internal fun Event.toDB(): EventDB {
         attributeOptionCombo = attributeOptionCombo(),
         deleted = deleted(),
         assignedUser = assignedUser(),
-        completedBy = completedBy()
+        completedBy = completedBy(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDataFilterDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDataFilterDB.kt
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.event
+
+import org.hisp.dhis.android.core.event.EventDataFilter
+import org.hisp.dhis.android.core.event.EventQueryCriteria
+import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.FilterOperatorsDB
+import org.hisp.dhis.android.persistence.common.FilterQueryCriteriaDB
+import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.StringSetDB
+import org.hisp.dhis.android.persistence.common.applyFilterOperatorsFields
+import org.hisp.dhis.android.persistence.common.applyFilterQueryCriteriaFields
+import org.hisp.dhis.android.persistence.common.toDB
+
+internal data class EventDataFilterDB(
+    override val le: String?,
+    override val ge: String?,
+    override val gt: String?,
+    override val lt: String?,
+    override val eq: String?,
+    override val inProperty: StringSetDB?,
+    override val like: String?,
+    override val dateFilter: DateFilterPeriodDB?,
+    val eventFilter: String?,
+    val dataItem: String?,
+) : EntityDB<EventDataFilter>, FilterOperatorsDB {
+
+    override fun toDomain(): EventDataFilter {
+        return EventDataFilter.builder()
+            .applyFilterOperatorsFields(this@EventDataFilterDB)
+            .eventFilter(eventFilter)
+            .dataItem(dataItem)
+            .build()
+    }
+}
+
+internal fun EventDataFilter.toDB(): EventDataFilterDB {
+    return EventDataFilterDB(
+        le = le(),
+        ge = ge(),
+        gt = gt(),
+        lt = lt(),
+        eq = eq(),
+        inProperty = `in`()?.toDB(),
+        like = like(),
+        dateFilter = dateFilter()?.toDB(),
+        eventFilter = eventFilter(),
+        dataItem = dataItem(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDataFilterDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDataFilterDB.kt
@@ -29,15 +29,11 @@
 package org.hisp.dhis.android.persistence.event
 
 import org.hisp.dhis.android.core.event.EventDataFilter
-import org.hisp.dhis.android.core.event.EventQueryCriteria
 import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.FilterOperatorsDB
-import org.hisp.dhis.android.persistence.common.FilterQueryCriteriaDB
-import org.hisp.dhis.android.persistence.common.StringListDB
 import org.hisp.dhis.android.persistence.common.StringSetDB
 import org.hisp.dhis.android.persistence.common.applyFilterOperatorsFields
-import org.hisp.dhis.android.persistence.common.applyFilterQueryCriteriaFields
 import org.hisp.dhis.android.persistence.common.toDB
 
 internal data class EventDataFilterDB(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventFilterDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventFilterDB.kt
@@ -5,6 +5,13 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.event.EventFilter
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.StringListDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
@@ -45,25 +52,78 @@ internal data class EventFilterDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val program: String,
     val programStage: String?,
     val description: String?,
-    val followUp: Int?,
+    val followUp: Boolean?,
     val organisationUnit: String?,
     val ouMode: String?,
     val assignedUserMode: String?,
     val orderProperty: String?,
-    val displayColumnOrder: String?,
-    val events: String?,
+    val displayColumnOrder: StringListDB?,
+    val events: StringListDB?,
     val eventStatus: String?,
-    val eventDate: String?,
-    val dueDate: String?,
-    val lastUpdatedDate: String?,
-    val completedDate: String?,
-)
+    val eventDate: DateFilterPeriodDB?,
+    val dueDate: DateFilterPeriodDB?,
+    val lastUpdatedDate: DateFilterPeriodDB?,
+    val completedDate: DateFilterPeriodDB?,
+) : EntityDB<EventFilter>, BaseIdentifiableObjectDB {
+    override fun toDomain(): EventFilter {
+        return EventFilter.builder()
+            .applyBaseIdentifiableFields(this@EventFilterDB)
+            .program(program)
+            .programStage(programStage)
+            .description(description)
+            .eventQueryCriteria(
+                EventQueryCriteriaDB(
+                    followUp = followUp,
+                    organisationUnit = organisationUnit,
+                    ouMode = ouMode,
+                    assignedUserMode = assignedUserMode,
+                    orderProperty = orderProperty,
+                    displayColumnOrder = displayColumnOrder,
+                    events = events,
+                    eventStatus = eventStatus,
+                    eventDate = eventDate,
+                    dueDate = dueDate,
+                    lastUpdatedDate = lastUpdatedDate,
+                    completedDate = completedDate,
+                ).toDomain(),
+            )
+            .build()
+    }
+}
+
+internal fun EventFilter.toDB(): EventFilterDB {
+    val eventQueryCriteria = eventQueryCriteria()?.toDB()
+
+    return EventFilterDB(
+        uid = uid()!!,
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created()?.dateFormat(),
+        lastUpdated = lastUpdated()?.dateFormat(),
+        program = program()!!,
+        programStage = programStage(),
+        description = description(),
+        followUp = eventQueryCriteria?.followUp,
+        organisationUnit = eventQueryCriteria?.organisationUnit,
+        ouMode = eventQueryCriteria?.ouMode,
+        assignedUserMode = eventQueryCriteria?.assignedUserMode,
+        orderProperty = eventQueryCriteria?.orderProperty,
+        displayColumnOrder = eventQueryCriteria?.displayColumnOrder,
+        events = eventQueryCriteria?.events,
+        eventStatus = eventQueryCriteria?.eventStatus,
+        eventDate = eventQueryCriteria?.eventDate,
+        dueDate = eventQueryCriteria?.dueDate,
+        lastUpdatedDate = eventQueryCriteria?.lastUpdatedDate,
+        completedDate = eventQueryCriteria?.completedDate,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventQueryCriteriaDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventQueryCriteriaDB.kt
@@ -26,10 +26,9 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.persistence.trackedentity
+package org.hisp.dhis.android.persistence.event
 
-import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
-import org.hisp.dhis.android.core.trackedentity.EntityQueryCriteria
+import org.hisp.dhis.android.core.event.EventQueryCriteria
 import org.hisp.dhis.android.persistence.common.DateFilterPeriodDB
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.FilterQueryCriteriaDB
@@ -37,8 +36,7 @@ import org.hisp.dhis.android.persistence.common.StringListDB
 import org.hisp.dhis.android.persistence.common.applyFilterQueryCriteriaFields
 import org.hisp.dhis.android.persistence.common.toDB
 
-internal data class EntityQueryCriteriaDB(
-    val enrollmentStatus: String?,
+internal data class EventQueryCriteriaDB(
     override val followUp: Boolean?,
     override val organisationUnit: String?,
     override val ouMode: String?,
@@ -48,29 +46,23 @@ internal data class EntityQueryCriteriaDB(
     override val eventStatus: String?,
     override val eventDate: DateFilterPeriodDB?,
     override val lastUpdatedDate: DateFilterPeriodDB?,
-    val programStage: String?,
-    val trackedEntityInstances: StringListDB?,
-    val enrollmentIncidentDate: DateFilterPeriodDB?,
-    val enrollmentCreatedDate: DateFilterPeriodDB?,
-    val trackedEntityType: String?,
-) : EntityDB<EntityQueryCriteria>, FilterQueryCriteriaDB {
+    val events: StringListDB?,
+    val dueDate: DateFilterPeriodDB?,
+    val completedDate: DateFilterPeriodDB?,
+) : EntityDB<EventQueryCriteria>, FilterQueryCriteriaDB {
 
-    override fun toDomain(): EntityQueryCriteria {
-        return EntityQueryCriteria.builder().apply {
-            applyFilterQueryCriteriaFields(this@EntityQueryCriteriaDB)
-            enrollmentStatus(enrollmentStatus?.let { EnrollmentStatus.valueOf(it) })
-            programStage(programStage)
-            trackedEntityInstances(trackedEntityInstances?.toDomain())
-            enrollmentIncidentDate(enrollmentIncidentDate?.toDomain())
-            enrollmentCreatedDate(enrollmentCreatedDate?.toDomain())
-            trackedEntityType(trackedEntityType)
+    override fun toDomain(): EventQueryCriteria {
+        return EventQueryCriteria.builder().apply {
+            applyFilterQueryCriteriaFields(this@EventQueryCriteriaDB)
+            events(events?.toDomain())
+            dueDate(dueDate?.toDomain())
+            completedDate(completedDate?.toDomain())
         }.build()
     }
 }
 
-internal fun EntityQueryCriteria.toDB(): EntityQueryCriteriaDB {
-    return EntityQueryCriteriaDB(
-        enrollmentStatus = enrollmentStatus()?.name,
+internal fun EventQueryCriteria.toDB(): EventQueryCriteriaDB {
+    return EventQueryCriteriaDB(
         followUp = followUp(),
         organisationUnit = organisationUnit(),
         ouMode = ouMode()?.name,
@@ -80,10 +72,8 @@ internal fun EntityQueryCriteria.toDB(): EntityQueryCriteriaDB {
         eventStatus = eventStatus()?.name,
         eventDate = eventDate()?.toDB(),
         lastUpdatedDate = lastUpdatedDate()?.toDB(),
-        programStage = programStage(),
-        trackedEntityInstances = trackedEntityInstances()?.toDB(),
-        enrollmentIncidentDate = enrollmentIncidentDate()?.toDB(),
-        enrollmentCreatedDate = enrollmentCreatedDate()?.toDB(),
-        trackedEntityType = trackedEntityType(),
+        events = events()?.toDB(),
+        dueDate = dueDate()?.toDB(),
+        completedDate = completedDate()?.toDB(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDB.kt
@@ -5,6 +5,10 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.event.internal.EventSync
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
 @Entity(
@@ -31,4 +35,24 @@ internal data class EventSyncDB(
     val organisationUnitIdsHash: Int?,
     val downloadLimit: Int,
     val lastUpdated: String,
-)
+) : EntityDB<EventSync> {
+
+    override fun toDomain(): EventSync {
+        return EventSync.builder()
+            .id(id?.toLong())
+            .program(program)
+            .organisationUnitIdsHash(organisationUnitIdsHash)
+            .downloadLimit(downloadLimit)
+            .lastUpdated(lastUpdated.toJavaDate())
+            .build()
+    }
+}
+
+internal fun EventSync.toDB(): EventSyncDB {
+    return EventSyncDB(
+        program = program(),
+        organisationUnitIdsHash = organisationUnitIdsHash(),
+        downloadLimit = downloadLimit(),
+        lastUpdated = lastUpdated().dateFormat()!!,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/expressiondimensionitem/ExpressionDimensionItemDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/expressiondimensionitem/ExpressionDimensionItemDB.kt
@@ -4,6 +4,11 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.expressiondimensionitem.ExpressionDimensionItem
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.persistence.common.BaseIdentifiableObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.applyBaseIdentifiableFields
 
 @Entity(
     tableName = "ExpressionDimensionItem",
@@ -15,11 +20,32 @@ internal data class ExpressionDimensionItemDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int? = 0,
-    val uid: String,
-    val code: String?,
-    val name: String?,
-    val displayName: String?,
-    val created: String?,
-    val lastUpdated: String?,
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: String?,
+    override val lastUpdated: String?,
     val expression: String?,
-)
+) : EntityDB<ExpressionDimensionItem>, BaseIdentifiableObjectDB {
+
+    override fun toDomain(): ExpressionDimensionItem {
+        return ExpressionDimensionItem.builder()
+            .applyBaseIdentifiableFields(this@ExpressionDimensionItemDB)
+            .id(id?.toLong())
+            .expression(expression)
+            .build()
+    }
+}
+
+internal fun ExpressionDimensionItem.toDB(): ExpressionDimensionItemDB {
+    return ExpressionDimensionItemDB(
+        uid = uid(),
+        code = code(),
+        name = name(),
+        displayName = displayName(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+        expression = expression(),
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/fileresource/FileResourceDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/fileresource/FileResourceDB.kt
@@ -4,6 +4,14 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import org.hisp.dhis.android.core.fileresource.FileResource
+import org.hisp.dhis.android.core.fileresource.FileResourceDomain
+import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.persistence.common.DataObjectDB
+import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.persistence.common.SyncStateDB
+import org.hisp.dhis.android.persistence.common.toDB
 
 @Entity(
     tableName = "FileResource",
@@ -20,8 +28,38 @@ internal data class FileResourceDB(
     val created: String?,
     val lastUpdated: String?,
     val contentType: String?,
-    val contentLength: Int?,
+    val contentLength: Long?,
     val path: String?,
-    val syncState: String?,
+    override val syncState: SyncStateDB?,
     val domain: String?,
-)
+) : EntityDB<FileResource>, DataObjectDB {
+
+    override fun toDomain(): FileResource {
+        return FileResource.builder().apply {
+            id(id?.toLong())
+            uid(uid)
+            name?.let { name(it) }
+            created?.let { created(it.toJavaDate()!!) }
+            lastUpdated?.let { lastUpdated(it.toJavaDate()!!) }
+            contentType?.let { contentType(it) }
+            contentLength?.let { contentLength(it) }
+            path?.let { path(it) }
+            syncState?.let { syncState(it.toDomain()) }
+            domain?.let { domain(FileResourceDomain.valueOf(it)) }
+        }.build()
+    }
+}
+
+internal fun FileResource.toDB(): FileResourceDB {
+    return FileResourceDB(
+        uid = uid()!!,
+        name = name(),
+        created = created().dateFormat(),
+        lastUpdated = lastUpdated().dateFormat(),
+        contentType = contentType(),
+        contentLength = contentLength(),
+        path = path(),
+        syncState = syncState()?.toDB(),
+        domain = domain()?.name,
+    )
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDB.kt
@@ -55,7 +55,7 @@ internal data class TrackedEntityInstanceDB(
     val geometryType: String?,
     val geometryCoordinates: String?,
     override val syncState: SyncStateDB?,
-    val aggregatedSyncState: String?,
+    val aggregatedSyncState: SyncStateDB?,
     override val deleted: Boolean?,
 ) : EntityDB<TrackedEntityInstance>, DataObjectDB, DeletableObjectDB {
     override fun toDomain(): TrackedEntityInstance {
@@ -70,7 +70,7 @@ internal data class TrackedEntityInstanceDB(
             trackedEntityType(trackedEntityType)
             geometry(GeometryDB(geometryType, geometryCoordinates).toDomain())
             syncState?.let { syncState(it.toDomain()) }
-            aggregatedSyncState(aggregatedSyncState?.let { State.valueOf(it) })
+            aggregatedSyncState?.let { aggregatedSyncState(it.toDomain()) }
             deleted(deleted)
         }.build()
     }
@@ -88,7 +88,7 @@ internal fun TrackedEntityInstance.toDB(): TrackedEntityInstanceDB {
         geometryType = geometry().toDB().geometryType,
         geometryCoordinates = geometry().toDB().geometryCoordinates,
         syncState = syncState()?.toDB(),
-        aggregatedSyncState = aggregatedSyncState()?.name,
+        aggregatedSyncState = aggregatedSyncState()?.toDB(),
         deleted = deleted(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDB.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate


### PR DESCRIPTION
This is subtask Part 9 from [ANDROSDK-2076](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2076)

In this PR, toDomain and toDB mappers have been added to the next packages:
Enrollment, domain, event, expressionDimensionItem and fileResource packages.



[ANDROSDK-2076]: https://dhis2.atlassian.net/browse/ANDROSDK-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ