### PR TITLE
bug: [ANDROSDK-2109] Tracked entity type access deserialization

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/network/trackedentitytype/TrackedEntityTypeDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/trackedentitytype/TrackedEntityTypeDTO.kt
@@ -63,7 +63,7 @@ internal data class TrackedEntityTypeDTO(
             applyBaseNameableFields(this@TrackedEntityTypeDTO)
             trackedEntityTypeAttributes?.let { trackedEntityTypeAttributes(it.map { it.toDomain() }) }
             featureType?.let { featureType(FeatureType.valueOf(it)) }
-            access?.let { it.toDomain() } ?: defaultAccess()
+            access?.let { access(it.toDomain()) } ?: defaultAccess()
             style?.let { style(style.toDomain()) }
         }.build()
     }


### PR DESCRIPTION
When mapping tracked entity types to the domain model, the access was not being correctly assigned.

Related task [ANDROSDK-2109](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2109)

[ANDROSDK-2109]: https://dhis2.atlassian.net/browse/ANDROSDK-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ