### PR TITLE
fix: [ANDROSDK-2131] Add subscription key parameter to Azure basemap imageUrl

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureNetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureNetworkHandler.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.core.map.layer.internal.microsoft
 import org.hisp.dhis.android.core.map.layer.MapLayer
 
 internal fun interface AzureNetworkHandler {
-    suspend fun getBaseMap(url: String, basemap: AzureBasemap): List<MapLayer>
+    suspend fun getBaseMap(url: String, basemap: AzureBasemap, key: String): List<MapLayer>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/MicrosoftMapsCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/MicrosoftMapsCallFactory.kt
@@ -63,7 +63,9 @@ internal class MicrosoftMapsCallFactory(
 
         return runCatching {
             val key = coroutineExecutor.wrap(storeError = true) { networkHandler.getBingApiKey() }
-                .getOrNull()?.value().orEmpty()
+                .getOrNull()?.value()
+            if (key.isNullOrBlank()) return@runCatching emptyList()
+
             val azureLayers = downloadWithTimeout(key, AzureBasemaps.list, ::downloadAzureBasemap, true)
             val resultLayers = azureLayers.takeIf { it.isNotEmpty() }
                 ?: downloadWithTimeout(key, BingBasemaps.list, ::downloadBingBasemap)

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/MicrosoftMapsCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/MicrosoftMapsCallFactory.kt
@@ -102,7 +102,7 @@ internal class MicrosoftMapsCallFactory(
 
     private suspend fun downloadAzureBasemap(key: String, basemap: AzureBasemap): List<MapLayer> {
         return coroutineExecutor.wrap(storeError = false) {
-            azureNetworkHandler.getBaseMap(getAzureUrl(basemap.style, key), basemap)
+            azureNetworkHandler.getBaseMap(getAzureUrl(basemap.style, key), basemap, key)
         }.let { result ->
             when (result) {
                 is Success -> result.value

--- a/core/src/main/java/org/hisp/dhis/android/network/azure/AzureNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/azure/AzureNetworkHandlerImpl.kt
@@ -39,8 +39,8 @@ internal class AzureNetworkHandlerImpl(
     httpServiceClient: HttpServiceClient,
 ) : AzureNetworkHandler {
     private val service = AzureService(httpServiceClient)
-    override suspend fun getBaseMap(url: String, basemap: AzureBasemap): List<MapLayer> {
+    override suspend fun getBaseMap(url: String, basemap: AzureBasemap, key: String): List<MapLayer> {
         val apiPayload = service.getBaseMap(url)
-        return apiPayload.toDomain(basemap)
+        return apiPayload.toDomain(basemap, key)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/azure/AzureServerResponseDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/azure/AzureServerResponseDTO.kt
@@ -50,7 +50,7 @@ internal data class AzureServerResponseDTO(
     val attribution: String? = null,
     val scheme: String? = null,
 ) {
-    fun toDomain(basemap: AzureBasemap): List<MapLayer> {
+    fun toDomain(basemap: AzureBasemap, key: String): List<MapLayer> {
         return tiles.map { tileTemplate ->
             val coverageAreas = listOf(
                 MapLayerImageryProviderArea.builder()
@@ -76,7 +76,7 @@ internal data class AzureServerResponseDTO(
                 .style(basemap.style)
                 .external(false)
                 .mapLayerPosition(MapLayerPosition.BASEMAP)
-                .imageUrl(tileTemplate)
+                .imageUrl("$tileTemplate&subscription-key=$key")
                 .subdomains(emptyList())
                 .imageryProviders(providers)
                 .mapService(scheme?.uppercase(Locale.ROOT)?.let { MapService.valueOf(it) })


### PR DESCRIPTION
This PR adds support for appending the Azure subscription key to the basemap `imageUrl` in order to authenticate requests to the Azure Maps service. [ANDROSDK-2131](https://dhis2.atlassian.net/browse/ANDROSDK-2131).

[ANDROSDK-2131]: https://dhis2.atlassian.net/browse/ANDROSDK-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ