### PR TITLE
[ANDROSDK-2114] allow null and not null filters for tracker line list

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -843,6 +843,17 @@ public final class org/hisp/dhis/android/core/analytics/trackerlinelist/DataFilt
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter$IsNull : org/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter$IsNull;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter$IsNull;ZILjava/lang/Object;)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter$IsNull;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter$Like : org/hisp/dhis/android/core/analytics/trackerlinelist/DataFilter {
 	public fun <init> (Ljava/lang/String;Z)V
 	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListModel.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListModel.kt
@@ -138,6 +138,7 @@ sealed class DataFilter {
     data class Like(val value: String, val ignoreCase: Boolean = true) : DataFilter()
     data class NotLike(val value: String, val ignoreCase: Boolean = true) : DataFilter()
     data class In(val values: List<String>) : DataFilter()
+    data class IsNull(val value: Boolean) : DataFilter()
 }
 
 internal object Label {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerVisualizationMapper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerVisualizationMapper.kt
@@ -221,7 +221,15 @@ internal class TrackerVisualizationMapper(
                 val value = filterPair.getOrNull(1)
                 if (operator != null && value != null) {
                     when (operator) {
-                        "EQ" -> DataFilter.EqualTo(value, ignoreCase = false)
+                        "EQ" -> if (value == "NV") {
+                            DataFilter.IsNull(true)
+                        } else {
+                            DataFilter.EqualTo(
+                                value,
+                                ignoreCase = false,
+                            )
+                        }
+
                         "!EQ" -> DataFilter.NotEqualTo(value, ignoreCase = false)
                         "IEQ" -> DataFilter.EqualTo(value, ignoreCase = true)
                         "!IEQ" -> DataFilter.NotEqualTo(value, ignoreCase = true)
@@ -229,7 +237,15 @@ internal class TrackerVisualizationMapper(
                         "GE" -> DataFilter.GreaterThanOrEqualTo(value)
                         "LT" -> DataFilter.LowerThan(value)
                         "LE" -> DataFilter.LowerThanOrEqualTo(value)
-                        "NE" -> DataFilter.NotEqualTo(value)
+                        "NE" -> if (value == "NV") {
+                            DataFilter.IsNull(false)
+                        } else {
+                            DataFilter.NotEqualTo(
+                                value,
+                                ignoreCase = false,
+                            )
+                        }
+
                         "LIKE" -> DataFilter.Like(value, ignoreCase = false)
                         "!LIKE" -> DataFilter.NotLike(value, ignoreCase = false)
                         "ILIKE" -> DataFilter.Like(value, ignoreCase = true)

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/DataFilterHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/DataFilterHelper.kt
@@ -51,6 +51,7 @@ internal object DataFilterHelper {
             is DataFilter.Like -> helper.like(filter.value, filter.ignoreCase)
             is DataFilter.NotLike -> helper.notLike(filter.value, filter.ignoreCase)
             is DataFilter.In -> helper.inValues(filter.values)
+            is DataFilter.IsNull -> helper.isNull(filter.value)
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/FilterHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/FilterHelper.kt
@@ -39,6 +39,7 @@ internal class FilterHelper(private val itemId: String) {
     fun like(value: String, ignoreCase: Boolean): String = itemTo("LIKE '%$value%'${case(ignoreCase)}")
     fun notLike(value: String, ignoreCase: Boolean): String = itemTo("NOT LIKE '%$value%'${case(ignoreCase)}")
     fun inValues(values: List<String>): String = itemTo("IN (${values.joinToString(", ") { "'$it'" }})")
+    fun isNull(isNull: Boolean): String = itemTo(if (isNull) "IS NULL" else "IS NOT NULL")
 
     private fun itemTo(comparison: String) = "\"$itemId\" $comparison"
 

--- a/core/src/test/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerVisualizationMapperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerVisualizationMapperShould.kt
@@ -51,7 +51,7 @@ class TrackerVisualizationMapperShould {
     @Test
     fun should_map_data_filters() {
         val item = TrackerVisualizationDimension.builder()
-            .filter("GT:6:ILIKE:ar:NE:4")
+            .filter("GT:6:ILIKE:ar:NE:4:NE:NV")
             .build()
 
         val dataFilters = mapper.mapDataFilters(item)
@@ -60,6 +60,7 @@ class TrackerVisualizationMapperShould {
             DataFilter.GreaterThan("6"),
             DataFilter.Like("ar", ignoreCase = true),
             DataFilter.NotEqualTo("4", ignoreCase = false),
+            DataFilter.IsNull(false),
         )
     }
 


### PR DESCRIPTION
In this PR, new filters have been added for elements in line list:
- Is null / empty -> filter": "EQ:NV",
- Is not null / empty -> filter": "NE:NV",

Related task[ ANDROSDK-2114](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2114)