### PR TITLE
fix: [ANDROSDK-2107] Mark update and insert methods as Synchronized

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.kt
@@ -64,6 +64,7 @@ internal open class ObjectStoreImpl<O : CoreObject> internal constructor(
 
     @Throws(RuntimeException::class)
     @Suppress("TooGenericExceptionThrown")
+    @Synchronized
     override fun insert(o: O): Long {
         CollectionsHelper.isNull(o)
         compileStatements()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithoutUidStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithoutUidStoreImpl.kt
@@ -73,6 +73,7 @@ internal open class ObjectWithoutUidStoreImpl<O : CoreObject>(
     private var adapterHashCode: Int? = null
 
     @Throws(RuntimeException::class)
+    @Synchronized
     override fun updateWhere(o: O) {
         CollectionsHelper.isNull(o)
         compileStatements()


### PR DESCRIPTION
Fixes these two bugs:
- https://dhis2.atlassian.net/browse/ANDROSDK-2107 
- https://dhis2.atlassian.net/browse/ANDROSDK-2108

Two parallel calls of the `updateWhere` or `insert` methods could generate these sequence:
1. (call 1) bindStatament
2. (call 1) executeStatement
3. (call 2) bindStatement
4. (call 1) clearBindings
5. (call 2) executeStatement -> error

As both calls share the same statement, the step 4 will clear the bindings made in step 3 (call 2), so the step 5 will fail because the bindings for the statement were cleared [ANDROSDK-2107](https://dhis2.atlassian.net/browse/ANDROSDK-2107). The same could happen for inserts [ANDROSDK-2108](https://dhis2.atlassian.net/browse/ANDROSDK-2108).

[ANDROSDK-2107]: https://dhis2.atlassian.net/browse/ANDROSDK-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROSDK-2108]: https://dhis2.atlassian.net/browse/ANDROSDK-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ