### PR TITLE
chore: [ANDROSDK-2106] update parsing library in documentation

### DIFF
--- a/docs/content/developer/overview.md
+++ b/docs/content/developer/overview.md
@@ -14,4 +14,4 @@ The SDK is mainly written in Java 8 using the reduced subset of features allowed
 
 It uses [RxJava](https://github.com/ReactiveX/RxJava) to facilitate the asynchronous treatment of some methods. Although it is optional, we recommend this approach to ensure non-blocking calls.
 
-Other libraries internally used by the SDK are: [Koin](https://insert-koin.io/) for dependency injection, [Jackson](https://github.com/FasterXML/jackson) for JSON parsing, [Ktor](https://github.com/ktorio/ktor) and [OkHttpClient](https://square.github.io/okhttp/) for API communication or [SQLCipher](https://www.zetetic.net/sqlcipher/) for DB encryption.
+Other libraries internally used by the SDK are: [Koin](https://insert-koin.io/) for dependency injection, [Kotlinx Serialization](https://github.com/Kotlin/kotlinx.serialization) for JSON parsing, [Ktor](https://github.com/ktorio/ktor) and [OkHttpClient](https://square.github.io/okhttp/) for API communication or [SQLCipher](https://www.zetetic.net/sqlcipher/) for DB encryption.


### PR DESCRIPTION
The library used for parsing API payloads needed to be updated from jackson to kotlix serialization