### PR TITLE
chore: [ANDROSDK-2124] Create store implementation and DAO Part 5

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementStoreImpl.kt
@@ -45,7 +45,7 @@ internal class DataElementStoreImpl(
 ) {
     override suspend fun getForSection(sectionUid: String): List<DataElement> {
         val projection = LinkTableChildProjection(
-            org.hisp.dhis.android.core.dataelement.DataElementTableInfo.TABLE_INFO,
+            DataElementTableInfo.TABLE_INFO,
             SectionDataElementLinkTableInfo.Columns.SECTION,
             SectionDataElementLinkTableInfo.Columns.DATA_ELEMENT,
         )
@@ -62,7 +62,7 @@ internal class DataElementStoreImpl(
 
     override suspend fun getForProgramStageSection(programStageSection: String): List<DataElement> {
         val projection = LinkTableChildProjection(
-            org.hisp.dhis.android.core.dataelement.DataElementTableInfo.TABLE_INFO,
+            DataElementTableInfo.TABLE_INFO,
             ProgramStageSectionDataElementLinkTableInfo.Columns.PROGRAM_STAGE_SECTION,
             ProgramStageSectionDataElementLinkTableInfo.Columns.DATA_ELEMENT,
         )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/enrollment/EnrollmentStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/enrollment/EnrollmentStoreImpl.kt
@@ -90,11 +90,11 @@ internal class EnrollmentStoreImpl(
     ): List<Enrollment> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(
-                org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE,
+                EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE,
                 teiUid,
             )
             .appendInSubQuery(
-                org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo.Columns.PROGRAM,
+                EnrollmentTableInfo.Columns.PROGRAM,
                 "SELECT ${ProgramTrackedEntityAttributeTableInfo.Columns.PROGRAM} " +
                     "FROM ${ProgramTrackedEntityAttributeTableInfo.TABLE_INFO.name()} " +
                     "WHERE ${ProgramTrackedEntityAttributeTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE} = " +

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkStoreImpl.kt
@@ -48,7 +48,7 @@ internal class IndicatorLegendSetLinkStoreImpl(
     override suspend fun getForIndicator(indicatorUid: String): List<ObjectWithUid> {
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(
-                org.hisp.dhis.android.core.indicator.IndicatorLegendSetLinkTableInfo.Columns.INDICATOR,
+                IndicatorLegendSetLinkTableInfo.Columns.INDICATOR,
                 indicatorUid,
             )
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.maintenance
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface D2ErrorDao : ObjectDao<D2ErrorDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.maintenance
+
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.ObjectStoreImpl
+
+internal class D2ErrorStoreImpl(
+    val dao: D2ErrorDao,
+) : D2ErrorStore, ObjectStoreImpl<D2Error, D2ErrorDB>(
+    dao,
+    D2Error::toDB,
+    SQLStatementBuilderImpl(D2ErrorTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.maintenance
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ForeignKeyViolationDao : ObjectDao<ForeignKeyViolationDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.maintenance
+
+import org.hisp.dhis.android.core.maintenance.ForeignKeyViolation
+import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.ObjectStoreImpl
+
+internal class ForeignKeyViolationStoreImpl(
+    val dao: ForeignKeyViolationDao,
+) : ForeignKeyViolationStore, ObjectStoreImpl<ForeignKeyViolation, ForeignKeyViolationDB>(
+    dao,
+    ForeignKeyViolation::toDB,
+    SQLStatementBuilderImpl(ForeignKeyViolationTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.map
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface MapLayerDao : ObjectDao<MapLayerDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.map
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface MapLayerImageryProviderDao : ObjectDao<MapLayerImageryProviderDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderStoreImpl.kt
@@ -40,6 +40,6 @@ internal class MapLayerImageryProviderStoreImpl(
     MapLayerImageryProvider::toDB,
     LinkSQLStatementBuilderImpl(
         MapLayerImageryProviderTableInfo.TABLE_INFO,
-        MapLayerImageryProviderTableInfo.Columns.MAP_LAYER
+        MapLayerImageryProviderTableInfo.Columns.MAP_LAYER,
     ),
 )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderStoreImpl.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.map
+
+import org.hisp.dhis.android.core.map.layer.MapLayerImageryProvider
+import org.hisp.dhis.android.core.map.layer.internal.MapLayerImageryProviderStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class MapLayerImageryProviderStoreImpl(
+    val dao: MapLayerImageryProviderDao,
+) : MapLayerImageryProviderStore, LinkStoreImpl<MapLayerImageryProvider, MapLayerImageryProviderDB>(
+    dao,
+    MapLayerImageryProvider::toDB,
+    LinkSQLStatementBuilderImpl(
+        MapLayerImageryProviderTableInfo.TABLE_INFO,
+        MapLayerImageryProviderTableInfo.Columns.MAP_LAYER
+    ),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.map
+
+import org.hisp.dhis.android.core.map.layer.MapLayer
+import org.hisp.dhis.android.core.map.layer.internal.MapLayerStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class MapLayerStoreImpl(
+    val dao: MapLayerDao,
+) : MapLayerStore, IdentifiableObjectStoreImpl<MapLayer, MapLayerDB>(
+    dao,
+    MapLayer::toDB,
+    SQLStatementBuilderImpl(MapLayerTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.note
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface NoteDao : ObjectDao<NoteDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteStoreImpl.kt
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.note
+
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.note.Note
+import org.hisp.dhis.android.core.note.internal.NoteStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class NoteStoreImpl(
+    val dao: NoteDao,
+) : NoteStore, IdentifiableObjectStoreImpl<Note, NoteDB>(
+    dao,
+    Note::toDB,
+    SQLStatementBuilderImpl(NoteTableInfo.TABLE_INFO),
+) {
+    override suspend fun getForEvent(eventUid: String): List<Note> {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(NoteTableInfo.Columns.EVENT, eventUid)
+            .build()
+        val selectStatement = builder.selectWhere(whereClause)
+        return selectRawQuery(selectStatement)
+    }
+
+    override suspend fun getForEnrollment(enrollmentUid: String): List<Note> {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(NoteTableInfo.Columns.ENROLLMENT, enrollmentUid)
+            .build()
+        val selectStatement = builder.selectWhere(whereClause)
+        return selectRawQuery(selectStatement)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OptionDao : ObjectDao<OptionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OptionGroupDao : ObjectDao<OptionGroupDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OptionGroupOptionLinkDao : ObjectDao<OptionGroupOptionLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkStoreImpl.kt
@@ -42,12 +42,15 @@ internal class OptionGroupOptionLinkStoreImpl(
     OptionGroupOptionLink::toDB,
     LinkSQLStatementBuilderImpl(
         OptionGroupOptionLinkTableInfo.TABLE_INFO,
-        OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP
+        OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP,
     ),
 ) {
     override suspend fun getForOptionGroup(optionGroupUid: String): List<ObjectWithUid> {
         val whereClause = WhereClauseBuilder()
-            .appendKeyStringValue(org.hisp.dhis.android.core.option.OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP, optionGroupUid)
+            .appendKeyStringValue(
+                OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP,
+                optionGroupUid,
+            )
             .build()
         val selectStatement = builder.selectWhere(whereClause)
         return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.option()) }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkStoreImpl.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.option.OptionGroupOptionLink
+import org.hisp.dhis.android.core.option.internal.OptionGroupOptionLinkStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class OptionGroupOptionLinkStoreImpl(
+    val dao: OptionGroupOptionLinkDao,
+) : OptionGroupOptionLinkStore, LinkStoreImpl<OptionGroupOptionLink, OptionGroupOptionLinkDB>(
+    dao,
+    OptionGroupOptionLink::toDB,
+    LinkSQLStatementBuilderImpl(
+        OptionGroupOptionLinkTableInfo.TABLE_INFO,
+        OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP
+    ),
+) {
+    override suspend fun getForOptionGroup(optionGroupUid: String): List<ObjectWithUid> {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(org.hisp.dhis.android.core.option.OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP, optionGroupUid)
+            .build()
+        val selectStatement = builder.selectWhere(whereClause)
+        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.option()) }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupStoreImpl.kt
@@ -30,7 +30,7 @@ package org.hisp.dhis.android.persistence.option
 
 import org.hisp.dhis.android.core.option.OptionGroup
 import org.hisp.dhis.android.core.option.internal.OptionGroupStore
-import org.hisp.dhis.android.persistence.common.querybuilders.IdentifiableDataObjectSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class OptionGroupStoreImpl(
@@ -38,5 +38,5 @@ internal class OptionGroupStoreImpl(
 ) : OptionGroupStore, IdentifiableObjectStoreImpl<OptionGroup, OptionGroupDB>(
     dao,
     OptionGroup::toDB,
-    IdentifiableDataObjectSQLStatementBuilderImpl(OptionGroupTableInfo.TABLE_INFO),
+    SQLStatementBuilderImpl(OptionGroupTableInfo.TABLE_INFO),
 )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import org.hisp.dhis.android.core.option.OptionGroup
+import org.hisp.dhis.android.core.option.internal.OptionGroupStore
+import org.hisp.dhis.android.persistence.common.querybuilders.IdentifiableDataObjectSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class OptionGroupStoreImpl(
+    val dao: OptionGroupDao,
+) : OptionGroupStore, IdentifiableObjectStoreImpl<OptionGroup, OptionGroupDB>(
+    dao,
+    OptionGroup::toDB,
+    IdentifiableDataObjectSQLStatementBuilderImpl(OptionGroupTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OptionSetDao : ObjectDao<OptionSetDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetStoreImpl.kt
@@ -30,7 +30,7 @@ package org.hisp.dhis.android.persistence.option
 
 import org.hisp.dhis.android.core.option.OptionSet
 import org.hisp.dhis.android.core.option.internal.OptionSetStore
-import org.hisp.dhis.android.persistence.common.querybuilders.IdentifiableDataObjectSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class OptionSetStoreImpl(
@@ -38,5 +38,5 @@ internal class OptionSetStoreImpl(
 ) : OptionSetStore, IdentifiableObjectStoreImpl<OptionSet, OptionSetDB>(
     dao,
     OptionSet::toDB,
-    IdentifiableDataObjectSQLStatementBuilderImpl(OptionSetTableInfo.TABLE_INFO),
+    SQLStatementBuilderImpl(OptionSetTableInfo.TABLE_INFO),
 )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import org.hisp.dhis.android.core.option.OptionSet
+import org.hisp.dhis.android.core.option.internal.OptionSetStore
+import org.hisp.dhis.android.persistence.common.querybuilders.IdentifiableDataObjectSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class OptionSetStoreImpl(
+    val dao: OptionSetDao,
+) : OptionSetStore, IdentifiableObjectStoreImpl<OptionSet, OptionSetDB>(
+    dao,
+    OptionSet::toDB,
+    IdentifiableDataObjectSQLStatementBuilderImpl(OptionSetTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionStoreImpl.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.option.internal.OptionStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
-
 internal class OptionStoreImpl(
     val dao: OptionDao,
 ) : OptionStore, IdentifiableObjectStoreImpl<Option, OptionDB>(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionStoreImpl.kt
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.option
+
+import org.hisp.dhis.android.core.option.Option
+import org.hisp.dhis.android.core.option.internal.OptionStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+
+internal class OptionStoreImpl(
+    val dao: OptionDao,
+) : OptionStore, IdentifiableObjectStoreImpl<Option, OptionDB>(
+    dao,
+    Option::toDB,
+    SQLStatementBuilderImpl(OptionTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OrganisationUnitDao : ObjectDao<OrganisationUnitDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitGroupDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitGroupDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OrganisationUnitGroupDao : ObjectDao<OrganisationUnitGroupDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitGroupStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitGroupStoreImpl.kt
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import org.hisp.dhis.android.core.arch.db.stores.projections.internal.LinkTableChildProjection
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitGroup
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitGroupStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class OrganisationUnitGroupStoreImpl(
+    val dao: OrganisationUnitGroupDao,
+) : OrganisationUnitGroupStore, IdentifiableObjectStoreImpl<OrganisationUnitGroup, OrganisationUnitGroupDB>(
+    dao,
+    OrganisationUnitGroup::toDB,
+    SQLStatementBuilderImpl(OrganisationUnitGroupTableInfo.TABLE_INFO),
+) {
+    override suspend fun getForOrganisationUnit(organisationUnitId: String): List<OrganisationUnitGroup> {
+        val projection = LinkTableChildProjection(
+            OrganisationUnitGroupTableInfo.TABLE_INFO,
+            OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT,
+            OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT_GROUP,
+        )
+        val sectionSqlBuilder = SQLStatementBuilderImpl(OrganisationUnitOrganisationUnitGroupLinkTableInfo.TABLE_INFO)
+        val query = sectionSqlBuilder.selectChildrenWithLinkTable(
+            projection,
+            organisationUnitId,
+            null,
+        )
+        return selectRawQuery(query)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitLevelDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitLevelDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OrganisationUnitLevelDao : ObjectDao<OrganisationUnitLevelDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitLevelStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitLevelStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitLevel
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitLevelStore
+import org.hisp.dhis.android.persistence.common.querybuilders.IdentifiableDataObjectSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class OrganisationUnitLevelStoreImpl(
+    val dao: OrganisationUnitLevelDao,
+) : OrganisationUnitLevelStore, IdentifiableObjectStoreImpl<OrganisationUnitLevel, OrganisationUnitLevelDB>(
+    dao,
+    OrganisationUnitLevel::toDB,
+    IdentifiableDataObjectSQLStatementBuilderImpl(OrganisationUnitLevelTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OrganisationUnitOrganisationUnitGroupLinkDao : ObjectDao<OrganisationUnitOrganisationUnitGroupLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkStoreImpl.kt
@@ -41,6 +41,6 @@ internal class OrganisationUnitOrganisationUnitGroupLinkStoreImpl(
         OrganisationUnitOrganisationUnitGroupLink::toDB,
         LinkSQLStatementBuilderImpl(
             OrganisationUnitOrganisationUnitGroupLinkTableInfo.TABLE_INFO,
-            OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT
+            OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT,
         ),
     )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkStoreImpl.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitOrganisationUnitGroupLink
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitOrganisationUnitGroupLinkStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class OrganisationUnitOrganisationUnitGroupLinkStoreImpl(
+    val dao: OrganisationUnitOrganisationUnitGroupLinkDao,
+) : OrganisationUnitOrganisationUnitGroupLinkStore,
+    LinkStoreImpl<OrganisationUnitOrganisationUnitGroupLink, OrganisationUnitOrganisationUnitGroupLinkDB>(
+        dao,
+        OrganisationUnitOrganisationUnitGroupLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            OrganisationUnitOrganisationUnitGroupLinkTableInfo.TABLE_INFO,
+            OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT
+        ),
+    )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface OrganisationUnitProgramLinkDao : ObjectDao<OrganisationUnitProgramLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkStoreImpl.kt
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class OrganisationUnitProgramLinkStoreImpl(
+    val dao: OrganisationUnitProgramLinkDao,
+) : OrganisationUnitProgramLinkStore,
+    LinkStoreImpl<OrganisationUnitProgramLink, OrganisationUnitProgramLinkDB>(
+        dao,
+        OrganisationUnitProgramLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            OrganisationUnitProgramLinkTableInfo.TABLE_INFO,
+            OrganisationUnitProgramLinkTableInfo.Columns.ORGANISATION_UNIT
+        ),
+    ) {
+    override suspend fun getForOrganisationUnit(organisationUnitUid: String): List<ObjectWithUid> {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(OrganisationUnitProgramLinkTableInfo.Columns.ORGANISATION_UNIT, organisationUnitUid)
+            .build()
+        val selectStatement = builder.selectWhere(whereClause)
+        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.program()) }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkStoreImpl.kt
@@ -43,7 +43,7 @@ internal class OrganisationUnitProgramLinkStoreImpl(
         OrganisationUnitProgramLink::toDB,
         LinkSQLStatementBuilderImpl(
             OrganisationUnitProgramLinkTableInfo.TABLE_INFO,
-            OrganisationUnitProgramLinkTableInfo.Columns.ORGANISATION_UNIT
+            OrganisationUnitProgramLinkTableInfo.Columns.ORGANISATION_UNIT,
         ),
     ) {
     override suspend fun getForOrganisationUnit(organisationUnitUid: String): List<ObjectWithUid> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.organisationunit
+
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class OrganisationUnitStoreImpl(
+    val dao: OrganisationUnitDao,
+) : OrganisationUnitStore, IdentifiableObjectStoreImpl<OrganisationUnit, OrganisationUnitDB>(
+    dao,
+    OrganisationUnit::toDB,
+    SQLStatementBuilderImpl(OrganisationUnitTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.period
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface PeriodDao : ObjectDao<PeriodDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodStoreImpl.kt
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.period
+
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
+import org.hisp.dhis.android.core.common.BaseIdentifiableObject
+import org.hisp.dhis.android.core.period.Period
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.period.internal.PeriodStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.ObjectWithoutUidStoreImpl
+import java.util.Date
+
+internal class PeriodStoreImpl(
+    val dao: PeriodDao,
+) : PeriodStore, ObjectWithoutUidStoreImpl<Period, PeriodDB>(
+    dao,
+    Period::toDB,
+    SQLStatementBuilderImpl(PeriodTableInfo.TABLE_INFO),
+) {
+    override suspend fun selectByPeriodId(periodId: String?): Period? {
+        return periodId?.let {
+            val whereClause = WhereClauseBuilder()
+                .appendKeyStringValue(PeriodTableInfo.Columns.PERIOD_ID, it)
+                .build()
+            selectOneWhere(whereClause)
+        }
+    }
+
+    override suspend fun selectPeriodByTypeAndDate(periodType: PeriodType, date: Date): Period? {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(PeriodTableInfo.Columns.PERIOD_TYPE, periodType)
+            .appendKeyLessThanOrEqStringValue(
+                PeriodTableInfo.Columns.START_DATE,
+                BaseIdentifiableObject.DATE_FORMAT.format(date),
+            )
+            .appendKeyGreaterOrEqStringValue(
+                PeriodTableInfo.Columns.END_DATE,
+                BaseIdentifiableObject.DATE_FORMAT.format(date),
+            )
+            .build()
+        return selectOneWhere(whereClause)
+    }
+
+    override suspend fun oldestPeriodStartDate(): Date? {
+        val period = selectOneOrderedBy(PeriodTableInfo.Columns.START_DATE, SQLOrderType.ASC)
+        return period?.startDate()
+    }
+
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodStoreImpl.kt
@@ -73,5 +73,4 @@ internal class PeriodStoreImpl(
         val period = selectOneOrderedBy(PeriodTableInfo.Columns.START_DATE, SQLOrderType.ASC)
         return period?.startDate()
     }
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface AnalyticsPeriodBoundaryDao : ObjectDao<AnalyticsPeriodBoundaryDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryStoreImpl.kt
@@ -40,6 +40,6 @@ internal class AnalyticsPeriodBoundaryStoreImpl(
     AnalyticsPeriodBoundary::toDB,
     LinkSQLStatementBuilderImpl(
         AnalyticsPeriodBoundaryTableInfo.TABLE_INFO,
-        AnalyticsPeriodBoundaryTableInfo.Columns.PROGRAM_INDICATOR
+        AnalyticsPeriodBoundaryTableInfo.Columns.PROGRAM_INDICATOR,
     ),
 )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryStoreImpl.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
+import org.hisp.dhis.android.core.program.internal.AnalyticsPeriodBoundaryStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class AnalyticsPeriodBoundaryStoreImpl(
+    val dao: AnalyticsPeriodBoundaryDao,
+) : AnalyticsPeriodBoundaryStore, LinkStoreImpl<AnalyticsPeriodBoundary, AnalyticsPeriodBoundaryDB>(
+    dao,
+    AnalyticsPeriodBoundary::toDB,
+    LinkSQLStatementBuilderImpl(
+        AnalyticsPeriodBoundaryTableInfo.TABLE_INFO,
+        AnalyticsPeriodBoundaryTableInfo.Columns.PROGRAM_INDICATOR
+    ),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramDao : ObjectDao<ProgramDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramIndicatorDao : ObjectDao<ProgramIndicatorDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorStoreImpl.kt
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.arch.db.stores.projections.internal.LinkTableChildProjection
+import org.hisp.dhis.android.core.program.ProgramIndicator
+import org.hisp.dhis.android.core.program.internal.ProgramIndicatorStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramIndicatorStoreImpl(
+    val dao: ProgramIndicatorDao,
+) : ProgramIndicatorStore, IdentifiableObjectStoreImpl<ProgramIndicator, ProgramIndicatorDB>(
+    dao,
+    ProgramIndicator::toDB,
+    SQLStatementBuilderImpl(ProgramIndicatorTableInfo.TABLE_INFO),
+) {
+    override suspend fun getForProgramStageSection(programStageSectionUid: String): List<ProgramIndicator> {
+        val projection = LinkTableChildProjection(
+            ProgramIndicatorTableInfo.TABLE_INFO,
+            ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_STAGE_SECTION,
+            ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_INDICATOR,
+        )
+        val sectionSqlBuilder = SQLStatementBuilderImpl(
+            ProgramStageSectionProgramIndicatorLinkTableInfo.TABLE_INFO
+        )
+        val query = sectionSqlBuilder.selectChildrenWithLinkTable(
+            projection,
+            programStageSectionUid,
+            null,
+        )
+        return selectRawQuery(query)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorStoreImpl.kt
@@ -48,7 +48,7 @@ internal class ProgramIndicatorStoreImpl(
             ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_INDICATOR,
         )
         val sectionSqlBuilder = SQLStatementBuilderImpl(
-            ProgramStageSectionProgramIndicatorLinkTableInfo.TABLE_INFO
+            ProgramStageSectionProgramIndicatorLinkTableInfo.TABLE_INFO,
         )
         val query = sectionSqlBuilder.selectChildrenWithLinkTable(
             projection,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramRuleActionDao : ObjectDao<ProgramRuleActionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionStoreImpl.kt
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.program.ProgramRuleAction
+import org.hisp.dhis.android.core.program.internal.ProgramRuleActionStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramRuleActionStoreImpl(
+    val dao: ProgramRuleActionDao,
+) : ProgramRuleActionStore, IdentifiableObjectStoreImpl<ProgramRuleAction, ProgramRuleActionDB>(
+    dao,
+    ProgramRuleAction::toDB,
+    SQLStatementBuilderImpl(ProgramRuleActionTableInfo.TABLE_INFO),
+) {
+    override suspend fun getForProgramRule(programRuleUid: String): List<ProgramRuleAction> {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(
+                ProgramRuleActionTableInfo.Columns.PROGRAM_RULE,
+                programRuleUid
+            )
+            .build()
+        val query = builder.selectWhere(whereClause)
+        return selectRawQuery(query)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionStoreImpl.kt
@@ -45,7 +45,7 @@ internal class ProgramRuleActionStoreImpl(
         val whereClause = WhereClauseBuilder()
             .appendKeyStringValue(
                 ProgramRuleActionTableInfo.Columns.PROGRAM_RULE,
-                programRuleUid
+                programRuleUid,
             )
             .build()
         val query = builder.selectWhere(whereClause)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramRuleDao : ObjectDao<ProgramRuleDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramRule
+import org.hisp.dhis.android.core.program.internal.ProgramRuleStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramRuleStoreImpl(
+    val dao: ProgramRuleDao,
+) : ProgramRuleStore, IdentifiableObjectStoreImpl<ProgramRule, ProgramRuleDB>(
+    dao,
+    ProgramRule::toDB,
+    SQLStatementBuilderImpl(ProgramRuleTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleVariableDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleVariableDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramRuleVariableDao : ObjectDao<ProgramRuleVariableDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleVariableStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleVariableStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramRuleVariable
+import org.hisp.dhis.android.core.program.internal.ProgramRuleVariableStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramRuleVariableStoreImpl(
+    val dao: ProgramRuleVariableDao,
+) : ProgramRuleVariableStore, IdentifiableObjectStoreImpl<ProgramRuleVariable, ProgramRuleVariableDB>(
+    dao,
+    ProgramRuleVariable::toDB,
+    SQLStatementBuilderImpl(ProgramRuleVariableTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramSectionAttributeLinkDao : ObjectDao<ProgramSectionAttributeLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkStoreImpl.kt
@@ -40,6 +40,6 @@ internal class ProgramSectionAttributeLinkStoreImpl(
     ProgramSectionAttributeLink::toDB,
     LinkSQLStatementBuilderImpl(
         ProgramSectionAttributeLinkTableInfo.TABLE_INFO,
-        ProgramSectionAttributeLinkTableInfo.Columns.PROGRAM_SECTION
+        ProgramSectionAttributeLinkTableInfo.Columns.PROGRAM_SECTION,
     ),
 )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkStoreImpl.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramSectionAttributeLink
+import org.hisp.dhis.android.core.program.internal.ProgramSectionAttributeLinkStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class ProgramSectionAttributeLinkStoreImpl(
+    val dao: ProgramSectionAttributeLinkDao,
+) : ProgramSectionAttributeLinkStore, LinkStoreImpl<ProgramSectionAttributeLink, ProgramSectionAttributeLinkDB>(
+    dao,
+    ProgramSectionAttributeLink::toDB,
+    LinkSQLStatementBuilderImpl(
+        ProgramSectionAttributeLinkTableInfo.TABLE_INFO,
+        ProgramSectionAttributeLinkTableInfo.Columns.PROGRAM_SECTION
+    ),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramSectionDao : ObjectDao<ProgramSectionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramSection
+import org.hisp.dhis.android.core.program.internal.ProgramSectionStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramSectionStoreImpl(
+    val dao: ProgramSectionDao,
+) : ProgramSectionStore, IdentifiableObjectStoreImpl<ProgramSection, ProgramSectionDB>(
+    dao,
+    ProgramSection::toDB,
+    SQLStatementBuilderImpl(ProgramSectionTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramStageDao : ObjectDao<ProgramStageDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDataElementDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDataElementDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramStageDataElementDao : ObjectDao<ProgramStageDataElementDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDataElementStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDataElementStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramStageDataElement
+import org.hisp.dhis.android.core.program.internal.ProgramStageDataElementStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramStageDataElementStoreImpl(
+    val dao: ProgramStageDataElementDao,
+) : ProgramStageDataElementStore, IdentifiableObjectStoreImpl<ProgramStageDataElement, ProgramStageDataElementDB>(
+    dao,
+    ProgramStageDataElement::toDB,
+    SQLStatementBuilderImpl(ProgramStageDataElementTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramStageSectionDao : ObjectDao<ProgramStageSectionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramStageSectionDataElementLinkDao : ObjectDao<ProgramStageSectionDataElementLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkStoreImpl.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramStageSectionDataElementLink
+import org.hisp.dhis.android.core.program.internal.ProgramStageSectionDataElementLinkStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class ProgramStageSectionDataElementLinkStoreImpl(
+    val dao: ProgramStageSectionDataElementLinkDao,
+) : ProgramStageSectionDataElementLinkStore,
+    LinkStoreImpl<ProgramStageSectionDataElementLink, ProgramStageSectionDataElementLinkDB>(
+        dao,
+        ProgramStageSectionDataElementLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            ProgramStageSectionDataElementLinkTableInfo.TABLE_INFO,
+            ProgramStageSectionDataElementLinkTableInfo.Columns.PROGRAM_STAGE_SECTION
+        ),
+    )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkStoreImpl.kt
@@ -41,6 +41,6 @@ internal class ProgramStageSectionDataElementLinkStoreImpl(
         ProgramStageSectionDataElementLink::toDB,
         LinkSQLStatementBuilderImpl(
             ProgramStageSectionDataElementLinkTableInfo.TABLE_INFO,
-            ProgramStageSectionDataElementLinkTableInfo.Columns.PROGRAM_STAGE_SECTION
+            ProgramStageSectionDataElementLinkTableInfo.Columns.PROGRAM_STAGE_SECTION,
         ),
     )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramStageSectionProgramIndicatorLinkDao : ObjectDao<ProgramStageSectionProgramIndicatorLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkStoreImpl.kt
@@ -41,6 +41,6 @@ internal class ProgramStageSectionProgramIndicatorLinkStoreImpl(
         ProgramStageSectionProgramIndicatorLink::toDB,
         LinkSQLStatementBuilderImpl(
             ProgramStageSectionProgramIndicatorLinkTableInfo.TABLE_INFO,
-            ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_STAGE_SECTION
+            ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_STAGE_SECTION,
         ),
     )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkStoreImpl.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramStageSectionProgramIndicatorLink
+import org.hisp.dhis.android.core.program.internal.ProgramStageSectionProgramIndicatorLinkStore
+import org.hisp.dhis.android.persistence.common.querybuilders.LinkSQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.LinkStoreImpl
+
+internal class ProgramStageSectionProgramIndicatorLinkStoreImpl(
+    val dao: ProgramStageSectionProgramIndicatorLinkDao,
+) : ProgramStageSectionProgramIndicatorLinkStore,
+    LinkStoreImpl<ProgramStageSectionProgramIndicatorLink, ProgramStageSectionProgramIndicatorLinkDB>(
+        dao,
+        ProgramStageSectionProgramIndicatorLink::toDB,
+        LinkSQLStatementBuilderImpl(
+            ProgramStageSectionProgramIndicatorLinkTableInfo.TABLE_INFO,
+            ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_STAGE_SECTION
+        ),
+    )

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramStageSection
+import org.hisp.dhis.android.core.program.internal.ProgramStageSectionStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramStageSectionStoreImpl(
+    val dao: ProgramStageSectionDao,
+) : ProgramStageSectionStore, IdentifiableObjectStoreImpl<ProgramStageSection, ProgramStageSectionDB>(
+    dao,
+    ProgramStageSection::toDB,
+    SQLStatementBuilderImpl(ProgramStageSectionTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramStage
+import org.hisp.dhis.android.core.program.internal.ProgramStageStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramStageStoreImpl(
+    val dao: ProgramStageDao,
+) : ProgramStageStore, IdentifiableObjectStoreImpl<ProgramStage, ProgramStageDB>(
+    dao,
+    ProgramStage::toDB,
+    SQLStatementBuilderImpl(ProgramStageTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStoreImpl.kt
@@ -48,5 +48,4 @@ internal class ProgramStoreImpl(
             .appendKeyStringValue(ProgramTableInfo.Columns.PROGRAM_TYPE, programType.toString()).build()
         return selectStringColumnsWhereClause(IdentifiableColumns.UID, whereClause)
     }
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStoreImpl.kt
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
+import org.hisp.dhis.android.core.common.IdentifiableColumns
+import org.hisp.dhis.android.core.program.Program
+import org.hisp.dhis.android.core.program.ProgramType
+import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramStoreImpl(
+    val dao: ProgramDao,
+) : ProgramStore, IdentifiableObjectStoreImpl<Program, ProgramDB>(
+    dao,
+    Program::toDB,
+    SQLStatementBuilderImpl(ProgramTableInfo.TABLE_INFO),
+) {
+    override suspend fun getUidsByProgramType(programType: ProgramType): List<String> {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(ProgramTableInfo.Columns.PROGRAM_TYPE, programType.toString()).build()
+        return selectStringColumnsWhereClause(IdentifiableColumns.UID, whereClause)
+    }
+
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeDao.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import androidx.room.Dao
+import org.hisp.dhis.android.persistence.common.daos.ObjectDao
+
+@Dao
+internal interface ProgramTrackedEntityAttributeDao : ObjectDao<ProgramTrackedEntityAttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeStoreImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.program
+
+import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
+import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
+import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
+
+internal class ProgramTrackedEntityAttributeStoreImpl(
+    val dao: ProgramTrackedEntityAttributeDao,
+) : ProgramTrackedEntityAttributeStore, IdentifiableObjectStoreImpl<ProgramTrackedEntityAttribute, ProgramTrackedEntityAttributeDB>(
+    dao,
+    ProgramTrackedEntityAttribute::toDB,
+    SQLStatementBuilderImpl(ProgramTrackedEntityAttributeTableInfo.TABLE_INFO),
+)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeStoreImpl.kt
@@ -29,14 +29,16 @@
 package org.hisp.dhis.android.persistence.program
 
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
+import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttributeTableInfo
 import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 
 internal class ProgramTrackedEntityAttributeStoreImpl(
     val dao: ProgramTrackedEntityAttributeDao,
-) : ProgramTrackedEntityAttributeStore, IdentifiableObjectStoreImpl<ProgramTrackedEntityAttribute, ProgramTrackedEntityAttributeDB>(
-    dao,
-    ProgramTrackedEntityAttribute::toDB,
-    SQLStatementBuilderImpl(ProgramTrackedEntityAttributeTableInfo.TABLE_INFO),
-)
+) : ProgramTrackedEntityAttributeStore,
+    IdentifiableObjectStoreImpl<ProgramTrackedEntityAttribute, ProgramTrackedEntityAttributeDB>(
+        dao,
+        ProgramTrackedEntityAttribute::toDB,
+        SQLStatementBuilderImpl(ProgramTrackedEntityAttributeTableInfo.TABLE_INFO),
+    )


### PR DESCRIPTION
Store implementations and daos have been added to the following DB entities:

maintenance
map
note
option
organisationunit
period
program

Related trask [ANDROSDK-2124](https://dhis2.atlassian.net/browse/ANDROSDK-2124)

[ANDROSDK-2124]: https://dhis2.atlassian.net/browse/ANDROSDK-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ