### PR TITLE
fix: [ANDROSDK-2085] Add missing sorting fields

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/network/trackervisualization/TrackerVisualizationFields.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/trackervisualization/TrackerVisualizationFields.kt
@@ -51,5 +51,6 @@ internal object TrackerVisualizationFields : BaseFields<TrackerVisualization>() 
         fh.nestedFieldWithUid(Columns.TRACKED_ENTITY_TYPE),
         fh.nestedField<TrackerVisualizationDimension>(COLUMNS).with(TrackerVisualizationDimensionFields.allFields),
         fh.nestedField<TrackerVisualizationDimension>(FILTERS).with(TrackerVisualizationDimensionFields.allFields),
+        fh.field(Columns.SORTING),
     )
 }


### PR DESCRIPTION
Defect for ANDROSDK-2085.

Based on this, I love the idea of using KSP to generate the fields automatically so it never happens again :-) 