### PR TITLE
chore: [ANDROSDK-2110] Adapt to changes in Custom intents payload

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11590,15 +11590,30 @@ public class org/hisp/dhis/android/core/settings/CustomIntentDataElementTableInf
 
 public abstract class org/hisp/dhis/android/core/settings/CustomIntentRequest {
 	public fun <init> ()V
-	public abstract fun arguments ()Ljava/util/Map;
+	public abstract fun arguments ()Ljava/util/List;
 	public static fun builder ()Lorg/hisp/dhis/android/core/settings/CustomIntentRequest$Builder;
 	public static fun create (Landroid/database/Cursor;)Lorg/hisp/dhis/android/core/settings/CustomIntentRequest;
 }
 
 public abstract class org/hisp/dhis/android/core/settings/CustomIntentRequest$Builder {
 	public fun <init> ()V
-	public abstract fun arguments (Ljava/util/Map;)Lorg/hisp/dhis/android/core/settings/CustomIntentRequest$Builder;
+	public abstract fun arguments (Ljava/util/List;)Lorg/hisp/dhis/android/core/settings/CustomIntentRequest$Builder;
 	public abstract fun build ()Lorg/hisp/dhis/android/core/settings/CustomIntentRequest;
+}
+
+public abstract class org/hisp/dhis/android/core/settings/CustomIntentRequestArgument {
+	public fun <init> ()V
+	public static fun builder ()Lorg/hisp/dhis/android/core/settings/CustomIntentRequestArgument$Builder;
+	public static fun create (Landroid/database/Cursor;)Lorg/hisp/dhis/android/core/settings/CustomIntentRequestArgument;
+	public abstract fun key ()Ljava/lang/String;
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract class org/hisp/dhis/android/core/settings/CustomIntentRequestArgument$Builder {
+	public fun <init> ()V
+	public abstract fun build ()Lorg/hisp/dhis/android/core/settings/CustomIntentRequestArgument;
+	public abstract fun key (Ljava/lang/String;)Lorg/hisp/dhis/android/core/settings/CustomIntentRequestArgument$Builder;
+	public abstract fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/settings/CustomIntentRequestArgument$Builder;
 }
 
 public abstract class org/hisp/dhis/android/core/settings/CustomIntentResponse {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentRequest.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentRequest.java
@@ -34,13 +34,13 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 
-import java.util.Map;
+import java.util.List;
 
 @AutoValue
 public abstract class CustomIntentRequest {
 
     @Nullable
-    public abstract Map<String, String> arguments();
+    public abstract List<CustomIntentRequestArgument> arguments();
 
     public static CustomIntentRequest create(Cursor cursor) {
         return AutoValue_CustomIntentRequest.createFromCursor(cursor);
@@ -52,7 +52,7 @@ public abstract class CustomIntentRequest {
 
     @AutoValue.Builder
     public abstract static class Builder {
-        public abstract Builder arguments(Map<String, String> arguments);
+        public abstract Builder arguments(List<CustomIntentRequestArgument> arguments);
 
         public abstract CustomIntentRequest build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentRequestArgument.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentRequestArgument.java
@@ -26,40 +26,33 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.settings.internal
+package org.hisp.dhis.android.core.settings;
 
-import android.content.ContentValues
-import android.database.Cursor
-import com.gabrielittner.auto.value.cursor.ColumnTypeAdapter
-import org.hisp.dhis.android.core.settings.CustomIntentRequest
-import org.hisp.dhis.android.core.settings.CustomIntentRequestArgument
-import org.hisp.dhis.android.core.settings.CustomIntentTableInfo
-import org.hisp.dhis.android.persistence.settings.CustomIntentRequestArgumentsDB
-import org.hisp.dhis.android.persistence.settings.toDB
+import android.database.Cursor;
 
-internal class CustomIntentRequestColumnAdapter : ColumnTypeAdapter<CustomIntentRequest> {
+import com.google.auto.value.AutoValue;
 
-    override fun fromCursor(cursor: Cursor, columnName: String): CustomIntentRequest {
-        val requestArgumentsIndex = cursor.getColumnIndex(CustomIntentTableInfo.Columns.REQUEST_ARGUMENTS)
+@AutoValue
+public abstract class CustomIntentRequestArgument {
 
-        val argumentsString = CustomIntentRequestArgumentsDB(cursor.getString(requestArgumentsIndex))
-        val arguments = argumentsString.toDomain()
+    public abstract String key();
 
-        return CustomIntentRequest.builder()
-            .arguments(arguments)
-            .build()
+    public abstract String value();
+
+    public static CustomIntentRequestArgument create(Cursor cursor) {
+        return AutoValue_CustomIntentRequestArgument.createFromCursor(cursor);
     }
 
-    override fun toContentValues(values: ContentValues, columnName: String, value: CustomIntentRequest?) {
-        value?.arguments()?.let {
-            val argumentsString: String = serialize(it)
-            values.put(CustomIntentTableInfo.Columns.REQUEST_ARGUMENTS, argumentsString)
-        }
+    public static Builder builder() {
+        return new AutoValue_CustomIntentRequestArgument.Builder();
     }
 
-    companion object {
-        fun serialize(list: List<CustomIntentRequestArgument>): String {
-            return list.toDB().value
-        }
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder key(String key);
+
+        public abstract Builder value(String value);
+
+        public abstract CustomIntentRequestArgument build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/settings/CustomIntentRequestArgumentDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/settings/CustomIntentRequestArgumentDTO.kt
@@ -26,33 +26,20 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.persistence.settings
+package org.hisp.dhis.android.network.settings
 
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.json.Json
-import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+import kotlinx.serialization.Serializable
+import org.hisp.dhis.android.core.settings.CustomIntentRequestArgument
 
-@JvmInline
-internal value class StringStringMapDB(
+@Serializable
+internal data class CustomIntentRequestArgumentDTO(
+    val key: String,
     val value: String,
 ) {
-    fun toDomain(): Map<String, String> {
-        return try {
-            KotlinxJsonParser.instance.decodeFromString<Map<String, String>>(value)
-        } catch (e: SerializationException) {
-            emptyMap()
-        }
-    }
-}
-
-internal fun Map<String, String>.toDB(): StringStringMapDB {
-    return try {
-        StringStringMapDB(
-            Json.encodeToString(MapSerializer(String.serializer(), String.serializer()), this),
-        )
-    } catch (e: SerializationException) {
-        StringStringMapDB("{}")
+    fun toDomain(): CustomIntentRequestArgument {
+        return CustomIntentRequestArgument.builder()
+            .key(key)
+            .value(value)
+            .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/settings/CustomIntentRequestDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/settings/CustomIntentRequestDTO.kt
@@ -33,11 +33,11 @@ import org.hisp.dhis.android.core.settings.CustomIntentRequest
 
 @Serializable
 internal data class CustomIntentRequestDTO(
-    val arguments: Map<String, String>,
+    val arguments: List<CustomIntentRequestArgumentDTO>,
 ) {
     fun toDomain(): CustomIntentRequest {
         return CustomIntentRequest.builder()
-            .arguments(arguments)
+            .arguments(arguments.map { it.toDomain() })
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDB.kt
@@ -24,7 +24,7 @@ internal data class CustomIntentDB(
     val name: String?,
     val action: CustomIntentActionTypeListDB?,
     val packageName: String?,
-    val requestArguments: StringStringMapDB?,
+    val requestArguments: CustomIntentRequestArgumentsDB?,
     val responseDataArgument: String?,
     val responseDataPath: String?,
 ) : EntityDB<CustomIntent> {

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/settings/CustomIntentSamples.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/settings/CustomIntentSamples.kt
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.settings.CustomIntentActionType
 import org.hisp.dhis.android.core.settings.CustomIntentAttribute
 import org.hisp.dhis.android.core.settings.CustomIntentDataElement
 import org.hisp.dhis.android.core.settings.CustomIntentRequest
+import org.hisp.dhis.android.core.settings.CustomIntentRequestArgument
 import org.hisp.dhis.android.core.settings.CustomIntentResponse
 import org.hisp.dhis.android.core.settings.CustomIntentResponseData
 import org.hisp.dhis.android.core.settings.CustomIntentTrigger
@@ -61,7 +62,14 @@ object CustomIntentSamples {
             .packageName("package.name")
             .request(
                 CustomIntentRequest.builder()
-                    .arguments(mapOf("some key" to "some value"))
+                    .arguments(
+                        listOf(
+                            CustomIntentRequestArgument.builder()
+                                .key("some key")
+                                .value("some value")
+                                .build()
+                        )
+                    )
                     .build(),
             )
             .response(

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/settings/CustomIntentSamples.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/settings/CustomIntentSamples.kt
@@ -67,8 +67,8 @@ object CustomIntentSamples {
                             CustomIntentRequestArgument.builder()
                                 .key("some key")
                                 .value("some value")
-                                .build()
-                        )
+                                .build(),
+                        ),
                     )
                     .build(),
             )

--- a/core/src/sharedTest/resources/settings/custom_intents.json
+++ b/core/src/sharedTest/resources/settings/custom_intents.json
@@ -24,11 +24,20 @@
       ],
       "packageName": "com.company.application.REGISTER",
       "request": {
-        "arguments": {
-          "projectID": "project one",
-          "serverUrl": "https://server.org",
-          "location": "V{orgunit_uid}"
-        }
+        "arguments": [
+          {
+            "key": "projectID",
+            "value": "project one"
+          },
+          {
+            "key": "serverUrl",
+            "value": "https://server.org"
+          },
+          {
+            "key": "location",
+            "value": "V{orgunit_uid}"
+          }
+        ]
       },
       "response": {
         "data": {
@@ -56,11 +65,20 @@
       ],
       "packageName": "com.company.application.REGISTER",
       "request": {
-        "arguments": {
-          "projectID": "project one",
-          "serverUrl": "https://server.org",
-          "location": "V{orgunit_uid}"
-        }
+        "arguments": [
+          {
+            "key": "projectID",
+            "value": "project one"
+          },
+          {
+            "key": "serverUrl",
+            "value": "https://server.org"
+          },
+          {
+            "key": "location",
+            "value": "V{orgunit_uid}"
+          }
+        ]
       },
       "response": {
         "data": {

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
@@ -49,7 +49,8 @@ class CustomIntentsShould : BaseObjectKotlinxShould("settings/custom_intents.jso
         assertThat(firstCustomIntent.trigger()?.attributes()?.get(0)?.uid()).isEqualTo("attributeUid")
         assertThat(firstCustomIntent.action()).isEqualTo(listOf(CustomIntentActionType.DATA_ENTRY))
         assertThat(firstCustomIntent.request()?.arguments()?.size).isEqualTo(3)
-        assertThat(firstCustomIntent.request()?.arguments()?.get("projectID")).isEqualTo("project one")
+        assertThat(firstCustomIntent.request()?.arguments()?.get(0)?.key()).isEqualTo("projectID")
+        assertThat(firstCustomIntent.request()?.arguments()?.get(0)?.value()).isEqualTo("project one")
         assertThat(firstCustomIntent.response()?.data()?.argument()).isEqualTo("registration")
         assertThat(firstCustomIntent.response()?.data()?.path()).isEqualTo("guid")
     }


### PR DESCRIPTION
The payload of custom intents has changed. In particular, the definition of the request parameters is slightly different: it is a list of parameters instead of a map. This has been changed in this PR accordinglt.

Related task [ANDROSDK-2110](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2110)

[ANDROSDK-2110]: https://dhis2.atlassian.net/browse/ANDROSDK-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ