### PR TITLE
chore: [ANDROSDK-2098] Migrate Repositories Layer to Kotlin Coroutines 

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2864,6 +2864,7 @@ public abstract interface class org/hisp/dhis/android/core/arch/repositories/col
 public abstract class org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository {
 	public fun blockingGetUids ()Ljava/util/List;
 	public fun getUids ()Lio/reactivex/Single;
+	protected final fun getUidsInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
@@ -2885,6 +2886,7 @@ public class org/hisp/dhis/android/core/arch/repositories/collection/internal/Re
 	public fun getPagingData (I)Lkotlinx/coroutines/flow/Flow;
 	protected final fun getWhereClause ()Ljava/lang/String;
 	public fun isEmpty ()Lio/reactivex/Single;
+	protected final fun isEmptyProtected (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
 }
@@ -2923,8 +2925,9 @@ public class org/hisp/dhis/android/core/arch/repositories/collection/internal/Re
 public abstract class org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository {
 	protected final field transformer Lorg/hisp/dhis/android/core/arch/handlers/internal/Transformer;
 	public fun add (Ljava/lang/Object;)Lio/reactivex/Single;
+	protected final fun addInternal (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun blockingAdd (Ljava/lang/Object;)Ljava/lang/String;
-	protected fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	protected fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/arch/repositories/filters/internal/AbstractFilterConnector {
@@ -3189,10 +3192,11 @@ public abstract interface class org/hisp/dhis/android/core/arch/repositories/obj
 public abstract class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl {
 	public final fun blockingDownload ()V
 	public final fun blockingExists ()Z
-	public abstract fun blockingGet ()Ljava/lang/Object;
+	public final fun blockingGet ()Ljava/lang/Object;
 	public final fun download ()Lio/reactivex/Completable;
 	public final fun exists ()Lio/reactivex/Single;
 	public final fun get ()Lio/reactivex/Single;
+	protected abstract fun getInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
@@ -3207,11 +3211,14 @@ public abstract class org/hisp/dhis/android/core/arch/repositories/object/intern
 	public abstract fun blockingGetWithoutChildren ()Ljava/lang/Object;
 	public fun exists ()Lio/reactivex/Single;
 	public fun get ()Lio/reactivex/Single;
+	protected final fun getInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun getScope ()Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope;
+	protected abstract fun getWithoutChildrenInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl {
 	public fun blockingGetWithoutChildren ()Ljava/lang/Object;
+	protected fun getWithoutChildrenInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository {
@@ -3219,14 +3226,17 @@ public abstract class org/hisp/dhis/android/core/arch/repositories/object/intern
 	public fun blockingDeleteIfExist ()V
 	public fun delete ()Lio/reactivex/Completable;
 	public fun deleteIfExist ()Lio/reactivex/Completable;
-	protected abstract fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	protected abstract fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	protected final fun deleteIfExistInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun deleteInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun updateIfChanged (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lorg/hisp/dhis/android/core/common/Unit;
-	protected fun updateObject (Lorg/hisp/dhis/android/core/common/CoreObject;)Lorg/hisp/dhis/android/core/common/Unit;
+	protected final fun updateIfChangedInternal (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun updateObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl {
-	protected fun updateObject (Lorg/hisp/dhis/android/core/common/CoreObject;)Lorg/hisp/dhis/android/core/common/Unit;
+	protected fun updateObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository {
@@ -3235,9 +3245,13 @@ public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWr
 	public fun delete ()Lio/reactivex/Completable;
 	protected fun delete (Lorg/hisp/dhis/android/core/common/CoreObject;)V
 	public fun deleteIfExist ()Lio/reactivex/Completable;
-	protected fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	protected final fun setObject (Lorg/hisp/dhis/android/core/common/CoreObject;)V
+	protected final fun deleteIfExistInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun deleteInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun deleteInternal (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun setObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun updateIfChanged (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lorg/hisp/dhis/android/core/common/Unit;
+	protected final fun updateIfChangedInternal (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/arch/repositories/paging/PageConfig {
@@ -6678,7 +6692,7 @@ public final class org/hisp/dhis/android/core/enrollment/EnrollmentCollectionRep
 	public final fun orderByIncidentDate (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository;
 	public final fun orderByLastUpdated (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository;
 	public final fun orderByLastUpdatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository;
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/enrollment/EnrollmentObjectRepository;
 	public final fun withNotes ()Lorg/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository;
@@ -6715,8 +6729,8 @@ public abstract interface class org/hisp/dhis/android/core/enrollment/Enrollment
 }
 
 public final class org/hisp/dhis/android/core/enrollment/EnrollmentObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl {
-	public synthetic fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setCompletedDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/common/Unit;
 	public final fun setEnrollmentDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/common/Unit;
 	public final fun setFollowUp (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/common/Unit;
@@ -6864,7 +6878,7 @@ public final class org/hisp/dhis/android/core/event/EventCollectionRepository : 
 	public final fun orderByLastUpdatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public final fun orderByOrganisationUnitName (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public final fun orderByTimeline (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventObjectRepository;
 	public fun upload ()Lio/reactivex/Observable;
@@ -7019,8 +7033,8 @@ public final class org/hisp/dhis/android/core/event/EventNonEditableReason : jav
 }
 
 public final class org/hisp/dhis/android/core/event/EventObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl {
-	public synthetic fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setAssignedUser (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/Unit;
 	public final fun setAttributeOptionComboUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/Unit;
 	public final fun setCompletedBy (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/Unit;
@@ -8666,7 +8680,7 @@ public final class org/hisp/dhis/android/core/note/NoteCollectionRepository : or
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun byValue ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 }
 
@@ -11125,16 +11139,12 @@ public abstract class org/hisp/dhis/android/core/settings/AnalyticsDhisVisualiza
 
 public final class org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
 	public final fun blockingByDataSet (Ljava/lang/String;)Ljava/util/List;
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSetting;
 	public final fun blockingGetByProgram (Ljava/lang/String;)Ljava/util/List;
 	public final fun getByDataSet (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun getByProgram (Ljava/lang/String;)Lio/reactivex/Single;
 }
 
 public final class org/hisp/dhis/android/core/settings/AnalyticsSettingObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/AnalyticsSettings;
 	public final fun teis ()Lorg/hisp/dhis/android/core/settings/AnalyticsTeiSettingCollectionRepository;
 	public final fun visualizationsSettings ()Lorg/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository;
 }
@@ -11428,8 +11438,6 @@ public abstract class org/hisp/dhis/android/core/settings/AppearanceSettings$Bui
 }
 
 public final class org/hisp/dhis/android/core/settings/AppearanceSettingsObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/AppearanceSettings;
 	public final fun getCompletionSpinnerByUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/settings/CompletionSpinner;
 	public final fun getDataSetConfigurationByUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/settings/DataSetConfigurationSetting;
 	public final fun getDataSetFiltersByUid (Ljava/lang/String;)Ljava/util/Map;
@@ -11792,8 +11800,6 @@ public abstract class org/hisp/dhis/android/core/settings/DataSetSettings$Builde
 }
 
 public final class org/hisp/dhis/android/core/settings/DataSetSettingsObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/DataSetSettings;
 }
 
 public final class org/hisp/dhis/android/core/settings/DataSyncPeriod : java/lang/Enum {
@@ -11894,8 +11900,6 @@ public abstract class org/hisp/dhis/android/core/settings/FilterSorting$Builder 
 }
 
 public final class org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/GeneralSettings;
 	public final fun blockingHasExperimentalFeature (Ljava/lang/String;)Z
 	public final fun blockingHasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;)Z
 	public final fun hasExperimentalFeature (Ljava/lang/String;)Lio/reactivex/Single;
@@ -12002,8 +12006,6 @@ public abstract class org/hisp/dhis/android/core/settings/LatestAppVersion$Build
 }
 
 public final class org/hisp/dhis/android/core/settings/LatestAppVersionObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/LatestAppVersion;
 }
 
 public final class org/hisp/dhis/android/core/settings/LatestAppVersionTableInfo {
@@ -12248,8 +12250,6 @@ public abstract class org/hisp/dhis/android/core/settings/ProgramSettings$Builde
 }
 
 public final class org/hisp/dhis/android/core/settings/ProgramSettingsObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/ProgramSettings;
 }
 
 public abstract class org/hisp/dhis/android/core/settings/QuickAction {
@@ -12294,8 +12294,6 @@ public abstract class org/hisp/dhis/android/core/settings/SettingsAppInfo$Builde
 }
 
 public final class org/hisp/dhis/android/core/settings/SynchronizationSettingObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/SynchronizationSettings;
 }
 
 public final class org/hisp/dhis/android/core/settings/SynchronizationSettingTableInfo {
@@ -12404,8 +12402,6 @@ public abstract class org/hisp/dhis/android/core/settings/UserSettings$Builder {
 }
 
 public final class org/hisp/dhis/android/core/settings/UserSettingsObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
-	public synthetic fun blockingGet ()Ljava/lang/Object;
-	public fun blockingGet ()Lorg/hisp/dhis/android/core/settings/UserSettings;
 }
 
 public final class org/hisp/dhis/android/core/settings/UserSettingsTableInfo {
@@ -13292,7 +13288,7 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityAttribu
 	public fun blockingExists ()Z
 	public fun blockingSet (Ljava/lang/String;)V
 	public synthetic fun delete (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;)V
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
 }
 
@@ -13358,7 +13354,7 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityDataVal
 	public fun blockingExists ()Z
 	public fun blockingSet (Ljava/lang/String;)V
 	public synthetic fun delete (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;)V
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
 }
 
@@ -13439,7 +13435,7 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanc
 	public final fun orderByCreatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
 	public final fun orderByLastUpdated (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
 	public final fun orderByLastUpdatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository;
 	public fun upload ()Lio/reactivex/Observable;
@@ -13588,8 +13584,8 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanc
 }
 
 public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl {
-	public synthetic fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;)V
-	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;)V
+	public synthetic fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setGeometry (Lorg/hisp/dhis/android/core/common/Geometry;)Lorg/hisp/dhis/android/core/common/Unit;
 	public final fun setOrganisationUnitUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/Unit;
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorIntegrationShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.common.internal
 
 import androidx.test.runner.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
@@ -159,7 +160,7 @@ class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatch
 
     @Test
     @Throws(D2Error::class)
-    fun reset_enrollment_and_event_states_if_uploading() {
+    fun reset_enrollment_and_event_states_if_uploading() = runTest {
         val teiUid = d2.trackedEntityModule().trackedEntityInstances().blockingAdd(sampleTEIProjection())
         val enrolmentUid1 = d2.enrollmentModule().enrollments().blockingAdd(sampleEnrollmentProjection(teiUid))
         val enrolmentUid2 = d2.enrollmentModule().enrollments().blockingAdd(sampleEnrollmentProjection(teiUid))
@@ -183,7 +184,7 @@ class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatch
 
     @Test
     @Throws(D2Error::class, ParseException::class)
-    fun propagate_last_updated_if_previous_is_older() {
+    fun propagate_last_updated_if_previous_is_older() = runTest {
         val oldDate = BaseIdentifiableObject.DATE_FORMAT.parse("1990-09-20T08:36:46.552")
         val teiUid = createTEIWithLastUpdated(oldDate)
 
@@ -196,7 +197,7 @@ class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatch
 
     @Test
     @Throws(D2Error::class, ParseException::class)
-    fun do_not_propagate_last_updated_if_previous_is_newer() {
+    fun do_not_propagate_last_updated_if_previous_is_newer() = runTest {
         val newerDate = BaseIdentifiableObject.DATE_FORMAT.parse("2990-09-20T08:36:46.552")
         val teiUid = createTEIWithLastUpdated(newerDate)
 
@@ -382,7 +383,7 @@ class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatch
     }
 
     @Throws(D2Error::class)
-    private fun assertThatSetTeiToUpdateWhenTrackedEntityDataValuePropagation(state: State) {
+    private fun assertThatSetTeiToUpdateWhenTrackedEntityDataValuePropagation(state: State) = runTest {
         val teiUid = createTEIWithState(state)
         val enrolmentUid = createEnrollmentWithState(state, teiUid)
         val eventUid = createEventWithState(state, enrolmentUid)
@@ -399,7 +400,7 @@ class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatch
     }
 
     @Throws(D2Error::class)
-    private fun assertThatDoNotSetTeiToUpdateWhenTrackedEntityDataValuePropagation(state: State) {
+    private fun assertThatDoNotSetTeiToUpdateWhenTrackedEntityDataValuePropagation(state: State) = runTest {
         val teiUid = createTEIWithState(state)
         val enrolmentUid = createEnrollmentWithState(state, teiUid)
         val eventUid = createEventWithState(state, enrolmentUid)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/settings/AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould.kt
@@ -40,7 +40,7 @@ class AnalyticsDhisVisualizationsSettingObjectRepositoryMockIntegrationShould :
             .settingModule()
             .analyticsSetting()
             .visualizationsSettings()
-            .blockingGet()
+            .blockingGet()!!
 
         assertThat(analyticsDhisVisualizationsSetting.home().size).isEqualTo(2)
         assertThat(

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
@@ -54,7 +56,7 @@ abstract class BaseReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollec
      * @return A `Single` object with the list of uids.
      */
     override fun getUids(): Single<List<String>> {
-        return Single.fromCallable { blockingGetUids() }
+        return rxSingle { getUidsInternal() }
     }
 
     /**
@@ -64,6 +66,10 @@ abstract class BaseReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollec
      * @return List of uids
      */
     override fun blockingGetUids(): List<String> {
+        return runBlocking { getUidsInternal() }
+    }
+
+    protected suspend fun getUidsInternal(): List<String> {
         return store.selectUidsWhere(
             whereClause,
             OrderByClauseBuilder.orderByFromItems(

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
@@ -70,7 +72,7 @@ internal class ReadOnlyWithUidAndTransformerCollectionRepositoryImpl<
      * @return A `Single` object with the list of uids.
      */
     override fun getUids(): Single<List<String>> {
-        return Single.fromCallable { blockingGetUids() }
+        return rxSingle { getUidsInternal() }
     }
 
     /**
@@ -80,6 +82,10 @@ internal class ReadOnlyWithUidAndTransformerCollectionRepositoryImpl<
      * @return List of uids
      */
     override fun blockingGetUids(): List<String> {
+        return runBlocking { getUidsInternal() }
+    }
+
+    suspend fun getUidsInternal(): List<String> {
         return store.selectUidsWhere(
             whereClause,
             OrderByClauseBuilder.orderByFromItems(

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.call.internal.DownloadProvider
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
@@ -55,7 +56,7 @@ internal constructor(
      * @return a `Completable` that completes when the download and processing is finished
      */
     override fun download(): Completable {
-        return rxCompletable { downloadProvider.download(true) }
+        return rxCompletable { downloadInternal() }
     }
 
     /**
@@ -64,6 +65,10 @@ internal constructor(
      * not be executed in the main thread. Consider the asynchronous version [.download].
      */
     override fun blockingDownload() {
-        download().blockingAwait()
+        runBlocking { downloadInternal() }
+    }
+
+    private suspend fun downloadInternal() {
+        downloadProvider.download(true)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -44,6 +45,10 @@ open class ReadOnlyOneObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> i
 ) : ReadOnlyObjectRepositoryImpl<M, R>(databaseAdapter, childrenAppenders, scope, repositoryFactory) {
 
     override fun blockingGetWithoutChildren(): M? {
+        return runBlocking { getWithoutChildrenInternal() }
+    }
+
+    override suspend fun getWithoutChildrenInternal(): M? {
         val whereClauseBuilder = WhereClauseFromScopeBuilder(WhereClauseBuilder())
         return store.selectOneWhere(whereClauseBuilder.getWhereClause(scope))
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -53,7 +53,7 @@ internal constructor(
         return runBlocking { getWithoutChildrenInternal() }
     }
 
-    protected suspend fun getWithoutChildrenInternal(): M? {
+    private suspend fun getWithoutChildrenInternal(): M? {
         val whereClauseBuilder = WhereClauseFromScopeBuilder(WhereClauseBuilder())
         return store.selectOneWhere(whereClauseBuilder.getWhereClause(scope))
     }
@@ -75,7 +75,7 @@ internal constructor(
         return runBlocking { getInternal() }
     }
 
-    protected suspend fun getInternal(): T? {
+    private suspend fun getInternal(): T? {
         val item = ChildrenAppenderExecutor.appendInObject(
             getWithoutChildrenInternal(),
             databaseAdapter,
@@ -103,7 +103,7 @@ internal constructor(
         return runBlocking { existsInternal() }
     }
 
-    protected suspend fun existsInternal(): Boolean {
+    private suspend fun existsInternal(): Boolean {
         return getWithoutChildrenInternal() != null
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -48,6 +50,10 @@ internal constructor(
 ) : ReadOnlyObjectRepository<T> {
 
     fun blockingGetWithoutChildren(): M? {
+        return runBlocking { getWithoutChildrenInternal() }
+    }
+
+    protected suspend fun getWithoutChildrenInternal(): M? {
         val whereClauseBuilder = WhereClauseFromScopeBuilder(WhereClauseBuilder())
         return store.selectOneWhere(whereClauseBuilder.getWhereClause(scope))
     }
@@ -66,8 +72,12 @@ internal constructor(
      * @return the object
      */
     override fun blockingGet(): T? {
+        return runBlocking { getInternal() }
+    }
+
+    protected suspend fun getInternal(): T? {
         val item = ChildrenAppenderExecutor.appendInObject(
-            blockingGetWithoutChildren(),
+            getWithoutChildrenInternal(),
             databaseAdapter,
             childrenAppenders,
             scope.children(),
@@ -81,7 +91,7 @@ internal constructor(
      * @return if the object exists, wrapped in a `Single`
      */
     override fun exists(): Single<Boolean> {
-        return Single.fromCallable { blockingExists() }
+        return rxSingle { existsInternal() }
     }
 
     /**
@@ -90,6 +100,10 @@ internal constructor(
      * @return if the object exists
      */
     override fun blockingExists(): Boolean {
-        return blockingGetWithoutChildren() != null
+        return runBlocking { existsInternal() }
+    }
+
+    protected suspend fun existsInternal(): Boolean {
+        return getWithoutChildrenInternal() != null
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
@@ -46,6 +46,7 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
+@Suppress("TooManyFunctions")
 abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     store: IdentifiableDeletableDataObjectStore<M>,
     databaseAdapter: DatabaseAdapter,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl.kt
@@ -55,7 +55,7 @@ open class ReadWriteWithUidObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<
 
     @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
-    protected open fun updateObject(m: M): Unit {
+    protected open suspend fun updateObject(m: M): Unit {
         return try {
             store.update(m)
             Unit()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
@@ -42,6 +42,7 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
+@Suppress("TooManyFunctions")
 open class ReadWriteWithValueObjectRepositoryImpl<M : CoreObject, R : ReadOnlyObjectRepository<M>>
 internal constructor(
     private val store: ObjectWithoutUidStore<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/common/internal/DataStatePropagator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/internal/DataStatePropagator.kt
@@ -39,35 +39,35 @@ import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwner
 @Suppress("TooManyFunctions")
 internal interface DataStatePropagator {
 
-    fun propagateTrackedEntityInstanceUpdate(tei: TrackedEntityInstance?)
+    suspend fun propagateTrackedEntityInstanceUpdate(tei: TrackedEntityInstance?)
 
-    fun propagateEnrollmentUpdate(enrollment: Enrollment?)
+    suspend fun propagateEnrollmentUpdate(enrollment: Enrollment?)
 
-    fun propagateEventUpdate(event: Event?)
+    suspend fun propagateEventUpdate(event: Event?)
 
-    fun propagateTrackedEntityDataValueUpdate(dataValue: TrackedEntityDataValue?)
+    suspend fun propagateTrackedEntityDataValueUpdate(dataValue: TrackedEntityDataValue?)
 
-    fun propagateTrackedEntityAttributeUpdate(trackedEntityAttributeValue: TrackedEntityAttributeValue?)
+    suspend fun propagateTrackedEntityAttributeUpdate(trackedEntityAttributeValue: TrackedEntityAttributeValue?)
 
-    fun propagateNoteCreation(note: Note?)
+    suspend fun propagateNoteCreation(note: Note?)
 
-    fun propagateRelationshipUpdate(relationship: Relationship?)
+    suspend fun propagateRelationshipUpdate(relationship: Relationship?)
 
-    fun propagateOwnershipUpdate(programOwner: ProgramOwner)
+    suspend fun propagateOwnershipUpdate(programOwner: ProgramOwner)
 
-    fun resetUploadingEnrollmentAndEventStates(trackedEntityInstanceUid: String?)
+    suspend fun resetUploadingEnrollmentAndEventStates(trackedEntityInstanceUid: String?)
 
-    fun resetUploadingEventStates(enrollmentUid: String?)
+    suspend fun resetUploadingEventStates(enrollmentUid: String?)
 
-    fun refreshTrackedEntityInstanceAggregatedSyncState(trackedEntityInstanceUid: String)
+    suspend fun refreshTrackedEntityInstanceAggregatedSyncState(trackedEntityInstanceUid: String)
 
-    fun refreshEnrollmentAggregatedSyncState(enrollmentUid: String)
+    suspend fun refreshEnrollmentAggregatedSyncState(enrollmentUid: String)
 
-    fun refreshEventAggregatedSyncState(eventUid: String)
+    suspend fun refreshEventAggregatedSyncState(eventUid: String)
 
-    fun refreshAggregatedSyncStates(uidHolder: DataStateUidHolder)
+    suspend fun refreshAggregatedSyncStates(uidHolder: DataStateUidHolder)
 
-    fun getRelatedUids(
+    suspend fun getRelatedUids(
         trackedEntityInstanceUids: List<String>,
         enrollmentUids: List<String>,
         eventUids: List<String>,

--- a/core/src/main/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorImpl.kt
@@ -36,7 +36,10 @@ import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventTableInfo
 import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.note.Note
-import org.hisp.dhis.android.core.relationship.*
+import org.hisp.dhis.android.core.relationship.Relationship
+import org.hisp.dhis.android.core.relationship.RelationshipConstraintType
+import org.hisp.dhis.android.core.relationship.RelationshipHelper
+import org.hisp.dhis.android.core.relationship.RelationshipItem
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemStore
 import org.hisp.dhis.android.core.relationship.internal.RelationshipStore
 import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStore
@@ -48,7 +51,7 @@ import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwner
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStore
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerTableInfo
 import org.koin.core.annotation.Singleton
-import java.util.*
+import java.util.Date
 
 @Singleton
 @Suppress("TooManyFunctions")
@@ -62,14 +65,14 @@ internal class DataStatePropagatorImpl(
     private val programOwner: ProgramOwnerStore,
 ) : DataStatePropagator {
 
-    override fun propagateTrackedEntityInstanceUpdate(tei: TrackedEntityInstance?) {
+    override suspend fun propagateTrackedEntityInstanceUpdate(tei: TrackedEntityInstance?) {
         tei?.let {
             refreshTrackedEntityInstanceAggregatedSyncState(it.uid())
             refreshTrackedEntityInstanceLastUpdated(it.uid())
         }
     }
 
-    override fun propagateEnrollmentUpdate(enrollment: Enrollment?) {
+    override suspend fun propagateEnrollmentUpdate(enrollment: Enrollment?) {
         enrollment?.let {
             refreshEnrollmentAggregatedSyncState(it.uid())
             refreshEnrollmentLastUpdated(it.uid())
@@ -79,7 +82,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun propagateEventUpdate(event: Event?) {
+    override suspend fun propagateEventUpdate(event: Event?) {
         event?.let {
             refreshEventAggregatedSyncState(it.uid())
             refreshEventLastUpdated(it.uid())
@@ -91,11 +94,13 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun propagateTrackedEntityDataValueUpdate(dataValue: TrackedEntityDataValue?) {
+    override suspend fun propagateTrackedEntityDataValueUpdate(dataValue: TrackedEntityDataValue?) {
         setEventSyncState(dataValue!!.event()!!, getStateForUpdate)
     }
 
-    override fun propagateTrackedEntityAttributeUpdate(trackedEntityAttributeValue: TrackedEntityAttributeValue?) {
+    override suspend fun propagateTrackedEntityAttributeUpdate(
+        trackedEntityAttributeValue: TrackedEntityAttributeValue?,
+    ) {
         trackedEntityAttributeValue!!.trackedEntityInstance()?.let { trackedEntityInstanceUid ->
             val enrollments = enrollmentStore.selectByTrackedEntityInstanceAndAttribute(
                 trackedEntityInstanceUid,
@@ -110,7 +115,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun propagateNoteCreation(note: Note?) {
+    override suspend fun propagateNoteCreation(note: Note?) {
         if (note!!.noteType() == Note.NoteType.ENROLLMENT_NOTE) {
             setEnrollmentSyncState(note.enrollment()!!, getStateForUpdate)
         } else if (note.noteType() == Note.NoteType.EVENT_NOTE) {
@@ -118,7 +123,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun propagateRelationshipUpdate(relationship: Relationship?) {
+    override suspend fun propagateRelationshipUpdate(relationship: Relationship?) {
         if (relationship != null) {
             val bidirectional = relationship.relationshipType()?.let {
                 relationshipTypeStore.selectByUid(it)?.bidirectional()
@@ -132,13 +137,13 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun propagateOwnershipUpdate(programOwner: ProgramOwner) {
+    override suspend fun propagateOwnershipUpdate(programOwner: ProgramOwner) {
         programOwner.trackedEntityInstance()?.let {
             setTeiSyncState(it, getStateForUpdate)
         }
     }
 
-    private fun propagateRelationshipUpdate(item: RelationshipItem?) {
+    private suspend fun propagateRelationshipUpdate(item: RelationshipItem?) {
         if (item != null) {
             if (item.hasTrackedEntityInstance()) {
                 val tei = trackedEntityInstanceStore.selectByUid(item.elementUid())
@@ -153,28 +158,28 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    private fun setTeiSyncState(trackedEntityInstanceUid: String?, getState: (State?) -> State) {
+    private suspend fun setTeiSyncState(trackedEntityInstanceUid: String?, getState: (State?) -> State) {
         trackedEntityInstanceStore.selectByUid(trackedEntityInstanceUid!!)?.let { instance ->
             trackedEntityInstanceStore.setSyncState(trackedEntityInstanceUid, getState(instance.syncState()))
             propagateTrackedEntityInstanceUpdate(instance)
         }
     }
 
-    private fun setEnrollmentSyncState(enrollmentUid: String, getState: (State?) -> State) {
+    private suspend fun setEnrollmentSyncState(enrollmentUid: String, getState: (State?) -> State) {
         enrollmentStore.selectByUid(enrollmentUid)?.let { enrollment ->
             enrollmentStore.setSyncState(enrollmentUid, getState(enrollment.syncState()))
             propagateEnrollmentUpdate(enrollment)
         }
     }
 
-    private fun setEventSyncState(eventUid: String, getState: (State?) -> State) {
+    private suspend fun setEventSyncState(eventUid: String, getState: (State?) -> State) {
         eventStore.selectByUid(eventUid)?.let { event ->
             eventStore.setSyncState(eventUid, getState(event.syncState()))
             propagateEventUpdate(event)
         }
     }
 
-    private fun refreshEventLastUpdated(eventUid: String) {
+    private suspend fun refreshEventLastUpdated(eventUid: String) {
         eventStore.selectByUid(eventUid)?.let { event ->
             val now = Date()
             val updatedEvent = event.toBuilder()
@@ -185,7 +190,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    private fun refreshEnrollmentLastUpdated(enrollmentUid: String) {
+    private suspend fun refreshEnrollmentLastUpdated(enrollmentUid: String) {
         enrollmentStore.selectByUid(enrollmentUid)?.let { enrollment ->
             val now = Date()
             val updatedEnrollment = enrollment.toBuilder()
@@ -196,7 +201,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    private fun refreshTrackedEntityInstanceLastUpdated(trackedEntityInstanceUid: String) {
+    private suspend fun refreshTrackedEntityInstanceLastUpdated(trackedEntityInstanceUid: String) {
         trackedEntityInstanceStore.selectByUid(trackedEntityInstanceUid)?.let { instance ->
             val now = Date()
             val updatedInstance = instance.toBuilder()
@@ -207,7 +212,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun resetUploadingEnrollmentAndEventStates(trackedEntityInstanceUid: String?) {
+    override suspend fun resetUploadingEnrollmentAndEventStates(trackedEntityInstanceUid: String?) {
         if (trackedEntityInstanceUid == null) {
             return
         }
@@ -223,7 +228,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun resetUploadingEventStates(enrollmentUid: String?) {
+    override suspend fun resetUploadingEventStates(enrollmentUid: String?) {
         if (enrollmentUid == null) {
             return
         }
@@ -256,7 +261,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun refreshTrackedEntityInstanceAggregatedSyncState(trackedEntityInstanceUid: String) {
+    override suspend fun refreshTrackedEntityInstanceAggregatedSyncState(trackedEntityInstanceUid: String) {
         trackedEntityInstanceStore.selectByUid(trackedEntityInstanceUid)?.let { instance ->
             val whereClause = WhereClauseBuilder()
                 .appendKeyStringValue(EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE, trackedEntityInstanceUid)
@@ -282,7 +287,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun refreshEnrollmentAggregatedSyncState(enrollmentUid: String) {
+    override suspend fun refreshEnrollmentAggregatedSyncState(enrollmentUid: String) {
         enrollmentStore.selectByUid(enrollmentUid)?.let { enrollment ->
             val whereClause = WhereClauseBuilder()
                 .appendKeyStringValue(EventTableInfo.Columns.ENROLLMENT, enrollmentUid)
@@ -298,7 +303,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun refreshEventAggregatedSyncState(eventUid: String) {
+    override suspend fun refreshEventAggregatedSyncState(eventUid: String) {
         eventStore.selectByUid(eventUid)?.let { event ->
             val relationships = getRelationshipsByItem(RelationshipHelper.eventItem(eventUid))
             val relationshipStates = relationships.map { it.syncState()!! }
@@ -308,7 +313,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    private fun getRelationshipsByItem(relationshipItem: RelationshipItem): List<Relationship> {
+    private suspend fun getRelationshipsByItem(relationshipItem: RelationshipItem): List<Relationship> {
         val relationships = relationshipStore.getRelationshipsByItem(relationshipItem)
 
         return relationships.filter { relationship ->
@@ -325,7 +330,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun refreshAggregatedSyncStates(uidHolder: DataStateUidHolder) {
+    override suspend fun refreshAggregatedSyncStates(uidHolder: DataStateUidHolder) {
         uidHolder.events.forEach {
             refreshEventAggregatedSyncState(it)
         }
@@ -339,7 +344,7 @@ internal class DataStatePropagatorImpl(
         }
     }
 
-    override fun getRelatedUids(
+    override suspend fun getRelatedUids(
         trackedEntityInstanceUids: List<String>,
         enrollmentUids: List<String>,
         eventUids: List<String>,
@@ -373,6 +378,7 @@ internal class DataStatePropagatorImpl(
             states.contains(State.UPLOADING) ||
                 states.contains(State.TO_POST) ||
                 states.contains(State.TO_UPDATE) -> State.TO_UPDATE
+
             states.contains(State.SENT_VIA_SMS) -> State.SENT_VIA_SMS
             states.contains(State.SYNCED_VIA_SMS) -> State.SYNCED_VIA_SMS
             else -> State.SYNCED

--- a/core/src/main/java/org/hisp/dhis/android/core/common/internal/TrackerDataManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/internal/TrackerDataManager.kt
@@ -35,19 +35,19 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 
 internal interface TrackerDataManager {
 
-    fun propagateTrackedEntityUpdate(tei: TrackedEntityInstance?, action: HandleAction)
+    suspend fun propagateTrackedEntityUpdate(tei: TrackedEntityInstance?, action: HandleAction)
 
-    fun propagateEnrollmentUpdate(enrollment: Enrollment?, action: HandleAction)
+    suspend fun propagateEnrollmentUpdate(enrollment: Enrollment?, action: HandleAction)
 
-    fun propagateEventUpdate(event: Event?, action: HandleAction)
+    suspend fun propagateEventUpdate(event: Event?, action: HandleAction)
 
-    fun propagateRelationshipUpdate(relationship: Relationship, action: HandleAction)
+    suspend fun propagateRelationshipUpdate(relationship: Relationship, action: HandleAction)
 
-    fun deleteTrackedEntity(tei: TrackedEntityInstance?)
+    suspend fun deleteTrackedEntity(tei: TrackedEntityInstance?)
 
-    fun deleteEnrollment(enrollment: Enrollment?)
+    suspend fun deleteEnrollment(enrollment: Enrollment?)
 
-    fun deleteEvent(event: Event?)
+    suspend fun deleteEvent(event: Event?)
 
-    fun deleteRelationship(relationship: Relationship?)
+    suspend fun deleteRelationship(relationship: Relationship?)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/common/internal/TrackerDataManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/internal/TrackerDataManagerImpl.kt
@@ -62,7 +62,7 @@ internal class TrackerDataManagerImpl(
     private val programOwner: ProgramOwnerStore,
 ) : TrackerDataManager {
 
-    override fun deleteTrackedEntity(tei: TrackedEntityInstance?) {
+    override suspend fun deleteTrackedEntity(tei: TrackedEntityInstance?) {
         tei?.let {
             deleteRelationships(tei)
             deleteCascadeItems(tei)
@@ -72,7 +72,7 @@ internal class TrackerDataManagerImpl(
         }
     }
 
-    override fun deleteEnrollment(enrollment: Enrollment?) {
+    override suspend fun deleteEnrollment(enrollment: Enrollment?) {
         enrollment?.let {
             deleteRelationships(enrollment)
             deleteCascadeItems(enrollment)
@@ -82,7 +82,7 @@ internal class TrackerDataManagerImpl(
         }
     }
 
-    override fun deleteEvent(event: Event?) {
+    override suspend fun deleteEvent(event: Event?) {
         event?.let {
             deleteRelationships(event)
             internalDelete(event, eventStore) {
@@ -91,7 +91,7 @@ internal class TrackerDataManagerImpl(
         }
     }
 
-    override fun deleteRelationship(relationship: Relationship?) {
+    override suspend fun deleteRelationship(relationship: Relationship?) {
         relationship?.let {
             internalDelete(relationship, relationshipStore) {
                 propagateRelationshipUpdate(relationship, HandleAction.Delete)
@@ -99,10 +99,10 @@ internal class TrackerDataManagerImpl(
         }
     }
 
-    private fun <O> internalDelete(
+    private suspend fun <O> internalDelete(
         obj: O,
         store: IdentifiableDeletableDataObjectStore<O>,
-        propagateState: (O) -> Any,
+        propagateState: suspend (O) -> Any,
     ) where O : ObjectWithUidInterface, O : DeletableDataObject {
         if (obj.syncState() === State.TO_POST) {
             store.delete(obj.uid())
@@ -113,22 +113,22 @@ internal class TrackerDataManagerImpl(
         propagateState(obj)
     }
 
-    override fun propagateTrackedEntityUpdate(tei: TrackedEntityInstance?, action: HandleAction) {
+    override suspend fun propagateTrackedEntityUpdate(tei: TrackedEntityInstance?, action: HandleAction) {
         dataStatePropagator.propagateTrackedEntityInstanceUpdate(tei)
     }
 
-    override fun propagateEnrollmentUpdate(enrollment: Enrollment?, action: HandleAction) {
+    override suspend fun propagateEnrollmentUpdate(enrollment: Enrollment?, action: HandleAction) {
         dataStatePropagator.propagateEnrollmentUpdate(enrollment)
         if (action == HandleAction.Insert) {
             createProgramOwnerIfNeeded(enrollment)
         }
     }
 
-    override fun propagateEventUpdate(event: Event?, action: HandleAction) {
+    override suspend fun propagateEventUpdate(event: Event?, action: HandleAction) {
         dataStatePropagator.propagateEventUpdate(event)
     }
 
-    override fun propagateRelationshipUpdate(relationship: Relationship, action: HandleAction) {
+    override suspend fun propagateRelationshipUpdate(relationship: Relationship, action: HandleAction) {
         val withChildren =
             if (relationship.from() == null || relationship.to() == null) {
                 relationshipChildrenAppender.appendChildren(relationship)
@@ -138,22 +138,22 @@ internal class TrackerDataManagerImpl(
         dataStatePropagator.propagateRelationshipUpdate(withChildren)
     }
 
-    private fun deleteRelationships(tei: TrackedEntityInstance) {
+    private suspend fun deleteRelationships(tei: TrackedEntityInstance) {
         relationshipStore.getRelationshipsByItem(RelationshipHelper.teiItem(tei.uid()))
             .forEach { deleteRelationship(it) }
     }
 
-    private fun deleteRelationships(enrollment: Enrollment) {
+    private suspend fun deleteRelationships(enrollment: Enrollment) {
         relationshipStore.getRelationshipsByItem(RelationshipHelper.enrollmentItem(enrollment.uid()))
             .forEach { deleteRelationship(it) }
     }
 
-    private fun deleteRelationships(event: Event) {
+    private suspend fun deleteRelationships(event: Event) {
         relationshipStore.getRelationshipsByItem(RelationshipHelper.eventItem(event.uid()))
             .forEach { deleteRelationship(it) }
     }
 
-    private fun deleteCascadeItems(tei: TrackedEntityInstance) {
+    private suspend fun deleteCascadeItems(tei: TrackedEntityInstance) {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE, tei.uid())
             .build()
@@ -163,7 +163,7 @@ internal class TrackerDataManagerImpl(
         }
     }
 
-    private fun deleteCascadeItems(enrollment: Enrollment) {
+    private suspend fun deleteCascadeItems(enrollment: Enrollment) {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(EventTableInfo.Columns.ENROLLMENT, enrollment.uid())
             .build()
@@ -173,7 +173,7 @@ internal class TrackerDataManagerImpl(
         }
     }
 
-    private fun createProgramOwnerIfNeeded(enrollment: Enrollment?) {
+    private suspend fun createProgramOwnerIfNeeded(enrollment: Enrollment?) {
         enrollment?.let {
             val program = enrollment.program()
             val instance = enrollment.trackedEntityInstance()

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
@@ -81,7 +81,7 @@ class DataStoreObjectRepository internal constructor(
     override suspend fun deleteInternal() {
         getWithoutChildrenInternal()?.let { entry ->
             if (entry.syncState() == State.TO_POST) {
-                super.blockingDelete()
+                super.deleteInternal()
             } else {
                 setObject(entry.toBuilder().deleted(true).syncState(State.TO_UPDATE).build())
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
@@ -60,11 +62,16 @@ class LocalDataStoreObjectRepository internal constructor(
 ),
     ReadWriteValueObjectRepository<KeyValuePair> {
     override fun set(value: String?): Completable {
-        return Completable.fromAction { blockingSet(value) }
+        return rxCompletable { setInternal(value) }
     }
 
     @Throws(D2Error::class)
     override fun blockingSet(value: String?) {
+        runBlocking { setInternal(value) }
+    }
+
+    @Throws(D2Error::class)
+    private suspend fun setInternal(value: String?) {
         val pair = KeyValuePair.builder()
             .key(key)
             .value(value)

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository.kt
@@ -72,7 +72,7 @@ class EnrollmentCollectionRepository internal constructor(
         )
     },
 ) {
-    override fun propagateState(m: Enrollment, action: HandleAction?) {
+    override suspend fun propagateState(m: Enrollment, action: HandleAction?) {
         trackerDataManager.propagateEnrollmentUpdate(m, action!!)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentObjectRepository.kt
@@ -128,11 +128,11 @@ class EnrollmentObjectRepository internal constructor(
             .lastUpdatedAtClient(updateDate)
     }
 
-    override fun propagateState(m: Enrollment, action: HandleAction) {
+    override suspend fun propagateState(m: Enrollment, action: HandleAction) {
         trackerDataManager.propagateEnrollmentUpdate(m, action)
     }
 
-    override fun deleteObject(m: Enrollment) {
+    override suspend fun deleteObject(m: Enrollment) {
         trackerDataManager.deleteEnrollment(m)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentImportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentImportHandler.kt
@@ -57,7 +57,7 @@ internal class EnrollmentImportHandler(
 ) {
 
     @Suppress("NestedBlockDepth")
-    fun handleEnrollmentImportSummary(
+    suspend fun handleEnrollmentImportSummary(
         enrollmentImportSummaries: List<EnrollmentImportSummary?>?,
         enrollments: List<Enrollment>,
         teiState: State,
@@ -108,7 +108,7 @@ internal class EnrollmentImportHandler(
         return summary
     }
 
-    private fun handleEventImportSummaries(
+    private suspend fun handleEventImportSummaries(
         enrollmentImportSummary: EnrollmentImportSummary,
         enrollments: List<Enrollment>,
     ): TEIWebResponseHandlerSummary {
@@ -147,7 +147,7 @@ internal class EnrollmentImportHandler(
         trackerImportConflicts.forEach { trackerImportConflictStore.insert(it) }
     }
 
-    private fun processIgnoredEnrollments(
+    private suspend fun processIgnoredEnrollments(
         enrollmentImportSummaries: List<EnrollmentImportSummary?>?,
         enrollments: List<Enrollment>,
         teiState: State,
@@ -176,7 +176,7 @@ internal class EnrollmentImportHandler(
         }
     }
 
-    private fun resetNestedDataStates(enrollment: Enrollment?) {
+    private suspend fun resetNestedDataStates(enrollment: Enrollment?) {
         enrollment?.let {
             dataStatePropagator.resetUploadingEventStates(enrollment.uid())
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
@@ -109,7 +109,7 @@ class EventCollectionRepository internal constructor(
         upload().blockingSubscribe()
     }
 
-    override fun propagateState(m: Event, action: HandleAction?) {
+    override suspend fun propagateState(m: Event, action: HandleAction?) {
         trackerDataManager.propagateEventUpdate(m, action!!)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventObjectRepository.kt
@@ -147,11 +147,11 @@ class EventObjectRepository internal constructor(
             .lastUpdatedAtClient(updateDate)
     }
 
-    override fun propagateState(m: Event, action: HandleAction) {
+    override suspend fun propagateState(m: Event, action: HandleAction) {
         trackerDataManager.propagateEventUpdate(m, action)
     }
 
-    override fun deleteObject(m: Event) {
+    override suspend fun deleteObject(m: Event) {
         trackerDataManager.deleteEvent(m)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventImportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventImportHandler.kt
@@ -55,7 +55,7 @@ internal class EventImportHandler(
 ) {
 
     @Suppress("NestedBlockDepth")
-    fun handleEventImportSummaries(
+    suspend fun handleEventImportSummaries(
         eventImportSummaries: List<EventImportSummary?>?,
         events: List<Event>,
     ): TEIWebResponseHandlerSummary {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -296,6 +296,7 @@ class EventQueryCollectionRepository internal constructor(
     override fun isEmpty(): Single<Boolean> {
         return eventCollectionRepository.isEmpty()
     }
+
     override fun blockingIsEmpty(): Boolean {
         return eventCollectionRepository.blockingIsEmpty()
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseHandler.kt
@@ -36,7 +36,7 @@ internal class TEIWebResponseHandler(
     private val trackedEntityInstanceImportHandler: TrackedEntityInstanceImportHandler,
 ) {
 
-    fun handleWebResponse(
+    suspend fun handleWebResponse(
         webResponse: TEIWebResponse?,
         instances: List<TrackedEntityInstance>,
     ): TEIWebResponseHandlerSummary {

--- a/core/src/main/java/org/hisp/dhis/android/core/note/NoteCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/note/NoteCollectionRepository.kt
@@ -108,7 +108,7 @@ class NoteCollectionRepository internal constructor(
         return ReadOnlyOneObjectRepositoryFinalImpl(store, databaseAdapter, childrenAppenders, updatedScope)
     }
 
-    override fun propagateState(m: Note, action: HandleAction?) {
+    override suspend fun propagateState(m: Note, action: HandleAction?) {
         dataStatePropagator.propagateNoteCreation(m)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.relationship
 
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
@@ -90,14 +91,12 @@ class RelationshipCollectionRepository internal constructor(
 ),
     ReadWriteWithUidCollectionRepository<Relationship, Relationship> {
     override fun add(o: Relationship): Single<String> {
-        return Single.fromCallable { blockingAdd(o) }
+        return rxSingle { addInternal(o) }
     }
 
     @Throws(D2Error::class)
     override fun blockingAdd(o: Relationship): String {
-        return runBlocking {
-            addInternal(o)
-        }
+        return runBlocking { addInternal(o) }
     }
 
     @Suppress("ThrowsCount")

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipObjectRepository.kt
@@ -59,11 +59,11 @@ internal class RelationshipObjectRepository(
         )
     },
 ) {
-    override fun propagateState(m: Relationship, action: HandleAction) {
+    override suspend fun propagateState(m: Relationship, action: HandleAction) {
         trackerDataManager.propagateRelationshipUpdate(m, action)
     }
 
-    override fun deleteObject(m: Relationship) {
+    override suspend fun deleteObject(m: Relationship) {
         trackerDataManager.deleteRelationship(m)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandler.kt
@@ -43,7 +43,7 @@ internal class RelationshipImportHandler internal constructor(
     private val relationshipRepository: RelationshipCollectionRepository,
 ) {
 
-    fun handleRelationshipImportSummaries(
+    suspend fun handleRelationshipImportSummaries(
         importSummaries: List<RelationshipImportSummary?>?,
         relationships: List<Relationship>,
     ) {
@@ -68,7 +68,7 @@ internal class RelationshipImportHandler internal constructor(
         processIgnoredRelationships(importSummaries, relationships)
     }
 
-    private fun processIgnoredRelationships(
+    private suspend fun processIgnoredRelationships(
         importSummaries: List<RelationshipImportSummary?>?,
         relationships: List<Relationship>,
     ) {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository.kt
@@ -56,7 +56,7 @@ class AnalyticsDhisVisualizationsSettingObjectRepository internal constructor(
         return generateGroups(analyticsDhisVisualizationStore.selectAll()).dataSet()[dataSet]
     }
 
-    override fun blockingGet(): AnalyticsDhisVisualizationsSetting {
+    override suspend fun getInternal(): AnalyticsDhisVisualizationsSetting {
         return generateGroups(analyticsDhisVisualizationStore.selectAll())
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsSettingObjectRepository.kt
@@ -39,7 +39,7 @@ class AnalyticsSettingObjectRepository internal constructor(
     private val analyticsDhisVisualizationsSettingObjectRepository: AnalyticsDhisVisualizationsSettingObjectRepository,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<AnalyticsSettings>(analyticsSettingCall),
     ReadOnlyWithDownloadObjectRepository<AnalyticsSettings> {
-    override fun blockingGet(): AnalyticsSettings? {
+    override suspend fun getInternal(): AnalyticsSettings? {
         val analyticsTeiSettings = analyticsTeiSettingRepository.blockingGet()
         val analyticsDhisVisualizationsSetting = analyticsDhisVisualizationsSettingObjectRepository.blockingGet()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AppearanceSettingsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AppearanceSettingsObjectRepository.kt
@@ -48,7 +48,7 @@ class AppearanceSettingsObjectRepository internal constructor(
     appearanceSettingCall: AppearanceSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<AppearanceSettings>(appearanceSettingCall),
     ReadOnlyWithDownloadObjectRepository<AppearanceSettings> {
-    override fun blockingGet(): AppearanceSettings? {
+    override suspend fun getInternal(): AppearanceSettings? {
         val filters = filterSettingStore.selectAll()
         val programConfigurationSettingList = programConfigurationSettingStore.selectAll()
         val dataSetConfigurationSettingList = dataSetConfigurationSettingStore.selectAll()

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/DataSetSettingsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/DataSetSettingsObjectRepository.kt
@@ -39,7 +39,7 @@ class DataSetSettingsObjectRepository internal constructor(
     dataSetSettingCall: DataSetSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<DataSetSettings>(dataSetSettingCall),
     ReadOnlyWithDownloadObjectRepository<DataSetSettings> {
-    override fun blockingGet(): DataSetSettings? {
+    override suspend fun getInternal(): DataSetSettings? {
         val settings = store.selectAll()
         return if (settings.isEmpty()) {
             null

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
@@ -42,7 +42,7 @@ class GeneralSettingObjectRepository internal constructor(
     generalSettingCall: GeneralSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<GeneralSettings>(generalSettingCall),
     ReadOnlyWithDownloadObjectRepository<GeneralSettings> {
-    override fun blockingGet(): GeneralSettings? {
+    override suspend fun getInternal(): GeneralSettings? {
         val generalSettings = store.selectAll()
         val syncSettings = syncStore.selectAll()
         return if (generalSettings.isEmpty() && syncSettings.isEmpty()) {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/LatestAppVersionObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/LatestAppVersionObjectRepository.kt
@@ -40,7 +40,7 @@ class LatestAppVersionObjectRepository internal constructor(
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<LatestAppVersion>(latestAppVersionCall),
     ReadOnlyWithDownloadObjectRepository<LatestAppVersion> {
 
-    override fun blockingGet(): LatestAppVersion? {
+    override suspend fun getInternal(): LatestAppVersion? {
         return store.selectAll().firstOrNull()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/ProgramSettingsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/ProgramSettingsObjectRepository.kt
@@ -39,7 +39,7 @@ class ProgramSettingsObjectRepository internal constructor(
     programSettingCall: ProgramSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<ProgramSettings>(programSettingCall),
     ReadOnlyWithDownloadObjectRepository<ProgramSettings> {
-    override fun blockingGet(): ProgramSettings? {
+    override suspend fun getInternal(): ProgramSettings? {
         val settings = store.selectAll()
         return if (settings.isEmpty()) {
             null

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SynchronizationSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SynchronizationSettingObjectRepository.kt
@@ -41,7 +41,7 @@ class SynchronizationSettingObjectRepository internal constructor(
     synchronizationSettingCall: SynchronizationSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<SynchronizationSettings>(synchronizationSettingCall),
     ReadOnlyWithDownloadObjectRepository<SynchronizationSettings> {
-    override fun blockingGet(): SynchronizationSettings? {
+    override suspend fun getInternal(): SynchronizationSettings? {
         val syncSettings = syncStore.selectAll()
         val dataSetSettings = dataSetSettingsRepository.blockingGet()
         val programSettings = programSettingsRepository.blockingGet()

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/UserSettingsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/UserSettingsObjectRepository.kt
@@ -39,7 +39,7 @@ class UserSettingsObjectRepository internal constructor(
     generalSettingCall: GeneralSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<UserSettings>(generalSettingCall),
     ReadOnlyWithDownloadObjectRepository<UserSettings> {
-    override fun blockingGet(): UserSettings? {
+    override suspend fun getInternal(): UserSettings? {
         return store.selectAll().firstOrNull()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/LocalDbRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/LocalDbRepositoryImpl.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.sms.data.localdbrepository.internal
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.common.State
@@ -179,7 +180,7 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun updateEventSubmissionState(eventUid: String, state: State): Completable {
-        return Completable.fromAction {
+        return rxCompletable {
             eventStore.setSyncState(eventUid, state)
             val event = eventStore.selectByUid(eventUid)
             dataStatePropagator.propagateEventUpdate(event)
@@ -187,7 +188,7 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun updateEnrollmentSubmissionState(tei: TrackedEntityInstance, state: State): Completable {
-        return Completable.fromAction {
+        return rxCompletable {
             val enrollment = TrackedEntityInstanceInternalAccessor.accessEnrollments(tei)[0]
             val events = EnrollmentInternalAccessor.accessEvents(enrollment)
             events?.forEach { event ->
@@ -202,7 +203,7 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun updateRelationshipSubmissionState(relationshipUid: String, state: State): Completable {
-        return Completable.fromAction {
+        return rxCompletable {
             relationshipStore.setSyncState(relationshipUid, state)
             val relationship = relationshipStore.selectByUid(relationshipUid)
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
@@ -109,7 +109,7 @@ class TrackedEntityAttributeValueObjectRepository internal constructor(
         }
     }
 
-    override fun propagateState(m: TrackedEntityAttributeValue?) {
+    override suspend fun propagateState(m: TrackedEntityAttributeValue?) {
         dataStatePropagator.propagateTrackedEntityAttributeUpdate(m)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
@@ -111,7 +111,7 @@ class TrackedEntityDataValueObjectRepository internal constructor(
         }
     }
 
-    override fun propagateState(m: TrackedEntityDataValue?) {
+    override suspend fun propagateState(m: TrackedEntityDataValue?) {
         dataStatePropagator.propagateTrackedEntityDataValueUpdate(m)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -90,7 +90,7 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
     },
 ),
     ReadWriteWithUploadWithUidCollectionRepository<TrackedEntityInstance, TrackedEntityInstanceCreateProjection> {
-    override fun propagateState(m: TrackedEntityInstance, action: HandleAction?) {
+    override suspend fun propagateState(m: TrackedEntityInstance, action: HandleAction?) {
         trackerDataManager.propagateTrackedEntityUpdate(m, action!!)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository.kt
@@ -103,11 +103,11 @@ class TrackedEntityInstanceObjectRepository internal constructor(
             .lastUpdatedAtClient(updateDate)
     }
 
-    override fun propagateState(m: TrackedEntityInstance, action: HandleAction) {
+    override suspend fun propagateState(m: TrackedEntityInstance, action: HandleAction) {
         trackerDataManager.propagateTrackedEntityUpdate(m, action)
     }
 
-    override fun deleteObject(m: TrackedEntityInstance) {
+    override suspend fun deleteObject(m: TrackedEntityInstance) {
         trackerDataManager.deleteTrackedEntity(m)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceImportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceImportHandler.kt
@@ -59,7 +59,7 @@ internal class TrackedEntityInstanceImportHandler internal constructor(
         Regex("Tracked entity instance (\\w{11}) cannot be deleted as it is not present in the system")
 
     @Suppress("NestedBlockDepth")
-    fun handleTrackedEntityInstanceImportSummaries(
+    suspend fun handleTrackedEntityInstanceImportSummaries(
         teiImportSummaries: List<TEIImportSummary?>?,
         instances: List<TrackedEntityInstance>,
     ): TEIWebResponseHandlerSummary {
@@ -108,7 +108,7 @@ internal class TrackedEntityInstanceImportHandler internal constructor(
         return summary
     }
 
-    private fun handleEnrollmentImportSummaries(
+    private suspend fun handleEnrollmentImportSummaries(
         teiImportSummary: TEIImportSummary,
         instances: List<TrackedEntityInstance>,
         teiState: State,
@@ -144,7 +144,7 @@ internal class TrackedEntityInstanceImportHandler internal constructor(
         trackerImportConflicts.forEach { trackerImportConflictStore.insert(it) }
     }
 
-    private fun processIgnoredTEIs(
+    private suspend fun processIgnoredTEIs(
         processedTEIs: List<String>,
         instances: List<TrackedEntityInstance>,
     ): List<TrackedEntityInstance> {
@@ -155,7 +155,7 @@ internal class TrackedEntityInstanceImportHandler internal constructor(
         }
     }
 
-    private fun resetNestedDataStates(instance: TrackedEntityInstance?) {
+    private suspend fun resetNestedDataStates(instance: TrackedEntityInstance?) {
         instance?.let {
             dataStatePropagator.resetUploadingEnrollmentAndEventStates(instance.uid())
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManagerImpl.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.trackedentity.ownership
 
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -100,10 +101,14 @@ internal class OwnershipManagerImpl(
     }
 
     override fun transfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String): Completable {
-        return Completable.fromCallable { blockingTransfer(trackedEntityInstance, program, ownerOrgUnit) }
+        return rxCompletable { transferInternal(trackedEntityInstance, program, ownerOrgUnit) }
     }
 
     override fun blockingTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String) {
+        runBlocking { transferInternal(trackedEntityInstance, program, ownerOrgUnit) }
+    }
+
+    private suspend fun transferInternal(trackedEntityInstance: String, program: String, ownerOrgUnit: String) {
         val programOwner = ProgramOwner.builder()
             .trackedEntityInstance(trackedEntityInstance)
             .program(program)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -174,7 +174,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return runBlocking { getProtected() }
     }
 
-    protected suspend fun getProtected(): List<TrackedEntityInstance> {
+    private suspend fun getProtected(): List<TrackedEntityInstance> {
         val dataFetcher = getDataFetcher()
         val searchResult =
             if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
@@ -203,7 +203,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return blockingGet().size
     }
 
-    protected suspend fun countProtected(): Int {
+    private suspend fun countProtected(): Int {
         return getProtected().size
     }
 
@@ -215,7 +215,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return runBlocking { isEmptyProtected() }
     }
 
-    protected suspend fun isEmptyProtected(): Boolean {
+    private suspend fun isEmptyProtected(): Boolean {
         return countProtected() == 0
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -37,6 +37,8 @@ import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
@@ -169,6 +171,10 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
 
     @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
     override fun blockingGet(): List<TrackedEntityInstance> {
+        return runBlocking { getProtected() }
+    }
+
+    protected suspend fun getProtected(): List<TrackedEntityInstance> {
         val dataFetcher = getDataFetcher()
         val searchResult =
             if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
@@ -197,12 +203,20 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return blockingGet().size
     }
 
+    protected suspend fun countProtected(): Int {
+        return getProtected().size
+    }
+
     override fun isEmpty(): Single<Boolean> {
-        return Single.fromCallable { blockingIsEmpty() }
+        return rxSingle { isEmptyProtected() }
     }
 
     override fun blockingIsEmpty(): Boolean {
-        return blockingCount() == 0
+        return runBlocking { isEmptyProtected() }
+    }
+
+    protected suspend fun isEmptyProtected(): Boolean {
+        return countProtected() == 0
     }
 
     override fun one(): ReadOnlyObjectRepository<TrackedEntityInstance> {
@@ -243,6 +257,10 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
     }
 
     override fun blockingGetUids(): List<String> {
+        return runBlocking { getUidsInternal() }
+    }
+
+    private suspend fun getUidsInternal(): List<String> {
         return if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
             getDataFetcher().queryAllOfflineUids()
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -42,7 +42,7 @@ import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceSt
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
 
 @Suppress("TooManyFunctions")
-internal class TrackedEntityInstanceQueryDataFetcher constructor(
+internal class TrackedEntityInstanceQueryDataFetcher(
     private val store: TrackedEntityInstanceStore,
     private val databaseAdapter: DatabaseAdapter,
     private val trackerParentCallFactory: TrackerParentCallFactory,
@@ -72,7 +72,7 @@ internal class TrackedEntityInstanceQueryDataFetcher constructor(
         returnedErrorCodes = HashSet()
     }
 
-    fun loadPages(requestedLoadSize: Int): List<Result<TrackedEntityInstance, D2Error>> {
+    suspend fun loadPages(requestedLoadSize: Int): List<Result<TrackedEntityInstance, D2Error>> {
         val result: MutableList<Result<TrackedEntityInstance, D2Error>> = ArrayList()
 
         if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
@@ -96,11 +96,11 @@ internal class TrackedEntityInstanceQueryDataFetcher constructor(
         return result
     }
 
-    fun queryAllOffline(): List<Result<TrackedEntityInstance, D2Error>> {
+    suspend fun queryAllOffline(): List<Result<TrackedEntityInstance, D2Error>> {
         return queryOffline(-1)
     }
 
-    fun queryAllOfflineUids(): List<String> {
+    suspend fun queryAllOfflineUids(): List<String> {
         val sqlQuery = localQueryHelper.getUidsWhereClause(scope, scope.excludedUids(), -1)
         return store.selectUidsWhere(sqlQuery)
     }
@@ -109,7 +109,7 @@ internal class TrackedEntityInstanceQueryDataFetcher constructor(
         return queryOnline(-1)
     }
 
-    private fun queryOffline(requestedLoadSize: Int): List<Result<TrackedEntityInstance, D2Error>> {
+    private suspend fun queryOffline(requestedLoadSize: Int): List<Result<TrackedEntityInstance, D2Error>> {
         val sqlQuery = localQueryHelper.getSqlQuery(
             scope,
             returnedUidsOffline,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSource.kt
@@ -28,10 +28,11 @@
 package org.hisp.dhis.android.core.trackedentity.search
 
 import androidx.paging.ItemKeyedDataSource
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 
-internal class TrackedEntityInstanceQueryDataSource constructor(
+internal class TrackedEntityInstanceQueryDataSource(
     private val dataFetcher: TrackedEntityInstanceQueryDataFetcher,
 ) : ItemKeyedDataSource<TrackedEntityInstance, TrackedEntityInstance>() {
 
@@ -40,14 +41,18 @@ internal class TrackedEntityInstanceQueryDataSource constructor(
         callback: LoadInitialCallback<TrackedEntityInstance>,
     ) {
         dataFetcher.refresh()
-        callback.onResult(loadPages(params.requestedLoadSize))
+        callback.onResult(
+            runBlocking { loadPages(params.requestedLoadSize) },
+        )
     }
 
     override fun loadAfter(
         params: LoadParams<TrackedEntityInstance>,
         callback: LoadCallback<TrackedEntityInstance>,
     ) {
-        callback.onResult(loadPages(params.requestedLoadSize))
+        callback.onResult(
+            runBlocking { loadPages(params.requestedLoadSize) },
+        )
     }
 
     override fun loadBefore(
@@ -61,7 +66,7 @@ internal class TrackedEntityInstanceQueryDataSource constructor(
         return item
     }
 
-    private fun loadPages(requestedLoadSize: Int): List<TrackedEntityInstance> {
+    private suspend fun loadPages(requestedLoadSize: Int): List<TrackedEntityInstance> {
         return dataFetcher.loadPages(requestedLoadSize).mapNotNull {
             when (it) {
                 is Result.Success -> it.value

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceResult.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceResult.kt
@@ -28,11 +28,12 @@
 package org.hisp.dhis.android.core.trackedentity.search
 
 import androidx.paging.PageKeyedDataSource
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 
-internal class TrackedEntityInstanceQueryDataSourceResult constructor(
+internal class TrackedEntityInstanceQueryDataSourceResult(
     private val dataFetcher: TrackedEntityInstanceQueryDataFetcher,
 ) : PageKeyedDataSource<TrackedEntityInstance, Result<TrackedEntityInstance, D2Error>>() {
 
@@ -65,6 +66,6 @@ internal class TrackedEntityInstanceQueryDataSourceResult constructor(
     }
 
     private fun loadPages(requestedLoadSize: Int): List<Result<TrackedEntityInstance, D2Error>> {
-        return dataFetcher.loadPages(requestedLoadSize)
+        return runBlocking { dataFetcher.loadPages(requestedLoadSize) }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryPagingSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryPagingSource.kt
@@ -82,7 +82,7 @@ internal class TrackedEntityInstanceQueryPagingSource(
         }
     }
 
-    private fun loadPages(loadSize: Int): LoadResult<TrackedEntityInstance, TrackedEntityInstance> {
+    private suspend fun loadPages(loadSize: Int): LoadResult<TrackedEntityInstance, TrackedEntityInstance> {
         val pages = dataFetcher.loadPages(loadSize)
 
         return pages.firstOrNull { it is Result.Failure }?.let {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -38,6 +38,7 @@ import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
@@ -134,8 +135,12 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     val resultDataSource: DataSource<TrackedEntitySearchItem, Result<TrackedEntitySearchItem, D2Error>>
         get() = TrackedEntitySearchDataSourceResult(getDataFetcher())
 
-    @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
     override fun blockingGet(): List<TrackedEntitySearchItem> {
+        return runBlocking { getInternal() }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
+    private suspend fun getInternal(): List<TrackedEntitySearchItem> {
         val dataFetcher = getDataFetcher()
         val searchResult =
             if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
@@ -211,6 +216,10 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     }
 
     override fun blockingGetUids(): List<String> {
+        return runBlocking { getUidsInternal() }
+    }
+
+    private suspend fun getUidsInternal(): List<String> {
         return if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
             getDataFetcher().queryAllOfflineUids()
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcher.kt
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.trackedentity.search
 
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.cache.internal.ExpirableCache
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
@@ -79,14 +80,14 @@ internal class TrackedEntitySearchDataFetcher(
     }
 
     fun loadPages(requestedLoadSize: Int): List<Result<TrackedEntitySearchItem, D2Error>> {
-        return transform(instanceFetcher.loadPages(requestedLoadSize))
+        return runBlocking { transform(instanceFetcher.loadPages(requestedLoadSize)) }
     }
 
-    fun queryAllOffline(): List<Result<TrackedEntitySearchItem, D2Error>> {
+    suspend fun queryAllOffline(): List<Result<TrackedEntitySearchItem, D2Error>> {
         return transform(instanceFetcher.queryAllOffline())
     }
 
-    fun queryAllOfflineUids(): List<String> {
+    suspend fun queryAllOfflineUids(): List<String> {
         return instanceFetcher.queryAllOfflineUids()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcher.kt
@@ -80,7 +80,11 @@ internal class TrackedEntitySearchDataFetcher(
     }
 
     fun loadPages(requestedLoadSize: Int): List<Result<TrackedEntitySearchItem, D2Error>> {
-        return runBlocking { transform(instanceFetcher.loadPages(requestedLoadSize)) }
+        return runBlocking { loadPagesSuspend(requestedLoadSize) }
+    }
+
+    suspend fun loadPagesSuspend(requestedLoadSize: Int): List<Result<TrackedEntitySearchItem, D2Error>> {
+        return transform(instanceFetcher.loadPages(requestedLoadSize))
     }
 
     suspend fun queryAllOffline(): List<Result<TrackedEntitySearchItem, D2Error>> {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchPagingSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchPagingSource.kt
@@ -84,8 +84,8 @@ internal class TrackedEntitySearchPagingSource(
         }
     }
 
-    private fun loadPages(loadSize: Int): LoadResult<TrackedEntitySearchItem, TrackedEntitySearchItem> {
-        val pages = dataFetcher.loadPages(loadSize)
+    private suspend fun loadPages(loadSize: Int): LoadResult<TrackedEntitySearchItem, TrackedEntitySearchItem> {
+        val pages = dataFetcher.loadPagesSuspend(loadSize)
 
         return pages.firstOrNull { it is Result.Failure }?.let {
             LoadResult.Error((it as Result.Failure).failure)

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportHandler.kt
@@ -41,7 +41,7 @@ internal class JobReportHandler internal constructor(
     private val dataStatePropagator: DataStatePropagator,
 ) {
 
-    fun handle(o: JobReport, jobObjects: List<TrackerJobObject>) {
+    suspend fun handle(o: JobReport, jobObjects: List<TrackerJobObject>) {
         val jobObjectsMap = jobObjects.associateBy { jo -> Pair(jo.trackerType(), jo.objectUid()) }
         val relatedUids = getRelatedUids(jobObjects)
 
@@ -112,7 +112,7 @@ internal class JobReportHandler internal constructor(
             .forEach { typeHandler.handleSuccess(it) }
     }
 
-    private fun getRelatedUids(jobObjects: List<TrackerJobObject>): DataStateUidHolder {
+    private suspend fun getRelatedUids(jobObjects: List<TrackerJobObject>): DataStateUidHolder {
         return dataStatePropagator.getRelatedUids(
             jobObjects.filter { it.trackerType() == TRACKED_ENTITY }.map { it.objectUid() },
             jobObjects.filter { it.trackerType() == ENROLLMENT }.map { it.objectUid() },

--- a/core/src/test/java/org/hisp/dhis/android/core/common/internal/TrackerDataManagerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/internal/TrackerDataManagerShould.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.common.internal
 
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
@@ -90,7 +91,7 @@ class TrackerDataManagerShould {
     }
 
     @Test
-    fun cascade_tracked_entity_deletion_when_existing() {
+    fun cascade_tracked_entity_deletion_when_existing() = runTest {
         whenever(trackedEntity.syncState()).doReturn(State.TO_UPDATE)
         whenever(enrollment.syncState()).doReturn(State.TO_UPDATE)
         whenever(event.syncState()).doReturn(State.TO_UPDATE)
@@ -109,7 +110,7 @@ class TrackerDataManagerShould {
     }
 
     @Test
-    fun cascade_tracked_entity_deletion_when_new() {
+    fun cascade_tracked_entity_deletion_when_new() = runTest {
         whenever(trackedEntity.syncState()).doReturn(State.TO_POST)
         whenever(enrollment.syncState()).doReturn(State.TO_POST)
         whenever(event.syncState()).doReturn(State.TO_POST)
@@ -124,7 +125,7 @@ class TrackerDataManagerShould {
     }
 
     @Test
-    fun create_program_owner_entry_on_new_enrollment() {
+    fun create_program_owner_entry_on_new_enrollment() = runTest {
         whenever(enrollment.program()).doReturn("program")
         whenever(enrollment.trackedEntityInstance()).doReturn("instance")
         whenever(enrollment.organisationUnit()).doReturn("orgunit")

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentImportHandlerShould.kt
@@ -116,19 +116,19 @@ class EnrollmentImportHandlerShould {
     }
 
     @Test
-    fun invoke_set_state_and_handle_event_import_summaries_when_enrollment_is_success_and_event_is_imported()
-    = runTest {
-        whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
-        whenever(importSummary.reference()).thenReturn(enrollmentUid)
-        whenever(importSummary.events()).thenReturn(importEvent)
+    fun invoke_set_state_and_handle_event_import_summaries_when_enrollment_is_success_and_event_is_imported() =
+        runTest {
+            whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
+            whenever(importSummary.reference()).thenReturn(enrollmentUid)
+            whenever(importSummary.events()).thenReturn(importEvent)
 
-        val eventSummaries: List<EventImportSummary> = listOf(eventSummary)
-        whenever(importEvent.importSummaries()).thenReturn(eventSummaries)
+            val eventSummaries: List<EventImportSummary> = listOf(eventSummary)
+            whenever(importEvent.importSummaries()).thenReturn(eventSummaries)
 
-        enrollmentImportHandler.handleEnrollmentImportSummary(listOf(importSummary), enrollments, teiState)
-        verify(enrollmentStore, times(1)).setSyncStateOrDelete(enrollmentUid, State.SYNCED)
-        verify(eventImportHandler, times(1)).handleEventImportSummaries(eq(eventSummaries), anyList())
-    }
+            enrollmentImportHandler.handleEnrollmentImportSummary(listOf(importSummary), enrollments, teiState)
+            verify(enrollmentStore, times(1)).setSyncStateOrDelete(enrollmentUid, State.SYNCED)
+            verify(eventImportHandler, times(1)).handleEventImportSummaries(eq(eventSummaries), anyList())
+        }
 
     @Test
     fun mark_as_to_update_enrollments_not_present_in_the_response() = runTest {

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentImportHandlerShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.enrollment.internal
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.common.internal.DataStatePropagator
@@ -95,7 +96,7 @@ class EnrollmentImportHandlerShould {
     }
 
     @Test
-    fun invoke_set_state_when_enrollment_import_summary_is_success_with_reference() {
+    fun invoke_set_state_when_enrollment_import_summary_is_success_with_reference() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).thenReturn(enrollmentUid)
 
@@ -105,7 +106,7 @@ class EnrollmentImportHandlerShould {
     }
 
     @Test
-    fun invoke_set_state_when_enrollment_import_summary_is_error_with_reference() {
+    fun invoke_set_state_when_enrollment_import_summary_is_error_with_reference() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.ERROR)
         whenever(importSummary.reference()).thenReturn(enrollmentUid)
 
@@ -115,7 +116,8 @@ class EnrollmentImportHandlerShould {
     }
 
     @Test
-    fun invoke_set_state_and_handle_event_import_summaries_when_enrollment_is_success_and_event_is_imported() {
+    fun invoke_set_state_and_handle_event_import_summaries_when_enrollment_is_success_and_event_is_imported()
+    = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).thenReturn(enrollmentUid)
         whenever(importSummary.events()).thenReturn(importEvent)
@@ -129,7 +131,7 @@ class EnrollmentImportHandlerShould {
     }
 
     @Test
-    fun mark_as_to_update_enrollments_not_present_in_the_response() {
+    fun mark_as_to_update_enrollments_not_present_in_the_response() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).thenReturn(enrollmentUid)
 
@@ -143,7 +145,7 @@ class EnrollmentImportHandlerShould {
     }
 
     @Test
-    fun return_enrollments_not_present_in_the_response() {
+    fun return_enrollments_not_present_in_the_response() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).thenReturn(enrollmentUid)
 

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventImportHandlerShould.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.event.internal
 
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.common.internal.DataStatePropagator
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
@@ -82,14 +83,14 @@ class EventImportHandlerShould {
     }
 
     @Test
-    fun do_nothing_when_passing_null_argument() {
+    fun do_nothing_when_passing_null_argument() = runTest {
         eventImportHandler.handleEventImportSummaries(null, events)
 
         verify(eventStore, never()).setSyncStateOrDelete(anyString(), any())
     }
 
     @Test
-    fun invoke_set_state_after_handle_event_import_summaries_with_success_status_and_reference() {
+    fun invoke_set_state_after_handle_event_import_summaries_with_success_status_and_reference() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).thenReturn("test_event_uid")
 
@@ -99,7 +100,7 @@ class EventImportHandlerShould {
     }
 
     @Test
-    fun invoke_set_state_after_handle_event_import_summaries_with_error_status_and_reference() {
+    fun invoke_set_state_after_handle_event_import_summaries_with_error_status_and_reference() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.ERROR)
         whenever(importSummary.reference()).thenReturn("test_event_uid")
 
@@ -109,7 +110,7 @@ class EventImportHandlerShould {
     }
 
     @Test
-    fun mark_as_to_update_events_not_present_in_the_response() {
+    fun mark_as_to_update_events_not_present_in_the_response() = runTest {
         whenever(importSummary.status()).thenReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).thenReturn("test_event_uid")
 

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandlerShould.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.relationship.internal
 
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.common.internal.DataStatePropagator
 import org.hisp.dhis.android.core.imports.ImportStatus
@@ -73,7 +74,7 @@ class RelationshipImportHandlerShould {
     }
 
     @Test
-    fun do_nothing_when_passing_null_argument() {
+    fun do_nothing_when_passing_null_argument() = runTest {
         relationshipImportHandler.handleRelationshipImportSummaries(null, relationships)
 
         verify(relationshipStore, never()).setSyncStateOrDelete(anyString(), any())
@@ -81,7 +82,7 @@ class RelationshipImportHandlerShould {
     }
 
     @Test
-    fun setStatus_shouldUpdateRelationshipStatusSuccess() {
+    fun setStatus_shouldUpdateRelationshipStatusSuccess() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn("test_uid")
 
@@ -95,7 +96,7 @@ class RelationshipImportHandlerShould {
     }
 
     @Test
-    fun setStatus_shouldUpdateRelationshipStatusError() {
+    fun setStatus_shouldUpdateRelationshipStatusError() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.ERROR)
         whenever(importSummary.reference()).doReturn("test_uid")
 
@@ -109,7 +110,7 @@ class RelationshipImportHandlerShould {
     }
 
     @Test
-    fun mark_as_to_update_relationships_not_present_in_the_response() {
+    fun mark_as_to_update_relationships_not_present_in_the_response() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn("test_uid")
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceImportHandlerShould.kt
@@ -120,27 +120,27 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun update_tracker_entity_instance_status_success_status_and_handle_import_enrollment_on_import_success()
-    = runTest {
-        whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
-        whenever(importSummary.reference()).doReturn(sampleTeiUid)
-        whenever(importSummary.enrollments()).thenReturn(importEnrollment)
+    fun update_tracker_entity_instance_status_success_status_and_handle_import_enrollment_on_import_success() =
+        runTest {
+            whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
+            whenever(importSummary.reference()).doReturn(sampleTeiUid)
+            whenever(importSummary.enrollments()).thenReturn(importEnrollment)
 
-        val enrollmentSummaries = listOf(enrollmentSummary)
-        whenever(importEnrollment.importSummaries()).doReturn(enrollmentSummaries)
+            val enrollmentSummaries = listOf(enrollmentSummary)
+            whenever(importEnrollment.importSummaries()).doReturn(enrollmentSummaries)
 
-        trackedEntityInstanceImportHandler.handleTrackedEntityInstanceImportSummaries(
-            listOf(importSummary),
-            instances,
-        )
+            trackedEntityInstanceImportHandler.handleTrackedEntityInstanceImportSummaries(
+                listOf(importSummary),
+                instances,
+            )
 
-        verify(trackedEntityInstanceStore, times(1)).setSyncStateOrDelete(sampleTeiUid, State.SYNCED)
-        verify(enrollmentImportHandler, times(1)).handleEnrollmentImportSummary(
-            eq(enrollmentSummaries),
-            anyList(),
-            eq(State.SYNCED),
-        )
-    }
+            verify(trackedEntityInstanceStore, times(1)).setSyncStateOrDelete(sampleTeiUid, State.SYNCED)
+            verify(enrollmentImportHandler, times(1)).handleEnrollmentImportSummary(
+                eq(enrollmentSummaries),
+                anyList(),
+                eq(State.SYNCED),
+            )
+        }
 
     @Test
     fun mark_as_to_update_tracked_entity_instances_not_present_in_the_response() = runTest {

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceImportHandlerShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.common.internal.DataStatePropagator
@@ -85,13 +86,13 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun do_nothing_when_passing_null_argument() {
+    fun do_nothing_when_passing_null_argument() = runTest {
         trackedEntityInstanceImportHandler.handleTrackedEntityInstanceImportSummaries(null, instances)
         verify(trackedEntityInstanceStore, never()).setSyncStateOrDelete(anyString(), any())
     }
 
     @Test
-    fun setStatus_shouldUpdateTrackedEntityInstanceStatusSuccess() {
+    fun setStatus_shouldUpdateTrackedEntityInstanceStatusSuccess() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn(sampleTeiUid)
 
@@ -105,7 +106,7 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun setStatus_shouldUpdateTrackedEntityInstanceStatusError() {
+    fun setStatus_shouldUpdateTrackedEntityInstanceStatusError() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.ERROR)
         whenever(importSummary.reference()).doReturn(sampleTeiUid)
 
@@ -119,7 +120,8 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun update_tracker_entity_instance_status_success_status_and_handle_import_enrollment_on_import_success() {
+    fun update_tracker_entity_instance_status_success_status_and_handle_import_enrollment_on_import_success()
+    = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn(sampleTeiUid)
         whenever(importSummary.enrollments()).thenReturn(importEnrollment)
@@ -141,7 +143,7 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun mark_as_to_update_tracked_entity_instances_not_present_in_the_response() {
+    fun mark_as_to_update_tracked_entity_instances_not_present_in_the_response() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn(sampleTeiUid)
 
@@ -158,7 +160,7 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun return_tracked_entity_instances_not_present_in_the_response() {
+    fun return_tracked_entity_instances_not_present_in_the_response() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn(sampleTeiUid)
 
@@ -175,7 +177,7 @@ class TrackedEntityInstanceImportHandlerShould {
     }
 
     @Test
-    fun deleted_tei_if_not_present_in_server_and_is_deleted_locally() {
+    fun deleted_tei_if_not_present_in_server_and_is_deleted_locally() = runTest {
         whenever(importSummary.status()).doReturn(ImportStatus.SUCCESS)
         whenever(importSummary.reference()).doReturn(null)
         whenever(importSummary.description())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManagerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManagerShould.kt
@@ -118,7 +118,7 @@ class OwnershipManagerShould {
     }
 
     @Test
-    fun propagate_program_ownership_update() {
+    fun propagate_program_ownership_update() = runTest {
         ownershipManager.blockingTransfer("tei_uid", "program_uid", "orgunit")
 
         verify(programOwnerStore).updateOrInsertWhere(any())


### PR DESCRIPTION
This PR migrates the entire Repositories layer [ANDROSDK-2098](https://dhis2.atlassian.net/browse/ANDROSDK-2098) from RxJava to Kotlin coroutines. Key changes include:

* **Repository APIs**

  * All `get()`, `count()`, `delete()`, etc., methods now have suspend variants.
  * `Single.fromCallable { … }` and `Completable.fromAction { … }` wrappers replaced with `rxSingle { … }`/`rxCompletable { … }` over suspend functions.
  * The `blocking*` methods delegate to `runBlocking { … }`.

* **DataStatePropagator & TrackerDataManager & Missing Handlers**

  * Propagation methods (e.g., `propagateEventUpdate`) converted to suspend functions.
  * Internal store updates now run without blocking, ensuring correct coroutine-based sync-state handling.
  * `ImportHandler.handleSummaries()` methods are now suspend functions.

* **Tests**

  * Unit and integration tests updated to use `runTest { … }` instead of blocking calls.



[ANDROSDK-2098]: https://dhis2.atlassian.net/browse/ANDROSDK-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ