### PR TITLE
chore: [ANDROSDK-2117] Force adapter recreation on testing db

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1721,9 +1721,11 @@ public class org/hisp/dhis/android/core/arch/db/access/internal/DatabaseAdapterF
 	public static fun create (Landroid/content/Context;Lorg/hisp/dhis/android/core/arch/storage/internal/SecureStore;)Lorg/hisp/dhis/android/core/arch/db/access/internal/DatabaseAdapterFactory;
 	public fun createOrOpenDatabase (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;Ljava/lang/String;Z)V
 	public fun createOrOpenDatabase (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;Ljava/lang/String;ZLjava/lang/Integer;)V
+	public fun createOrOpenDatabase (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;Ljava/lang/String;ZLjava/lang/Integer;Z)V
 	public fun createOrOpenDatabase (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount;)V
+	public fun createOrRecreateDatabase (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount;)V
 	public fun deleteDatabase (Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount;)V
-	public fun getDatabaseAdapter (Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount;)Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;
+	public fun getDatabaseAdapter (Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount;Z)Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;
 	public fun newParentDatabaseAdapter ()Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;
 	public fun removeDatabaseAdapter (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;)V
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2Manager.kt
@@ -64,7 +64,7 @@ internal class MultiUserDatabaseManagerForD2Manager(
             .databaseCreationDate(DateUtils.DATE_FORMAT.format(Date()))
             .build()
         ServerURLWrapper.setServerUrl(serverUrl)
-        databaseAdapterFactory.createOrOpenDatabase(databaseAdapter, config)
+        databaseAdapterFactory.createOrRecreateDatabase(databaseAdapter, config)
     }
 
     fun applyMigration() {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -138,7 +138,7 @@ internal class AccountManagerImpl(
 
     private fun updateSyncState(account: DatabaseAccount): DatabaseAccount {
         return if (account.importDB()?.status() != DatabaseAccountImportStatus.PENDING_TO_IMPORT) {
-            val databaseAdapter = databaseAdapterFactory.getDatabaseAdapter(account)
+            val databaseAdapter = databaseAdapterFactory.getDatabaseAdapter(account, false)
             val syncState = AccountManagerHelper.getSyncState(databaseAdapter)
 
             account.toBuilder()


### PR DESCRIPTION
This change should only affect the testing flow. It forces the recreation of the openHelper when the database is opened again. It should solved the scenario when the database file is directly copied in the filesystem and there was a previous openHelper pointing to the same dbname.