### PR TITLE
chore: [ANDROSDK-2119] Extend from suspend common and specific stores

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/AttributeStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/AttributeStoreImpl.kt
@@ -29,12 +29,13 @@
 package org.hisp.dhis.android.persistence.attribute
 
 import org.hisp.dhis.android.core.attribute.Attribute
+import org.hisp.dhis.android.core.attribute.internal.AttributeStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class AttributeStoreImpl(
     val dao: AttributeDao,
-) : IdentifiableObjectStoreImpl<Attribute, AttributeDB>(
+) : AttributeStore, IdentifiableObjectStoreImpl<Attribute, AttributeDB>(
     dao,
     Attribute::toDB,
     SQLStatementBuilderImpl(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkStoreImpl.kt
@@ -30,12 +30,13 @@ package org.hisp.dhis.android.persistence.attribute
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.attribute.DataElementAttributeValueLink
+import org.hisp.dhis.android.core.attribute.internal.DataElementAttributeValueLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class DataElementAttributeValueLinkStoreImpl(
     val dao: DataElementAttributeValueLinkDao,
-) : LinkStoreImpl<DataElementAttributeValueLink, DataElementAttributeValueLinkDB>(
+) : DataElementAttributeValueLinkStore, LinkStoreImpl<DataElementAttributeValueLink, DataElementAttributeValueLinkDB>(
     dao,
     DataElementAttributeValueLink::toDB,
     LinkSQLStatementBuilderImpl(
@@ -43,7 +44,7 @@ internal class DataElementAttributeValueLinkStoreImpl(
         DataElementAttributeValueLinkTableInfo.Columns.DATA_ELEMENT,
     ),
 ) {
-    suspend fun getLinksForDataElement(dataElementUid: String): List<DataElementAttributeValueLink> {
+    override suspend fun getLinksForDataElement(dataElementUid: String): List<DataElementAttributeValueLink> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(
                 DataElementAttributeValueLinkTableInfo.Columns.DATA_ELEMENT,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkStoreImpl.kt
@@ -30,12 +30,13 @@ package org.hisp.dhis.android.persistence.attribute
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.attribute.ProgramAttributeValueLink
+import org.hisp.dhis.android.core.attribute.internal.ProgramAttributeValueLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class ProgramAttributeValueLinkStoreImpl(
     val dao: ProgramAttributeValueLinkDao,
-) : LinkStoreImpl<ProgramAttributeValueLink, ProgramAttributeValueLinkDB>(
+) : ProgramAttributeValueLinkStore, LinkStoreImpl<ProgramAttributeValueLink, ProgramAttributeValueLinkDB>(
     dao,
     ProgramAttributeValueLink::toDB,
     LinkSQLStatementBuilderImpl(
@@ -43,7 +44,7 @@ internal class ProgramAttributeValueLinkStoreImpl(
         ProgramAttributeValueLinkTableInfo.Columns.PROGRAM,
     ),
 ) {
-    suspend fun getLinksForProgram(programUid: String): List<ProgramAttributeValueLink> {
+    override suspend fun getLinksForProgram(programUid: String): List<ProgramAttributeValueLink> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(
                 ProgramAttributeValueLinkTableInfo.Columns.PROGRAM,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkStoreImpl.kt
@@ -30,20 +30,22 @@ package org.hisp.dhis.android.persistence.attribute
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.attribute.ProgramStageAttributeValueLink
+import org.hisp.dhis.android.core.attribute.internal.ProgramStageAttributeValueLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class ProgramStageAttributeValueLinkStoreImpl(
     val dao: ProgramStageAttributeValueLinkDao,
-) : LinkStoreImpl<ProgramStageAttributeValueLink, ProgramStageAttributeValueLinkDB>(
-    dao,
-    ProgramStageAttributeValueLink::toDB,
-    LinkSQLStatementBuilderImpl(
-        ProgramStageAttributeValueLinkTableInfo.TABLE_INFO,
-        ProgramStageAttributeValueLinkTableInfo.Columns.PROGRAM_STAGE,
-    ),
-) {
-    suspend fun getLinksForProgramStage(programStageUid: String): List<ProgramStageAttributeValueLink> {
+) : ProgramStageAttributeValueLinkStore,
+    LinkStoreImpl<ProgramStageAttributeValueLink, ProgramStageAttributeValueLinkDB>(
+        dao,
+        ProgramStageAttributeValueLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            ProgramStageAttributeValueLinkTableInfo.TABLE_INFO,
+            ProgramStageAttributeValueLinkTableInfo.Columns.PROGRAM_STAGE,
+        ),
+    ) {
+    override suspend fun getLinksForProgramStage(programStageUid: String): List<ProgramStageAttributeValueLink> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(ProgramStageAttributeValueLinkTableInfo.Columns.PROGRAM_STAGE, programStageUid)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkStoreImpl.kt
@@ -29,12 +29,13 @@
 package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLink
+import org.hisp.dhis.android.core.category.internal.CategoryCategoryComboLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class CategoryCategoryComboLinkStoreImpl(
     val dao: CategoryCategoryComboLinkDao,
-) : LinkStoreImpl<CategoryCategoryComboLink, CategoryCategoryComboLinkDB>(
+) : CategoryCategoryComboLinkStore, LinkStoreImpl<CategoryCategoryComboLink, CategoryCategoryComboLinkDB>(
     dao,
     CategoryCategoryComboLink::toDB,
     LinkSQLStatementBuilderImpl(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkStoreImpl.kt
@@ -29,12 +29,13 @@
 package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.category.CategoryCategoryOptionLink
+import org.hisp.dhis.android.core.category.internal.CategoryCategoryOptionLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class CategoryCategoryOptionLinkStoreImpl(
     val dao: CategoryCategoryOptionLinkDao,
-) : LinkStoreImpl<CategoryCategoryOptionLink, CategoryCategoryOptionLinkDB>(
+) : CategoryCategoryOptionLinkStore, LinkStoreImpl<CategoryCategoryOptionLink, CategoryCategoryOptionLinkDB>(
     dao,
     CategoryCategoryOptionLink::toDB,
     LinkSQLStatementBuilderImpl(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryComboStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryComboStoreImpl.kt
@@ -29,12 +29,13 @@
 package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.category.CategoryCombo
+import org.hisp.dhis.android.core.category.internal.CategoryComboStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class CategoryComboStoreImpl(
     val dao: CategoryComboDao,
-) : IdentifiableObjectStoreImpl<CategoryCombo, CategoryComboDB>(
+) : CategoryComboStore, IdentifiableObjectStoreImpl<CategoryCombo, CategoryComboDB>(
     dao,
     CategoryCombo::toDB,
     SQLStatementBuilderImpl(CategoryComboTableInfo.TABLE_INFO),

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkStoreImpl.kt
@@ -29,16 +29,18 @@
 package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.category.CategoryOptionComboCategoryOptionLink
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboCategoryOptionLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class CategoryOptionComboCategoryOptionLinkStoreImpl(
     val dao: CategoryOptionComboCategoryOptionLinkDao,
-) : LinkStoreImpl<CategoryOptionComboCategoryOptionLink, CategoryOptionComboCategoryOptionLinkDB>(
-    dao,
-    CategoryOptionComboCategoryOptionLink::toDB,
-    LinkSQLStatementBuilderImpl(
-        CategoryOptionComboCategoryOptionLinkTableInfo.TABLE_INFO,
-        CategoryOptionComboCategoryOptionLinkTableInfo.Columns.CATEGORY_OPTION_COMBO,
-    ),
-)
+) : CategoryOptionComboCategoryOptionLinkStore,
+    LinkStoreImpl<CategoryOptionComboCategoryOptionLink, CategoryOptionComboCategoryOptionLinkDB>(
+        dao,
+        CategoryOptionComboCategoryOptionLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            CategoryOptionComboCategoryOptionLinkTableInfo.TABLE_INFO,
+            CategoryOptionComboCategoryOptionLinkTableInfo.Columns.CATEGORY_OPTION_COMBO,
+        ),
+    )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboStoreImpl.kt
@@ -30,17 +30,19 @@ package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class CategoryOptionComboStoreImpl(
     val dao: CategoryOptionComboDao,
-) : IdentifiableObjectStoreImpl<CategoryOptionCombo, CategoryOptionComboDB>(
-    dao,
-    CategoryOptionCombo::toDB,
-    SQLStatementBuilderImpl(CategoryOptionComboTableInfo.TABLE_INFO),
-) {
-    suspend fun getForCategoryCombo(categoryComboUid: String): List<CategoryOptionCombo> {
+) : CategoryOptionComboStore,
+    IdentifiableObjectStoreImpl<CategoryOptionCombo, CategoryOptionComboDB>(
+        dao,
+        CategoryOptionCombo::toDB,
+        SQLStatementBuilderImpl(CategoryOptionComboTableInfo.TABLE_INFO),
+    ) {
+    override suspend fun getForCategoryCombo(categoryComboUid: String): List<CategoryOptionCombo> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(CategoryOptionComboTableInfo.Columns.CATEGORY_COMBO, categoryComboUid)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkStoreImpl.kt
@@ -28,41 +28,20 @@
 
 package org.hisp.dhis.android.persistence.category
 
-import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.category.CategoryOptionOrganisationUnitLink
 import org.hisp.dhis.android.core.category.CategoryOptionOrganisationUnitLinkTableInfo
+import org.hisp.dhis.android.core.category.internal.CategoryOptionOrganisationUnitLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class CategoryOptionOrganisationUnitLinkStoreImpl(
     val dao: CategoryOptionOrganisationUnitLinkDao,
-) : LinkStoreImpl<CategoryOptionOrganisationUnitLink, CategoryOptionOrganisationUnitLinkDB>(
-    dao,
-    CategoryOptionOrganisationUnitLink::toDB,
-    LinkSQLStatementBuilderImpl(
-        CategoryOptionOrganisationUnitLinkTableInfo.TABLE_INFO,
-        CategoryOptionOrganisationUnitLinkTableInfo.Columns.CATEGORY_OPTION,
-    ),
-) {
-    suspend fun getLinksForCategoryOption(categoryOptionUid: String): List<CategoryOptionOrganisationUnitLink> {
-        val whereClause = WhereClauseBuilder()
-            .appendKeyStringValue(
-                CategoryOptionOrganisationUnitLinkTableInfo.Columns.CATEGORY_OPTION,
-                categoryOptionUid,
-            ).build()
-        val query = builder.selectWhere(whereClause)
-        val dbEntities = dao.objectListRawQuery(query)
-        return dbEntities.map { it.toDomain() }
-    }
-
-    suspend fun getLinksForOrganisationUnit(organisationUnitUid: String): List<CategoryOptionOrganisationUnitLink> {
-        val whereClause = WhereClauseBuilder()
-            .appendKeyStringValue(
-                CategoryOptionOrganisationUnitLinkTableInfo.Columns.ORGANISATION_UNIT,
-                organisationUnitUid,
-            ).build()
-        val query = builder.selectWhere(whereClause)
-        val dbEntities = dao.objectListRawQuery(query)
-        return dbEntities.map { it.toDomain() }
-    }
-}
+) : CategoryOptionOrganisationUnitLinkStore,
+    LinkStoreImpl<CategoryOptionOrganisationUnitLink, CategoryOptionOrganisationUnitLinkDB>(
+        dao,
+        CategoryOptionOrganisationUnitLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            CategoryOptionOrganisationUnitLinkTableInfo.TABLE_INFO,
+            CategoryOptionOrganisationUnitLinkTableInfo.Columns.CATEGORY_OPTION,
+        ),
+    )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionStoreImpl.kt
@@ -30,17 +30,18 @@ package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.LinkTableChildProjection
 import org.hisp.dhis.android.core.category.CategoryOption
+import org.hisp.dhis.android.core.category.internal.CategoryOptionStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class CategoryOptionStoreImpl(
     val dao: CategoryOptionDao,
-) : IdentifiableObjectStoreImpl<CategoryOption, CategoryOptionDB>(
+) : CategoryOptionStore, IdentifiableObjectStoreImpl<CategoryOption, CategoryOptionDB>(
     dao,
     CategoryOption::toDB,
     SQLStatementBuilderImpl(CategoryOptionTableInfo.TABLE_INFO),
 ) {
-    suspend fun getForCategoryOptionCombo(categoryOptionComboUid: String): List<CategoryOption> {
+    override suspend fun getForCategoryOptionCombo(categoryOptionComboUid: String): List<CategoryOption> {
         val projection = LinkTableChildProjection(
             CategoryOptionTableInfo.TABLE_INFO,
             CategoryOptionComboCategoryOptionLinkTableInfo.Columns.CATEGORY_OPTION_COMBO,
@@ -54,7 +55,7 @@ internal class CategoryOptionStoreImpl(
         return selectRawQuery(query)
     }
 
-    suspend fun getForCategory(categoryUid: String): List<CategoryOption> {
+    override suspend fun getForCategory(categoryUid: String): List<CategoryOption> {
         val projection = LinkTableChildProjection(
             CategoryOptionTableInfo.TABLE_INFO,
             CategoryCategoryOptionLinkTableInfo.Columns.CATEGORY,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryStoreImpl.kt
@@ -30,17 +30,18 @@ package org.hisp.dhis.android.persistence.category
 
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.LinkTableChildProjection
 import org.hisp.dhis.android.core.category.Category
+import org.hisp.dhis.android.core.category.internal.CategoryStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class CategoryStoreImpl(
     val dao: CategoryDao,
-) : IdentifiableObjectStoreImpl<Category, CategoryDB>(
+) : CategoryStore, IdentifiableObjectStoreImpl<Category, CategoryDB>(
     dao,
     Category::toDB,
     SQLStatementBuilderImpl(CategoryTableInfo.TABLE_INFO),
 ) {
-    suspend fun getForCategoryCombo(categoryComboUid: String): List<Category> {
+    override suspend fun getForCategoryCombo(categoryComboUid: String): List<Category> {
         val projection = LinkTableChildProjection(
             CategoryTableInfo.TABLE_INFO,
             CategoryCategoryComboLinkTableInfo.Columns.CATEGORY_COMBO,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/stores/IdentifiableDataObjectStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/stores/IdentifiableDataObjectStoreImpl.kt
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.persistence.common.stores
 
 import androidx.room.RoomRawQuery
+import org.hisp.dhis.android.core.arch.db.stores.internal.StoreWithState
 import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper
 import org.hisp.dhis.android.core.common.DataObject
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface
@@ -42,46 +43,46 @@ internal open class IdentifiableDataObjectStoreImpl<D, P : EntityDB<D>>(
     protected val identifiableDataObjectDao: IdentifiableDataObjectDao<P>,
     mapper: MapperToDB<D, P>,
     override val builder: IdentifiableDataObjectSQLStatementBuilder,
-) : IdentifiableObjectStoreImpl<D, P>(identifiableDataObjectDao, mapper, builder)
+) : StoreWithState<D>, IdentifiableObjectStoreImpl<D, P>(identifiableDataObjectDao, mapper, builder)
     where D : DataObject, D : ObjectWithUidInterface {
 
     @Throws(RuntimeException::class)
-    suspend fun setSyncState(uid: String, state: State): Int {
+    override suspend fun setSyncState(uid: String, state: State): Int {
         CollectionsHelper.isNull(uid)
         val query: RoomRawQuery = builder.setSyncState(uid, state.toString())
         return identifiableDataObjectDao.intRawQuery(query)
     }
 
     @Throws(RuntimeException::class)
-    suspend fun setSyncState(uids: List<String>, state: State): Int {
+    override suspend fun setSyncState(uids: List<String>, state: State): Int {
         val nonNullUids = uids.filterNotNull()
         val query: RoomRawQuery = builder.setSyncState(nonNullUids, state.toString())
         return identifiableDataObjectDao.intRawQuery(query)
     }
 
     @Throws(RuntimeException::class)
-    suspend fun setSyncStateIfUploading(uid: String, state: State): Int {
+    override suspend fun setSyncStateIfUploading(uid: String, state: State): Int {
         CollectionsHelper.isNull(uid)
         val query: RoomRawQuery = builder.setSyncStateIfUploading(uid, state.toString())
         return identifiableDataObjectDao.intRawQuery(query)
     }
 
     @Throws(RuntimeException::class)
-    suspend fun getSyncState(uid: String): State? {
+    override suspend fun getSyncState(uid: String): State? {
         CollectionsHelper.isNull(uid)
         val query: RoomRawQuery = builder.getSyncState(uid)
         return identifiableDataObjectDao.stateRawQuery(query)
     }
 
     @Throws(RuntimeException::class)
-    suspend fun exists(uid: String): Boolean {
+    override suspend fun exists(uid: String): Boolean {
         CollectionsHelper.isNull(uid)
         val query: RoomRawQuery = builder.exists(uid)
         return identifiableDataObjectDao.intRawQuery(query) > 0
     }
 
     @Throws(RuntimeException::class)
-    suspend fun getUploadableSyncStatesIncludingError(): List<D> {
+    override suspend fun getUploadableSyncStatesIncludingError(): List<D> {
         val query: RoomRawQuery = builder.getUploadableSyncStatesIncludingError()
         val entitiesDB = identifiableDataObjectDao.objectListRawQuery(query)
         return entitiesDB.map { it.toDomain() }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/stores/IdentifiableDeletableDataObjectStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/stores/IdentifiableDeletableDataObjectStoreImpl.kt
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.persistence.common.stores
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.arch.db.stores.internal.DeletableStoreWithState
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper
 import org.hisp.dhis.android.core.common.CoreObject
@@ -47,14 +48,14 @@ internal open class IdentifiableDeletableDataObjectStoreImpl<D, P : EntityDB<D>>
     protected val identifiableDeletableDataObjectDao: IdentifiableDeletableDataObjectStoreDao<P>,
     mapper: MapperToDB<D, P>,
     override val builder: IdentifiableDeletableDataObjectSQLStatementBuilder,
-) : IdentifiableDataObjectStoreImpl<D, P>(
+) : DeletableStoreWithState<D>, IdentifiableDataObjectStoreImpl<D, P>(
     identifiableDeletableDataObjectDao,
     mapper,
     builder,
 ) where D : CoreObject, D : DeletableDataObject, D : ObjectWithUidInterface {
 
     @Throws(RuntimeException::class)
-    suspend fun setSyncStateOrDelete(uid: String, state: State): HandleAction {
+    override suspend fun setSyncStateOrDelete(uid: String, state: State): HandleAction {
         CollectionsHelper.isNull(uid)
         var deleted = false
         if (state == State.SYNCED) {
@@ -74,13 +75,13 @@ internal open class IdentifiableDeletableDataObjectStoreImpl<D, P : EntityDB<D>>
     }
 
     @Throws(RuntimeException::class)
-    suspend fun setDeleted(uid: String): Int {
+    override suspend fun setDeleted(uid: String): Int {
         CollectionsHelper.isNull(uid)
         val query = builder.setDeleted(uid)
         return identifiableDeletableDataObjectDao.intRawQuery(query)
     }
 
-    suspend fun selectSyncStateWhere(where: String): List<State> {
+    override suspend fun selectSyncStateWhere(where: String): List<State> {
         val query = builder.selectSyncStateWhere(where)
         return identifiableDeletableDataObjectDao.stateListRawQuery(query)
     }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/constant/ConstantStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/constant/ConstantStoreImpl.kt
@@ -29,13 +29,14 @@
 package org.hisp.dhis.android.persistence.constant
 
 import org.hisp.dhis.android.core.constant.Constant
+import org.hisp.dhis.android.core.constant.internal.ConstantStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilder
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class ConstantStoreImpl(
     val constantDao: ConstantDao,
     override val builder: SQLStatementBuilder,
-) : IdentifiableObjectStoreImpl<Constant, ConstantDB>(
+) : ConstantStore, IdentifiableObjectStoreImpl<Constant, ConstantDB>(
     constantDao,
     Constant::toDB,
     builder,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataapproval/DataApprovalStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataapproval/DataApprovalStoreImpl.kt
@@ -29,14 +29,15 @@
 package org.hisp.dhis.android.persistence.dataapproval
 
 import org.hisp.dhis.android.core.dataapproval.DataApproval
+import org.hisp.dhis.android.core.dataapproval.internal.DataApprovalStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
-import org.hisp.dhis.android.persistence.common.stores.ObjectStoreImpl
+import org.hisp.dhis.android.persistence.common.stores.ObjectWithoutUidStoreImpl
 
 internal class DataApprovalStoreImpl(
     val dao: DataApprovalDao,
     override val builder: SQLStatementBuilder,
-) : ObjectStoreImpl<DataApproval, DataApprovalDB>(
+) : DataApprovalStore, ObjectWithoutUidStoreImpl<DataApproval, DataApprovalDB>(
     dao,
     DataApproval::toDB,
     SQLStatementBuilderImpl(DataApprovalTableInfo.TABLE_INFO),

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementOperandStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementOperandStoreImpl.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.persistence.dataelement
 
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.LinkTableChildProjection
 import org.hisp.dhis.android.core.dataelement.DataElementOperand
+import org.hisp.dhis.android.core.dataelement.internal.DataElementOperandStore
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLinkTableInfo
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
@@ -37,12 +38,12 @@ import org.hisp.dhis.android.persistence.dataset.SectionGreyedFieldsLinkTableInf
 
 internal class DataElementOperandStoreImpl(
     val dao: DataElementOperandDao,
-) : IdentifiableObjectStoreImpl<DataElementOperand, DataElementOperandDB>(
+) : DataElementOperandStore, IdentifiableObjectStoreImpl<DataElementOperand, DataElementOperandDB>(
     dao,
     DataElementOperand::toDB,
     SQLStatementBuilderImpl(DataElementOperandTableInfo.TABLE_INFO),
 ) {
-    suspend fun getForSection(sectionUid: String): List<DataElementOperand> {
+    override suspend fun getForSection(sectionUid: String): List<DataElementOperand> {
         val projection = LinkTableChildProjection(
             DataElementOperandTableInfo.TABLE_INFO,
             SectionGreyedFieldsLinkTableInfo.Columns.SECTION,
@@ -57,7 +58,7 @@ internal class DataElementOperandStoreImpl(
         return selectRawQuery(query)
     }
 
-    suspend fun getForDataSet(dataSetUid: String): List<DataElementOperand> {
+    override suspend fun getForDataSet(dataSetUid: String): List<DataElementOperand> {
         val projection = LinkTableChildProjection(
             DataElementOperandTableInfo.TABLE_INFO,
             DataSetCompulsoryDataElementOperandLinkTableInfo.Columns.DATA_SET,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementStoreImpl.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.persistence.dataelement
 
 import org.hisp.dhis.android.core.arch.db.stores.projections.internal.LinkTableChildProjection
 import org.hisp.dhis.android.core.dataelement.DataElement
+import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 import org.hisp.dhis.android.persistence.dataset.SectionDataElementLinkTableInfo
@@ -37,12 +38,12 @@ import org.hisp.dhis.android.persistence.program.ProgramStageSectionDataElementL
 
 internal class DataElementStoreImpl(
     val dao: DataElementDao,
-) : IdentifiableObjectStoreImpl<DataElement, DataElementDB>(
+) : DataElementStore, IdentifiableObjectStoreImpl<DataElement, DataElementDB>(
     dao,
     DataElement::toDB,
     SQLStatementBuilderImpl(DataElementTableInfo.TABLE_INFO),
 ) {
-    suspend fun getForSection(sectionUid: String): List<DataElement> {
+    override suspend fun getForSection(sectionUid: String): List<DataElement> {
         val projection = LinkTableChildProjection(
             org.hisp.dhis.android.core.dataelement.DataElementTableInfo.TABLE_INFO,
             SectionDataElementLinkTableInfo.Columns.SECTION,
@@ -59,7 +60,7 @@ internal class DataElementStoreImpl(
         return selectRawQuery(query)
     }
 
-    suspend fun getForProgramStageSection(programStageSection: String): List<DataElement> {
+    override suspend fun getForProgramStageSection(programStageSection: String): List<DataElement> {
         val projection = LinkTableChildProjection(
             org.hisp.dhis.android.core.dataelement.DataElementTableInfo.TABLE_INFO,
             ProgramStageSectionDataElementLinkTableInfo.Columns.PROGRAM_STAGE_SECTION,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodStoreImpl.kt
@@ -31,17 +31,18 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.dataset.DataInputPeriod
 import org.hisp.dhis.android.core.dataset.DataInputPeriodTableInfo
-import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
-import org.hisp.dhis.android.persistence.common.stores.ObjectStoreImpl
+import org.hisp.dhis.android.core.dataset.internal.DataInputPeriodStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class DataInputPeriodStoreImpl(
     val dao: DataInputPeriodDao,
-) : ObjectStoreImpl<DataInputPeriod, DataInputPeriodDB>(
+) : DataInputPeriodStore, LinkStoreImpl<DataInputPeriod, DataInputPeriodDB>(
     dao,
     DataInputPeriod::toDB,
-    SQLStatementBuilderImpl(DataInputPeriodTableInfo.TABLE_INFO),
+    LinkSQLStatementBuilderImpl(DataInputPeriodTableInfo.TABLE_INFO, DataInputPeriodTableInfo.Columns.DATA_SET),
 ) {
-    suspend fun getForDataSet(dataSetUid: String): List<DataInputPeriod> {
+    override suspend fun getForDataSet(dataSetUid: String): List<DataInputPeriod> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(DataInputPeriodTableInfo.Columns.DATA_SET, dataSetUid)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegistrationStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegistrationStoreImpl.kt
@@ -31,33 +31,35 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.dataset.DataSetCompleteRegistration
+import org.hisp.dhis.android.core.dataset.internal.DataSetCompleteRegistrationStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.ObjectWithoutUidStoreImpl
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitTableInfo
 
 internal class DataSetCompleteRegistrationStoreImpl(
     val dao: DataSetCompleteRegistrationDao,
-) : ObjectWithoutUidStoreImpl<DataSetCompleteRegistration, DataSetCompleteRegistrationDB>(
-    dao,
-    DataSetCompleteRegistration::toDB,
-    SQLStatementBuilderImpl(DataSetCompleteRegistrationTableInfo.TABLE_INFO),
-) {
+) : DataSetCompleteRegistrationStore,
+    ObjectWithoutUidStoreImpl<DataSetCompleteRegistration, DataSetCompleteRegistrationDB>(
+        dao,
+        DataSetCompleteRegistration::toDB,
+        SQLStatementBuilderImpl(DataSetCompleteRegistrationTableInfo.TABLE_INFO),
+    ) {
 
     /**
      * @param dataSetCompleteRegistration DataSetCompleteRegistration element you want to update
      * @param newState                    The new state to be set for the DataValue
      */
-    suspend fun setState(dataSetCompleteRegistration: DataSetCompleteRegistration, newState: State?) {
+    override suspend fun setState(dataSetCompleteRegistration: DataSetCompleteRegistration, newState: State?) {
         val updatedDataSetCompleteRegistration = dataSetCompleteRegistration.toBuilder().syncState(newState).build()
         updateWhere(updatedDataSetCompleteRegistration)
     }
 
-    suspend fun setDeleted(dataSetCompleteRegistration: DataSetCompleteRegistration) {
+    override suspend fun setDeleted(dataSetCompleteRegistration: DataSetCompleteRegistration) {
         val updatedDataSetCompleteRegistration = dataSetCompleteRegistration.toBuilder().deleted(true).build()
         updateWhere(updatedDataSetCompleteRegistration)
     }
 
-    suspend fun removeNotPresentAndSynced(
+    override suspend fun removeNotPresentAndSynced(
         dataSetUids: Collection<String>,
         periodIds: Collection<String>,
         rootOrgunitUid: String,
@@ -77,7 +79,7 @@ internal class DataSetCompleteRegistrationStoreImpl(
         return deleteWhere(whereClause.build())
     }
 
-    suspend fun isBeingUpload(dscr: DataSetCompleteRegistration): Boolean {
+    override suspend fun isBeingUpload(dscr: DataSetCompleteRegistration): Boolean {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(DataSetCompleteRegistrationTableInfo.Columns.PERIOD, dscr.period())
             .appendKeyStringValue(DataSetCompleteRegistrationTableInfo.Columns.DATA_SET, dscr.dataSet())

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandLinkStoreImpl.kt
@@ -29,16 +29,18 @@
 package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLink
+import org.hisp.dhis.android.core.dataset.internal.DataSetCompulsoryDataElementOperandLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class DataSetCompulsoryDataElementOperandLinkStoreImpl(
     val dao: DataSetCompulsoryDataElementOperandLinkDao,
-) : LinkStoreImpl<DataSetCompulsoryDataElementOperandLink, DataSetCompulsoryDataElementOperandsLinkDB>(
-    dao,
-    DataSetCompulsoryDataElementOperandLink::toDB,
-    LinkSQLStatementBuilderImpl(
-        DataSetCompulsoryDataElementOperandsLinkTableInfo.TABLE_INFO,
-        DataSetCompulsoryDataElementOperandsLinkTableInfo.Columns.DATA_SET,
-    ),
-)
+) : DataSetCompulsoryDataElementOperandLinkStore,
+    LinkStoreImpl<DataSetCompulsoryDataElementOperandLink, DataSetCompulsoryDataElementOperandsLinkDB>(
+        dao,
+        DataSetCompulsoryDataElementOperandLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            DataSetCompulsoryDataElementOperandsLinkTableInfo.TABLE_INFO,
+            DataSetCompulsoryDataElementOperandsLinkTableInfo.Columns.DATA_SET,
+        ),
+    )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkStoreImpl.kt
@@ -30,12 +30,13 @@ package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.dataset.DataSetElement
+import org.hisp.dhis.android.core.dataset.internal.DataSetElementStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class DataSetDataElementLinkStoreImpl(
     val dao: DataSetDataElementLinkDao,
-) : LinkStoreImpl<DataSetElement, DataSetDataElementLinkDB>(
+) : DataSetElementStore, LinkStoreImpl<DataSetElement, DataSetDataElementLinkDB>(
     dao,
     DataSetElement::toDB,
     LinkSQLStatementBuilderImpl(
@@ -43,7 +44,7 @@ internal class DataSetDataElementLinkStoreImpl(
         DataSetDataElementLinkTableInfo.Columns.DATA_SET,
     ),
 ) {
-    suspend fun getForDataSet(dataSetUid: String): List<DataSetElement> {
+    override suspend fun getForDataSet(dataSetUid: String): List<DataSetElement> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(DataSetDataElementLinkTableInfo.Columns.DATA_SET, dataSetUid)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkStoreImpl.kt
@@ -31,12 +31,13 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLink
+import org.hisp.dhis.android.core.dataset.internal.DataSetOrganisationUnitLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class DataSetOrganisationUnitLinkStoreImpl(
     val dao: DataSetOrganisationUnitLinkDao,
-) : LinkStoreImpl<DataSetOrganisationUnitLink, DataSetOrganisationUnitLinkDB>(
+) : DataSetOrganisationUnitLinkStore, LinkStoreImpl<DataSetOrganisationUnitLink, DataSetOrganisationUnitLinkDB>(
     dao,
     DataSetOrganisationUnitLink::toDB,
     LinkSQLStatementBuilderImpl(
@@ -44,7 +45,7 @@ internal class DataSetOrganisationUnitLinkStoreImpl(
         DataSetOrganisationUnitLinkTableInfo.Columns.ORGANISATION_UNIT,
     ),
 ) {
-    suspend fun getForOrganisationUnit(orgUnitUid: String): List<ObjectWithUid> {
+    override suspend fun getForOrganisationUnit(orgUnitUid: String): List<ObjectWithUid> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(DataSetOrganisationUnitLinkTableInfo.Columns.ORGANISATION_UNIT, orgUnitUid)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetStoreImpl.kt
@@ -29,12 +29,13 @@
 package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.dataset.DataSet
+import org.hisp.dhis.android.core.dataset.internal.DataSetStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class DataSetStoreImpl(
     val dao: DataSetDao,
-) : IdentifiableObjectStoreImpl<DataSet, DataSetDB>(
+) : DataSetStore, IdentifiableObjectStoreImpl<DataSet, DataSetDB>(
     dao,
     DataSet::toDB,
     SQLStatementBuilderImpl(DataSetTableInfo.TABLE_INFO),

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkStoreImpl.kt
@@ -30,12 +30,13 @@ package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.dataset.SectionDataElementLink
 import org.hisp.dhis.android.core.dataset.SectionDataElementLinkTableInfo
+import org.hisp.dhis.android.core.dataset.internal.SectionDataElementLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class SectionDataElementLinkStoreImpl(
     val dao: SectionDataElementLinkDao,
-) : LinkStoreImpl<SectionDataElementLink, SectionDataElementLinkDB>(
+) : SectionDataElementLinkStore, LinkStoreImpl<SectionDataElementLink, SectionDataElementLinkDB>(
     dao,
     SectionDataElementLink::toDB,
     LinkSQLStatementBuilderImpl(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkStoreImpl.kt
@@ -30,12 +30,13 @@ package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLink
 import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLinkTableInfo
+import org.hisp.dhis.android.core.dataset.internal.SectionGreyedFieldsLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class SectionGreyedFieldsLinkStoreImpl(
     val dao: SectionGreyedFieldsLinkDao,
-) : LinkStoreImpl<SectionGreyedFieldsLink, SectionGreyedFieldsLinkDB>(
+) : SectionGreyedFieldsLinkStore, LinkStoreImpl<SectionGreyedFieldsLink, SectionGreyedFieldsLinkDB>(
     dao,
     SectionGreyedFieldsLink::toDB,
     LinkSQLStatementBuilderImpl(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkStoreImpl.kt
@@ -29,12 +29,13 @@
 package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.dataset.internal.SectionIndicatorLink
+import org.hisp.dhis.android.core.dataset.internal.SectionIndicatorLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
 
 internal class SectionIndicatorLinkStoreImpl(
     val dao: SectionIndicatorLinkDao,
-) : LinkStoreImpl<SectionIndicatorLink, SectionIndicatorLinkDB>(
+) : SectionIndicatorLinkStore, LinkStoreImpl<SectionIndicatorLink, SectionIndicatorLinkDB>(
     dao,
     SectionIndicatorLink::toDB,
     LinkSQLStatementBuilderImpl(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionStoreImpl.kt
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.persistence.dataset
 
 import org.hisp.dhis.android.core.dataset.Section
+import org.hisp.dhis.android.core.dataset.internal.SectionStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
@@ -36,7 +37,7 @@ import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreIm
 internal class SectionStoreImpl(
     val dao: SectionDao,
     override val builder: SQLStatementBuilder,
-) : IdentifiableObjectStoreImpl<Section, SectionDB>(
+) : SectionStore, IdentifiableObjectStoreImpl<Section, SectionDB>(
     dao,
     Section::toDB,
     SQLStatementBuilderImpl(SectionTableInfo.TABLE_INFO),


### PR DESCRIPTION
In this PR, the common store implementations in the persistence layer have been extended from the domain common stores, now that those are suspend functions.

Also, the already created specific store implementations have been extended from their corresponding interfaces.

[Related task ANDROSDK-2119](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2119)