### PR TITLE
chore: [ANDROSDK-2100] Refactor sync and DB logic to use coroutines and Mutex locks

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -8371,10 +8371,6 @@ public final class org/hisp/dhis/android/core/maintenance/PerformanceHintsServic
 	public final fun invoke (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;II)Lorg/hisp/dhis/android/core/maintenance/PerformanceHintsService;
 }
 
-public abstract interface class org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleaner {
-	public abstract fun cleanForeignKeyErrors (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public abstract interface class org/hisp/dhis/android/core/map/MapModule {
 	public abstract fun mapLayers ()Lorg/hisp/dhis/android/core/map/layer/MapLayerCollectionRepository;
 	public abstract fun mapLayersDownloader ()Lorg/hisp/dhis/android/core/arch/modules/internal/UntypedModuleDownloader;
@@ -12727,8 +12723,10 @@ public abstract interface class org/hisp/dhis/android/core/sms/domain/repository
 	public abstract fun deleteWaitingResultTimeout ()Lio/reactivex/Completable;
 	public abstract fun generateNextSubmissionId ()Lio/reactivex/Single;
 	public abstract fun getConfirmationSenderNumber ()Lio/reactivex/Single;
+	public abstract fun getConfirmationSenderNumberSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDataValueSet (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun getGatewayNumber ()Lio/reactivex/Single;
+	public abstract fun getGatewayNumberSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMetadataDownloadConfig (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getMetadataIds ()Lio/reactivex/Single;
 	public abstract fun getOngoingSubmissions ()Lio/reactivex/Single;
@@ -12738,12 +12736,15 @@ public abstract interface class org/hisp/dhis/android/core/sms/domain/repository
 	public abstract fun getTrackerEventToSubmit (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun getUserName ()Lio/reactivex/Single;
 	public abstract fun getWaitingForResultEnabled ()Lio/reactivex/Single;
+	public abstract fun getWaitingForResultEnabledSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getWaitingResultTimeout ()Lio/reactivex/Single;
+	public abstract fun getWaitingResultTimeoutSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun isModuleEnabled ()Lio/reactivex/Single;
 	public abstract fun isModuleEnabledSuspend (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun removeOngoingSubmission (I)Lio/reactivex/Completable;
 	public abstract fun setConfirmationSenderNumber (Ljava/lang/String;)Lio/reactivex/Completable;
 	public abstract fun setGatewayNumber (Ljava/lang/String;)Lio/reactivex/Completable;
+	public abstract fun setGatewayNumberSuspend (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setMetadataDownloadConfig (Lorg/hisp/dhis/android/core/sms/domain/repository/WebApiRepository$GetMetadataIdsConfig;)Lio/reactivex/Completable;
 	public abstract fun setMetadataIds (Lorg/hisp/dhis/smscompression/models/SMSMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setModuleEnabled (Z)Lio/reactivex/Completable;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectStoreImpl.kt
@@ -29,6 +29,8 @@ package org.hisp.dhis.android.core.arch.db.stores.internal
 
 import android.content.ContentValues
 import android.database.Cursor
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.SQLStatementBuilderImpl
@@ -61,10 +63,11 @@ internal open class ObjectStoreImpl<O : CoreObject> internal constructor(
 
     private var insertStatement: StatementWrapper? = null
     private var adapterHashCode: Int? = null
+    private val insertMutex = Mutex()
 
     @Throws(RuntimeException::class)
     @Suppress("TooGenericExceptionThrown")
-    override suspend fun insert(o: O): Long {
+    override suspend fun insert(o: O): Long = insertMutex.withLock {
         CollectionsHelper.isNull(o)
         compileStatements()
         binder.bindToStatement(o, insertStatement!!)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithoutUidStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ObjectWithoutUidStoreImpl.kt
@@ -73,10 +73,11 @@ internal open class ObjectWithoutUidStoreImpl<O : CoreObject>(
     private var updateWhereStatement: StatementWrapper? = null
     private var deleteWhereStatement: StatementWrapper? = null
     private var adapterHashCode: Int? = null
+    private val updateWhereMutex = Mutex()
     private val upsertMutex = Mutex()
 
     @Throws(RuntimeException::class)
-    override suspend fun updateWhere(o: O) {
+    override suspend fun updateWhere(o: O) = updateWhereMutex.withLock {
         CollectionsHelper.isNull(o)
         compileStatements()
         binder.bindToStatement(o, updateWhereStatement!!)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/IdentifiableDataHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/IdentifiableDataHandlerImpl.kt
@@ -234,8 +234,8 @@ internal abstract class IdentifiableDataHandlerImpl<O>(
 
         return os.filter { o ->
             !storedObjectUids.contains(o.uid()) ||
-                    allowedObjectUids.contains(o.uid()) ||
-                    CollectionsHelper.isDeleted(o)
+                allowedObjectUids.contains(o.uid()) ||
+                CollectionsHelper.isDeleted(o)
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
@@ -102,12 +102,10 @@ class EventCollectionRepository internal constructor(
     override fun upload(): Observable<D2Progress> {
         val progressFlow: Flow<D2Progress> = flow {
             emitAll(jobQueryCall.queryPendingJobs().asFlow())
-
             val events = byAggregatedSyncState()
                 .`in`(*uploadableStatesIncludingError())
                 .byEnrollmentUid().isNull
                 .blockingGetWithoutChildren()
-
             emitAll(postCall.uploadEvents(events).asFlow())
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventPostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventPostParentCall.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.event.internal
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.trackedentity.internal.OldTrackerImporterPostCall
@@ -44,11 +43,9 @@ internal class EventPostParentCall internal constructor(
     private val trackerParentCallHelper: TrackerPostParentCallHelper,
 ) {
 
-    fun uploadEvents(events: List<Event>): Flow<D2Progress> = flow {
-        when {
-            events.isEmpty() -> emptyFlow()
-            trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadEvents(events)
-            else -> oldTrackerImporterCall.uploadEvents(events)
-        }
+    suspend fun uploadEvents(events: List<Event>): Flow<D2Progress> = when {
+        events.isEmpty() -> emptyFlow()
+        trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadEvents(events)
+        else -> oldTrackerImporterCall.uploadEvents(events)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventPostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventPostParentCall.kt
@@ -28,7 +28,8 @@
 package org.hisp.dhis.android.core.event.internal
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.trackedentity.internal.OldTrackerImporterPostCall
@@ -43,9 +44,11 @@ internal class EventPostParentCall internal constructor(
     private val trackerParentCallHelper: TrackerPostParentCallHelper,
 ) {
 
-    suspend fun uploadEvents(events: List<Event>): Flow<D2Progress> = when {
-        events.isEmpty() -> emptyFlow()
-        trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadEvents(events)
-        else -> oldTrackerImporterCall.uploadEvents(events)
+    fun uploadEvents(events: List<Event>): Flow<D2Progress> = flow {
+        when {
+            events.isEmpty() -> return@flow
+            trackerParentCallHelper.useNewTrackerImporter() -> emitAll(trackerImporterCall.uploadEvents(events))
+            else -> emitAll(oldTrackerImporterCall.uploadEvents(events))
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventPostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventPostParentCall.kt
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.android.core.event.internal
 
-import io.reactivex.Observable
-import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.trackedentity.internal.OldTrackerImporterPostCall
@@ -43,15 +44,11 @@ internal class EventPostParentCall internal constructor(
     private val trackerParentCallHelper: TrackerPostParentCallHelper,
 ) {
 
-    suspend fun uploadEvents(events: List<Event>): Observable<D2Progress> {
-        return if (events.isEmpty()) {
-            Observable.empty()
-        } else {
-            if (trackerParentCallHelper.useNewTrackerImporter()) {
-                trackerImporterCall.uploadEvents(events).asObservable()
-            } else {
-                oldTrackerImporterCall.uploadEvents(events).asObservable()
-            }
+    fun uploadEvents(events: List<Event>): Flow<D2Progress> = flow {
+        when {
+            events.isEmpty() -> emptyFlow()
+            trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadEvents(events)
+            else -> oldTrackerImporterCall.uploadEvents(events)
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.core.imports
 
 import io.reactivex.Observable
+import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.tracker.importer.internal.JobQueryCall
 import org.koin.core.annotation.Singleton
@@ -38,7 +39,7 @@ class TrackerJobManager internal constructor(
     private val jobQueryCall: JobQueryCall,
 ) {
     fun resumePendingJobs(): Observable<D2Progress> {
-        return jobQueryCall.queryPendingJobs()
+        return jobQueryCall.queryPendingJobs().asObservable()
     }
 
     fun blockingResumePendingJobs() {

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleaner.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyCleaner.kt
@@ -27,6 +27,6 @@
  */
 package org.hisp.dhis.android.core.maintenance.internal
 
-fun interface ForeignKeyCleaner {
+internal fun interface ForeignKeyCleaner {
     suspend fun cleanForeignKeyErrors(): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/LocalDbRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/LocalDbRepositoryImpl.kt
@@ -87,11 +87,19 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun getGatewayNumber(): Single<String> {
-        return rxSingle { smsConfigStore.get(SMSConfigKey.GATEWAY) ?: "" }
+        return rxSingle { getGatewayNumberSuspend() }
+    }
+
+    override suspend fun getGatewayNumberSuspend(): String {
+        return smsConfigStore.get(SMSConfigKey.GATEWAY) ?: ""
     }
 
     override fun setGatewayNumber(number: String): Completable {
-        return rxCompletable { smsConfigStore.set(SMSConfigKey.GATEWAY, number) }
+        return rxCompletable { setGatewayNumberSuspend(number) }
+    }
+
+    override suspend fun setGatewayNumberSuspend(number: String) {
+        smsConfigStore.set(SMSConfigKey.GATEWAY, number)
     }
 
     override fun deleteGatewayNumber(): Completable {
@@ -99,9 +107,11 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun getWaitingResultTimeout(): Single<Int> {
-        return rxSingle {
-            smsConfigStore.get(SMSConfigKey.WAITING_RESULT_TIMEOUT)?.toInt() ?: DEFAULT_WAIT_TIMEOUT
-        }
+        return rxSingle { getWaitingResultTimeoutSuspend() }
+    }
+
+    override suspend fun getWaitingResultTimeoutSuspend(): Int {
+        return smsConfigStore.get(SMSConfigKey.WAITING_RESULT_TIMEOUT)?.toInt() ?: DEFAULT_WAIT_TIMEOUT
     }
 
     override fun setWaitingResultTimeout(timeoutSeconds: Int): Completable {
@@ -115,7 +125,11 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun getConfirmationSenderNumber(): Single<String> {
-        return rxSingle { smsConfigStore.get(SMSConfigKey.CONFIRMATION_SENDER) ?: "" }
+        return rxSingle { getConfirmationSenderNumberSuspend() }
+    }
+
+    override suspend fun getConfirmationSenderNumberSuspend(): String {
+        return smsConfigStore.get(SMSConfigKey.CONFIRMATION_SENDER) ?: ""
     }
 
     override fun setConfirmationSenderNumber(number: String): Completable {
@@ -252,7 +266,11 @@ internal class LocalDbRepositoryImpl(
     }
 
     override fun getWaitingForResultEnabled(): Single<Boolean> {
-        return rxSingle { smsConfigStore.get(SMSConfigKey.WAIT_FOR_RESULT)?.toBoolean() ?: false }
+        return rxSingle { getWaitingForResultEnabledSuspend() }
+    }
+
+    override suspend fun getWaitingForResultEnabledSuspend(): Boolean {
+        return smsConfigStore.get(SMSConfigKey.WAIT_FOR_RESULT)?.toBoolean() ?: false
     }
 
     override fun getOngoingSubmissions(): Single<Map<Int, SubmissionType>> {

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/domain/interactor/ConfigCase.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/domain/interactor/ConfigCase.kt
@@ -45,27 +45,16 @@ class ConfigCase(
     private val localDbRepository: LocalDbRepository,
 ) {
 
-    fun getSmsModuleConfig(): Single<SmsConfig> {
-        return Single.zip(
-            rxSingle { localDbRepository.isModuleEnabledSuspend() },
-            localDbRepository.getGatewayNumber(),
-            localDbRepository.getWaitingForResultEnabled(),
-            localDbRepository.getConfirmationSenderNumber(),
-            localDbRepository.getWaitingResultTimeout(),
-        ) { moduleEnabled: Boolean,
-            gateway: String,
-            waitingForResult: Boolean,
-            resultSender: String,
-            resultWaitingTimeout: Int,
-            ->
-            SmsConfig(
-                moduleEnabled,
-                gateway,
-                waitingForResult,
-                resultSender,
-                resultWaitingTimeout,
-            )
-        }
+    fun getSmsModuleConfig(): Single<SmsConfig> = rxSingle { getSmsModuleConfigSuspend() }
+
+    private suspend fun getSmsModuleConfigSuspend(): SmsConfig {
+        return SmsConfig(
+            isModuleEnabled = localDbRepository.isModuleEnabledSuspend(),
+            gateway = localDbRepository.getGatewayNumberSuspend(),
+            isWaitingForResult = localDbRepository.getWaitingForResultEnabledSuspend(),
+            resultSender = localDbRepository.getConfirmationSenderNumberSuspend(),
+            resultWaitingTimeout = localDbRepository.getWaitingResultTimeoutSuspend(),
+        )
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/domain/repository/internal/LocalDbRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/domain/repository/internal/LocalDbRepository.kt
@@ -41,12 +41,16 @@ import org.hisp.dhis.smscompression.models.SMSMetadata
 interface LocalDbRepository {
     fun getUserName(): Single<String>
     fun getGatewayNumber(): Single<String>
+    suspend fun getGatewayNumberSuspend(): String
     fun setGatewayNumber(number: String): Completable
+    suspend fun setGatewayNumberSuspend(number: String)
     fun deleteGatewayNumber(): Completable
     fun getWaitingResultTimeout(): Single<Int>
+    suspend fun getWaitingResultTimeoutSuspend(): Int
     fun setWaitingResultTimeout(timeoutSeconds: Int): Completable
     fun deleteWaitingResultTimeout(): Completable
     fun getConfirmationSenderNumber(): Single<String>
+    suspend fun getConfirmationSenderNumberSuspend(): String
     fun setConfirmationSenderNumber(number: String): Completable
     fun deleteConfirmationSenderNumber(): Completable
     fun getMetadataIds(): Single<SMSMetadata>
@@ -64,6 +68,7 @@ interface LocalDbRepository {
     suspend fun isModuleEnabledSuspend(): Boolean
     fun setWaitingForResultEnabled(enabled: Boolean): Completable
     fun getWaitingForResultEnabled(): Single<Boolean>
+    suspend fun getWaitingForResultEnabledSuspend(): Boolean
     fun getOngoingSubmissions(): Single<Map<Int, SubmissionType>>
     fun generateNextSubmissionId(): Single<Int>
     fun addOngoingSubmission(id: Int, type: SubmissionType): Completable

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -28,10 +28,8 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Observable
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
@@ -100,17 +98,13 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
     }
 
     @Suppress("SpreadOperator")
-    override fun upload(): Observable<D2Progress> {
-        val progressFlow: Flow<D2Progress> = flow {
-            emitAll(jobQueryCall.queryPendingJobs().asFlow())
-            val trackedEntityInstances = byAggregatedSyncState()
-                .`in`(*uploadableStatesIncludingError())
-                .blockingGetWithoutChildren()
-            emitAll(postCall.uploadTrackedEntityInstances(trackedEntityInstances).asFlow())
-        }
-
-        return progressFlow.asObservable()
-    }
+    override fun upload(): Observable<D2Progress> = flow {
+        emitAll(jobQueryCall.queryPendingJobs())
+        val trackedEntityInstances = byAggregatedSyncState()
+            .`in`(*uploadableStatesIncludingError())
+            .blockingGetWithoutChildren()
+        emitAll(postCall.uploadTrackedEntityInstances(trackedEntityInstances))
+    }.asObservable()
 
     override fun blockingUpload() {
         upload().blockingSubscribe()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -28,7 +28,11 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Observable
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.rx2.asFlow
+import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
@@ -97,15 +101,15 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
 
     @Suppress("SpreadOperator")
     override fun upload(): Observable<D2Progress> {
-        return Observable.concat(
-            jobQueryCall.queryPendingJobs(),
-            Observable.fromCallable {
-                byAggregatedSyncState().`in`(*uploadableStatesIncludingError()).blockingGetWithoutChildren()
-            }
-                .flatMap { trackedEntityInstances: List<TrackedEntityInstance> ->
-                    runBlocking { postCall.uploadTrackedEntityInstances(trackedEntityInstances) }
-                },
-        )
+        val progressFlow: Flow<D2Progress> = flow {
+            emitAll(jobQueryCall.queryPendingJobs().asFlow())
+            val trackedEntityInstances = byAggregatedSyncState()
+                .`in`(*uploadableStatesIncludingError())
+                .blockingGetWithoutChildren()
+            emitAll(postCall.uploadTrackedEntityInstances(trackedEntityInstances).asFlow())
+        }
+
+        return progressFlow.asObservable()
     }
 
     override fun blockingUpload() {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import io.reactivex.Observable
-import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.tracker.TrackerPostParentCallHelper
@@ -42,17 +43,14 @@ internal class TrackedEntityInstancePostParentCall internal constructor(
     private val trackerParentCallHelper: TrackerPostParentCallHelper,
 ) {
 
-    suspend fun uploadTrackedEntityInstances(
-        trackedEntityInstances: List<TrackedEntityInstance>,
-    ): Observable<D2Progress> {
-        return if (trackedEntityInstances.isEmpty()) {
-            Observable.empty()
-        } else {
-            if (trackerParentCallHelper.useNewTrackerImporter()) {
-                trackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances).asObservable()
-            } else {
-                oldTrackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances).asObservable()
-            }
+    fun uploadTrackedEntityInstances(trackedEntityInstances: List<TrackedEntityInstance>): Flow<D2Progress> = flow {
+        when {
+            trackedEntityInstances.isEmpty() -> emptyFlow()
+            trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadTrackedEntityInstances(
+                trackedEntityInstances,
+            )
+
+            else -> oldTrackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances)
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
@@ -28,7 +28,8 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.tracker.TrackerPostParentCallHelper
@@ -42,12 +43,14 @@ internal class TrackedEntityInstancePostParentCall internal constructor(
     private val trackerParentCallHelper: TrackerPostParentCallHelper,
 ) {
 
-    suspend fun uploadTrackedEntityInstances(trackedEntityInstances: List<TrackedEntityInstance>): Flow<D2Progress> =
+    fun uploadTrackedEntityInstances(trackedEntityInstances: List<TrackedEntityInstance>): Flow<D2Progress> = flow {
         when {
-            trackedEntityInstances.isEmpty() -> emptyFlow()
-            trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadTrackedEntityInstances(
-                trackedEntityInstances,
+            trackedEntityInstances.isEmpty() -> return@flow
+            trackerParentCallHelper.useNewTrackerImporter() -> emitAll(
+                trackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances)
             )
-            else -> oldTrackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances)
+
+            else -> emitAll(oldTrackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances))
         }
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.tracker.TrackerPostParentCallHelper
@@ -43,14 +42,12 @@ internal class TrackedEntityInstancePostParentCall internal constructor(
     private val trackerParentCallHelper: TrackerPostParentCallHelper,
 ) {
 
-    fun uploadTrackedEntityInstances(trackedEntityInstances: List<TrackedEntityInstance>): Flow<D2Progress> = flow {
+    suspend fun uploadTrackedEntityInstances(trackedEntityInstances: List<TrackedEntityInstance>): Flow<D2Progress> =
         when {
             trackedEntityInstances.isEmpty() -> emptyFlow()
             trackerParentCallHelper.useNewTrackerImporter() -> trackerImporterCall.uploadTrackedEntityInstances(
                 trackedEntityInstances,
             )
-
             else -> oldTrackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances)
         }
-    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostParentCall.kt
@@ -47,7 +47,7 @@ internal class TrackedEntityInstancePostParentCall internal constructor(
         when {
             trackedEntityInstances.isEmpty() -> return@flow
             trackerParentCallHelper.useNewTrackerImporter() -> emitAll(
-                trackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances)
+                trackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances),
             )
 
             else -> emitAll(oldTrackerImporterCall.uploadTrackedEntityInstances(trackedEntityInstances))

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobQueryCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobQueryCall.kt
@@ -27,12 +27,10 @@
  */
 package org.hisp.dhis.android.core.tracker.importer.internal
 
-import io.reactivex.Observable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
@@ -59,7 +57,7 @@ internal class JobQueryCall internal constructor(
     private val stateManager: NewTrackerImporterTrackedEntityPostStateManager,
 ) {
 
-    fun queryPendingJobs(): Observable<D2Progress> = flow {
+    fun queryPendingJobs(): Flow<D2Progress> = flow {
         val pendingJobs = trackerJobObjectStore.selectAll()
             .sortedBy { it.lastUpdated() }
             .groupBy { it.jobUid() }
@@ -71,7 +69,7 @@ internal class JobQueryCall internal constructor(
             emitAll(queryJobInternal(it.first, it.second, it.third, ATTEMPTS_WHEN_QUERYING))
             updateFileResourceStates(it.second)
         }
-    }.asObservable()
+    }
 
     fun queryJob(jobId: String): Flow<D2Progress> = flow {
         val jobObjects = trackerJobObjectStore.selectWhere(byJobIdClause(jobId))

--- a/core/src/test/java/org/hisp/dhis/android/core/sms/mockrepos/MockLocalDbRepository.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/sms/mockrepos/MockLocalDbRepository.kt
@@ -65,8 +65,16 @@ class MockLocalDbRepository : LocalDbRepository {
         return Single.fromCallable { gatewayNumber ?: "" }
     }
 
+    override suspend fun getGatewayNumberSuspend(): String {
+        return gatewayNumber ?: ""
+    }
+
     override fun setGatewayNumber(number: String): Completable {
         return Completable.fromAction { gatewayNumber = number }
+    }
+
+    override suspend fun setGatewayNumberSuspend(number: String) {
+        gatewayNumber = number
     }
 
     override fun deleteGatewayNumber(): Completable {
@@ -75,6 +83,10 @@ class MockLocalDbRepository : LocalDbRepository {
 
     override fun getWaitingResultTimeout(): Single<Int> {
         return Single.fromCallable { resultWaitingTimeout }
+    }
+
+    override suspend fun getWaitingResultTimeoutSuspend(): Int {
+        return resultWaitingTimeout
     }
 
     override fun setWaitingResultTimeout(timeoutSeconds: Int): Completable {
@@ -87,6 +99,10 @@ class MockLocalDbRepository : LocalDbRepository {
 
     override fun getConfirmationSenderNumber(): Single<String> {
         return Single.fromCallable { confirmationSenderNumber ?: "" }
+    }
+
+    override suspend fun getConfirmationSenderNumberSuspend(): String {
+        return confirmationSenderNumber ?: ""
     }
 
     override fun setConfirmationSenderNumber(number: String): Completable {
@@ -173,6 +189,10 @@ class MockLocalDbRepository : LocalDbRepository {
 
     override fun getWaitingForResultEnabled(): Single<Boolean> {
         return Single.fromCallable { waitingForResult }
+    }
+
+    override suspend fun getWaitingForResultEnabledSuspend(): Boolean {
+        return waitingForResult
     }
 
     override fun getOngoingSubmissions(): Single<Map<Int, SubmissionType>> {

--- a/processor/src/main/java/org/hisp/dhis/android/processor/EntityProcessor.kt
+++ b/processor/src/main/java/org/hisp/dhis/android/processor/EntityProcessor.kt
@@ -98,18 +98,18 @@ class EntityProcessor(
                     override fun all(): Array<String> {
                         return arrayOf(
                             ${columns.joinToString(
-                                separator = "\n                            ",
-                            ) { c ->
-                                "${c.propertyName}," 
-                            }}
+                separator = "\n                            ",
+            ) { c ->
+                "${c.propertyName},"
+            }}
                         )
                     }
                     companion object {
                         ${columns.joinToString(
-                            separator = "\n                        ",
-                        ) { c ->
-                            "const val ${c.propertyName} = \"${c.columnName}\"" 
-                        }}
+                separator = "\n                        ",
+            ) { c ->
+                "const val ${c.propertyName} = \"${c.columnName}\""
+            }}
                     }
                 }
             }


### PR DESCRIPTION
Replaces all runBlocking and @Synchronized usages with suspend functions and Mutex.withLock for thread-safe, non-blocking DB and sync operations. Refactors upload methods to Kotlin Flows, updates handlers and repository interfaces to suspend signatures, and cleans up tests and generated code accordingly.