### PR TITLE
chore: [ANDROSDK-2130] Remove databaseAdapter dependency in childrenAppenders

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -24,9 +24,9 @@
             <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/core" />
             <option value="$PROJECT_DIR$/instrumented-test-app" />
+            <option value="$PROJECT_DIR$/processor" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/internal/ChildrenAppenderExecutor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/internal/ChildrenAppenderExecutor.kt
@@ -27,19 +27,17 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.children.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.common.CoreObject
 
 internal object ChildrenAppenderExecutor {
     @JvmStatic
     suspend fun <M> appendInObject(
         m: M?,
-        databaseAdapter: DatabaseAdapter,
         childrenAppenders: ChildrenAppenderGetter<M>,
         childrenSelection: ChildrenSelection,
     ): M? {
         return m?.let {
-            val selectedAppenders = getSelectedChildrenAppenders(databaseAdapter, childrenAppenders, childrenSelection)
+            val selectedAppenders = getSelectedChildrenAppenders(childrenAppenders, childrenSelection)
             selectedAppenders.fold(m) { nWithChildren: M, appender ->
                 appender.prepareChildren(setOf(nWithChildren))
                 appender.appendChildren(nWithChildren)
@@ -50,11 +48,10 @@ internal object ChildrenAppenderExecutor {
     @JvmStatic
     suspend fun <M : CoreObject?> appendInObjectCollection(
         list: List<M>,
-        databaseAdapter: DatabaseAdapter,
         childrenAppenders: ChildrenAppenderGetter<M>,
         childrenSelection: ChildrenSelection,
     ): List<M> {
-        val selectedAppenders = getSelectedChildrenAppenders(databaseAdapter, childrenAppenders, childrenSelection)
+        val selectedAppenders = getSelectedChildrenAppenders(childrenAppenders, childrenSelection)
 
         selectedAppenders.forEach { it.prepareChildren(list) }
 
@@ -66,10 +63,9 @@ internal object ChildrenAppenderExecutor {
     }
 
     private fun <M> getSelectedChildrenAppenders(
-        databaseAdapter: DatabaseAdapter,
         appendersMap: ChildrenAppenderGetter<M>,
         childrenSelection: ChildrenSelection,
     ): Collection<ChildrenAppender<M>> {
-        return childrenSelection.children.mapNotNull { key -> appendersMap[key]?.invoke(databaseAdapter) }
+        return childrenSelection.children.mapNotNull { key -> appendersMap[key]?.invoke() }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/internal/ChildrenAppenderGetter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/internal/ChildrenAppenderGetter.kt
@@ -28,6 +28,4 @@
 
 package org.hisp.dhis.android.core.arch.repositories.children.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
-
-internal typealias ChildrenAppenderGetter<M> = Map<String, (DatabaseAdapter) -> ChildrenAppender<M>>
+internal typealias ChildrenAppenderGetter<M> = Map<String, () -> ChildrenAppender<M>>

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/internal/SimpleChildrenAppenderGetter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/children/internal/SimpleChildrenAppenderGetter.kt
@@ -25,33 +25,7 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.user
 
-import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
-import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
-import org.hisp.dhis.android.core.user.internal.UserGroupStore
-import org.koin.core.annotation.Singleton
+package org.hisp.dhis.android.core.arch.repositories.children.internal
 
-@Singleton
-class UserGroupCollectionRepository internal constructor(
-    store: UserGroupStore,
-    scope: RepositoryScope,
-) : ReadOnlyIdentifiableCollectionRepositoryImpl<UserGroup, UserGroupCollectionRepository>(
-    store,
-    childrenAppenders,
-    scope,
-    FilterConnectorFactory(
-        scope,
-    ) { s: RepositoryScope ->
-        UserGroupCollectionRepository(
-            store,
-            s,
-        )
-    },
-) {
-    internal companion object {
-        val childrenAppenders: ChildrenAppenderGetter<UserGroup> = emptyMap()
-    }
-}
+internal typealias SimpleChildrenAppenderGetter<M> = Map<String, () -> ChildrenAppender<M>>

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.collection.internal
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -43,11 +42,10 @@ import org.hisp.dhis.android.core.common.ObjectWithUidInterface
 
 abstract class BaseReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollectionRepository<M>> internal constructor(
     @JvmField internal val store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
-) : ReadOnlyCollectionRepositoryImpl<M, R>(store, databaseAdapter, childrenAppenders, scope, cf),
+) : ReadOnlyCollectionRepositoryImpl<M, R>(store, childrenAppenders, scope, cf),
     ReadOnlyWithUidCollectionRepository<M> where M : CoreObject, M : ObjectWithUidInterface {
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -39,7 +39,6 @@ import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -57,7 +56,6 @@ import org.hisp.dhis.android.core.common.CoreObject
 @Suppress("TooManyFunctions")
 open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollectionRepository<M>> internal constructor(
     private val store: ReadableStore<M>,
-    internal val databaseAdapter: DatabaseAdapter,
     internal val childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
@@ -82,7 +80,7 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
      * @return Object repository
      */
     override fun one(): ReadOnlyOneObjectRepositoryFinalImpl<M> {
-        return ReadOnlyOneObjectRepositoryFinalImpl(store, databaseAdapter, childrenAppenders, scope)
+        return ReadOnlyOneObjectRepositoryFinalImpl(store, childrenAppenders, scope)
     }
 
     /**
@@ -109,7 +107,6 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
     private suspend fun getInternal(): List<M> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             getWithoutChildrenInternal(),
-            databaseAdapter,
             childrenAppenders,
             scope.children(),
         )
@@ -145,10 +142,10 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
 
     @Deprecated("Use {@link #getPagingData()} instead}", replaceWith = ReplaceWith("getPagingData()"))
     val dataSource: DataSource<Int, M>
-        get() = RepositoryDataSource(store, databaseAdapter, scope, childrenAppenders)
+        get() = RepositoryDataSource(store, scope, childrenAppenders)
 
     private val pagingSource: PagingSource<Int, M>
-        get() = RepositoryPagingSource(store, databaseAdapter, scope, childrenAppenders)
+        get() = RepositoryPagingSource(store, scope, childrenAppenders)
 
     /**
      * Get the count of elements in an asynchronous way, returning a `Single`.

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyIdentifiableCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyIdentifiableCollectionRepositoryImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyCollectionRepository
@@ -44,11 +43,10 @@ import org.hisp.dhis.android.core.common.IdentifiableObject
 @Suppress("TooManyFunctions")
 open class ReadOnlyIdentifiableCollectionRepositoryImpl<M, R : ReadOnlyCollectionRepository<M>> internal constructor(
     store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
-) : ReadOnlyWithUidCollectionRepositoryImpl<M, R>(store, databaseAdapter, childrenAppenders, scope, cf),
+) : ReadOnlyWithUidCollectionRepositoryImpl<M, R>(store, childrenAppenders, scope, cf),
     ReadOnlyIdentifiableCollectionRepository<M, R> where M : CoreObject, M : IdentifiableObject {
     override fun byUid(): StringFilterConnector<R> {
         return cf.string(IdentifiableColumns.UID)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyNameableCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyNameableCollectionRepositoryImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyCollectionRepository
@@ -42,13 +41,11 @@ import org.hisp.dhis.android.core.common.NameableObject
 
 open class ReadOnlyNameableCollectionRepositoryImpl<M, R : ReadOnlyCollectionRepository<M>> internal constructor(
     store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<M, R>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     cf,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
@@ -39,7 +39,6 @@ import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -63,7 +62,6 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
     R : ReadOnlyCollectionRepository<T>,
     > internal constructor(
     private val store: ReadableStore<M>,
-    internal val databaseAdapter: DatabaseAdapter,
     internal val childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
@@ -91,7 +89,6 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
     override fun one(): ReadOnlyObjectRepository<T> {
         return ReadOnlyWithTransformerObjectRepositoryImpl(
             store,
-            databaseAdapter,
             childrenAppenders,
             scope,
             transformer,
@@ -120,7 +117,6 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
     private suspend fun getInternal(): List<T> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             getWithoutChildrenInternal(),
-            databaseAdapter,
             childrenAppenders,
             scope.children(),
         ).map { transformer.transform(it) }
@@ -159,10 +155,10 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
     }
 
     val dataSource: DataSource<Int, T>
-        get() = RepositoryDataSourceWithTransformer(store, databaseAdapter, scope, childrenAppenders, transformer)
+        get() = RepositoryDataSourceWithTransformer(store, scope, childrenAppenders, transformer)
 
     private val pagingSource: PagingSource<Int, T>
-        get() = RepositoryPagingSourceWithTransformer(store, databaseAdapter, scope, childrenAppenders, transformer)
+        get() = RepositoryPagingSourceWithTransformer(store, scope, childrenAppenders, transformer)
 
     /**
      * Get the count of elements in an asynchronous way, returning a `Single`.

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.collection.internal
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.TwoWayTransformer
@@ -51,14 +50,12 @@ internal class ReadOnlyWithUidAndTransformerCollectionRepositoryImpl<
     R : ReadOnlyCollectionRepository<T>,
     > internal constructor(
     private val store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
     override val transformer: TwoWayTransformer<M, T>,
 ) : ReadOnlyWithTransformerCollectionRepositoryImpl<M, T, R>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     cf,
@@ -104,7 +101,6 @@ internal class ReadOnlyWithUidAndTransformerCollectionRepositoryImpl<
         val updatedScope: RepositoryScope = RepositoryScopeHelper.withUidFilterItem(scope, uid)
         return ReadOnlyWithTransformerObjectRepositoryImpl(
             store,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             transformer,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidCollectionRepositoryImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyCollectionRepository
@@ -40,13 +39,11 @@ import org.hisp.dhis.android.core.common.ObjectWithUidInterface
 
 open class ReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollectionRepository<M>> internal constructor(
     store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     cf: FilterConnectorFactory<R>,
 ) : BaseReadOnlyWithUidCollectionRepositoryImpl<M, R>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     cf,
@@ -59,6 +56,6 @@ open class ReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollectionRepo
      */
     override fun uid(uid: String?): ReadOnlyOneObjectRepositoryFinalImpl<M> {
         val updatedScope: RepositoryScope = RepositoryScopeHelper.withUidFilterItem(scope, uid)
-        return ReadOnlyOneObjectRepositoryFinalImpl(store, databaseAdapter, childrenAppenders, updatedScope)
+        return ReadOnlyOneObjectRepositoryFinalImpl(store, childrenAppenders, updatedScope)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.collection.internal
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
@@ -47,14 +46,12 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
 abstract class ReadWriteWithUidCollectionRepositoryImpl<M, P, R : ReadOnlyCollectionRepository<M>>internal constructor(
     store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     @JvmField protected val transformer: Transformer<P, M>,
     cf: FilterConnectorFactory<R>,
 ) : BaseReadOnlyWithUidCollectionRepositoryImpl<M, R>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     cf,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -36,18 +35,15 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
 class ReadOnlyOneObjectRepositoryFinalImpl<M> internal constructor(
     store: ReadableStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
 ) : ReadOnlyOneObjectRepositoryImpl<M, ReadOnlyOneObjectRepositoryFinalImpl<M>>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         ReadOnlyOneObjectRepositoryFinalImpl(
             store,
-            databaseAdapter,
             childrenAppenders,
             s,
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
@@ -31,7 +31,6 @@ import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.call.internal.DownloadProvider
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
@@ -42,12 +41,11 @@ import org.hisp.dhis.android.core.common.CoreObject
 open class ReadOnlyFirstObjectWithDownloadRepositoryImpl<M : CoreObject, R : ReadOnlyObjectRepository<M>>
 internal constructor(
     store: ObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     private val downloadProvider: DownloadProvider,
     repositoryFactory: ObjectRepositoryFactory<R>,
-) : ReadOnlyOneObjectRepositoryImpl<M, R>(store, databaseAdapter, childrenAppenders, scope, repositoryFactory),
+) : ReadOnlyOneObjectRepositoryImpl<M, R>(store, childrenAppenders, scope, repositoryFactory),
     ReadOnlyWithDownloadObjectRepository<M> {
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderExecutor
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -38,7 +37,6 @@ import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepos
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
 abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
-    private val databaseAdapter: DatabaseAdapter,
     private val childrenAppenderGetter: ChildrenAppenderGetter<M>,
     protected val scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,
@@ -68,7 +66,6 @@ abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> 
     protected suspend fun getInternal(): M? {
         return ChildrenAppenderExecutor.appendInObject(
             blockingGetWithoutChildren(),
-            databaseAdapter,
             childrenAppenderGetter,
             scope.children(),
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -38,11 +37,10 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFr
 
 open class ReadOnlyOneObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val store: ReadableStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,
-) : ReadOnlyObjectRepositoryImpl<M, R>(databaseAdapter, childrenAppenders, scope, repositoryFactory) {
+) : ReadOnlyObjectRepositoryImpl<M, R>(childrenAppenders, scope, repositoryFactory) {
 
     override fun blockingGetWithoutChildren(): M? {
         return runBlocking { getWithoutChildrenInternal() }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
 import org.hisp.dhis.android.core.arch.handlers.internal.TwoWayTransformer
@@ -43,7 +42,6 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFr
 internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T, R : ReadOnlyObjectRepository<T>>
 internal constructor(
     private val store: ReadableStore<M>,
-    private val databaseAdapter: DatabaseAdapter,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
     private val scope: RepositoryScope,
     private val transformer: TwoWayTransformer<M, T>,
@@ -78,7 +76,6 @@ internal constructor(
     private suspend fun getInternal(): T? {
         val item = ChildrenAppenderExecutor.appendInObject(
             getWithoutChildrenInternal(),
-            databaseAdapter,
             childrenAppenders,
             scope.children(),
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
@@ -31,7 +31,6 @@ import android.util.Log
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableDeletableDataObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -49,11 +48,10 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 @Suppress("TooManyFunctions")
 abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     store: IdentifiableDeletableDataObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,
-) : ReadWriteWithUidObjectRepositoryImpl<M, R>(store, databaseAdapter, childrenAppenders, scope, repositoryFactory),
+) : ReadWriteWithUidObjectRepositoryImpl<M, R>(store, childrenAppenders, scope, repositoryFactory),
     ReadWriteObjectRepository<M> where M : CoreObject, M : ObjectWithUidInterface, M : DeletableDataObject {
     /**
      * Removes the object in scope in an asynchronous way. Field [DataObject.syncState] is marked as

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
@@ -41,13 +40,11 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
 open class ReadWriteWithUidObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val store: IdentifiableObjectStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,
 ) : ReadOnlyOneObjectRepositoryImpl<M, R>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     repositoryFactory,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
@@ -31,7 +31,6 @@ import android.util.Log
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
@@ -46,11 +45,10 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 open class ReadWriteWithValueObjectRepositoryImpl<M : CoreObject, R : ReadOnlyObjectRepository<M>>
 internal constructor(
     private val store: ObjectWithoutUidStore<M>,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,
-) : ReadOnlyOneObjectRepositoryImpl<M, R>(store, databaseAdapter, childrenAppenders, scope, repositoryFactory),
+) : ReadOnlyOneObjectRepositoryImpl<M, R>(store, childrenAppenders, scope, repositoryFactory),
     ReadWriteObjectRepository<M> {
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSource.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.arch.repositories.paging.internal
 
 import androidx.paging.PageKeyedDataSource
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -41,7 +40,6 @@ import org.hisp.dhis.android.core.common.CoreObject
 
 class RepositoryDataSource<M : CoreObject> internal constructor(
     private val store: ReadableStore<M>,
-    private val databaseAdapter: DatabaseAdapter,
     private val scope: RepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
 ) : PageKeyedDataSource<Int, M>() {
@@ -81,6 +79,6 @@ class RepositoryDataSource<M : CoreObject> internal constructor(
     }
 
     private suspend fun appendChildren(withoutChildren: List<M>): List<M> {
-        return appendInObjectCollection(withoutChildren, databaseAdapter, childrenAppenders, scope.children())
+        return appendInObjectCollection(withoutChildren, childrenAppenders, scope.children())
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSourceWithTransformer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryDataSourceWithTransformer.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.arch.repositories.paging.internal
 
 import androidx.paging.PageKeyedDataSource
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -42,7 +41,6 @@ import org.hisp.dhis.android.core.common.CoreObject
 
 internal class RepositoryDataSourceWithTransformer<M : CoreObject, T : Any> internal constructor(
     private val store: ReadableStore<M>,
-    private val databaseAdapter: DatabaseAdapter,
     private val scope: RepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
     private val transformer: TwoWayTransformer<M, T>,
@@ -84,7 +82,6 @@ internal class RepositoryDataSourceWithTransformer<M : CoreObject, T : Any> inte
     private suspend fun appendChildren(withoutChildren: List<M>): List<T> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             withoutChildren,
-            databaseAdapter,
             childrenAppenders,
             scope.children(),
         ).map { transformer.transform(it) }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSource.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.paging.internal
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -43,7 +42,6 @@ import java.io.IOException
 
 class RepositoryPagingSource<M : CoreObject> internal constructor(
     private val store: ReadableStore<M>,
-    private val databaseAdapter: DatabaseAdapter,
     private val scope: RepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
 ) : PagingSource<Int, M>() {
@@ -64,7 +62,7 @@ class RepositoryPagingSource<M : CoreObject> internal constructor(
                 offset,
             )
 
-            val items = appendInObjectCollection(withoutChildren, databaseAdapter, childrenAppenders, scope.children())
+            val items = appendInObjectCollection(withoutChildren, childrenAppenders, scope.children())
 
             val prevKey = if (offset == null) null else offset - params.loadSize
             val nextKey = if (items.size < params.loadSize) null else (offset ?: 0) + params.loadSize

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSourceWithTransformer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/paging/internal/RepositoryPagingSourceWithTransformer.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.arch.repositories.paging.internal
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.OrderByClauseBuilder
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
@@ -44,7 +43,6 @@ import java.io.IOException
 
 internal class RepositoryPagingSourceWithTransformer<M : CoreObject, T : Any> internal constructor(
     private val store: ReadableStore<M>,
-    private val databaseAdapter: DatabaseAdapter,
     private val scope: RepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<M>,
     private val transformer: TwoWayTransformer<M, T>,
@@ -66,7 +64,6 @@ internal class RepositoryPagingSourceWithTransformer<M : CoreObject, T : Any> in
             )
             val items = ChildrenAppenderExecutor.appendInObjectCollection(
                 withoutChildren,
-                databaseAdapter,
                 childrenAppenders,
                 scope.children(),
             )

--- a/core/src/main/java/org/hisp/dhis/android/core/attribute/AttributeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/attribute/AttributeCollectionRepository.kt
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.attribute
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class AttributeCollectionRepository internal constructor(
     store: AttributeStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Attribute, AttributeCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class AttributeCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         AttributeCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.category
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class CategoryCollectionRepository internal constructor(
     store: CategoryStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Category, CategoryCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class CategoryCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         CategoryCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryComboCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryComboCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.category
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class CategoryComboCollectionRepository internal constructor(
     store: CategoryComboStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<CategoryCombo, CategoryComboCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class CategoryComboCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         CategoryComboCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.category
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyNameableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class CategoryOptionCollectionRepository internal constructor(
     store: CategoryOptionStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyNameableCollectionRepositoryImpl<CategoryOption, CategoryOptionCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class CategoryOptionCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         CategoryOptionCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.category
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class CategoryOptionComboCollectionRepository internal constructor(
     store: CategoryOptionComboStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<CategoryOptionCombo, CategoryOptionComboCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class CategoryOptionComboCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         CategoryOptionComboCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.category.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.category.CategoryCombo
 
@@ -42,8 +42,8 @@ internal class CategoryCategoryComboChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<CategoryCombo> {
-            return CategoryCategoryComboChildrenAppender(CategoryStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<CategoryCombo> {
+            return CategoryCategoryComboChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryOptionChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryOptionChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.category.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.category.Category
 
@@ -42,8 +42,8 @@ internal class CategoryCategoryOptionChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Category> {
-            return CategoryCategoryOptionChildrenAppender(CategoryOptionStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Category> {
+            return CategoryCategoryOptionChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboCategoryOptionChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboCategoryOptionChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.category.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
 
@@ -42,8 +42,8 @@ internal class CategoryOptionComboCategoryOptionChildrenAppender private constru
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<CategoryOptionCombo> {
-            return CategoryOptionComboCategoryOptionChildrenAppender(CategoryOptionStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<CategoryOptionCombo> {
+            return CategoryOptionComboCategoryOptionChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionOrganisationUnitChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionOrganisationUnitChildrenAppender.kt
@@ -27,19 +27,17 @@
  */
 package org.hisp.dhis.android.core.category.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
-import org.hisp.dhis.android.core.arch.db.stores.internal.LinkStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.category.CategoryOption
-import org.hisp.dhis.android.core.category.CategoryOptionOrganisationUnitLink
 import org.hisp.dhis.android.core.category.CategoryOptionOrganisationUnitLinkTableInfo
 import org.hisp.dhis.android.core.category.internal.CategoryOptionOrganisationUnitsCall.CategoryOptionRestriction.Companion.NOT_ACCESSIBLE_TO_USER
 import org.hisp.dhis.android.core.category.internal.CategoryOptionOrganisationUnitsCall.CategoryOptionRestriction.Companion.NOT_RESTRICTED
 import org.hisp.dhis.android.core.common.ObjectWithUid
 
 internal class CategoryOptionOrganisationUnitChildrenAppender private constructor(
-    private val childStore: LinkStore<CategoryOptionOrganisationUnitLink>,
+    private val childStore: CategoryOptionOrganisationUnitLinkStore,
 ) : ChildrenAppender<CategoryOption>() {
 
     override suspend fun appendChildren(categoryOption: CategoryOption): CategoryOption {
@@ -63,10 +61,8 @@ internal class CategoryOptionOrganisationUnitChildrenAppender private constructo
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<CategoryOption> {
-            return CategoryOptionOrganisationUnitChildrenAppender(
-                CategoryOptionOrganisationUnitLinkStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<CategoryOption> {
+            return CategoryOptionOrganisationUnitChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/constant/ConstantCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/constant/ConstantCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.constant
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DoubleFilterConnector
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ConstantCollectionRepository internal constructor(
     store: ConstantStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Constant, ConstantCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class ConstantCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ConstantCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataapproval/DataApprovalCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataapproval/DataApprovalCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.dataapproval
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class DataApprovalCollectionRepository internal constructor(
     dataApprovalStore: DataApprovalStore,
-    databaseAdapter: DatabaseAdapter,
     repositoryScope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<DataApproval, DataApprovalCollectionRepository>(
     dataApprovalStore,
-    databaseAdapter,
     emptyMap(),
     repositoryScope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class DataApprovalCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataApprovalCollectionRepository(
             dataApprovalStore,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElementCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/DataElementCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.dataelement
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -45,11 +44,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class DataElementCollectionRepository internal constructor(
     store: DataElementStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<DataElement, DataElementCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -57,7 +54,6 @@ class DataElementCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataElementCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementAttributeChildrenAppender.kt
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.dataelement.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.attribute.AttributeValue
 import org.hisp.dhis.android.core.attribute.internal.DataElementAttributeValueLinkStore
-import org.hisp.dhis.android.core.attribute.internal.DataElementAttributeValueLinkStoreImpl
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.dataelement.DataElement
 
@@ -55,10 +54,8 @@ internal class DataElementAttributeChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<DataElement> {
-            return DataElementAttributeChildrenAppender(
-                DataElementAttributeValueLinkStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<DataElement> {
+            return DataElementAttributeChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementLegendSetChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementLegendSetChildrenAppender.kt
@@ -27,11 +27,10 @@
  */
 package org.hisp.dhis.android.core.dataelement.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.legendset.internal.DataElementLegendSetLinkStore
-import org.hisp.dhis.android.core.legendset.internal.DataElementLegendSetLinkStoreImpl
 
 internal class DataElementLegendSetChildrenAppender private constructor(
     private val linkStore: DataElementLegendSetLinkStore,
@@ -44,10 +43,8 @@ internal class DataElementLegendSetChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<DataElement> {
-            return DataElementLegendSetChildrenAppender(
-                DataElementLegendSetLinkStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<DataElement> {
+            return DataElementLegendSetChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.dataset
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -51,11 +50,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class DataSetCollectionRepository internal constructor(
     store: DataSetStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<DataSet, DataSetCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -63,7 +60,6 @@ class DataSetCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataSetCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationCollectionRepository.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
@@ -54,14 +53,12 @@ import org.koin.core.annotation.Singleton
 @Suppress("SpreadOperator", "TooManyFunctions")
 class DataSetCompleteRegistrationCollectionRepository internal constructor(
     private val dataSetCompleteRegistrationStore: DataSetCompleteRegistrationStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     handler: DataSetCompleteRegistrationHandler,
     private val postCall: DataSetCompleteRegistrationPostCall,
     private val credentialsRepository: UserCredentialsObjectRepository,
 ) : ReadOnlyCollectionRepositoryImpl<DataSetCompleteRegistration, DataSetCompleteRegistrationCollectionRepository>(
     dataSetCompleteRegistrationStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -69,7 +66,6 @@ class DataSetCompleteRegistrationCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataSetCompleteRegistrationCollectionRepository(
             dataSetCompleteRegistrationStore,
-            databaseAdapter,
             s,
             handler,
             postCall,
@@ -90,7 +86,6 @@ class DataSetCompleteRegistrationCollectionRepository internal constructor(
             .byAttributeOptionComboUid().eq(attributeOptionCombo).scope
         return DataSetCompleteRegistrationObjectRepository(
             dataSetCompleteRegistrationStore,
-            databaseAdapter,
             credentialsRepository,
             childrenAppenders,
             updatedScope,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationObjectRepository.kt
@@ -31,7 +31,6 @@ import android.util.Log
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -47,7 +46,6 @@ import java.util.Date
 
 class DataSetCompleteRegistrationObjectRepository internal constructor(
     private val dataSetCompleteRegistrationStore: DataSetCompleteRegistrationStore,
-    databaseAdapter: DatabaseAdapter,
     private val credentialsRepository: UserCredentialsObjectRepository,
     childrenAppenders: ChildrenAppenderGetter<DataSetCompleteRegistration>,
     scope: RepositoryScope,
@@ -57,13 +55,11 @@ class DataSetCompleteRegistrationObjectRepository internal constructor(
     private val attributeOptionCombo: String,
 ) : ReadOnlyOneObjectRepositoryImpl<DataSetCompleteRegistration, DataSetCompleteRegistrationObjectRepository>(
     dataSetCompleteRegistrationStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         DataSetCompleteRegistrationObjectRepository(
             dataSetCompleteRegistrationStore,
-            databaseAdapter,
             credentialsRepository,
             childrenAppenders,
             s,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.dataset
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -44,11 +43,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class DataSetInstanceCollectionRepository internal constructor(
     store: DataSetInstanceStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<DataSetInstance, DataSetInstanceCollectionRepository>(
     store,
-    databaseAdapter,
     emptyMap(),
     scope,
     FilterConnectorFactory(
@@ -56,7 +53,6 @@ class DataSetInstanceCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataSetInstanceCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceSummaryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceSummaryCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.dataset
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -43,11 +42,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class DataSetInstanceSummaryCollectionRepository internal constructor(
     store: DataSetInstanceSummaryStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<DataSetInstanceSummary, DataSetInstanceSummaryCollectionRepository>(
     store,
-    databaseAdapter,
     emptyMap(),
     scope,
     FilterConnectorFactory(
@@ -55,7 +52,6 @@ class DataSetInstanceSummaryCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataSetInstanceSummaryCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/SectionCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/SectionCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.dataset
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -46,11 +45,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class SectionCollectionRepository internal constructor(
     store: SectionStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Section, SectionCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -58,7 +55,6 @@ class SectionCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         SectionCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataInputPeriodChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataInputPeriodChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataset.DataSet
 
@@ -42,8 +42,8 @@ internal class DataInputPeriodChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<DataSet> {
-            return DataInputPeriodChildrenAppender(DataInputPeriodStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<DataSet> {
+            return DataInputPeriodChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompulsoryDataElementOperandChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompulsoryDataElementOperandChildrenAppender.kt
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataelement.internal.DataElementOperandStore
-import org.hisp.dhis.android.core.dataelement.internal.DataElementOperandStoreImpl
 import org.hisp.dhis.android.core.dataset.DataSet
 
 internal class DataSetCompulsoryDataElementOperandChildrenAppender private constructor(
@@ -44,10 +43,8 @@ internal class DataSetCompulsoryDataElementOperandChildrenAppender private const
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<DataSet> {
-            return DataSetCompulsoryDataElementOperandChildrenAppender(
-                DataElementOperandStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<DataSet> {
+            return DataSetCompulsoryDataElementOperandChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetElementChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetElementChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataset.DataSet
 
@@ -42,8 +42,8 @@ internal class DataSetElementChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<DataSet> {
-            return DataSetElementChildrenAppender(DataSetElementStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<DataSet> {
+            return DataSetElementChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionDataElementChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionDataElementChildrenAppender.kt
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
 import org.hisp.dhis.android.core.dataset.Section
 
 internal class SectionDataElementChildrenAppender private constructor(
@@ -46,10 +45,8 @@ internal class SectionDataElementChildrenAppender private constructor(
 
     companion object {
 
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Section> {
-            return SectionDataElementChildrenAppender(
-                DataElementStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<Section> {
+            return SectionDataElementChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionGreyedFieldsChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionGreyedFieldsChildrenAppender.kt
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataelement.internal.DataElementOperandStore
-import org.hisp.dhis.android.core.dataelement.internal.DataElementOperandStoreImpl
 import org.hisp.dhis.android.core.dataset.Section
 
 internal class SectionGreyedFieldsChildrenAppender private constructor(
@@ -44,8 +43,8 @@ internal class SectionGreyedFieldsChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Section> {
-            return SectionGreyedFieldsChildrenAppender(DataElementOperandStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Section> {
+            return SectionGreyedFieldsChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionIndicatorsChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionIndicatorsChildrenAppender.kt
@@ -27,11 +27,10 @@
  */
 package org.hisp.dhis.android.core.dataset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataset.Section
 import org.hisp.dhis.android.core.indicator.internal.IndicatorStore
-import org.hisp.dhis.android.core.indicator.internal.IndicatorStoreImpl
 
 internal class SectionIndicatorsChildrenAppender private constructor(
     private val childStore: IndicatorStore,
@@ -45,8 +44,8 @@ internal class SectionIndicatorsChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Section> {
-            return SectionIndicatorsChildrenAppender(IndicatorStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Section> {
+            return SectionIndicatorsChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Observable
 import org.hisp.dhis.android.core.arch.call.D2Progress
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
@@ -50,14 +49,12 @@ import org.koin.core.annotation.Singleton
 class DataStoreCollectionRepository internal constructor(
     private val store: DataStoreEntryStore,
     private val call: DataStorePostCall,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<DataStoreEntry, DataStoreCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
-    FilterConnectorFactory(scope) { s -> DataStoreCollectionRepository(store, call, databaseAdapter, s) },
+    FilterConnectorFactory(scope) { s -> DataStoreCollectionRepository(store, call, s) },
 ),
     ReadOnlyWithUploadCollectionRepository<DataStoreEntry> {
     override fun upload(): Observable<D2Progress> {
@@ -77,7 +74,7 @@ class DataStoreCollectionRepository internal constructor(
             .byKey().eq(key)
             .scope
 
-        return DataStoreObjectRepository(store, databaseAdapter, childrenAppenders, valueScope, namespace, key)
+        return DataStoreObjectRepository(store, childrenAppenders, valueScope, namespace, key)
     }
 
     fun byNamespace(): StringFilterConnector<DataStoreCollectionRepository> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
@@ -31,7 +31,6 @@ package org.hisp.dhis.android.core.datastore
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -42,18 +41,16 @@ import org.hisp.dhis.android.core.datastore.internal.DataStoreEntryStore
 
 class DataStoreObjectRepository internal constructor(
     store: DataStoreEntryStore,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<DataStoreEntry>,
     scope: RepositoryScope,
     private val namespace: String,
     private val key: String,
 ) : ReadWriteWithValueObjectRepositoryImpl<DataStoreEntry, DataStoreObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s ->
-        DataStoreObjectRepository(store, databaseAdapter, childrenAppenders, s, namespace, key)
+        DataStoreObjectRepository(store, childrenAppenders, s, namespace, key)
     },
 ),
     ReadWriteValueObjectRepository<DataStoreEntry> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.datastore
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class LocalDataStoreCollectionRepository internal constructor(
     private val store: LocalDataStoreStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<KeyValuePair, LocalDataStoreCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class LocalDataStoreCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         LocalDataStoreCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },
@@ -59,7 +55,7 @@ class LocalDataStoreCollectionRepository internal constructor(
 
     fun value(key: String): LocalDataStoreObjectRepository {
         val updatedScope = byKey().eq(key).scope
-        return LocalDataStoreObjectRepository(store, databaseAdapter, childrenAppenders, updatedScope, key)
+        return LocalDataStoreObjectRepository(store, childrenAppenders, updatedScope, key)
     }
 
     fun byKey(): StringFilterConnector<LocalDataStoreCollectionRepository> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.datastore
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -41,19 +40,16 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 
 class LocalDataStoreObjectRepository internal constructor(
     store: LocalDataStoreStore,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<KeyValuePair>,
     scope: RepositoryScope,
     private val key: String,
 ) : ReadWriteWithValueObjectRepositoryImpl<KeyValuePair, LocalDataStoreObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         LocalDataStoreObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             s,
             key,

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueCollectionRepository.kt
@@ -32,11 +32,14 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.*
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datavalue.DataValueByDataSetQueryHelper.dataValueKey
@@ -50,16 +53,14 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class DataValueCollectionRepository internal constructor(
     private val store: DataValueStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     private val postCall: DataValuePostCall,
 ) : ReadOnlyCollectionRepositoryImpl<DataValue, DataValueCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(scope) { s: RepositoryScope ->
-        DataValueCollectionRepository(store, databaseAdapter, s, postCall)
+        DataValueCollectionRepository(store, s, postCall)
     },
 ),
     ReadOnlyWithUploadCollectionRepository<DataValue> {
@@ -88,7 +89,6 @@ class DataValueCollectionRepository internal constructor(
             .byAttributeOptionComboUid().eq(attributeOptionCombo).scope
         return DataValueObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             period,

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueConflictCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueConflictCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.datavalue
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyCollectionRepository
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
@@ -47,11 +46,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class DataValueConflictCollectionRepository internal constructor(
     store: DataValueConflictStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<DataValueConflict, DataValueConflictCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -59,7 +56,6 @@ class DataValueConflictCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         DataValueConflictCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueObjectRepository.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.datavalue
 import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -43,7 +42,6 @@ import java.util.Date
 
 class DataValueObjectRepository internal constructor(
     store: DataValueStore,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<DataValue>,
     scope: RepositoryScope,
     private val period: String,
@@ -53,13 +51,11 @@ class DataValueObjectRepository internal constructor(
     private val attributeOptionCombo: String,
 ) : ReadWriteWithValueObjectRepositoryImpl<DataValue, DataValueObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         DataValueObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             s,
             period,

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.enrollment
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadWriteWithUidCollectionRepositoryImpl
@@ -52,20 +51,17 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class EnrollmentCollectionRepository internal constructor(
     private val enrollmentStore: EnrollmentStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     transformer: EnrollmentProjectionTransformer,
     private val trackerDataManager: TrackerDataManager,
 ) : ReadWriteWithUidCollectionRepositoryImpl<Enrollment, EnrollmentCreateProjection, EnrollmentCollectionRepository>(
     enrollmentStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     transformer,
     FilterConnectorFactory(scope) { s: RepositoryScope ->
         EnrollmentCollectionRepository(
             enrollmentStore,
-            databaseAdapter,
             s,
             transformer,
             trackerDataManager,
@@ -81,7 +77,6 @@ class EnrollmentCollectionRepository internal constructor(
         return EnrollmentObjectRepository(
             enrollmentStore,
             uid,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             trackerDataManager,

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.enrollment
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -45,20 +44,17 @@ import java.util.Date
 class EnrollmentObjectRepository internal constructor(
     store: EnrollmentStore,
     uid: String?,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<Enrollment>,
     scope: RepositoryScope,
     private val trackerDataManager: TrackerDataManager,
 ) : ReadWriteWithUidDataObjectRepositoryImpl<Enrollment, EnrollmentObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         EnrollmentObjectRepository(
             store,
             uid,
-            databaseAdapter,
             childrenAppenders,
             s,
             trackerDataManager,

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadWriteWithUploadWithUidCollectionRepository
@@ -69,7 +68,6 @@ import org.koin.core.annotation.Singleton
 class EventCollectionRepository internal constructor(
     private val eventStore: EventStore,
     private val userStore: UserStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     private val postCall: EventPostParentCall,
     transformer: EventProjectionTransformer,
@@ -77,7 +75,6 @@ class EventCollectionRepository internal constructor(
     private val jobQueryCall: JobQueryCall,
 ) : ReadWriteWithUidCollectionRepositoryImpl<Event, EventCreateProjection, EventCollectionRepository>(
     eventStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     transformer,
@@ -85,7 +82,6 @@ class EventCollectionRepository internal constructor(
         EventCollectionRepository(
             eventStore,
             userStore,
-            databaseAdapter,
             s,
             postCall,
             transformer,
@@ -120,7 +116,6 @@ class EventCollectionRepository internal constructor(
             eventStore,
             userStore,
             uid,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             trackerDataManager,

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventFilterCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventFilterCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.event
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -45,11 +44,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class EventFilterCollectionRepository internal constructor(
     store: EventFilterStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<EventFilter, EventFilterCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -57,7 +54,6 @@ class EventFilterCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         EventFilterCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.event
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -48,13 +47,11 @@ class EventObjectRepository internal constructor(
     store: EventStore,
     private val userStore: UserStore,
     uid: String?,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<Event>,
     scope: RepositoryScope,
     private val trackerDataManager: TrackerDataManager,
 ) : ReadWriteWithUidDataObjectRepositoryImpl<Event, EventObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
@@ -62,7 +59,6 @@ class EventObjectRepository internal constructor(
             store,
             userStore,
             uid,
-            databaseAdapter,
             childrenAppenders,
             s,
             trackerDataManager,

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventFilterEventDataFilterChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventFilterEventDataFilterChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.event.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.event.EventFilter
 
@@ -45,8 +45,8 @@ internal class EventFilterEventDataFilterChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<EventFilter> {
-            return EventFilterEventDataFilterChildrenAppender(EventDataFilterStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<EventFilter> {
+            return EventFilterEventDataFilterChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.expressiondimensionitem
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ExpressionDimensionItemCollectionRepository internal constructor(
     store: ExpressionDimensionItemStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ExpressionDimensionItem, ExpressionDimensionItemCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class ExpressionDimensionItemCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ExpressionDimensionItemCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.arch.call.D2Progress
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadWriteWithUidCollectionRepository
@@ -62,21 +61,18 @@ import java.io.File
 @Suppress("TooManyFunctions", "TooGenericExceptionCaught")
 class FileResourceCollectionRepository internal constructor(
     private val fileResourceStore: FileResourceStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     transformer: FileResourceProjectionTransformer,
     dataStatePropagator: DataStatePropagator,
     private val context: Context,
 ) : ReadWriteWithUidCollectionRepositoryImpl<FileResource, File, FileResourceCollectionRepository>(
     fileResourceStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     transformer,
     FilterConnectorFactory(scope) { s: RepositoryScope ->
         FileResourceCollectionRepository(
             fileResourceStore,
-            databaseAdapter,
             s,
             transformer,
             dataStatePropagator,
@@ -133,7 +129,7 @@ class FileResourceCollectionRepository internal constructor(
 
     override fun uid(uid: String?): FileResourceObjectRepository {
         val updatedScope = withUidFilterItem(scope, uid)
-        return FileResourceObjectRepository(fileResourceStore, uid, databaseAdapter, childrenAppenders, updatedScope)
+        return FileResourceObjectRepository(fileResourceStore, uid, childrenAppenders, updatedScope)
     }
 
     fun byUid(): StringFilterConnector<FileResourceCollectionRepository> {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.fileresource
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyOneObjectRepositoryImpl
@@ -37,19 +36,16 @@ import org.hisp.dhis.android.core.fileresource.internal.FileResourceStore
 class FileResourceObjectRepository internal constructor(
     store: FileResourceStore,
     uid: String?,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<FileResource>,
     scope: RepositoryScope,
 ) : ReadOnlyOneObjectRepositoryImpl<FileResource, FileResourceObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         FileResourceObjectRepository(
             store,
             uid,
-            databaseAdapter,
             childrenAppenders,
             s,
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerImportConflictCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerImportConflictCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.imports
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class TrackerImportConflictCollectionRepository internal constructor(
     store: TrackerImportConflictStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<TrackerImportConflict, TrackerImportConflictCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class TrackerImportConflictCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackerImportConflictCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.indicator
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyNameableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -45,11 +44,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class IndicatorCollectionRepository internal constructor(
     store: IndicatorStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyNameableCollectionRepositoryImpl<Indicator, IndicatorCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -57,7 +54,6 @@ class IndicatorCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         IndicatorCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorTypeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorTypeCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.indicator
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class IndicatorTypeCollectionRepository internal constructor(
     store: IndicatorTypeStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<IndicatorType, IndicatorTypeCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class IndicatorTypeCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         IndicatorTypeCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/DataSetIndicatorChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/DataSetIndicatorChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.indicator.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataset.DataSet
 
@@ -42,8 +42,8 @@ internal class DataSetIndicatorChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<DataSet> {
-            return DataSetIndicatorChildrenAppender(IndicatorStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<DataSet> {
+            return DataSetIndicatorChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/IndicatorLegendSetChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/internal/IndicatorLegendSetChildrenAppender.kt
@@ -27,11 +27,10 @@
  */
 package org.hisp.dhis.android.core.indicator.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.indicator.Indicator
 import org.hisp.dhis.android.core.legendset.internal.IndicatorLegendSetLinkStore
-import org.hisp.dhis.android.core.legendset.internal.IndicatorLegendSetLinkStoreImpl
 
 internal class IndicatorLegendSetChildrenAppender(
     private val linkStore: IndicatorLegendSetLinkStore,
@@ -43,8 +42,8 @@ internal class IndicatorLegendSetChildrenAppender(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Indicator> {
-            return IndicatorLegendSetChildrenAppender(IndicatorLegendSetLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Indicator> {
+            return IndicatorLegendSetChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.legendset
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DoubleFilterConnector
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class LegendCollectionRepository internal constructor(
     store: LegendStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Legend, LegendCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class LegendCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         LegendCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendSetCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/LegendSetCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.legendset
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class LegendSetCollectionRepository internal constructor(
     store: LegendSetStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<LegendSet, LegendSetCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class LegendSetCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         LegendSetCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/LegendChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/legendset/internal/LegendChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.legendset.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.legendset.LegendSet
 
@@ -42,8 +42,8 @@ internal class LegendChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<LegendSet> {
-            return LegendChildrenAppender(LegendStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<LegendSet> {
+            return LegendChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2ErrorCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2ErrorCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.maintenance
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class D2ErrorCollectionRepository internal constructor(
     store: D2ErrorStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<D2Error, D2ErrorCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class D2ErrorCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         D2ErrorCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/ForeignKeyViolationCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/ForeignKeyViolationCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.maintenance
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ForeignKeyViolationCollectionRepository internal constructor(
     store: ForeignKeyViolationStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<ForeignKeyViolation, ForeignKeyViolationCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class ForeignKeyViolationCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ForeignKeyViolationCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.map.layer
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyWithUidCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -43,16 +42,14 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class MapLayerCollectionRepository internal constructor(
     store: MapLayerStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyWithUidCollectionRepositoryImpl<MapLayer, MapLayerCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
         scope,
-    ) { s: RepositoryScope -> MapLayerCollectionRepository(store, databaseAdapter, s) },
+    ) { s: RepositoryScope -> MapLayerCollectionRepository(store, s) },
 ) {
 
     fun byUid(): StringFilterConnector<MapLayerCollectionRepository> {
@@ -105,7 +102,7 @@ class MapLayerCollectionRepository internal constructor(
 
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<MapLayer> = mapOf(
-            MapLayer.IMAGERY_PROVIDERS to ::MapLayerImagerProviderChildrenAppender,
+            MapLayer.IMAGERY_PROVIDERS to MapLayerImagerProviderChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/MapLayerImagerProviderChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/MapLayerImagerProviderChildrenAppender.kt
@@ -27,18 +27,23 @@
  */
 package org.hisp.dhis.android.core.map.layer.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.map.layer.MapLayer
 
 internal class MapLayerImagerProviderChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val mapLayerImageryProviderStore: MapLayerImageryProviderStore,
 ) : ChildrenAppender<MapLayer>() {
-    private val mapLayerImageryProviderStore = MapLayerImageryProviderStoreImpl(databaseAdapter)
 
     override suspend fun appendChildren(mapLayer: MapLayer): MapLayer {
         return mapLayer.toBuilder()
             .imageryProviders(mapLayerImageryProviderStore.selectLinksForMasterUid(mapLayer.uid()))
             .build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<MapLayer> {
+            return MapLayerImagerProviderChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/note/NoteCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/note/NoteCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.note
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadWriteWithUidCollectionRepositoryImpl
@@ -49,13 +48,11 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class NoteCollectionRepository internal constructor(
     store: NoteStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     transformer: NoteProjectionTransformer,
     private val dataStatePropagator: DataStatePropagator,
 ) : ReadWriteWithUidCollectionRepositoryImpl<Note, NoteCreateProjection, NoteCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     transformer,
@@ -64,7 +61,6 @@ class NoteCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         NoteCollectionRepository(
             store,
-            databaseAdapter,
             s,
             transformer,
             dataStatePropagator,
@@ -105,7 +101,7 @@ class NoteCollectionRepository internal constructor(
 
     override fun uid(uid: String?): ReadOnlyObjectRepository<Note> {
         val updatedScope: RepositoryScope = withUidFilterItem(scope, uid)
-        return ReadOnlyOneObjectRepositoryFinalImpl(store, databaseAdapter, childrenAppenders, updatedScope)
+        return ReadOnlyOneObjectRepositoryFinalImpl(store, childrenAppenders, updatedScope)
     }
 
     override suspend fun propagateState(m: Note, action: HandleAction?) {

--- a/core/src/main/java/org/hisp/dhis/android/core/note/internal/NoteForEnrollmentChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/note/internal/NoteForEnrollmentChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.note.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.enrollment.Enrollment
 
@@ -42,8 +42,8 @@ internal class NoteForEnrollmentChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Enrollment> {
-            return NoteForEnrollmentChildrenAppender(NoteStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Enrollment> {
+            return NoteForEnrollmentChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/note/internal/NoteForEventChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/note/internal/NoteForEventChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.note.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.event.Event
 
@@ -42,8 +42,8 @@ internal class NoteForEventChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Event> {
-            return NoteForEventChildrenAppender(NoteStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Event> {
+            return NoteForEventChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.option
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class OptionCollectionRepository internal constructor(
     store: OptionStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Option, OptionCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class OptionCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         OptionCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionGroupCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionGroupCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.option
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -40,11 +39,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class OptionGroupCollectionRepository internal constructor(
     store: OptionGroupStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<OptionGroup, OptionGroupCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -52,7 +49,6 @@ class OptionGroupCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         OptionGroupCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionSetCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionSetCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.option
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class OptionSetCollectionRepository internal constructor(
     store: OptionSetStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<OptionSet, OptionSetCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class OptionSetCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         OptionSetCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionGroupOptionChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionGroupOptionChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.option.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.option.OptionGroup
 
@@ -41,8 +41,8 @@ internal class OptionGroupOptionChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<OptionGroup> {
-            return OptionGroupOptionChildrenAppender(OptionGroupOptionLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<OptionGroup> {
+            return OptionGroupOptionChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.organisationunit
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
@@ -50,11 +49,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class OrganisationUnitCollectionRepository internal constructor(
     store: OrganisationUnitStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<OrganisationUnit, OrganisationUnitCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -62,7 +59,6 @@ class OrganisationUnitCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         OrganisationUnitCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitGroupCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitGroupCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.organisationunit
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class OrganisationUnitGroupCollectionRepository internal constructor(
     store: OrganisationUnitGroupStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<OrganisationUnitGroup, OrganisationUnitGroupCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class OrganisationUnitGroupCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         OrganisationUnitGroupCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitLevelCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitLevelCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.organisationunit
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class OrganisationUnitLevelCollectionRepository internal constructor(
     store: OrganisationUnitLevelStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<OrganisationUnitLevel, OrganisationUnitLevelCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class OrganisationUnitLevelCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         OrganisationUnitLevelCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitDataSetChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitDataSetChildrenAppender.kt
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.android.core.organisationunit.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataset.internal.DataSetOrganisationUnitLinkStore
-import org.hisp.dhis.android.core.dataset.internal.DataSetOrganisationUnitLinkStoreImpl
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 
 internal class OrganisationUnitDataSetChildrenAppender private constructor(
@@ -43,8 +42,8 @@ internal class OrganisationUnitDataSetChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<OrganisationUnit> {
-            return OrganisationUnitDataSetChildrenAppender(DataSetOrganisationUnitLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<OrganisationUnit> {
+            return OrganisationUnitDataSetChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitOrganisationUnitGroupProgramChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitOrganisationUnitGroupProgramChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.organisationunit.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 
@@ -40,12 +40,8 @@ internal class OrganisationUnitOrganisationUnitGroupProgramChildrenAppender priv
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<OrganisationUnit> {
-            return OrganisationUnitOrganisationUnitGroupProgramChildrenAppender(
-                OrganisationUnitGroupStoreImpl(
-                    databaseAdapter,
-                ),
-            )
+        fun create(): ChildrenAppender<OrganisationUnit> {
+            return OrganisationUnitOrganisationUnitGroupProgramChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitProgramChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitProgramChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.organisationunit.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 
@@ -41,8 +41,8 @@ internal class OrganisationUnitProgramChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<OrganisationUnit> {
-            return OrganisationUnitProgramChildrenAppender(OrganisationUnitProgramLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<OrganisationUnit> {
+            return OrganisationUnitProgramChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/PeriodCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/PeriodCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.period
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class PeriodCollectionRepository internal constructor(
     store: PeriodStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<Period, PeriodCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class PeriodCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         PeriodCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -51,11 +50,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class ProgramCollectionRepository internal constructor(
     store: ProgramStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Program, ProgramCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -63,7 +60,6 @@ class ProgramCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },
@@ -241,7 +237,7 @@ class ProgramCollectionRepository internal constructor(
         private const val ATTRIBUTE_VALUES = "attributeValues"
 
         val childrenAppenders: ChildrenAppenderGetter<Program> = mapOf(
-            ProgramTableInfo.Columns.TRACKED_ENTITY_TYPE to ::ProgramTrackedEntityTypeChildrenAppender,
+            ProgramTableInfo.Columns.TRACKED_ENTITY_TYPE to ProgramTrackedEntityTypeChildrenAppender::create,
             ATTRIBUTE_VALUES to ProgramAttributeChildrenAppender::create,
         )
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramIndicatorCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramIndicatorCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -45,11 +44,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramIndicatorCollectionRepository internal constructor(
     store: ProgramIndicatorStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramIndicator, ProgramIndicatorCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -57,7 +54,6 @@ class ProgramIndicatorCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramIndicatorCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRuleActionCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRuleActionCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class ProgramRuleActionCollectionRepository internal constructor(
     store: ProgramRuleActionStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramRuleAction, ProgramRuleActionCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class ProgramRuleActionCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramRuleActionCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRuleCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRuleCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramRuleCollectionRepository internal constructor(
     store: ProgramRuleStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramRule, ProgramRuleCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class ProgramRuleCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramRuleCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRuleVariableCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramRuleVariableCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramRuleVariableCollectionRepository internal constructor(
     store: ProgramRuleVariableStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramRuleVariable, ProgramRuleVariableCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class ProgramRuleVariableCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramRuleVariableCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramSectionCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramSectionCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramSectionCollectionRepository internal constructor(
     store: ProgramSectionStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramSection, ProgramSectionCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class ProgramSectionCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramSectionCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -49,11 +48,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class ProgramStageCollectionRepository internal constructor(
     store: ProgramStageStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramStage, ProgramStageCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -61,7 +58,6 @@ class ProgramStageCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramStageCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageDataElementCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageDataElementCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -43,11 +42,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramStageDataElementCollectionRepository internal constructor(
     store: ProgramStageDataElementStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramStageDataElement, ProgramStageDataElementCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -55,7 +52,6 @@ class ProgramStageDataElementCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramStageDataElementCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },
@@ -100,7 +96,7 @@ class ProgramStageDataElementCollectionRepository internal constructor(
         private const val RENDER_TYPE = "renderType"
 
         val childrenAppenders: ChildrenAppenderGetter<ProgramStageDataElement> = mapOf(
-            RENDER_TYPE to ::DataElementValueTypeRenderingChildrenAppender,
+            RENDER_TYPE to DataElementValueTypeRenderingChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramStageSectionsCollectionRepository internal constructor(
     store: ProgramStageSectionStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramStageSection, ProgramStageSectionsCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class ProgramStageSectionsCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramStageSectionsCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.program
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyNameableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -43,14 +42,12 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class ProgramTrackedEntityAttributeCollectionRepository internal constructor(
     store: ProgramTrackedEntityAttributeStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyNameableCollectionRepositoryImpl<
     ProgramTrackedEntityAttribute,
     ProgramTrackedEntityAttributeCollectionRepository,
     >(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -58,7 +55,6 @@ class ProgramTrackedEntityAttributeCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramTrackedEntityAttributeCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },
@@ -105,8 +101,7 @@ class ProgramTrackedEntityAttributeCollectionRepository internal constructor(
         private const val RENDER_TYPE = "renderType"
 
         val childrenAppenders: ChildrenAppenderGetter<ProgramTrackedEntityAttribute> = mapOf(
-            RENDER_TYPE to
-                ::ProgramTrackedEntityAttributeValueTypeRenderingChildrenAppender,
+            RENDER_TYPE to ProgramTrackedEntityAttributeValueTypeRenderingChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/DataElementValueTypeRenderingChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/DataElementValueTypeRenderingChildrenAppender.kt
@@ -27,15 +27,22 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
-import org.hisp.dhis.android.core.common.valuetype.devicerendering.internal.ValueTypeDeviceRenderingStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
+import org.hisp.dhis.android.core.common.valuetype.devicerendering.internal.ValueTypeDeviceRenderingStore
 import org.hisp.dhis.android.core.program.ProgramStageDataElement
 
 internal class DataElementValueTypeRenderingChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
-) : ValueTypeRenderingChildrenAppender<ProgramStageDataElement>(ValueTypeDeviceRenderingStoreImpl(databaseAdapter)) {
+    store: ValueTypeDeviceRenderingStore,
+) : ValueTypeRenderingChildrenAppender<ProgramStageDataElement>(store) {
     override suspend fun appendChildren(m: ProgramStageDataElement): ProgramStageDataElement {
         val valueTypeRendering = getValueTypeDeviceRendering(m)
         return m.toBuilder().renderType(valueTypeRendering).build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<ProgramStageDataElement> {
+            return DataElementValueTypeRenderingChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramAttributeChildrenAppender.kt
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.attribute.AttributeValue
 import org.hisp.dhis.android.core.attribute.internal.ProgramAttributeValueLinkStore
-import org.hisp.dhis.android.core.attribute.internal.ProgramAttributeValueLinkStoreImpl
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.program.Program
 
@@ -52,8 +51,8 @@ internal class ProgramAttributeChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Program> {
-            return ProgramAttributeChildrenAppender(ProgramAttributeValueLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Program> {
+            return ProgramAttributeChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorAnalyticsPeriodBoundaryChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorAnalyticsPeriodBoundaryChildrenAppender.kt
@@ -27,16 +27,15 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
-import org.hisp.dhis.android.core.arch.db.stores.internal.LinkStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundaryTableInfo
 import org.hisp.dhis.android.core.program.ProgramIndicator
 
 internal class ProgramIndicatorAnalyticsPeriodBoundaryChildrenAppender private constructor(
-    private val childStore: LinkStore<AnalyticsPeriodBoundary>,
+    private val childStore: AnalyticsPeriodBoundaryStore,
 ) : ChildrenAppender<ProgramIndicator>() {
     override suspend fun appendChildren(programIndicator: ProgramIndicator): ProgramIndicator {
         return programIndicator.toBuilder().analyticsPeriodBoundaries(getChildren(programIndicator)).build()
@@ -50,10 +49,8 @@ internal class ProgramIndicatorAnalyticsPeriodBoundaryChildrenAppender private c
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramIndicator> {
-            return ProgramIndicatorAnalyticsPeriodBoundaryChildrenAppender(
-                AnalyticsPeriodBoundaryStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<ProgramIndicator> {
+            return ProgramIndicatorAnalyticsPeriodBoundaryChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorLegendSetChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorLegendSetChildrenAppender.kt
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.legendset.internal.ProgramIndicatorLegendSetLinkStore
-import org.hisp.dhis.android.core.legendset.internal.ProgramIndicatorLegendSetLinkStoreImpl
 import org.hisp.dhis.android.core.program.ProgramIndicator
 
 internal class ProgramIndicatorLegendSetChildrenAppender private constructor(
@@ -44,8 +43,8 @@ internal class ProgramIndicatorLegendSetChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramIndicator> {
-            return ProgramIndicatorLegendSetChildrenAppender(ProgramIndicatorLegendSetLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<ProgramIndicator> {
+            return ProgramIndicatorLegendSetChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.program.ProgramRule
 
@@ -40,8 +40,8 @@ internal class ProgramRuleActionChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramRule> {
-            return ProgramRuleActionChildrenAppender(ProgramRuleActionStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<ProgramRule> {
+            return ProgramRuleActionChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramSectionAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramSectionAttributeChildrenAppender.kt
@@ -27,11 +27,10 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.program.ProgramSection
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStoreImpl
 
 internal class ProgramSectionAttributeChildrenAppender private constructor(
     private val childStore: TrackedEntityAttributeStore,
@@ -43,8 +42,8 @@ internal class ProgramSectionAttributeChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramSection> {
-            return ProgramSectionAttributeChildrenAppender(TrackedEntityAttributeStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<ProgramSection> {
+            return ProgramSectionAttributeChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageAttributeChildrenAppender.kt
@@ -28,11 +28,10 @@
 
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.attribute.AttributeValue
 import org.hisp.dhis.android.core.attribute.internal.ProgramStageAttributeValueLinkStore
-import org.hisp.dhis.android.core.attribute.internal.ProgramStageAttributeValueLinkStoreImpl
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.program.ProgramStage
 
@@ -52,8 +51,8 @@ internal class ProgramStageAttributeChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramStage> {
-            return ProgramStageAttributeChildrenAppender(ProgramStageAttributeValueLinkStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<ProgramStage> {
+            return ProgramStageAttributeChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionDataElementChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionDataElementChildrenAppender.kt
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
 import org.hisp.dhis.android.core.program.ProgramStageSection
 
 internal class ProgramStageSectionDataElementChildrenAppender private constructor(
@@ -44,8 +43,8 @@ internal class ProgramStageSectionDataElementChildrenAppender private constructo
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramStageSection> {
-            return ProgramStageSectionDataElementChildrenAppender(DataElementStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<ProgramStageSection> {
+            return ProgramStageSectionDataElementChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionProgramIndicatorChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionProgramIndicatorChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.program.ProgramStageSection
 
@@ -41,8 +41,8 @@ internal class ProgramStageSectionProgramIndicatorChildrenAppender private const
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramStageSection> {
-            return ProgramStageSectionProgramIndicatorChildrenAppender(ProgramIndicatorStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<ProgramStageSection> {
+            return ProgramStageSectionProgramIndicatorChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeValueTypeRenderingChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeValueTypeRenderingChildrenAppender.kt
@@ -27,17 +27,22 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
-import org.hisp.dhis.android.core.common.valuetype.devicerendering.internal.ValueTypeDeviceRenderingStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
+import org.hisp.dhis.android.core.common.valuetype.devicerendering.internal.ValueTypeDeviceRenderingStore
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
 
 internal class ProgramTrackedEntityAttributeValueTypeRenderingChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
-) : ValueTypeRenderingChildrenAppender<ProgramTrackedEntityAttribute>(
-    ValueTypeDeviceRenderingStoreImpl(databaseAdapter),
-) {
+    store: ValueTypeDeviceRenderingStore,
+) : ValueTypeRenderingChildrenAppender<ProgramTrackedEntityAttribute>(store) {
     override suspend fun appendChildren(m: ProgramTrackedEntityAttribute): ProgramTrackedEntityAttribute {
         val valueTypeRendering = getValueTypeDeviceRendering(m)
         return m.toBuilder().renderType(valueTypeRendering).build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<ProgramTrackedEntityAttribute> {
+            return ProgramTrackedEntityAttributeValueTypeRenderingChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityTypeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityTypeChildrenAppender.kt
@@ -27,15 +27,14 @@
  */
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.program.Program
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStore
 
 internal class ProgramTrackedEntityTypeChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val store: TrackedEntityTypeStore,
 ) : ChildrenAppender<Program>() {
-    private val store = TrackedEntityTypeStoreImpl(databaseAdapter)
     override suspend fun appendChildren(m: Program): Program {
         val builder = m.toBuilder()
         val trackedEntityType = m.trackedEntityType()
@@ -43,5 +42,11 @@ internal class ProgramTrackedEntityTypeChildrenAppender(
             builder.trackedEntityType(store.selectByUid(trackedEntityType.uid()))
         }
         return builder.build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<Program> {
+            return ProgramTrackedEntityTypeChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.programstageworkinglist
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -48,11 +47,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class ProgramStageWorkingListCollectionRepository internal constructor(
     store: ProgramStageWorkingListStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<ProgramStageWorkingList, ProgramStageWorkingListCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -60,7 +57,6 @@ class ProgramStageWorkingListCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ProgramStageWorkingListCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/internal/ProgramStageWorkingListAttributeValueFilterChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/internal/ProgramStageWorkingListAttributeValueFilterChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.programstageworkinglist.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
 
@@ -47,10 +47,8 @@ internal class ProgramStageWorkingListAttributeValueFilterChildrenAppender priva
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramStageWorkingList> {
-            return ProgramStageWorkingListAttributeValueFilterChildrenAppender(
-                ProgramStageWorkingListAttributeValueFilterStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<ProgramStageWorkingList> {
+            return ProgramStageWorkingListAttributeValueFilterChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/internal/ProgramStageWorkingListDataFilterChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/internal/ProgramStageWorkingListDataFilterChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.programstageworkinglist.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
 
@@ -47,12 +47,8 @@ internal class ProgramStageWorkingListDataFilterChildrenAppender private constru
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<ProgramStageWorkingList> {
-            return ProgramStageWorkingListDataFilterChildrenAppender(
-                ProgramStageWorkingListEventDataFilterStoreImpl(
-                    databaseAdapter,
-                ),
-            )
+        fun create(): ChildrenAppender<ProgramStageWorkingList> {
+            return ProgramStageWorkingListDataFilterChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.relationship
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.helpers.DateUtils.toJavaDate
@@ -64,7 +63,6 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class RelationshipCollectionRepository internal constructor(
     private val relationshipStore: RelationshipStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     private val relationshipHandler: RelationshipHandler,
     private val storeSelector: RelationshipItemElementStoreSelector,
@@ -72,7 +70,6 @@ class RelationshipCollectionRepository internal constructor(
     private val trackerDataManager: TrackerDataManager,
 ) : BaseReadOnlyWithUidCollectionRepositoryImpl<Relationship, RelationshipCollectionRepository>(
     relationshipStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -80,7 +77,6 @@ class RelationshipCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         RelationshipCollectionRepository(
             relationshipStore,
-            databaseAdapter,
             s,
             relationshipHandler,
             storeSelector,
@@ -157,7 +153,6 @@ class RelationshipCollectionRepository internal constructor(
         return RelationshipObjectRepository(
             relationshipStore,
             uid,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             trackerDataManager,
@@ -265,7 +260,7 @@ class RelationshipCollectionRepository internal constructor(
         private const val ITEMS = "items"
 
         val childrenAppenders: ChildrenAppenderGetter<Relationship> = mapOf(
-            ITEMS to ::RelationshipItemChildrenAppender,
+            ITEMS to RelationshipItemChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.relationship
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -39,20 +38,17 @@ import org.hisp.dhis.android.core.relationship.internal.RelationshipStore
 internal class RelationshipObjectRepository(
     store: RelationshipStore,
     uid: String?,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<Relationship>,
     scope: RepositoryScope,
     private val trackerDataManager: TrackerDataManager,
 ) : ReadWriteWithUidDataObjectRepositoryImpl<Relationship, RelationshipObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         RelationshipObjectRepository(
             store,
             uid,
-            databaseAdapter,
             childrenAppenders,
             s,
             trackerDataManager,

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipTypeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipTypeCollectionRepository.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.relationship
 
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
@@ -53,11 +52,9 @@ class RelationshipTypeCollectionRepository internal constructor(
     private val teiStore: TrackedEntityInstanceStore,
     private val enrollmentStore: EnrollmentStore,
     private val eventStore: EventStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<RelationshipType, RelationshipTypeCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(scope) { s: RepositoryScope ->
@@ -66,7 +63,6 @@ class RelationshipTypeCollectionRepository internal constructor(
             teiStore,
             enrollmentStore,
             eventStore,
-            databaseAdapter,
             s,
         )
     },
@@ -167,7 +163,7 @@ class RelationshipTypeCollectionRepository internal constructor(
         private const val CONSTRAINTS = "constraints"
 
         val childrenAppenders: ChildrenAppenderGetter<RelationshipType> = mapOf(
-            CONSTRAINTS to ::RelationshipConstraintChildrenAppender,
+            CONSTRAINTS to RelationshipConstraintChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipConstraintChildrenAppender.kt
@@ -27,16 +27,15 @@
  */
 package org.hisp.dhis.android.core.relationship.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.relationship.RelationshipConstraint
 import org.hisp.dhis.android.core.relationship.RelationshipConstraintType
 import org.hisp.dhis.android.core.relationship.RelationshipType
 
 internal class RelationshipConstraintChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val constraintStore: RelationshipConstraintStore,
 ) : ChildrenAppender<RelationshipType>() {
-    private val constraintStore = RelationshipConstraintStoreImpl(databaseAdapter)
 
     private var constraints: List<RelationshipConstraint>? = null
 
@@ -56,5 +55,11 @@ internal class RelationshipConstraintChildrenAppender(
             }
         }
         return builder.build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<RelationshipType> {
+            return RelationshipConstraintChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.relationship.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.relationship.Relationship
 import org.hisp.dhis.android.core.relationship.RelationshipConstraintType
@@ -35,9 +35,8 @@ import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class RelationshipItemChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val store: RelationshipItemStore,
 ) : ChildrenAppender<Relationship>() {
-    private val store = RelationshipItemStoreImpl(databaseAdapter)
 
     override suspend fun appendChildren(relationship: Relationship): Relationship {
         val fromItem = store.getForRelationshipUidAndConstraintType(
@@ -52,5 +51,11 @@ internal class RelationshipItemChildrenAppender(
             .from(fromItem)
             .to(toItem)
             .build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<Relationship> {
+            return RelationshipItemChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsTeiSettingCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsTeiSettingCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.settings
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class AnalyticsTeiSettingCollectionRepository internal constructor(
     store: AnalyticsTeiSettingStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<AnalyticsTeiSetting, AnalyticsTeiSettingCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope.toBuilder().children(scope.children().withChild(AnalyticsTeiDataChildrenAppender.KEY)).build(),
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class AnalyticsTeiSettingCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         AnalyticsTeiSettingCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },
@@ -89,7 +85,7 @@ class AnalyticsTeiSettingCollectionRepository internal constructor(
 
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<AnalyticsTeiSetting> = mapOf(
-            AnalyticsTeiDataChildrenAppender.KEY to ::AnalyticsTeiDataChildrenAppender,
+            AnalyticsTeiDataChildrenAppender.KEY to AnalyticsTeiDataChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentCollectionRepository.kt
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.settings
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyWithUidCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class CustomIntentCollectionRepository internal constructor(
     store: CustomIntentStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyWithUidCollectionRepositoryImpl<CustomIntent, CustomIntentCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope.toBuilder().children(
         scope.children()
@@ -53,7 +50,7 @@ class CustomIntentCollectionRepository internal constructor(
     ).build(),
     FilterConnectorFactory(
         scope,
-    ) { s: RepositoryScope -> CustomIntentCollectionRepository(store, databaseAdapter, s) },
+    ) { s: RepositoryScope -> CustomIntentCollectionRepository(store, s) },
 ) {
 
     fun byUid(): StringFilterConnector<CustomIntentCollectionRepository> {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.settings
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class SystemSettingCollectionRepository internal constructor(
     store: SystemSettingStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<SystemSetting, SystemSettingCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class SystemSettingCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         SystemSettingCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiDataChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiDataChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.settings.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.settings.AnalyticsTeiAttribute
 import org.hisp.dhis.android.core.settings.AnalyticsTeiDataElement
@@ -39,16 +39,11 @@ import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class AnalyticsTeiDataChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val analyticsTeiDataElementStore: AnalyticsTeiDataElementStore,
+    private val analyticsTeiIndicatorStore: AnalyticsTeiIndicatorStore,
+    private val analyticsTeiAttributeStore: AnalyticsTeiAttributeStore,
+    private val analyticsTeiWHONutritionDataStore: AnalyticsTeiWHONutritionDataStore,
 ) : ChildrenAppender<AnalyticsTeiSetting>() {
-    private val analyticsTeiDataElementStore = AnalyticsTeiDataElementStoreImpl(databaseAdapter)
-    private val analyticsTeiIndicatorStore = AnalyticsTeiIndicatorStoreImpl(databaseAdapter)
-    private val analyticsTeiAttributeStore = AnalyticsTeiAttributeStoreImpl(databaseAdapter)
-    private val analyticsTeiWHONutritionDataStore = AnalyticsTeiWHONutritionDataStoreImpl(databaseAdapter)
-
-    companion object {
-        const val KEY = "DATA"
-    }
 
     private var dataElements: List<AnalyticsTeiDataElement>? = null
     private var indicators: List<AnalyticsTeiIndicator>? = null
@@ -70,5 +65,13 @@ internal class AnalyticsTeiDataChildrenAppender(
             attributes!!,
             whoNutritionData!!,
         )
+    }
+
+    companion object {
+        const val KEY = "DATA"
+
+        fun create(): ChildrenAppender<AnalyticsTeiSetting> {
+            return AnalyticsTeiDataChildrenAppender(koin.get(), koin.get(), koin.get(), koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentTriggerChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentTriggerChildrenAppender.kt
@@ -28,7 +28,7 @@
 
 package org.hisp.dhis.android.core.settings.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.settings.CustomIntent
 import org.hisp.dhis.android.core.settings.CustomIntentTrigger
@@ -49,11 +49,8 @@ internal class CustomIntentTriggerChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<CustomIntent> {
-            return CustomIntentTriggerChildrenAppender(
-                CustomIntentDataElementStoreImpl(databaseAdapter),
-                CustomIntentAttributeStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<CustomIntent> {
+            return CustomIntentTriggerChildrenAppender(koin.get(), koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/SystemInfoObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/SystemInfoObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.systeminfo
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyFirstObjectWithDownloadRepositoryImpl
@@ -39,19 +38,16 @@ import org.koin.core.annotation.Singleton
 @Singleton(binds = [SystemInfoObjectRepository::class])
 class SystemInfoObjectRepository internal constructor(
     store: SystemInfoStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     systemInfoCall: SystemInfoCall,
 ) : ReadOnlyFirstObjectWithDownloadRepositoryImpl<SystemInfo, SystemInfoObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     systemInfoCall,
     ObjectRepositoryFactory { cs: RepositoryScope ->
         SystemInfoObjectRepository(
             store,
-            databaseAdapter,
             cs,
             systemInfoCall,
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyNameableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -45,11 +44,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class TrackedEntityAttributeCollectionRepository internal constructor(
     store: TrackedEntityAttributeStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyNameableCollectionRepositoryImpl<TrackedEntityAttribute, TrackedEntityAttributeCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -57,7 +54,6 @@ class TrackedEntityAttributeCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityAttributeCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.DateFilterConnector
@@ -42,12 +41,10 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class TrackedEntityAttributeValueCollectionRepository internal constructor(
     private val store: TrackedEntityAttributeValueStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     private val dataStatePropagator: DataStatePropagator,
 ) : ReadOnlyCollectionRepositoryImpl<TrackedEntityAttributeValue, TrackedEntityAttributeValueCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -55,7 +52,6 @@ class TrackedEntityAttributeValueCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityAttributeValueCollectionRepository(
             store,
-            databaseAdapter,
             s,
             dataStatePropagator,
         )
@@ -69,7 +65,6 @@ class TrackedEntityAttributeValueCollectionRepository internal constructor(
             .byTrackedEntityInstance().eq(trackedEntityInstance).scope
         return TrackedEntityAttributeValueObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             dataStatePropagator,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Completable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -42,7 +41,6 @@ import java.util.Date
 
 class TrackedEntityAttributeValueObjectRepository internal constructor(
     store: TrackedEntityAttributeValueStore,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<TrackedEntityAttributeValue>,
     scope: RepositoryScope,
     private val dataStatePropagator: DataStatePropagator,
@@ -50,13 +48,11 @@ class TrackedEntityAttributeValueObjectRepository internal constructor(
     private val trackedEntityInstance: String,
 ) : ReadWriteWithValueObjectRepositoryImpl<TrackedEntityAttributeValue, TrackedEntityAttributeValueObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         TrackedEntityAttributeValueObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             s,
             dataStatePropagator,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -43,12 +42,10 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class TrackedEntityDataValueCollectionRepository internal constructor(
     private val store: TrackedEntityDataValueStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     private val dataStatePropagator: DataStatePropagator,
 ) : ReadOnlyCollectionRepositoryImpl<TrackedEntityDataValue, TrackedEntityDataValueCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -56,7 +53,6 @@ class TrackedEntityDataValueCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityDataValueCollectionRepository(
             store,
-            databaseAdapter,
             s,
             dataStatePropagator,
         )
@@ -66,7 +62,6 @@ class TrackedEntityDataValueCollectionRepository internal constructor(
         val updatedScope = byEvent().eq(event).byDataElement().eq(dataElement).scope
         return TrackedEntityDataValueObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             dataStatePropagator,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Completable
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -42,7 +41,6 @@ import java.util.Date
 
 class TrackedEntityDataValueObjectRepository internal constructor(
     store: TrackedEntityDataValueStore,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<TrackedEntityDataValue>,
     scope: RepositoryScope,
     private val dataStatePropagator: DataStatePropagator,
@@ -50,13 +48,11 @@ class TrackedEntityDataValueObjectRepository internal constructor(
     private val dataElement: String,
 ) : ReadWriteWithValueObjectRepositoryImpl<TrackedEntityDataValue, TrackedEntityDataValueObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         TrackedEntityDataValueObjectRepository(
             store,
-            databaseAdapter,
             childrenAppenders,
             s,
             dataStatePropagator,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadWriteWithUploadWithUidCollectionRepository
@@ -62,7 +61,6 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class TrackedEntityInstanceCollectionRepository internal constructor(
     private val trackedEntityInstanceStore: TrackedEntityInstanceStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     transformer: TrackedEntityInstanceProjectionTransformer,
     private val trackerDataManager: TrackerDataManager,
@@ -74,7 +72,6 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
     TrackedEntityInstanceCollectionRepository,
     >(
     trackedEntityInstanceStore,
-    databaseAdapter,
     childrenAppenders,
     scope,
     transformer,
@@ -83,7 +80,6 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityInstanceCollectionRepository(
             trackedEntityInstanceStore,
-            databaseAdapter,
             s,
             transformer,
             trackerDataManager,
@@ -115,7 +111,6 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
         return TrackedEntityInstanceObjectRepository(
             trackedEntityInstanceStore,
             uid,
-            databaseAdapter,
             childrenAppenders,
             updatedScope,
             trackerDataManager,
@@ -221,7 +216,7 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
 
         val childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance> = mapOf(
             TRACKED_ENTITY_ATTRIBUTE_VALUES to TrackedEntityAttributeValueChildrenAppender::create,
-            PROGRAM_OWNERS to ::ProgramOwnerChildrenAppender,
+            PROGRAM_OWNERS to ProgramOwnerChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -49,14 +48,12 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class TrackedEntityInstanceFilterCollectionRepository internal constructor(
     store: TrackedEntityInstanceFilterStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<
     TrackedEntityInstanceFilter,
     TrackedEntityInstanceFilterCollectionRepository,
     >(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -64,7 +61,6 @@ class TrackedEntityInstanceFilterCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityInstanceFilterCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.helpers.GeometryHelper
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -47,20 +46,17 @@ import java.util.Date
 class TrackedEntityInstanceObjectRepository internal constructor(
     store: TrackedEntityInstanceStore,
     uid: String?,
-    databaseAdapter: DatabaseAdapter,
     childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance>,
     scope: RepositoryScope,
     private val trackerDataManager: TrackerDataManager,
 ) : ReadWriteWithUidDataObjectRepositoryImpl<TrackedEntityInstance, TrackedEntityInstanceObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         TrackedEntityInstanceObjectRepository(
             store,
             uid,
-            databaseAdapter,
             childrenAppenders,
             s,
             trackerDataManager,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -41,11 +40,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class TrackedEntityTypeAttributeCollectionRepository internal constructor(
     store: TrackedEntityTypeAttributeStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<TrackedEntityTypeAttribute, TrackedEntityTypeAttributeCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -53,7 +50,6 @@ class TrackedEntityTypeAttributeCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityTypeAttributeCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyNameableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class TrackedEntityTypeCollectionRepository internal constructor(
     store: TrackedEntityTypeStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyNameableCollectionRepositoryImpl<TrackedEntityType, TrackedEntityTypeCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class TrackedEntityTypeCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackedEntityTypeCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/ProgramOwnerChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/ProgramOwnerChildrenAppender.kt
@@ -27,17 +27,16 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
-import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStoreImpl
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStore
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerTableInfo
 
-internal class ProgramOwnerChildrenAppender constructor(
-    databaseAdapter: DatabaseAdapter,
+internal class ProgramOwnerChildrenAppender private constructor(
+    private val childStore: ProgramOwnerStore,
 ) : ChildrenAppender<TrackedEntityInstance>() {
-    private val childStore = ProgramOwnerStoreImpl(databaseAdapter)
 
     override suspend fun appendChildren(tei: TrackedEntityInstance): TrackedEntityInstance {
         val builder = tei.toBuilder()
@@ -47,5 +46,11 @@ internal class ProgramOwnerChildrenAppender constructor(
                 .build(),
         )
         return builder.programOwners(programOwners).build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<TrackedEntityInstance> {
+            return ProgramOwnerChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeLegendSetChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeLegendSetChildrenAppender.kt
@@ -28,7 +28,7 @@
 
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
 
@@ -44,10 +44,8 @@ internal class TrackedEntityAttributeLegendSetChildrenAppender(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): TrackedEntityAttributeLegendSetChildrenAppender {
-            return TrackedEntityAttributeLegendSetChildrenAppender(
-                TrackedEntityAttributeLegendSetLinkStoreImpl(databaseAdapter),
-            )
+        fun create(): TrackedEntityAttributeLegendSetChildrenAppender {
+            return TrackedEntityAttributeLegendSetChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 
@@ -42,8 +42,8 @@ internal class TrackedEntityAttributeValueChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<TrackedEntityInstance> {
-            return TrackedEntityAttributeValueChildrenAppender(TrackedEntityAttributeValueStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<TrackedEntityInstance> {
+            return TrackedEntityAttributeValueChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityDataValueChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.event.Event
 
@@ -40,8 +40,8 @@ internal class TrackedEntityDataValueChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Event> {
-            return TrackedEntityDataValueChildrenAppender(TrackedEntityDataValueStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<Event> {
+            return TrackedEntityDataValueChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterAttributeValueFilterChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterAttributeValueFilterChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 
@@ -42,12 +42,8 @@ internal class TrackedEntityInstanceFilterAttributeValueFilterChildrenAppender p
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<TrackedEntityInstanceFilter> {
-            return TrackedEntityInstanceFilterAttributeValueFilterChildrenAppender(
-                AttributeValueFilterStoreImpl(
-                    databaseAdapter,
-                ),
-            )
+        fun create(): ChildrenAppender<TrackedEntityInstanceFilter> {
+            return TrackedEntityInstanceFilterAttributeValueFilterChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterEvenFilterChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterEvenFilterChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 
@@ -41,12 +41,8 @@ internal class TrackedEntityInstanceFilterEvenFilterChildrenAppender private con
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<TrackedEntityInstanceFilter> {
-            return TrackedEntityInstanceFilterEvenFilterChildrenAppender(
-                TrackedEntityInstanceEventFilterStoreImpl(
-                    databaseAdapter,
-                ),
-            )
+        fun create(): ChildrenAppender<TrackedEntityInstanceFilter> {
+            return TrackedEntityInstanceFilterEvenFilterChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeAttributeChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType
 
@@ -40,8 +40,8 @@ internal class TrackedEntityTypeAttributeChildrenAppender private constructor(
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<TrackedEntityType> {
-            return TrackedEntityTypeAttributeChildrenAppender(TrackedEntityTypeAttributeStoreImpl(databaseAdapter))
+        fun create(): ChildrenAppender<TrackedEntityType> {
+            return TrackedEntityTypeAttributeChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -39,7 +39,6 @@ import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUids
@@ -65,7 +64,6 @@ import java.util.Date
 class TrackedEntityInstanceQueryCollectionRepository internal constructor(
     private val store: TrackedEntityInstanceStore,
     private val trackerParentCallFactory: TrackerParentCallFactory,
-    private val databaseAdapter: DatabaseAdapter,
     scope: TrackedEntityInstanceQueryRepositoryScope,
     scopeHelper: TrackedEntityInstanceQueryRepositoryScopeHelper,
     versionManager: DHISVersionManager,
@@ -90,7 +88,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
             > =
         ScopedFilterConnectorFactory { s: TrackedEntityInstanceQueryRepositoryScope ->
             TrackedEntityInstanceQueryCollectionRepository(
-                store, trackerParentCallFactory, databaseAdapter,
+                store, trackerParentCallFactory,
                 s, scopeHelper, versionManager, filtersRepository, workingListRepository, onlineCache,
                 onlineHelper, localQueryHelper,
             )
@@ -156,7 +154,6 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
     val pagingSource: PagingSource<TrackedEntityInstance, TrackedEntityInstance>
         get() = TrackedEntityInstanceQueryPagingSource(
             store,
-            databaseAdapter,
             trackerParentCallFactory,
             scope,
             childrenAppenders,
@@ -226,7 +223,6 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
     private fun getDataFetcher(): TrackedEntityInstanceQueryDataFetcher {
         return TrackedEntityInstanceQueryDataFetcher(
             store,
-            databaseAdapter,
             trackerParentCallFactory,
             scope,
             childrenAppenders,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.trackedentity.search
 
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderExecutor
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -44,7 +43,6 @@ import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactor
 @Suppress("TooManyFunctions")
 internal class TrackedEntityInstanceQueryDataFetcher(
     private val store: TrackedEntityInstanceStore,
-    private val databaseAdapter: DatabaseAdapter,
     private val trackerParentCallFactory: TrackerParentCallFactory,
     private val scope: TrackedEntityInstanceQueryRepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance>,
@@ -216,7 +214,6 @@ internal class TrackedEntityInstanceQueryDataFetcher(
     private suspend fun appendAttributes(withoutChildren: List<TrackedEntityInstance>): List<TrackedEntityInstance> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             withoutChildren,
-            databaseAdapter,
             childrenAppenders,
             ChildrenSelection(
                 setOf(

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryPagingSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryPagingSource.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.trackedentity.search
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
@@ -39,7 +38,6 @@ import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactor
 
 internal class TrackedEntityInstanceQueryPagingSource(
     store: TrackedEntityInstanceStore,
-    databaseAdapter: DatabaseAdapter,
     trackerParentCallFactory: TrackerParentCallFactory,
     scope: TrackedEntityInstanceQueryRepositoryScope,
     childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance>,
@@ -50,7 +48,6 @@ internal class TrackedEntityInstanceQueryPagingSource(
 
     private val dataFetcher = TrackedEntityInstanceQueryDataFetcher(
         store,
-        databaseAdapter,
         trackerParentCallFactory,
         scope,
         childrenAppenders,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -39,7 +39,6 @@ import androidx.paging.PagingSource
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper
@@ -61,7 +60,6 @@ import org.koin.core.annotation.Singleton
 class TrackedEntitySearchCollectionRepository internal constructor(
     private val store: TrackedEntityInstanceStore,
     private val trackerParentCallFactory: TrackerParentCallFactory,
-    private val databaseAdapter: DatabaseAdapter,
     scope: TrackedEntityInstanceQueryRepositoryScope,
     scopeHelper: TrackedEntityInstanceQueryRepositoryScopeHelper,
     versionManager: DHISVersionManager,
@@ -87,7 +85,7 @@ class TrackedEntitySearchCollectionRepository internal constructor(
             > =
         ScopedFilterConnectorFactory { s: TrackedEntityInstanceQueryRepositoryScope ->
             TrackedEntitySearchCollectionRepository(
-                store, trackerParentCallFactory, databaseAdapter,
+                store, trackerParentCallFactory,
                 s, scopeHelper, versionManager, filtersRepository, workingListRepository, onlineCache,
                 onlineHelper, localQueryHelper, searchDataFetcherHelper,
             )
@@ -122,7 +120,6 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     val pagingSource: PagingSource<TrackedEntitySearchItem, TrackedEntitySearchItem>
         get() = TrackedEntitySearchPagingSource(
             store,
-            databaseAdapter,
             trackerParentCallFactory,
             scope,
             childrenAppenders,
@@ -184,7 +181,6 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     private fun getDataFetcher(): TrackedEntitySearchDataFetcher {
         return TrackedEntitySearchDataFetcher(
             store,
-            databaseAdapter,
             trackerParentCallFactory,
             scope,
             childrenAppenders,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcher.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.trackedentity.search
 
 import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.cache.internal.ExpirableCache
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.maintenance.D2Error
@@ -43,7 +42,6 @@ import java.util.concurrent.TimeUnit
 
 internal class TrackedEntitySearchDataFetcher(
     store: TrackedEntityInstanceStore,
-    databaseAdapter: DatabaseAdapter,
     trackerParentCallFactory: TrackerParentCallFactory,
     scope: TrackedEntityInstanceQueryRepositoryScope,
     childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance>,
@@ -55,7 +53,6 @@ internal class TrackedEntitySearchDataFetcher(
 
     private val instanceFetcher = TrackedEntityInstanceQueryDataFetcher(
         store,
-        databaseAdapter,
         trackerParentCallFactory,
         scope,
         childrenAppenders,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchPagingSource.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchPagingSource.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.trackedentity.search
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
@@ -39,7 +38,6 @@ import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactor
 
 internal class TrackedEntitySearchPagingSource(
     store: TrackedEntityInstanceStore,
-    databaseAdapter: DatabaseAdapter,
     trackerParentCallFactory: TrackerParentCallFactory,
     scope: TrackedEntityInstanceQueryRepositoryScope,
     childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance>,
@@ -51,7 +49,6 @@ internal class TrackedEntitySearchPagingSource(
 
     private val dataFetcher = TrackedEntitySearchDataFetcher(
         store,
-        databaseAdapter,
         trackerParentCallFactory,
         scope,
         childrenAppenders,

--- a/core/src/main/java/org/hisp/dhis/android/core/usecase/stock/StockUseCaseCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/usecase/stock/StockUseCaseCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.usecase.stock
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUidCollectionRepository
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyWithUidAndTransformerCollectionRepositoryImpl
@@ -41,23 +40,21 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class StockUseCaseCollectionRepository internal constructor(
     store: StockUseCaseStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     transformer: StockUseCaseTransformer,
 ) : ReadOnlyWithUidCollectionRepository<StockUseCase> by
 ReadOnlyWithUidAndTransformerCollectionRepositoryImpl(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(scope) { s: RepositoryScope ->
-        StockUseCaseCollectionRepository(store, databaseAdapter, s, transformer)
+        StockUseCaseCollectionRepository(store, s, transformer)
     },
     transformer,
 ) {
     private val cf: FilterConnectorFactory<StockUseCaseCollectionRepository> =
         FilterConnectorFactory(scope) { s: RepositoryScope ->
-            StockUseCaseCollectionRepository(store, databaseAdapter, s, transformer)
+            StockUseCaseCollectionRepository(store, s, transformer)
         }
 
     fun withTransactions(): StockUseCaseCollectionRepository {
@@ -66,7 +63,7 @@ ReadOnlyWithUidAndTransformerCollectionRepositoryImpl(
 
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<InternalStockUseCase> = mapOf(
-            InternalStockUseCase.TRANSACTIONS to ::StockUseCaseTransactionChildrenAppender,
+            InternalStockUseCase.TRANSACTIONS to StockUseCaseTransactionChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseTransactionChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseTransactionChildrenAppender.kt
@@ -27,18 +27,23 @@
  */
 package org.hisp.dhis.android.core.usecase.stock.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.usecase.stock.InternalStockUseCase
 
 internal class StockUseCaseTransactionChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val transactionLinkStore: StockUseCaseTransactionLinkStore,
 ) : ChildrenAppender<InternalStockUseCase>() {
-    private val transactionLinkStore = StockUseCaseTransactionLinkStoreImpl(databaseAdapter)
 
     override suspend fun appendChildren(internalStockUseCase: InternalStockUseCase): InternalStockUseCase {
         return internalStockUseCase.toBuilder()
             .transactions(transactionLinkStore.selectLinksForMasterUid(internalStockUseCase.uid()))
             .build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<InternalStockUseCase> {
+            return StockUseCaseTransactionChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/AuthenticatedUserObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/AuthenticatedUserObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.user
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyOneObjectRepositoryImpl
@@ -38,17 +37,14 @@ import org.koin.core.annotation.Singleton
 @Singleton(binds = [AuthenticatedUserObjectRepository::class])
 class AuthenticatedUserObjectRepository internal constructor(
     store: AuthenticatedUserStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyOneObjectRepositoryImpl<AuthenticatedUser, AuthenticatedUserObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { updatedScope: RepositoryScope ->
         AuthenticatedUserObjectRepository(
             store,
-            databaseAdapter,
             updatedScope,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/user/AuthorityCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/AuthorityCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.user
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -39,11 +38,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class AuthorityCollectionRepository internal constructor(
     store: AuthorityStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyCollectionRepositoryImpl<Authority, AuthorityCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -51,7 +48,6 @@ class AuthorityCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         AuthorityCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentialsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentialsObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.user
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
@@ -41,19 +40,17 @@ import org.koin.core.annotation.Singleton
 @Singleton(binds = [UserCredentialsObjectRepository::class])
 class UserCredentialsObjectRepository internal constructor(
     store: UserStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
     transformer: UserUserCredentialsTransformer,
 ) : ReadOnlyObjectRepository<UserCredentials> by ReadOnlyWithTransformerObjectRepositoryImpl(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     transformer,
 ) {
 
     private val cf: FilterConnectorFactory<UserCredentialsObjectRepository> = FilterConnectorFactory(scope) { s ->
-        UserCredentialsObjectRepository(store, databaseAdapter, s, transformer)
+        UserCredentialsObjectRepository(store, s, transformer)
     }
 
     fun withUserRoles(): UserCredentialsObjectRepository {
@@ -64,7 +61,7 @@ class UserCredentialsObjectRepository internal constructor(
         private const val USER_ROLES = "userRoles"
 
         val childrenAppenders: ChildrenAppenderGetter<User> = mapOf(
-            USER_ROLES to ::UserRoleChildrenAppender,
+            USER_ROLES to UserRoleChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.user
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyOneObjectRepositoryImpl
@@ -39,17 +38,14 @@ import org.koin.core.annotation.Singleton
 @Singleton(binds = [UserObjectRepository::class])
 class UserObjectRepository internal constructor(
     store: UserStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyOneObjectRepositoryImpl<User, UserObjectRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     ObjectRepositoryFactory { s: RepositoryScope ->
         UserObjectRepository(
             store,
-            databaseAdapter,
             s,
         )
     },
@@ -62,7 +58,7 @@ class UserObjectRepository internal constructor(
         private const val USER_ROLES = "userRoles"
 
         val childrenAppenders: ChildrenAppenderGetter<User> = mapOf(
-            USER_ROLES to ::UserRoleChildrenAppender,
+            USER_ROLES to UserRoleChildrenAppender::create,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserRoleCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserRoleCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.user
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
@@ -38,11 +37,9 @@ import org.koin.core.annotation.Singleton
 @Singleton
 class UserRoleCollectionRepository internal constructor(
     store: UserRoleStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<UserRole, UserRoleCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -50,7 +47,6 @@ class UserRoleCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         UserRoleCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserGroupChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserGroupChildrenAppender.kt
@@ -27,20 +27,25 @@
  */
 package org.hisp.dhis.android.core.user.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.user.User
 import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class UserGroupChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val store: UserGroupStore,
 ) : ChildrenAppender<User>() {
-    private val store = UserGroupStoreImpl(databaseAdapter)
 
     override suspend fun appendChildren(user: User): User {
         val builder = user.toBuilder()
         builder.userGroups(store.selectAll())
         return builder.build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<User> {
+            return UserGroupChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserRoleChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserRoleChildrenAppender.kt
@@ -27,20 +27,25 @@
  */
 package org.hisp.dhis.android.core.user.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.user.User
 import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class UserRoleChildrenAppender(
-    databaseAdapter: DatabaseAdapter,
+    private val store: UserRoleStore,
 ) : ChildrenAppender<User>() {
-    private val store = UserRoleStoreImpl(databaseAdapter)
 
     override suspend fun appendChildren(user: User): User {
         val builder = user.toBuilder()
         builder.userRoles(store.selectAll())
         return builder.build()
+    }
+
+    companion object {
+        fun create(): ChildrenAppender<User> {
+            return UserRoleChildrenAppender(koin.get())
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/validation/ValidationRuleCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/validation/ValidationRuleCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.validation
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyNameableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -44,11 +43,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class ValidationRuleCollectionRepository internal constructor(
     store: ValidationRuleStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyNameableCollectionRepositoryImpl<ValidationRule, ValidationRuleCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -56,7 +53,6 @@ class ValidationRuleCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         ValidationRuleCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/visualization/TrackerVisualizationCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/visualization/TrackerVisualizationCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.visualization
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EnumFilterConnector
@@ -42,11 +41,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class TrackerVisualizationCollectionRepository internal constructor(
     store: TrackerVisualizationStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<TrackerVisualization, TrackerVisualizationCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -54,7 +51,6 @@ class TrackerVisualizationCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         TrackerVisualizationCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/visualization/VisualizationCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/visualization/VisualizationCollectionRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.visualization
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.internal.ReadOnlyIdentifiableCollectionRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -43,11 +42,9 @@ import org.koin.core.annotation.Singleton
 @Suppress("TooManyFunctions")
 class VisualizationCollectionRepository internal constructor(
     store: VisualizationStore,
-    databaseAdapter: DatabaseAdapter,
     scope: RepositoryScope,
 ) : ReadOnlyIdentifiableCollectionRepositoryImpl<Visualization, VisualizationCollectionRepository>(
     store,
-    databaseAdapter,
     childrenAppenders,
     scope,
     FilterConnectorFactory(
@@ -55,7 +52,6 @@ class VisualizationCollectionRepository internal constructor(
     ) { s: RepositoryScope ->
         VisualizationCollectionRepository(
             store,
-            databaseAdapter,
             s,
         )
     },

--- a/core/src/main/java/org/hisp/dhis/android/core/visualization/internal/TrackerVisualizationColumnsFiltersChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/visualization/internal/TrackerVisualizationColumnsFiltersChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.visualization.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.visualization.LayoutPosition
 import org.hisp.dhis.android.core.visualization.TrackerVisualization
@@ -46,10 +46,8 @@ internal class TrackerVisualizationColumnsFiltersChildrenAppender private constr
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<TrackerVisualization> {
-            return TrackerVisualizationColumnsFiltersChildrenAppender(
-                TrackerVisualizationDimensionStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<TrackerVisualization> {
+            return TrackerVisualizationColumnsFiltersChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/visualization/internal/VisualizationColumnsRowsFiltersChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/visualization/internal/VisualizationColumnsRowsFiltersChildrenAppender.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.visualization.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.visualization.LayoutPosition
 import org.hisp.dhis.android.core.visualization.Visualization
@@ -58,10 +58,8 @@ internal class VisualizationColumnsRowsFiltersChildrenAppender private construct
     }
 
     companion object {
-        fun create(databaseAdapter: DatabaseAdapter): ChildrenAppender<Visualization> {
-            return VisualizationColumnsRowsFiltersChildrenAppender(
-                VisualizationDimensionItemStoreImpl(databaseAdapter),
-            )
+        fun create(): ChildrenAppender<Visualization> {
+            return VisualizationColumnsRowsFiltersChildrenAppender(koin.get())
         }
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/collection/RepositoryPagingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/collection/RepositoryPagingShould.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.arch.repositories.collection
 
 import androidx.paging.PageKeyedDataSource
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.paging.internal.RepositoryDataSource
@@ -56,7 +55,6 @@ class RepositoryPagingShould {
     private val emptyScope = RepositoryScope.empty()
 
     private val store: IdentifiableObjectStore<CategoryOption> = mock()
-    private val databaseAdapter: DatabaseAdapter = mock()
     private val `object`: CategoryOption = mock()
 
     private val objects = listOf(`object`)
@@ -74,7 +72,7 @@ class RepositoryPagingShould {
     @Test
     fun get_initial_page_objects_without_order_by() = runTest {
         val dataSource: RepositoryDataSource<CategoryOption> =
-            RepositoryDataSource(store, databaseAdapter, emptyScope, childrenAppenders)
+            RepositoryDataSource(store, emptyScope, childrenAppenders)
 
         dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
         verify(store).selectWhere("1", null, 3)
@@ -91,7 +89,7 @@ class RepositoryPagingShould {
                 .build(),
         )
         val dataSource: RepositoryDataSource<CategoryOption> =
-            RepositoryDataSource(store, databaseAdapter, updatedScope, childrenAppenders)
+            RepositoryDataSource(store, updatedScope, childrenAppenders)
 
         dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
         verify(store).selectWhere("1", "name ASC", 3)
@@ -108,7 +106,7 @@ class RepositoryPagingShould {
                 .build(),
         )
         val dataSource: RepositoryDataSource<CategoryOption> =
-            RepositoryDataSource(store, databaseAdapter, updatedScope, childrenAppenders)
+            RepositoryDataSource(store, updatedScope, childrenAppenders)
 
         dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
         verify(store).selectWhere("1", "name DESC", 3)
@@ -132,7 +130,7 @@ class RepositoryPagingShould {
                 .build(),
         )
         val dataSource: RepositoryDataSource<CategoryOption> =
-            RepositoryDataSource(store, databaseAdapter, updatedScope2, childrenAppenders)
+            RepositoryDataSource(store, updatedScope2, childrenAppenders)
 
         dataSource.loadInitial(PageKeyedDataSource.LoadInitialParams(3, false), initialCallback)
         verify(store).selectWhere("1", "c1 DESC, c2 ASC", 3)
@@ -160,7 +158,7 @@ class RepositoryPagingShould {
                 .build(),
         )
         val dataSource: RepositoryDataSource<CategoryOption> =
-            RepositoryDataSource(store, databaseAdapter, updatedScope2, childrenAppenders)
+            RepositoryDataSource(store, updatedScope2, childrenAppenders)
         dataSource.loadAfter(PageKeyedDataSource.LoadParams(6, 3), loadCallback)
         verify(store).selectWhere(
             "program = 'uid'",

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
@@ -31,7 +31,6 @@ import androidx.paging.ItemKeyedDataSource
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMode
@@ -48,7 +47,16 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.kotlin.*
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import java.util.concurrent.TimeUnit
 
 @RunWith(JUnit4::class)
@@ -58,7 +66,6 @@ class TrackedEntityInstanceQueryDataSourceShould {
     private lateinit var multipleEventFilterScope: TrackedEntityInstanceQueryRepositoryScope
 
     private val store: TrackedEntityInstanceStore = mock()
-    private val databaseAdapter: DatabaseAdapter = mock()
     private val trackerParentCallFactory: TrackerParentCallFactory = mock()
     private val onlineCallFactory: TrackedEntityEndpointCallFactory = mock()
     private val trackedEntity: TrackedEntityInstance = mock()
@@ -122,7 +129,7 @@ class TrackedEntityInstanceQueryDataSourceShould {
                 .doReturn(TrackerQueryResult(emptyList(), true))
         }
 
-        whenever(childrenAppenders[anyString()]).doReturn { _ -> identityAppender() }
+        whenever(childrenAppenders[anyString()]).doReturn { identityAppender() }
     }
 
     @Test
@@ -266,7 +273,6 @@ class TrackedEntityInstanceQueryDataSourceShould {
     ): TrackedEntityInstanceQueryDataFetcher {
         return TrackedEntityInstanceQueryDataFetcher(
             store,
-            databaseAdapter,
             trackerParentCallFactory,
             scope,
             childrenAppenders,


### PR DESCRIPTION
Solves []().

It removes the databaseAdapter dependency in the ChildrenAppenders. Now, the ChlidrenAppenders fetch the stores from the koin tree.

Changes are mainly:
- Remove databaseAdapter as a property in all the repositories (object and collection).
- Modify the `create()` method in the ChildreAppenders to get the store from the koin tree.