### PR TITLE
chore: [ANDROSDK-2112] Implement paging using offset and limit 

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2517,8 +2517,7 @@ public class org/hisp/dhis/android/core/arch/db/querybuilders/internal/MultipleT
 }
 
 public final class org/hisp/dhis/android/core/arch/db/querybuilders/internal/OrderByClauseBuilder {
-	public static fun addSortingClauses (Lorg/hisp/dhis/android/core/arch/db/querybuilders/internal/WhereClauseBuilder;Ljava/util/List;Landroid/content/ContentValues;ZLjava/lang/String;)V
-	public static fun orderByFromItems (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
+	public static fun orderByFromItems (Ljava/util/List;)Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/arch/db/sqlorder/internal/SQLOrderType : java/lang/Enum {
@@ -2581,6 +2580,7 @@ public abstract interface class org/hisp/dhis/android/core/arch/db/stores/intern
 	public abstract fun selectWhere (Ljava/lang/String;)Ljava/util/List;
 	public abstract fun selectWhere (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
 	public abstract fun selectWhere (Ljava/lang/String;Ljava/lang/String;I)Ljava/util/List;
+	public abstract fun selectWhere (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;)Ljava/util/List;
 }
 
 public class org/hisp/dhis/android/core/arch/db/stores/projections/internal/LinkTableChildProjection {
@@ -3277,17 +3277,15 @@ public final class org/hisp/dhis/android/core/arch/repositories/paging/PageConfi
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSource : androidx/paging/ItemKeyedDataSource {
-	public synthetic fun getKey (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun getKey (Lorg/hisp/dhis/android/core/common/CoreObject;)Lorg/hisp/dhis/android/core/common/CoreObject;
-	public fun loadAfter (Landroidx/paging/ItemKeyedDataSource$LoadParams;Landroidx/paging/ItemKeyedDataSource$LoadCallback;)V
-	public fun loadBefore (Landroidx/paging/ItemKeyedDataSource$LoadParams;Landroidx/paging/ItemKeyedDataSource$LoadCallback;)V
-	public fun loadInitial (Landroidx/paging/ItemKeyedDataSource$LoadInitialParams;Landroidx/paging/ItemKeyedDataSource$LoadInitialCallback;)V
+public final class org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSource : androidx/paging/PageKeyedDataSource {
+	public fun loadAfter (Landroidx/paging/PageKeyedDataSource$LoadParams;Landroidx/paging/PageKeyedDataSource$LoadCallback;)V
+	public fun loadBefore (Landroidx/paging/PageKeyedDataSource$LoadParams;Landroidx/paging/PageKeyedDataSource$LoadCallback;)V
+	public fun loadInitial (Landroidx/paging/PageKeyedDataSource$LoadInitialParams;Landroidx/paging/PageKeyedDataSource$LoadInitialCallback;)V
 }
 
 public final class org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSource : androidx/paging/PagingSource {
+	public fun getRefreshKey (Landroidx/paging/PagingState;)Ljava/lang/Integer;
 	public synthetic fun getRefreshKey (Landroidx/paging/PagingState;)Ljava/lang/Object;
-	public fun getRefreshKey (Landroidx/paging/PagingState;)Lorg/hisp/dhis/android/core/common/CoreObject;
 	public fun load (Landroidx/paging/PagingSource$LoadParams;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -3303,7 +3301,6 @@ public abstract class org/hisp/dhis/android/core/arch/repositories/scope/Reposit
 	public abstract fun filters ()Ljava/util/List;
 	public fun hasFilters ()Z
 	public abstract fun orderBy ()Ljava/util/List;
-	public abstract fun pagingKey ()Ljava/lang/String;
 	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$Builder;
 }
 
@@ -3314,7 +3311,6 @@ public abstract class org/hisp/dhis/android/core/arch/repositories/scope/Reposit
 	public abstract fun complexFilters (Ljava/util/List;)Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$Builder;
 	public abstract fun filters (Ljava/util/List;)Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$Builder;
 	public abstract fun orderBy (Ljava/util/List;)Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$Builder;
-	public abstract fun pagingKey (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$Builder;
 }
 
 public final class org/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection : java/lang/Enum {
@@ -6135,6 +6131,7 @@ public class org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSQLState
 	public fun selectWhere (Ljava/lang/String;I)Ljava/lang/String;
 	public fun selectWhere (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun selectWhere (Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;
+	public fun selectWhere (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;)Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSQLStatementBuilder$Companion {
@@ -6151,6 +6148,7 @@ public final class org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSu
 	public fun selectWhere (Ljava/lang/String;I)Ljava/lang/String;
 	public fun selectWhere (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun selectWhere (Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;
+	public fun selectWhere (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Integer;)Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSummarySQLStatementBuilder$Companion {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/repositories/collection/PagingMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/repositories/collection/PagingMockIntegrationShould.kt
@@ -54,7 +54,7 @@ class PagingMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     private lateinit var allValues: List<CategoryOption>
 
     private val empty = RepositoryScope.empty()
-    private val orderByClause = OrderByClauseBuilder.orderByFromItems(empty.orderBy(), empty.pagingKey())
+    private val orderByClause = OrderByClauseBuilder.orderByFromItems(empty.orderBy())
 
     @Before
     fun setUp() {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/RelationshipServiceIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/RelationshipServiceIntegrationShould.kt
@@ -43,17 +43,23 @@ class RelationshipServiceIntegrationShould : BaseMockIntegrationTestFullDispatch
             .getRelationshipTypesForTrackedEntities("nEenWmSyUEp")
 
         assertThat(relationshipsWithoutProgram.size).isEqualTo(2)
-        assertThat(relationshipsWithoutProgram[0].relationshipType.uid()).isEqualTo("WiH6923nMtb")
-        assertThat(relationshipsWithoutProgram[0].entitySide).isEqualTo(RelationshipConstraintType.TO)
-        assertThat(relationshipsWithoutProgram[1].relationshipType.uid()).isEqualTo("V2kkHafqs8G")
-        assertThat(relationshipsWithoutProgram[1].entitySide).isEqualTo(RelationshipConstraintType.FROM)
+        assertThat(
+            relationshipsWithoutProgram.any { r ->
+                r.relationshipType.uid() == "WiH6923nMtb" && r.entitySide == RelationshipConstraintType.TO
+            },
+        ).isTrue()
+        assertThat(
+            relationshipsWithoutProgram.any { r ->
+                r.relationshipType.uid() == "V2kkHafqs8G" && r.entitySide == RelationshipConstraintType.FROM
+            },
+        ).isTrue()
 
         val relationshipsWithProgram = d2.relationshipModule().relationshipService()
             .getRelationshipTypesForTrackedEntities("nEenWmSyUEp", "other_program")
 
         assertThat(relationshipsWithProgram.size).isEqualTo(1)
-        assertThat(relationshipsWithoutProgram[0].relationshipType.uid()).isEqualTo("WiH6923nMtb")
-        assertThat(relationshipsWithoutProgram[0].entitySide).isEqualTo(RelationshipConstraintType.TO)
+        assertThat(relationshipsWithProgram[0].relationshipType.uid()).isEqualTo("WiH6923nMtb")
+        assertThat(relationshipsWithProgram[0].entitySide).isEqualTo(RelationshipConstraintType.TO)
     }
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/OrderByClauseBuilder.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/OrderByClauseBuilder.java
@@ -27,10 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.db.querybuilders.internal;
 
-import android.content.ContentValues;
-
 import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper;
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope;
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeOrderByItem;
 
 import java.util.ArrayList;
@@ -38,97 +35,16 @@ import java.util.List;
 
 public final class OrderByClauseBuilder {
 
-    public static String orderByFromItems(List<RepositoryScopeOrderByItem> orderByItems, String pagingKey) {
+    public static String orderByFromItems(List<RepositoryScopeOrderByItem> orderByItems) {
         List<String> stringList = new ArrayList<>(orderByItems.size());
-        boolean hasPagingKey = false;
         for (RepositoryScopeOrderByItem item: orderByItems) {
             stringList.add(item.toSQLString());
-            if (item.column().equals(pagingKey)) {
-                hasPagingKey = true;
-            }
         }
 
-        if (!hasPagingKey) {
-            stringList.add(RepositoryScopeOrderByItem.builder()
-                    .column(pagingKey)
-                    .direction(RepositoryScope.OrderByDirection.ASC)
-                    .build()
-                    .toSQLString());
-        }
-        return CollectionsHelper.commaAndSpaceSeparatedCollectionValues(stringList);
-    }
-
-    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops"})
-    public static void addSortingClauses(WhereClauseBuilder whereClauseBuilder,
-                                         List<RepositoryScopeOrderByItem> orderByItems,
-                                         ContentValues object,
-                                         boolean reversed,
-                                         String pagingKey) {
-        boolean hasPagingKey = false;
-        List<RepositoryScopeOrderByItem> items = new ArrayList<>();
-
-        for (RepositoryScopeOrderByItem item: orderByItems) {
-            items.add(item);
-            if (item.column().equals(pagingKey)) {
-                hasPagingKey = true;
-            }
-        }
-        if (!hasPagingKey) {
-            items.add(RepositoryScopeOrderByItem.builder().column(pagingKey)
-                    .direction(RepositoryScope.OrderByDirection.ASC).build());
-        }
-
-        WhereClauseBuilder wrapperClause = new WhereClauseBuilder();
-        do {
-            List<RepositoryScopeOrderByItem> nextIterationItems = new ArrayList<>();
-            WhereClauseBuilder subWhereClause = new WhereClauseBuilder();
-            for (int i = 0; i < items.size(); i++) {
-                RepositoryScopeOrderByItem item = items.get(i);
-                if (i == items.size() - 1) {
-                    addItemInequality(subWhereClause, item, object, reversed);
-                } else {
-                    addItemEquality(subWhereClause, item, object);
-                    nextIterationItems.add(item);
-                }
-            }
-            wrapperClause.appendOrComplexQuery(subWhereClause.build());
-            items = nextIterationItems;
-        }
-        while (!items.isEmpty());
-
-        whereClauseBuilder.appendComplexQuery(wrapperClause.build());
-    }
-
-    private static void addItemInequality(WhereClauseBuilder whereClauseBuilder, RepositoryScopeOrderByItem item,
-                                          ContentValues object, boolean reversed) {
-        String operator = reversed ? getReversedDirectionOperator(item) : getDirectionOperator(item);
-        addItemOperator(whereClauseBuilder, item, object, operator);
-    }
-
-    private static void addItemEquality(WhereClauseBuilder whereClauseBuilder, RepositoryScopeOrderByItem item,
-                                        ContentValues object) {
-        String operator = "=";
-        addItemOperator(whereClauseBuilder, item, object, operator);    }
-
-    private static void addItemOperator(WhereClauseBuilder whereClauseBuilder, RepositoryScopeOrderByItem item,
-                                        ContentValues object, String operator) {
-        String key = item.getKey(object);
-        whereClauseBuilder.appendKeyOperatorValue(item.column(), operator, key);
-    }
-
-    private static String getDirectionOperator(RepositoryScopeOrderByItem item) {
-        if (item.direction() == RepositoryScope.OrderByDirection.ASC) {
-            return ">";
+        if (stringList.isEmpty()) {
+            return null;
         } else {
-            return "<";
-        }
-    }
-
-    private static String getReversedDirectionOperator(RepositoryScopeOrderByItem item) {
-        if (item.direction() == RepositoryScope.OrderByDirection.ASC) {
-            return "<";
-        } else {
-            return ">";
+            return CollectionsHelper.commaAndSpaceSeparatedCollectionValues(stringList);
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/ReadOnlySQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/ReadOnlySQLStatementBuilder.kt
@@ -32,8 +32,9 @@ import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
 internal interface ReadOnlySQLStatementBuilder {
     fun selectWhere(whereClause: String): String
     fun selectWhere(whereClause: String, limit: Int): String
-    fun selectWhere(whereClause: String, orderByClause: String): String
-    fun selectWhere(whereClause: String, orderByClause: String, limit: Int): String
+    fun selectWhere(whereClause: String, orderByClause: String?): String
+    fun selectWhere(whereClause: String, orderByClause: String?, limit: Int): String
+    fun selectWhere(whereClause: String, orderByClause: String?, limit: Int, offset: Int?): String
     fun selectOneOrderedBy(orderingColumName: String, orderingType: SQLOrderType): String
     fun selectAll(): String
     fun count(): String

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/SQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/SQLStatementBuilder.kt
@@ -35,7 +35,7 @@ internal interface SQLStatementBuilder : ReadOnlySQLStatementBuilder {
     fun getColumns(): Array<String>
     fun selectUids(): String
     fun selectUidsWhere(whereClause: String): String
-    fun selectUidsWhere(whereClause: String, orderByClause: String): String
+    fun selectUidsWhere(whereClause: String, orderByClause: String?): String
     fun selectColumnWhere(column: String, whereClause: String): String
     fun selectChildrenWithLinkTable(
         projection: LinkTableChildProjection,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/SQLStatementBuilderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/querybuilders/internal/SQLStatementBuilderImpl.kt
@@ -102,9 +102,9 @@ internal class SQLStatementBuilderImpl internal constructor(
         return SELECT + IdentifiableColumns.UID + FROM + tableName + WHERE + whereClause + ";"
     }
 
-    override fun selectUidsWhere(whereClause: String, orderByClause: String): String {
+    override fun selectUidsWhere(whereClause: String, orderByClause: String?): String {
         return SELECT + IdentifiableColumns.UID + FROM + tableName + WHERE + whereClause +
-            ORDER_BY + orderByClause + ";"
+            getOrderBy(orderByClause) + ";"
     }
 
     override fun selectColumnWhere(column: String, whereClause: String): String {
@@ -156,12 +156,16 @@ internal class SQLStatementBuilderImpl internal constructor(
         return selectWhere(whereClause + LIMIT + limit)
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String): String {
-        return selectWhere(whereClause + ORDER_BY + orderByClause)
+    override fun selectWhere(whereClause: String, orderByClause: String?): String {
+        return selectWhere(whereClause + getOrderBy(orderByClause))
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String, limit: Int): String {
-        return selectWhere(whereClause + ORDER_BY + orderByClause + LIMIT + limit)
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int): String {
+        return selectWhere(whereClause + getOrderBy(orderByClause) + LIMIT + limit)
+    }
+
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int, offset: Int?): String {
+        return selectWhere(whereClause + getOrderBy(orderByClause) + LIMIT + limit + getOffset(offset))
     }
 
     override fun selectAll(): String {
@@ -218,5 +222,14 @@ internal class SQLStatementBuilderImpl internal constructor(
         private const val SELECT = "SELECT "
         private const val AND = " AND "
         private const val ORDER_BY = " ORDER BY "
+        private const val OFFSET = " OFFSET "
+
+        internal fun getOrderBy(orderByClause: String?): String {
+            return orderByClause?.let { ORDER_BY + it } ?: ""
+        }
+
+        internal fun getOffset(offset: Int?): String {
+            return offset?.let { OFFSET + it } ?: ""
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStore.kt
@@ -50,7 +50,7 @@ internal interface IdentifiableObjectStore<O : ObjectWithUidInterface> : ObjectS
     fun selectUidsWhere(whereClause: String): List<String>
 
     @Throws(RuntimeException::class)
-    fun selectUidsWhere(whereClause: String, orderByClause: String): List<String>
+    fun selectUidsWhere(whereClause: String, orderByClause: String?): List<String>
 
     @Throws(RuntimeException::class)
     fun selectByUid(uid: String): O?

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/IdentifiableObjectStoreImpl.kt
@@ -150,7 +150,7 @@ internal open class IdentifiableObjectStoreImpl<O>(
     }
 
     @Throws(RuntimeException::class)
-    override fun selectUidsWhere(whereClause: String, orderByClause: String): List<String> {
+    override fun selectUidsWhere(whereClause: String, orderByClause: String?): List<String> {
         val cursor = databaseAdapter.rawQuery(builder.selectUidsWhere(whereClause, orderByClause))
         return mapStringColumnSetFromCursor(cursor)
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStore.kt
@@ -33,8 +33,9 @@ import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
 interface ReadableStore<O> {
     fun selectAll(): List<O>
     fun selectWhere(whereClause: String): List<O>
-    fun selectWhere(filterWhereClause: String, orderByClause: String): List<O>
-    fun selectWhere(filterWhereClause: String, orderByClause: String, limit: Int): List<O>
+    fun selectWhere(filterWhereClause: String, orderByClause: String?): List<O>
+    fun selectWhere(filterWhereClause: String, orderByClause: String?, limit: Int): List<O>
+    fun selectWhere(filterWhereClause: String, orderByClause: String?, limit: Int, offset: Int?): List<O>
     fun selectOneOrderedBy(orderingColumName: String, orderingType: SQLOrderType): O?
     fun selectRawQuery(sqlRawQuery: String): List<O>
     fun selectOneWhere(whereClause: String): O?

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStoreImpl.kt
@@ -52,13 +52,18 @@ internal open class ReadableStoreImpl<O : CoreObject>(
         return selectRawQuery(query)
     }
 
-    override fun selectWhere(filterWhereClause: String, orderByClause: String): List<O> {
+    override fun selectWhere(filterWhereClause: String, orderByClause: String?): List<O> {
         val query = builder.selectWhere(filterWhereClause, orderByClause)
         return selectRawQuery(query)
     }
 
-    override fun selectWhere(filterWhereClause: String, orderByClause: String, limit: Int): List<O> {
+    override fun selectWhere(filterWhereClause: String, orderByClause: String?, limit: Int): List<O> {
         val query = builder.selectWhere(filterWhereClause, orderByClause, limit)
+        return selectRawQuery(query)
+    }
+
+    override fun selectWhere(filterWhereClause: String, orderByClause: String?, limit: Int, offset: Int?): List<O> {
+        val query = builder.selectWhere(filterWhereClause, orderByClause, limit, offset)
         return selectRawQuery(query)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
@@ -74,7 +74,6 @@ abstract class BaseReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollec
             whereClause,
             OrderByClauseBuilder.orderByFromItems(
                 scope.orderBy(),
-                scope.pagingKey(),
             ),
         )
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -72,7 +72,6 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
             whereClause,
             OrderByClauseBuilder.orderByFromItems(
                 scope.orderBy(),
-                scope.pagingKey(),
             ),
         )
     }
@@ -124,8 +123,8 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
      */
     @Deprecated("Use {@link #getPagingData()} instead}", replaceWith = ReplaceWith("getPagingData()"))
     override fun getPaged(pageSize: Int): LiveData<PagedList<M>> {
-        val factory: DataSource.Factory<M, M> = object : DataSource.Factory<M, M>() {
-            override fun create(): DataSource<M, M> {
+        val factory: DataSource.Factory<Int, M> = object : DataSource.Factory<Int, M>() {
+            override fun create(): DataSource<Int, M> {
                 return dataSource
             }
         }
@@ -136,7 +135,7 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
         return getPager(pageSize).flow
     }
 
-    fun getPager(pageSize: Int): Pager<M, M> {
+    fun getPager(pageSize: Int): Pager<Int, M> {
         return Pager(
             config = PagingConfig(pageSize = pageSize),
         ) {
@@ -145,10 +144,10 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
     }
 
     @Deprecated("Use {@link #getPagingData()} instead}", replaceWith = ReplaceWith("getPagingData()"))
-    val dataSource: DataSource<M, M>
+    val dataSource: DataSource<Int, M>
         get() = RepositoryDataSource(store, databaseAdapter, scope, childrenAppenders)
 
-    private val pagingSource: PagingSource<M, M>
+    private val pagingSource: PagingSource<Int, M>
         get() = RepositoryPagingSource(store, databaseAdapter, scope, childrenAppenders)
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
@@ -79,7 +79,6 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
             whereClause,
             OrderByClauseBuilder.orderByFromItems(
                 scope.orderBy(),
-                scope.pagingKey(),
             ),
         )
     }
@@ -135,8 +134,8 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
      */
     @Deprecated("Use {@link #getPagingData()} instead}", replaceWith = ReplaceWith("getPagingData()"))
     override fun getPaged(pageSize: Int): LiveData<PagedList<T>> {
-        val factory: DataSource.Factory<M, T> = object : DataSource.Factory<M, T>() {
-            override fun create(): DataSource<M, T> {
+        val factory: DataSource.Factory<Int, T> = object : DataSource.Factory<Int, T>() {
+            override fun create(): DataSource<Int, T> {
                 return dataSource
             }
         }
@@ -151,7 +150,7 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
         }.flow
     }
 
-    fun getPager(pageSize: Int): Pager<M, T> {
+    fun getPager(pageSize: Int): Pager<Int, T> {
         return Pager(
             config = PagingConfig(pageSize = pageSize),
         ) {
@@ -159,10 +158,10 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
         }
     }
 
-    val dataSource: DataSource<M, T>
+    val dataSource: DataSource<Int, T>
         get() = RepositoryDataSourceWithTransformer(store, databaseAdapter, scope, childrenAppenders, transformer)
 
-    private val pagingSource: PagingSource<M, T>
+    private val pagingSource: PagingSource<Int, T>
         get() = RepositoryPagingSourceWithTransformer(store, databaseAdapter, scope, childrenAppenders, transformer)
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
@@ -90,7 +90,6 @@ internal class ReadOnlyWithUidAndTransformerCollectionRepositoryImpl<
             whereClause,
             OrderByClauseBuilder.orderByFromItems(
                 scope.orderBy(),
-                scope.pagingKey(),
             ),
         )
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSourceWithTransformer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSourceWithTransformer.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.paging.internal
 
-import androidx.paging.ItemKeyedDataSource
+import androidx.paging.PageKeyedDataSource
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
@@ -45,46 +45,37 @@ internal class RepositoryDataSourceWithTransformer<M : CoreObject, T : Any> inte
     private val scope: RepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
     private val transformer: TwoWayTransformer<M, T>,
-) : ItemKeyedDataSource<M, T>() {
+) : PageKeyedDataSource<Int, T>() {
 
-    override fun loadInitial(params: LoadInitialParams<M>, callback: LoadInitialCallback<T>) {
+    override fun loadInitial(params: LoadInitialParams<Int>, callback: LoadInitialCallback<Int, T>) {
         val whereClause = WhereClauseFromScopeBuilder(WhereClauseBuilder()).getWhereClause(scope)
         val withoutChildren = store.selectWhere(
             whereClause,
-            OrderByClauseBuilder.orderByFromItems(scope.orderBy(), scope.pagingKey()),
+            OrderByClauseBuilder.orderByFromItems(scope.orderBy()),
             params.requestedLoadSize,
         )
-        callback.onResult(appendChildren(withoutChildren))
+        callback.onResult(appendChildren(withoutChildren), null, params.requestedLoadSize)
     }
 
-    override fun loadAfter(params: LoadParams<M>, callback: LoadCallback<T>) {
-        loadPages(params, callback, false)
+    override fun loadAfter(params: LoadParams<Int>, callback: LoadCallback<Int, T>) {
+        loadPages(params, callback, nextOffset = params.key + params.requestedLoadSize)
     }
 
-    override fun loadBefore(params: LoadParams<M>, callback: LoadCallback<T>) {
-        loadPages(params, callback, true)
+    override fun loadBefore(params: LoadParams<Int>, callback: LoadCallback<Int, T>) {
+        loadPages(params, callback, nextOffset = params.key - params.requestedLoadSize)
     }
 
-    private fun loadPages(params: LoadParams<M>, callback: LoadCallback<T>, reversed: Boolean) {
-        val whereClauseBuilder = WhereClauseBuilder()
-        OrderByClauseBuilder.addSortingClauses(
-            whereClauseBuilder,
-            scope.orderBy(),
-            params.key.toContentValues(),
-            reversed,
-            scope.pagingKey(),
-        )
-        val whereClause = WhereClauseFromScopeBuilder(whereClauseBuilder).getWhereClause(scope)
+    private fun loadPages(params: LoadParams<Int>, callback: LoadCallback<Int, T>, nextOffset: Int) {
+        val offset = params.key
+
+        val whereClause = WhereClauseFromScopeBuilder(WhereClauseBuilder()).getWhereClause(scope)
         val withoutChildren = store.selectWhere(
             whereClause,
-            OrderByClauseBuilder.orderByFromItems(scope.orderBy(), scope.pagingKey()),
+            OrderByClauseBuilder.orderByFromItems(scope.orderBy()),
             params.requestedLoadSize,
+            offset,
         )
-        callback.onResult(appendChildren(withoutChildren))
-    }
-
-    override fun getKey(item: T): M {
-        return transformer.deTransform(item)
+        callback.onResult(appendChildren(withoutChildren), nextOffset)
     }
 
     private fun appendChildren(withoutChildren: List<M>): List<T> {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSource.kt
@@ -46,45 +46,33 @@ class RepositoryPagingSource<M : CoreObject> internal constructor(
     private val databaseAdapter: DatabaseAdapter,
     private val scope: RepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
-) : PagingSource<M, M>() {
+) : PagingSource<Int, M>() {
 
-    override fun getRefreshKey(state: PagingState<M, M>): M? {
+    override fun getRefreshKey(state: PagingState<Int, M>): Int? {
         return state.anchorPosition?.let { state.closestPageToPosition(it)?.prevKey }
     }
 
-    override suspend fun load(params: LoadParams<M>): LoadResult<M, M> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, M> {
         try {
-            val whereClauseBuilder = WhereClauseBuilder()
+            val offset = params.key
 
-            params.key?.let { key ->
-                val reverse = when (params) {
-                    is LoadParams.Prepend -> true
-                    else -> false
-                }
-
-                OrderByClauseBuilder.addSortingClauses(
-                    whereClauseBuilder,
-                    scope.orderBy(),
-                    key.toContentValues(),
-                    reverse,
-                    scope.pagingKey(),
-                )
-            }
-
-            val whereClause = WhereClauseFromScopeBuilder(whereClauseBuilder).getWhereClause(
-                scope,
-            )
+            val whereClause = WhereClauseFromScopeBuilder(WhereClauseBuilder()).getWhereClause(scope)
             val withoutChildren = store.selectWhere(
                 whereClause,
-                OrderByClauseBuilder.orderByFromItems(scope.orderBy(), scope.pagingKey()),
+                OrderByClauseBuilder.orderByFromItems(scope.orderBy()),
                 params.loadSize,
+                offset,
             )
 
             val items = appendInObjectCollection(withoutChildren, databaseAdapter, childrenAppenders, scope.children())
+
+            val prevKey = if (offset == null) null else offset - params.loadSize
+            val nextKey = if (items.size < params.loadSize) null else (offset ?: 0) + params.loadSize
+
             return LoadResult.Page(
                 data = items,
-                prevKey = items.firstOrNull(),
-                nextKey = items.getOrNull(params.loadSize - 1),
+                prevKey = prevKey,
+                nextKey = nextKey,
             )
         } catch (e: IOException) {
             return LoadResult.Error(e)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenSe
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeComplexFilterItem;
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem;
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeOrderByItem;
-import org.hisp.dhis.android.core.common.CoreColumns;
 
 import java.util.Collections;
 import java.util.List;
@@ -69,9 +68,6 @@ public abstract class RepositoryScope {
     public abstract List<RepositoryScopeOrderByItem> orderBy();
 
     @NonNull
-    public abstract String pagingKey();
-
-    @NonNull
     public abstract ChildrenSelection children();
 
     public boolean hasFilters() {
@@ -84,7 +80,6 @@ public abstract class RepositoryScope {
                 .filters(Collections.emptyList())
                 .complexFilters(Collections.emptyList())
                 .orderBy(Collections.emptyList())
-                .pagingKey(CoreColumns.ID)
                 .build();
     }
 
@@ -104,8 +99,6 @@ public abstract class RepositoryScope {
         public abstract Builder children(ChildrenSelection children);
 
         public abstract Builder orderBy(List<RepositoryScopeOrderByItem> orderBy);
-
-        public abstract Builder pagingKey(String pagingKey);
 
         public abstract RepositoryScope build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSQLStatementBuilder.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.dataset.internal
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.ReadOnlySQLStatementBuilder
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl.Companion.getOffset
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl.Companion.getOrderBy
 import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
 import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper
 import org.hisp.dhis.android.core.category.CategoryOptionComboTableInfo
@@ -70,12 +72,16 @@ open class DataSetInstanceSQLStatementBuilder : ReadOnlySQLStatementBuilder {
         return "SELECT $column , COUNT(*) FROM (${selectAll()}) GROUP BY $column;"
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String): String {
-        return selectWhere(whereClause) + " ORDER BY " + orderByClause
+    override fun selectWhere(whereClause: String, orderByClause: String?): String {
+        return selectWhere(whereClause) + getOrderBy(orderByClause)
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String, limit: Int): String {
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int): String {
         return selectWhere(whereClause, orderByClause) + " LIMIT " + limit
+    }
+
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int, offset: Int?): String {
+        return selectWhere(whereClause, orderByClause) + " LIMIT " + limit + getOffset(offset)
     }
 
     override fun selectOneOrderedBy(orderingColumnName: String, orderingType: SQLOrderType): String {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSummarySQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceSummarySQLStatementBuilder.kt
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl.Companion.getOffset
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl.Companion.getOrderBy
 import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
 import org.hisp.dhis.android.core.common.DeletableDataColumns
 import org.hisp.dhis.android.core.common.IdentifiableColumns
@@ -57,12 +59,16 @@ class DataSetInstanceSummarySQLStatementBuilder : DataSetInstanceSQLStatementBui
         return "SELECT count(*) FROM (${selectWhere(whereClause)})"
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String): String {
-        return selectWhere(whereClause) + " ORDER BY " + orderByClause
+    override fun selectWhere(whereClause: String, orderByClause: String?): String {
+        return selectWhere(whereClause) + getOrderBy(orderByClause)
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String, limit: Int): String {
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int): String {
         return selectWhere(whereClause, orderByClause) + " LIMIT " + limit
+    }
+
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int, offset: Int?): String {
+        return selectWhere(whereClause, orderByClause) + " LIMIT " + limit + getOffset(offset)
     }
 
     override fun selectOneOrderedBy(orderingColumnName: String, orderingType: SQLOrderType): String {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -278,11 +278,11 @@ class EventQueryCollectionRepository internal constructor(
         return eventCollectionRepository.getPagingData(pageSize)
     }
 
-    fun getPager(pageSize: Int): Pager<Event, Event> {
+    fun getPager(pageSize: Int): Pager<Int, Event> {
         return eventCollectionRepository.getPager(pageSize)
     }
 
-    val dataSource: DataSource<Event, Event>
+    val dataSource: DataSource<Int, Event>
         get() = eventCollectionRepository.dataSource
 
     override fun count(): Single<Int> {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -46,7 +46,6 @@ import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuil
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUidOrNull
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeOrderByItem
-import org.hisp.dhis.android.core.common.CoreColumns
 import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
@@ -232,7 +231,6 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
                 RepositoryScopeOrderByItem.builder().column(IdentifiableColumns.DISPLAY_NAME)
                     .direction(RepositoryScope.OrderByDirection.ASC).build(),
             ),
-            CoreColumns.ID,
         )
         val trackedEntityAttributes = trackedEntityAttributeStore.selectWhere(whereClause, orderByClause)
         val reservedValueSummaries: MutableList<ReservedValueSummary> = ArrayList()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilder.kt
@@ -35,8 +35,9 @@ import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
 internal interface ReadOnlySQLStatementBuilder {
     fun selectWhere(whereClause: String): RoomRawQuery
     fun selectWhere(whereClause: String, limit: Int): RoomRawQuery
-    fun selectWhere(whereClause: String, orderByClause: String): RoomRawQuery
-    fun selectWhere(whereClause: String, orderByClause: String, limit: Int): RoomRawQuery
+    fun selectWhere(whereClause: String, orderByClause: String?): RoomRawQuery
+    fun selectWhere(whereClause: String, orderByClause: String?, limit: Int): RoomRawQuery
+    fun selectWhere(whereClause: String, orderByClause: String?, limit: Int, offset: Int?): RoomRawQuery
     fun selectOneOrderedBy(orderingColumName: String, orderingType: SQLOrderType): RoomRawQuery
     fun selectAll(): RoomRawQuery
     fun selectStringColumn(column: String, clause: String): RoomRawQuery

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilderImpl.kt
@@ -45,12 +45,16 @@ internal open class ReadOnlySQLStatementBuilderImpl(
         return selectWhere(whereClause + LIMIT + limit)
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String): RoomRawQuery {
-        return selectWhere(whereClause + ORDER_BY + orderByClause)
+    override fun selectWhere(whereClause: String, orderByClause: String?): RoomRawQuery {
+        return selectWhere(whereClause + getOrderBy(orderByClause))
     }
 
-    override fun selectWhere(whereClause: String, orderByClause: String, limit: Int): RoomRawQuery {
-        return selectWhere(whereClause + ORDER_BY + orderByClause + LIMIT + limit)
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int): RoomRawQuery {
+        return selectWhere(whereClause + getOrderBy(orderByClause) + LIMIT + limit)
+    }
+
+    override fun selectWhere(whereClause: String, orderByClause: String?, limit: Int, offset: Int?): RoomRawQuery {
+        return selectWhere(whereClause + getOrderBy(orderByClause) + LIMIT + limit + getOffset(offset))
     }
 
     override fun selectOneOrderedBy(
@@ -109,5 +113,14 @@ internal open class ReadOnlySQLStatementBuilderImpl(
         internal const val SELECT = "SELECT "
         internal const val AND = " AND "
         internal const val ORDER_BY = " ORDER BY "
+        internal const val OFFSET = " OFFSET "
+
+        internal fun getOrderBy(orderByClause: String?): String {
+            return orderByClause?.let { ORDER_BY + it } ?: ""
+        }
+
+        internal fun getOffset(offset: Int?): String {
+            return offset?.let { OFFSET + it } ?: ""
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/SQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/SQLStatementBuilder.kt
@@ -36,7 +36,7 @@ internal interface SQLStatementBuilder : ReadOnlySQLStatementBuilder {
     fun getTableName(): String
     fun selectUids(): RoomRawQuery
     fun selectUidsWhere(whereClause: String): RoomRawQuery
-    fun selectUidsWhere(whereClause: String, orderByClause: String): RoomRawQuery
+    fun selectUidsWhere(whereClause: String, orderByClause: String?): RoomRawQuery
     fun selectColumnWhere(column: String, whereClause: String): RoomRawQuery
     fun selectChildrenWithLinkTable(
         projection: LinkTableChildProjection,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/SQLStatementBuilderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/SQLStatementBuilderImpl.kt
@@ -55,10 +55,10 @@ internal open class SQLStatementBuilderImpl(
         )
     }
 
-    override fun selectUidsWhere(whereClause: String, orderByClause: String): RoomRawQuery {
+    override fun selectUidsWhere(whereClause: String, orderByClause: String?): RoomRawQuery {
         return RoomRawQuery(
             SELECT + IdentifiableColumns.UID + FROM + tableName + WHERE + whereClause +
-                ORDER_BY + orderByClause + ";",
+                getOrderBy(orderByClause) + ";",
         )
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/collection/RepositoryPagingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/collection/RepositoryPagingShould.kt
@@ -27,8 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection
 
-import android.content.ContentValues
-import androidx.paging.ItemKeyedDataSource
+import androidx.paging.PageKeyedDataSource
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -46,6 +45,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -58,17 +58,17 @@ class RepositoryPagingShould {
     private val store: IdentifiableObjectStore<CategoryOption> = mock()
     private val databaseAdapter: DatabaseAdapter = mock()
     private val `object`: CategoryOption = mock()
-    private val key: CategoryOption = mock()
-    private val keyContentValues: ContentValues = mock()
 
     private val objects = listOf(`object`)
     private val childrenAppenders: ChildrenAppenderGetter<CategoryOption> = emptyMap()
 
-    private val initialCallback: ItemKeyedDataSource.LoadInitialCallback<CategoryOption> = mock()
+    private val initialCallback: PageKeyedDataSource.LoadInitialCallback<Int, CategoryOption> = mock()
+    private val loadCallback: PageKeyedDataSource.LoadCallback<Int, CategoryOption> = mock()
 
     @Before
     fun setUp() {
-        whenever(store.selectWhere(any(), any(), any())).doReturn(objects)
+        whenever(store.selectWhere(any(), anyOrNull(), any())).doReturn(objects)
+        whenever(store.selectWhere(any(), anyOrNull(), any(), anyOrNull())).doReturn(objects)
     }
 
     @Test
@@ -76,9 +76,9 @@ class RepositoryPagingShould {
         val dataSource: RepositoryDataSource<CategoryOption> =
             RepositoryDataSource(store, databaseAdapter, emptyScope, childrenAppenders)
 
-        dataSource.loadInitial(ItemKeyedDataSource.LoadInitialParams(null, 3, false), initialCallback)
-        verify(store).selectWhere("1", "_id ASC", 3)
-        verify(initialCallback).onResult(objects)
+        dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
+        verify(store).selectWhere("1", null, 3)
+        verify(initialCallback).onResult(objects, null, 3)
     }
 
     @Test
@@ -93,9 +93,9 @@ class RepositoryPagingShould {
         val dataSource: RepositoryDataSource<CategoryOption> =
             RepositoryDataSource(store, databaseAdapter, updatedScope, childrenAppenders)
 
-        dataSource.loadInitial(ItemKeyedDataSource.LoadInitialParams(null, 3, false), initialCallback)
-        verify(store).selectWhere("1", "name DESC, _id ASC", 3)
-        verify(initialCallback).onResult(objects)
+        dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
+        verify(store).selectWhere("1", "name DESC", 3)
+        verify(initialCallback).onResult(objects, null, 3)
     }
 
     @Test
@@ -110,9 +110,9 @@ class RepositoryPagingShould {
         val dataSource: RepositoryDataSource<CategoryOption> =
             RepositoryDataSource(store, databaseAdapter, updatedScope, childrenAppenders)
 
-        dataSource.loadInitial(ItemKeyedDataSource.LoadInitialParams(null, 3, false), initialCallback)
+        dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
         verify(store).selectWhere("1", "_id ASC", 3)
-        verify(initialCallback).onResult(objects)
+        verify(initialCallback).onResult(objects, null, 3)
     }
 
     @Test
@@ -127,9 +127,9 @@ class RepositoryPagingShould {
         val dataSource: RepositoryDataSource<CategoryOption> =
             RepositoryDataSource(store, databaseAdapter, updatedScope, childrenAppenders)
 
-        dataSource.loadInitial(ItemKeyedDataSource.LoadInitialParams(null, 3, false), initialCallback)
+        dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
         verify(store).selectWhere("1", "_id DESC", 3)
-        verify(initialCallback).onResult(objects)
+        verify(initialCallback).onResult(objects, null, 3)
     }
 
     @Test
@@ -151,17 +151,13 @@ class RepositoryPagingShould {
         val dataSource: RepositoryDataSource<CategoryOption> =
             RepositoryDataSource(store, databaseAdapter, updatedScope2, childrenAppenders)
 
-        dataSource.loadInitial(ItemKeyedDataSource.LoadInitialParams(null, 3, false), initialCallback)
-        verify(store).selectWhere("1", "c1 DESC, c2 ASC, _id ASC", 3)
-        verify(initialCallback).onResult(objects)
+        dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
+        verify(store).selectWhere("1", "c1 DESC, c2 ASC", 3)
+        verify(initialCallback).onResult(objects, null, 3)
     }
 
     @Test
     fun get_after_page_objects_with_order_by_and_filter() {
-        whenever(key.toContentValues()).doReturn(keyContentValues)
-        whenever(keyContentValues.getAsString("_id")).doReturn("5")
-        whenever(keyContentValues.getAsString("code")).doReturn("key-code")
-        whenever(keyContentValues.getAsString("name")).doReturn("key-name")
         val filterScope = withFilterItem(
             emptyScope,
             RepositoryScopeFilterItem.builder()
@@ -182,15 +178,13 @@ class RepositoryPagingShould {
         )
         val dataSource: RepositoryDataSource<CategoryOption> =
             RepositoryDataSource(store, databaseAdapter, updatedScope2, childrenAppenders)
-        dataSource.loadAfter(ItemKeyedDataSource.LoadParams(key, 3), initialCallback)
+        dataSource.loadAfter(PageKeyedDataSource.LoadParams(6, 3), loadCallback)
         verify(store).selectWhere(
-            "((code = 'key-code' AND name = 'key-name' AND _id > '5') OR " +
-                "(code = 'key-code' AND name > 'key-name') OR " +
-                "(code < 'key-code')) " +
-                "AND program = 'uid'",
-            "code DESC, name ASC, _id ASC",
+            "program = 'uid'",
+            "code DESC, name ASC",
             3,
+            6,
         )
-        verify(initialCallback).onResult(objects)
+        verify(loadCallback).onResult(objects, 9)
     }
 }


### PR DESCRIPTION
This PR changes the pagination strategy to use Offset/Limit instead of a custom where clause.

The main changes are:
- DataSource (deprecated): the implementation has changed from a `ItemKeyedDataSource<M,M>` to a `PageKeyedDataSource<Int,M>`. This is because paging is based on a page number instead of the previous object.
- In the API, this change modifies the signature of the dataSource from `DataSource<M,M>` to `DataSource<Int,M>`. The change in the app is straightforward, but must be done.
- The property `pagingKey` in the RepositoryScope has been removed.
- There are some new statementBuilders to make `order by` optional. Previously, the order by clause contained, at least, the column `_id`.
- In general, the code in DataSource and PagingSource has been simplified and it is much easier to follow.