### PR TITLE
[ANDROSDK-2134] Remove databaseAdapter dependency in Store instantation

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -8367,15 +8367,10 @@ public abstract interface class org/hisp/dhis/android/core/maintenance/Maintenan
 }
 
 public final class org/hisp/dhis/android/core/maintenance/PerformanceHintsService {
-	public static final field Companion Lorg/hisp/dhis/android/core/maintenance/PerformanceHintsService$Companion;
 	public final fun areThereExcessiveOrganisationUnits ()Z
 	public final fun areThereProgramsWithExcessiveProgramRules ()Z
 	public final fun areThereVulnerabilities ()Z
 	public final fun getProgramsWithExcessiveProgramRules ()Ljava/util/List;
-}
-
-public final class org/hisp/dhis/android/core/maintenance/PerformanceHintsService$Companion {
-	public final fun invoke (Lorg/hisp/dhis/android/core/arch/db/access/DatabaseAdapter;II)Lorg/hisp/dhis/android/core/maintenance/PerformanceHintsService;
 }
 
 public abstract interface class org/hisp/dhis/android/core/map/MapModule {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/BaseRealIntegrationTest.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/BaseRealIntegrationTest.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core
 
 import org.hisp.dhis.android.core.arch.call.internal.GenericCallData
 import org.hisp.dhis.android.core.arch.d2.internal.D2DIComponent
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.data.server.RealServerMother
 import org.hisp.dhis.android.core.resource.internal.ResourceHandler
 import org.junit.After
@@ -59,7 +60,7 @@ abstract class BaseRealIntegrationTest {
     internal fun getGenericCallData(d2: D2): GenericCallData {
         return GenericCallData(
             d2.databaseAdapter(),
-            ResourceHandler.create(d2.databaseAdapter()),
+            ResourceHandler(koin.get()),
             d2.systemInfoModule().versionManager(),
         )
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/MockIntegrationTestObjects.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/MockIntegrationTestObjects.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core
 import android.util.Log
 import org.hisp.dhis.android.core.D2Factory.clear
 import org.hisp.dhis.android.core.arch.d2.internal.D2DIComponent
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.mockwebserver.Dhis2MockServer
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
@@ -37,7 +38,7 @@ import org.hisp.dhis.android.core.period.clock.internal.setFixed
 import org.hisp.dhis.android.core.resource.internal.ResourceHandler
 import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestDatabaseContent
 import java.io.IOException
-import java.util.*
+import java.util.Date
 
 class MockIntegrationTestObjects(
     val d2: D2,
@@ -47,7 +48,7 @@ class MockIntegrationTestObjects(
     val databaseAdapter: DatabaseAdapter = d2.databaseAdapter()
 
     private var serverDate = Date()
-    private var resourceHandler: ResourceHandler = ResourceHandler.create(databaseAdapter)
+    private var resourceHandler: ResourceHandler = ResourceHandler(koin.get())
 
     @JvmField
     internal val d2DIComponent: D2DIComponent = d2.d2DIComponent

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsRepositoryIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsRepositoryIntegrationShould.kt
@@ -32,10 +32,11 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.analytics.AnalyticsException
 import org.hisp.dhis.android.core.analytics.aggregated.DimensionItem
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.common.AggregationType
 import org.hisp.dhis.android.core.common.RelativePeriod
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
+import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -92,7 +93,7 @@ class AnalyticsRepositoryIntegrationShould : BaseMockIntegrationTestFullDispatch
 
     @Test
     fun should_fail_if_unsupported_aggregation_type() = runTest {
-        val dataElementStore = DataElementStoreImpl(databaseAdapter)
+        val dataElementStore: DataElementStore = koin.get()
         val dataElement = dataElementStore.selectByUid("g9eOBujte1U")!!
 
         val varianceDataElement = dataElement.toBuilder().aggregationType(AggregationType.VARIANCE.name).build()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/BaseEvaluatorIntegrationShould.kt
@@ -76,45 +76,46 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEv
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipTypeFrom
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.relationshipTypeTo
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.trackedEntityType
-import org.hisp.dhis.android.core.category.internal.CategoryCategoryComboLinkStoreImpl
-import org.hisp.dhis.android.core.category.internal.CategoryCategoryOptionLinkStoreImpl
-import org.hisp.dhis.android.core.category.internal.CategoryComboStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.category.internal.CategoryCategoryComboLinkStore
+import org.hisp.dhis.android.core.category.internal.CategoryCategoryOptionLinkStore
+import org.hisp.dhis.android.core.category.internal.CategoryComboStore
 import org.hisp.dhis.android.core.category.internal.CategoryOptionComboCategoryOptionLinkStoreImpl
-import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStoreImpl
-import org.hisp.dhis.android.core.category.internal.CategoryOptionStoreImpl
-import org.hisp.dhis.android.core.category.internal.CategoryStoreImpl
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
+import org.hisp.dhis.android.core.category.internal.CategoryOptionStore
+import org.hisp.dhis.android.core.category.internal.CategoryStore
 import org.hisp.dhis.android.core.common.RelativeOrganisationUnit
 import org.hisp.dhis.android.core.common.RelativePeriod
-import org.hisp.dhis.android.core.constant.internal.ConstantStoreImpl
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
+import org.hisp.dhis.android.core.constant.internal.ConstantStore
+import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.core.datavalue.DataValue
-import org.hisp.dhis.android.core.datavalue.internal.DataValueStoreImpl
+import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
 import org.hisp.dhis.android.core.enrollment.Enrollment
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.event.Event
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
-import org.hisp.dhis.android.core.expressiondimensionitem.internal.ExpressionDimensionItemStoreImpl
-import org.hisp.dhis.android.core.indicator.internal.IndicatorStoreImpl
-import org.hisp.dhis.android.core.indicator.internal.IndicatorTypeStoreImpl
-import org.hisp.dhis.android.core.option.internal.OptionSetStoreImpl
-import org.hisp.dhis.android.core.option.internal.OptionStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitGroupStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitLevelStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
+import org.hisp.dhis.android.core.event.internal.EventStore
+import org.hisp.dhis.android.core.expressiondimensionitem.internal.ExpressionDimensionItemStore
+import org.hisp.dhis.android.core.indicator.internal.IndicatorStore
+import org.hisp.dhis.android.core.indicator.internal.IndicatorTypeStore
+import org.hisp.dhis.android.core.option.internal.OptionSetStore
+import org.hisp.dhis.android.core.option.internal.OptionStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitGroupStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitLevelStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.parser.internal.service.ExpressionService
-import org.hisp.dhis.android.core.period.internal.PeriodStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStageStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
-import org.hisp.dhis.android.core.relationship.internal.RelationshipConstraintStoreImpl
-import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStoreImpl
+import org.hisp.dhis.android.core.period.internal.PeriodStore
+import org.hisp.dhis.android.core.program.internal.ProgramStageStore
+import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.core.relationship.internal.RelationshipConstraintStore
+import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStore
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.junit.After
 import org.junit.Before
@@ -122,45 +123,45 @@ import org.junit.Before
 internal open class BaseEvaluatorIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
 
     // Data stores
-    protected val dataValueStore = DataValueStoreImpl(databaseAdapter)
-    protected val eventStore = EventStoreImpl(databaseAdapter)
-    protected val enrollmentStore = EnrollmentStoreImpl(databaseAdapter)
-    protected val trackedEntityStore = TrackedEntityInstanceStoreImpl(databaseAdapter)
-    protected val trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
-    protected val trackedEntityAttributeValueStore = TrackedEntityAttributeValueStoreImpl(databaseAdapter)
+    protected val dataValueStore: DataValueStore = koin.get()
+    protected val eventStore: EventStore = koin.get()
+    protected val enrollmentStore: EnrollmentStore = koin.get()
+    protected val trackedEntityStore: TrackedEntityInstanceStore = koin.get()
+    protected val trackedEntityDataValueStore: TrackedEntityDataValueStore = koin.get()
+    protected val trackedEntityAttributeValueStore: TrackedEntityAttributeValueStore = koin.get()
 
     // Metadata stores
-    protected val categoryStore = CategoryStoreImpl(databaseAdapter)
-    protected val categoryOptionStore = CategoryOptionStoreImpl(databaseAdapter)
-    protected val categoryCategoryOptionStore = CategoryCategoryOptionLinkStoreImpl(databaseAdapter)
-    protected val categoryComboStore = CategoryComboStoreImpl(databaseAdapter)
-    protected val categoryOptionComboStore = CategoryOptionComboStoreImpl(databaseAdapter)
-    protected val categoryCategoryComboLinkStore = CategoryCategoryComboLinkStoreImpl(databaseAdapter)
+    protected val categoryStore: CategoryStore = koin.get()
+    protected val categoryOptionStore: CategoryOptionStore = koin.get()
+    protected val categoryCategoryOptionStore: CategoryCategoryOptionLinkStore = koin.get()
+    protected val categoryComboStore: CategoryComboStore = koin.get()
+    protected val categoryOptionComboStore: CategoryOptionComboStore = koin.get()
+    protected val categoryCategoryComboLinkStore: CategoryCategoryComboLinkStore = koin.get()
     protected val categoryOptionComboCategoryOptionLinkStore = CategoryOptionComboCategoryOptionLinkStoreImpl(
         databaseAdapter,
     )
-    protected val optionSetStore = OptionSetStoreImpl(databaseAdapter)
-    protected val optionStore = OptionStoreImpl(databaseAdapter)
-    protected val dataElementStore = DataElementStoreImpl(databaseAdapter)
-    protected val organisationUnitStore = OrganisationUnitStoreImpl(databaseAdapter)
-    protected val organisationUnitLevelStore = OrganisationUnitLevelStoreImpl(databaseAdapter)
-    protected val organisationUnitGroupStore = OrganisationUnitGroupStoreImpl(databaseAdapter)
-    protected val periodStore = PeriodStoreImpl(databaseAdapter)
+    protected val optionSetStore: OptionSetStore = koin.get()
+    protected val optionStore: OptionStore = koin.get()
+    protected val dataElementStore: DataElementStore = koin.get()
+    protected val organisationUnitStore: OrganisationUnitStore = koin.get()
+    protected val organisationUnitLevelStore: OrganisationUnitLevelStore = koin.get()
+    protected val organisationUnitGroupStore: OrganisationUnitGroupStore = koin.get()
+    protected val periodStore: PeriodStore = koin.get()
 
-    protected val trackedEntityTypeStore = TrackedEntityTypeStoreImpl(databaseAdapter)
-    protected val trackedEntityAttributeStore = TrackedEntityAttributeStoreImpl(databaseAdapter)
-    protected val programStore = ProgramStoreImpl(databaseAdapter)
-    protected val programStageStore = ProgramStageStoreImpl(databaseAdapter)
+    protected val trackedEntityTypeStore: TrackedEntityTypeStore = koin.get()
+    protected val trackedEntityAttributeStore: TrackedEntityAttributeStore = koin.get()
+    protected val programStore: ProgramStore = koin.get()
+    protected val programStageStore: ProgramStageStore = koin.get()
 
-    protected val indicatorTypeStore = IndicatorTypeStoreImpl(databaseAdapter)
-    protected val indicatorStore = IndicatorStoreImpl(databaseAdapter)
+    protected val indicatorTypeStore: IndicatorTypeStore = koin.get()
+    protected val indicatorStore: IndicatorStore = koin.get()
 
-    protected val relationshipTypeStore = RelationshipTypeStoreImpl(databaseAdapter)
-    protected val relationshipConstraintStore = RelationshipConstraintStoreImpl(databaseAdapter)
+    protected val relationshipTypeStore: RelationshipTypeStore = koin.get()
+    protected val relationshipConstraintStore: RelationshipConstraintStore = koin.get()
 
-    protected val constantStore = ConstantStoreImpl(databaseAdapter)
+    protected val constantStore: ConstantStore = koin.get()
 
-    protected val expressionDimensionItemStore = ExpressionDimensionItemStoreImpl(databaseAdapter)
+    protected val expressionDimensionItemStore: ExpressionDimensionItemStore = koin.get()
 
     protected val expressionService = ExpressionService(
         dataElementStore,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/EventDataItemSQLEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/EventDataItemSQLEvaluatorIntegrationShould.kt
@@ -69,7 +69,7 @@ internal class EventDataItemSQLEvaluatorIntegrationShould : BaseEvaluatorIntegra
 
     private val eventDataItemEvaluator = EventDataItemSQLEvaluator(databaseAdapter)
 
-    private val helper = BaseTrackerDataIntegrationHelper(databaseAdapter)
+    private val helper = BaseTrackerDataIntegrationHelper()
     private val event1 = generator.generate()
     private val enrollment1 = generator.generate()
     private val event2 = generator.generate()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ProgramIndicatorEvaluatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/ProgramIndicatorEvaluatorIntegrationShould.kt
@@ -41,12 +41,11 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEv
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.trackedEntity1
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.trackedEntity2
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.trackedEntityType
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.AggregationType
 import org.hisp.dhis.android.core.common.AnalyticsType
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.common.RelativePeriod
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundaryType
 import org.hisp.dhis.android.core.program.ProgramIndicator
@@ -60,12 +59,12 @@ import org.junit.runner.RunWith
 internal class ProgramIndicatorEvaluatorIntegrationShould : BaseEvaluatorIntegrationShould() {
 
     private val programIndicatorEvaluator = ProgramIndicatorEvaluator(
-        EventStoreImpl(databaseAdapter),
-        EnrollmentStoreImpl(databaseAdapter),
+        koin.get(),
+        koin.get(),
         d2.programModule().programIndicatorEngine(),
     )
 
-    private val helper = BaseTrackerDataIntegrationHelper(databaseAdapter)
+    private val helper = BaseTrackerDataIntegrationHelper()
 
     @Test
     fun should_aggregate_data_from_multiple_teis() = runTest {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/analyticexpressionengine/AnalyticExpressionEngineFactoryHelper.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/analyticexpressionengine/AnalyticExpressionEngineFactoryHelper.kt
@@ -31,12 +31,8 @@ import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.DataElementSQLEvaluator
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.EventDataItemSQLEvaluator
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.ProgramIndicatorSQLEvaluator
-import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStoreImpl
-import org.hisp.dhis.android.core.constant.internal.ConstantStoreImpl
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLExecutor
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStoreImpl
 
 internal object AnalyticExpressionEngineFactoryHelper {
 
@@ -46,9 +42,9 @@ internal object AnalyticExpressionEngineFactoryHelper {
         val dataElementEvaluator = DataElementSQLEvaluator(databaseAdapter)
 
         val programIndicatorExecutor = ProgramIndicatorSQLExecutor(
-            ConstantStoreImpl(databaseAdapter),
-            DataElementStoreImpl(databaseAdapter),
-            TrackedEntityAttributeStoreImpl(databaseAdapter),
+            koin.get(),
+            koin.get(),
+            koin.get(),
             databaseAdapter,
         )
 
@@ -59,15 +55,15 @@ internal object AnalyticExpressionEngineFactoryHelper {
         val eventDataItemEvaluator = EventDataItemSQLEvaluator(databaseAdapter)
 
         return AnalyticExpressionEngineFactory(
-            DataElementStoreImpl(databaseAdapter),
-            TrackedEntityAttributeStoreImpl(databaseAdapter),
-            CategoryOptionComboStoreImpl(databaseAdapter),
-            ProgramStoreImpl(databaseAdapter),
+            koin.get(),
+            koin.get(),
+            koin.get(),
+            koin.get(),
             d2.programModule().programIndicators(),
             dataElementEvaluator,
             programIndicatorEvaluator,
             eventDataItemEvaluator,
-            ConstantStoreImpl(databaseAdapter),
+            koin.get(),
         )
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
@@ -50,35 +50,43 @@ import org.hisp.dhis.android.core.analytics.linelist.EventLineListParams
 import org.hisp.dhis.android.core.analytics.linelist.EventLineListService
 import org.hisp.dhis.android.core.analytics.linelist.EventLineListServiceImpl
 import org.hisp.dhis.android.core.analytics.linelist.LineListItem
-import org.hisp.dhis.android.core.category.internal.CategoryComboStoreImpl
-import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStoreImpl
-import org.hisp.dhis.android.core.common.*
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.category.internal.CategoryComboStore
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
+import org.hisp.dhis.android.core.common.BaseIdentifiableObject
+import org.hisp.dhis.android.core.common.DateFilterPeriod
+import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
+import org.hisp.dhis.android.core.common.DatePeriodType
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.common.OrganisationUnitFilter
+import org.hisp.dhis.android.core.common.RelativeOrganisationUnit
+import org.hisp.dhis.android.core.common.RelativePeriod
+import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.event.Event
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
+import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.legendset.DataElementLegendSetLink
 import org.hisp.dhis.android.core.legendset.ProgramIndicatorLegendSetLink
-import org.hisp.dhis.android.core.legendset.internal.DataElementLegendSetLinkStoreImpl
-import org.hisp.dhis.android.core.legendset.internal.LegendSetStoreImpl
-import org.hisp.dhis.android.core.legendset.internal.LegendStoreImpl
-import org.hisp.dhis.android.core.legendset.internal.ProgramIndicatorLegendSetLinkStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitLevelStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitOrganisationUnitGroupLinkStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
+import org.hisp.dhis.android.core.legendset.internal.DataElementLegendSetLinkStore
+import org.hisp.dhis.android.core.legendset.internal.LegendSetStore
+import org.hisp.dhis.android.core.legendset.internal.LegendStore
+import org.hisp.dhis.android.core.legendset.internal.ProgramIndicatorLegendSetLinkStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitLevelStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitOrganisationUnitGroupLinkStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
 import org.hisp.dhis.android.core.period.clock.internal.createFixed
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
 import org.hisp.dhis.android.core.program.ProgramIndicator
-import org.hisp.dhis.android.core.program.internal.ProgramIndicatorStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStageStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
+import org.hisp.dhis.android.core.program.internal.ProgramIndicatorStore
+import org.hisp.dhis.android.core.program.internal.ProgramStageStore
+import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStoreImpl
-import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStore
+import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.After
@@ -90,25 +98,25 @@ import org.junit.runner.RunWith
 class EventLineListIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
 
     // Stores
-    private val trackedEntityTypeStore = TrackedEntityTypeStoreImpl(databaseAdapter)
-    private val categoryComboStore = CategoryComboStoreImpl(databaseAdapter)
-    private val categoryOptionComboStore = CategoryOptionComboStoreImpl(databaseAdapter)
-    private val programStore = ProgramStoreImpl(databaseAdapter)
-    private val programStageStore = ProgramStageStoreImpl(databaseAdapter)
-    private val dataElementStore = DataElementStoreImpl(databaseAdapter)
-    private val dataElementLegendSetLinkStore = DataElementLegendSetLinkStoreImpl(databaseAdapter)
-    private val organisationUnitStore = OrganisationUnitStoreImpl(databaseAdapter)
-    private val userOrganisationUnitStore = UserOrganisationUnitLinkStoreImpl(databaseAdapter)
-    private val organisationUnitGroupLinkStore = OrganisationUnitOrganisationUnitGroupLinkStoreImpl(databaseAdapter)
-    private val organisationUnitLevelStore = OrganisationUnitLevelStoreImpl(databaseAdapter)
-    private val trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(databaseAdapter)
-    private val eventStore = EventStoreImpl(databaseAdapter)
-    private val trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
-    private val programIndicatorStore = ProgramIndicatorStoreImpl(databaseAdapter)
-    private val programIndicatorLegendSetLinkStore = ProgramIndicatorLegendSetLinkStoreImpl(databaseAdapter)
-    private val enrollmentStore = EnrollmentStoreImpl(databaseAdapter)
-    private val legendSetStore = LegendSetStoreImpl(databaseAdapter)
-    private val legendStore = LegendStoreImpl(databaseAdapter)
+    private val trackedEntityTypeStore: TrackedEntityTypeStore = koin.get()
+    private val categoryComboStore: CategoryComboStore = koin.get()
+    private val categoryOptionComboStore: CategoryOptionComboStore = koin.get()
+    private val programStore: ProgramStore = koin.get()
+    private val programStageStore: ProgramStageStore = koin.get()
+    private val dataElementStore: DataElementStore = koin.get()
+    private val dataElementLegendSetLinkStore: DataElementLegendSetLinkStore = koin.get()
+    private val organisationUnitStore: OrganisationUnitStore = koin.get()
+    private val userOrganisationUnitStore: UserOrganisationUnitLinkStore = koin.get()
+    private val organisationUnitGroupLinkStore: OrganisationUnitOrganisationUnitGroupLinkStore = koin.get()
+    private val organisationUnitLevelStore: OrganisationUnitLevelStore = koin.get()
+    private val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
+    private val eventStore: EventStore = koin.get()
+    private val trackedEntityDataValueStore: TrackedEntityDataValueStore = koin.get()
+    private val programIndicatorStore: ProgramIndicatorStore = koin.get()
+    private val programIndicatorLegendSetLinkStore: ProgramIndicatorLegendSetLinkStore = koin.get()
+    private val enrollmentStore: EnrollmentStore = koin.get()
+    private val legendSetStore: LegendSetStore = koin.get()
+    private val legendStore: LegendStore = koin.get()
     private val clockProvider = ClockProviderFactory.createFixed()
     private val dateFilterPeriodHelper =
         DateFilterPeriodHelper(clockProvider, ParentPeriodGeneratorImpl.create(clockProvider))

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerEntityInstanceLineListRepositoryEvaluatorShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerEntityInstanceLineListRepositoryEvaluatorShould.kt
@@ -63,7 +63,7 @@ import java.util.Date
 @RunWith(D2JunitRunner::class)
 internal class TrackerEntityInstanceLineListRepositoryEvaluatorShould : BaseEvaluatorIntegrationShould() {
 
-    private val helper = BaseTrackerDataIntegrationHelper(databaseAdapter)
+    private val helper = BaseTrackerDataIntegrationHelper()
 
     val programOther: Program = Program.builder()
         .uid(generator.generate())

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepositoryEvaluatorShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepositoryEvaluatorShould.kt
@@ -63,7 +63,7 @@ import java.util.Date
 @RunWith(D2JunitRunner::class)
 internal class TrackerLineListRepositoryEvaluatorShould : BaseEvaluatorIntegrationShould() {
 
-    private val helper = BaseTrackerDataIntegrationHelper(databaseAdapter)
+    private val helper = BaseTrackerDataIntegrationHelper()
 
     @Test
     fun evaluate_program_attributes() = runTest {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboEndpointCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboEndpointCallRealIntegrationShould.kt
@@ -31,9 +31,8 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
-import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLink
-import org.hisp.dhis.android.core.category.CategoryOptionCombo
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CategoryComboEndpointCallRealIntegrationShould : BaseRealIntegrationTest() {
@@ -69,31 +68,30 @@ class CategoryComboEndpointCallRealIntegrationShould : BaseRealIntegrationTest()
     }
 
     private suspend fun assertNotCombosInDB() {
-        val categoryComboStore = CategoryComboStoreImpl(d2.databaseAdapter())
+        val categoryComboStore: CategoryComboStore = koin.get()
         val categoryCombos = categoryComboStore.selectAll()
         assertThat(categoryCombos.isEmpty()).isTrue()
     }
 
     private suspend fun assertThereAreCombosInDB() {
-        val categoryComboStore = CategoryComboStoreImpl(d2.databaseAdapter())
+        val categoryComboStore: CategoryComboStore = koin.get()
         val categoryCombos = categoryComboStore.selectAll()
         assertThat(categoryCombos.isNotEmpty()).isTrue()
     }
 
     private suspend fun categoryCategoryComboLinks(): List<CategoryCategoryComboLink> {
-        val categoryCategoryComboLinkStore = CategoryCategoryComboLinkStoreImpl(d2.databaseAdapter())
+        val categoryCategoryComboLinkStore: CategoryCategoryComboLinkStore = koin.get()
         return categoryCategoryComboLinkStore.selectAll()
     }
 
     private suspend fun assertThereAreCategoryOptionCombosInDB() {
-        val categoryOptionComboStore: IdentifiableObjectStore<CategoryOptionCombo> =
-            CategoryOptionComboStoreImpl(d2.databaseAdapter())
+        val categoryOptionComboStore: CategoryOptionComboStore = koin.get()
         val categoryOptionCombos = categoryOptionComboStore.selectAll()
         assertThat(categoryOptionCombos.isNotEmpty()).isTrue()
     }
 
     private suspend fun assertThereAreCategoriesInDB() {
-        val categoryOptionStore = CategoryOptionStoreImpl(d2.databaseAdapter())
+        val categoryOptionStore: CategoryComboStore = koin.get()
         val categoryOptionUids = categoryOptionStore.selectUids()
         assertThat(categoryOptionUids.isNotEmpty()).isTrue()
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorIntegrationShould.kt
@@ -30,32 +30,31 @@ package org.hisp.dhis.android.core.common.internal
 import androidx.test.runner.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.enrollment.EnrollmentCreateProjection
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
 import org.hisp.dhis.android.core.event.EventCreateProjection
 import org.hisp.dhis.android.core.event.internal.EventStore
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.relationship.Relationship
 import org.hisp.dhis.android.core.relationship.RelationshipHelper
-import org.hisp.dhis.android.core.relationship.internal.*
+import org.hisp.dhis.android.core.relationship.internal.RelationshipItemStore
+import org.hisp.dhis.android.core.relationship.internal.RelationshipStore
+import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStore
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceCreateProjection
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStore
-import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
 import java.text.ParseException
-import java.util.*
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
@@ -73,13 +72,13 @@ class DataStatePropagatorIntegrationShould : BaseMockIntegrationTestFullDispatch
     @Before
     @Throws(IOException::class)
     fun setUp() {
-        trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(d2.databaseAdapter())
-        enrollmentStore = EnrollmentStoreImpl(d2.databaseAdapter())
-        eventStore = EventStoreImpl(d2.databaseAdapter())
-        relationshipStore = RelationshipStoreImpl(d2.databaseAdapter())
-        relationshipItemStore = RelationshipItemStoreImpl(d2.databaseAdapter())
-        relationshipTypeStore = RelationshipTypeStoreImpl(d2.databaseAdapter())
-        programOwnerStore = ProgramOwnerStoreImpl(d2.databaseAdapter())
+        trackedEntityInstanceStore = koin.get()
+        enrollmentStore = koin.get()
+        eventStore = koin.get()
+        relationshipStore = koin.get()
+        relationshipItemStore = koin.get()
+        relationshipTypeStore = koin.get()
+        programOwnerStore = koin.get()
 
         propagator = DataStatePropagatorImpl(
             trackedEntityInstanceStore,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.configuration.internal
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.internal.DatabaseAdapterFactory
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.configuration.internal
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.internal.DatabaseAdapterFactory
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
@@ -186,7 +185,7 @@ class DatabaseConfigurationMigrationIntegrationShould {
         databaseAdapter.execSQL("CREATE TABLE UserCredentials (_id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT)")
         databaseAdapter.setForeignKeyConstraintsEnabled(false)
         databaseAdapter.execSQL("INSERT INTO UserCredentials (username) VALUES ('${credentials.username()}')")
-        val configurationStore: ConfigurationStore = koin.get()
+        val configurationStore = ConfigurationStoreImpl(databaseAdapter)
         configurationStore.insert(Configuration.forServerUrl(serverUrl))
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
@@ -185,7 +185,7 @@ class DatabaseConfigurationMigrationIntegrationShould {
         databaseAdapter.execSQL("CREATE TABLE UserCredentials (_id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT)")
         databaseAdapter.setForeignKeyConstraintsEnabled(false)
         databaseAdapter.execSQL("INSERT INTO UserCredentials (username) VALUES ('${credentials.username()}')")
-        val configurationStore = ConfigurationStoreImpl(databaseAdapter)
+        val configurationStore: ConfigurationStore = koin.get()
         configurationStore.insert(Configuration.forServerUrl(serverUrl))
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompleteRegistrationPostCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetCompleteRegistrationPostCallRealIntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.dataset.internal
 import com.google.common.truth.Truth
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.dataset.DataSetCompleteRegistration
 import org.hisp.dhis.android.core.dataset.DataSetCompleteRegistrationCollectionRepository
@@ -42,7 +43,7 @@ class DataSetCompleteRegistrationPostCallRealIntegrationShould : BaseRealIntegra
     @Before
     override fun setUp() {
         super.setUp()
-        dataSetCompleteRegistrationStore = DataSetCompleteRegistrationStoreImpl(d2.databaseAdapter())
+        dataSetCompleteRegistrationStore = koin.get()
     }
 
     // commented out since it is a flaky test that works against a real server.

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceStoreIntegrationShould.kt
@@ -30,10 +30,10 @@ package org.hisp.dhis.android.core.dataset.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
-import org.hisp.dhis.android.core.datavalue.internal.DataValueStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataDispatcher
 import org.junit.After
 import org.junit.Before
@@ -46,8 +46,8 @@ class DataSetInstanceStoreIntegrationShould : BaseMockIntegrationTestMetadataDis
 
     @Before
     fun setUp() = runTest {
-        dataSetInstanceStore = DataSetInstanceStoreImpl(databaseAdapter)
-        dataValueStore = DataValueStoreImpl(databaseAdapter)
+        dataSetInstanceStore = koin.get()
+        dataValueStore = koin.get()
 
         dataValueStore.delete()
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datastore/internal/DataStorePostCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datastore/internal/DataStorePostCallMockIntegrationShould.kt
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.core.datastore.internal
 import com.google.common.truth.Truth.assertThat
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataEnqueable
@@ -136,7 +137,7 @@ class DataStorePostCallMockIntegrationShould : BaseMockIntegrationTestMetadataEn
     private suspend fun setState(state: State) {
         val entries = d2.dataStoreModule().dataStore().blockingGet()
 
-        val store = DataStoreEntryStoreImpl(databaseAdapter)
+        val store: DataStoreEntryStore = koin.get()
         entries.forEach {
             store.setState(it, state)
         }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValueEndpointCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValueEndpointCallRealIntegrationShould.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
 import org.hisp.dhis.android.core.arch.api.executors.internal.APIDownloader
 import org.hisp.dhis.android.core.arch.api.executors.internal.APIDownloaderImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.data.datavalue.DataValueUtils
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.domain.aggregated.data.internal.AggregatedDataCallBundle
@@ -63,7 +64,7 @@ class DataValueEndpointCallRealIntegrationShould : BaseRealIntegrationTest() {
     }
 
     private suspend fun download(): List<DataValue> {
-        val dataValueHandler = DataValueHandler(DataValueStoreImpl(d2.databaseAdapter()))
+        val dataValueHandler = DataValueHandler(koin.get())
 
         val key = AggregatedDataCallBundleKey(
             periodType = PeriodType.Daily,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValuePostCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValuePostCallRealIntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.datavalue.internal
 import com.google.common.truth.Truth
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.junit.Before
@@ -40,7 +41,7 @@ class DataValuePostCallRealIntegrationShould : BaseRealIntegrationTest() {
     @Before
     override fun setUp() {
         super.setUp()
-        dataValueStore = DataValueStoreImpl(d2.databaseAdapter())
+        dataValueStore = koin.get()
     }
 
     // commented out since it is a flaky test that works against a real server.

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventWithLimitCallBaseMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/EventWithLimitCallBaseMockIntegrationShould.kt
@@ -29,9 +29,10 @@ package org.hisp.dhis.android.core.event
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.settings.SynchronizationSettings
-import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStoreImpl
+import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStore
 import org.hisp.dhis.android.core.tracker.TrackerExporterVersion
 import org.hisp.dhis.android.core.tracker.TrackerImporterVersion
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataEnqueable
@@ -47,7 +48,7 @@ abstract class EventWithLimitCallBaseMockIntegrationShould : BaseMockIntegration
     abstract val downloadEventsByUidLimitedByOneFile: String
 
     private lateinit var initSyncParams: SynchronizationSettings
-    private val syncStore = SynchronizationSettingStoreImpl(databaseAdapter)
+    private val syncStore: SynchronizationSettingStore = koin.get()
 
     @Before
     fun setUp() = runTest {
@@ -71,7 +72,7 @@ abstract class EventWithLimitCallBaseMockIntegrationShould : BaseMockIntegration
         dhis2MockServer.enqueueSystemInfoResponse()
         dhis2MockServer.enqueueMockResponse(downloadEventsFile)
         d2.eventModule().eventDownloader().limit(eventLimitByOrgUnit).blockingDownload()
-        val eventStore = EventStoreImpl(databaseAdapter)
+        val eventStore: EventStore = koin.get()
         val downloadedEvents = eventStore.querySingleEvents()
         assertThat(downloadedEvents.size).isEqualTo(eventLimitByOrgUnit)
     }
@@ -86,7 +87,7 @@ abstract class EventWithLimitCallBaseMockIntegrationShould : BaseMockIntegration
             .`in`("wAiGPfJGMxt", "PpNGhvEYnXe")
             .limit(eventLimitByOrgUnit)
             .blockingDownload()
-        val eventStore = EventStoreImpl(databaseAdapter)
+        val eventStore: EventStore = koin.get()
         val downloadedEvents = eventStore.querySingleEvents()
         assertThat(downloadedEvents.size).isEqualTo(eventLimitByOrgUnit)
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventEndpointCallBaseMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventEndpointCallBaseMockIntegrationShould.kt
@@ -29,10 +29,11 @@ package org.hisp.dhis.android.core.event.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.settings.SynchronizationSettings
-import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStoreImpl
+import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStore
 import org.hisp.dhis.android.core.tracker.TrackerExporterVersion
 import org.hisp.dhis.android.core.tracker.TrackerImporterVersion
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataEnqueable
@@ -49,7 +50,7 @@ abstract class EventEndpointCallBaseMockIntegrationShould : BaseMockIntegrationT
     abstract val eventsWithUids: String
 
     private lateinit var initSyncParams: SynchronizationSettings
-    private val syncStore = SynchronizationSettingStoreImpl(databaseAdapter)
+    private val syncStore: SynchronizationSettingStore = koin.get()
 
     @Before
     fun setUp() = runTest {
@@ -98,7 +99,7 @@ abstract class EventEndpointCallBaseMockIntegrationShould : BaseMockIntegrationT
         val event = events[0]
         assertThat(event.uid()).isEqualTo("V1CerIi3sdL")
         assertThat(events.size).isEqualTo(1)
-        EventStoreImpl(d2.databaseAdapter()).update(
+        koin.get<EventStore>().update(
             event.toBuilder()
                 .syncState(state)
                 .aggregatedSyncState(state)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventEndpointCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventEndpointCallRealIntegrationShould.kt
@@ -30,8 +30,9 @@ package org.hisp.dhis.android.core.event.internal
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.event.internal.EventCallFactory.create
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
 
 class EventEndpointCallRealIntegrationShould : BaseRealIntegrationTest() {
     // This test is commented because technically it is flaky.
@@ -65,20 +66,20 @@ class EventEndpointCallRealIntegrationShould : BaseRealIntegrationTest() {
     }
 
     private suspend fun verifyAtLeastOneEventWithOptionCombo(): Boolean {
-        val eventStore = EventStoreImpl(d2.databaseAdapter())
+        val eventStore = koin.get<EventStore>()
         val downloadedEvents = eventStore.querySingleEvents()
         return downloadedEvents.any { it.attributeOptionCombo() != null }
     }
 
     private suspend fun verifyNumberOfDownloadedEvents(numEvents: Int) {
-        val eventStore = EventStoreImpl(d2.databaseAdapter())
+        val eventStore = koin.get<EventStore>()
         val downloadedEvents = eventStore.querySingleEvents()
 
         assertThat(downloadedEvents.size).isEqualTo(numEvents)
     }
 
     private suspend fun verifyNumberOfDownloadedTrackedEntityDataValue(num: Int) {
-        val trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(d2.databaseAdapter())
+        val trackedEntityDataValueStore = koin.get<TrackedEntityDataValueStore>()
         val numPersisted = trackedEntityDataValueStore.selectAll().size
 
         assertThat(numPersisted).isEqualTo(num)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostBaseMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostBaseMockIntegrationShould.kt
@@ -29,12 +29,12 @@ package org.hisp.dhis.android.core.event.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityDataValueSamples
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.settings.SynchronizationSettings
-import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
 import org.hisp.dhis.android.core.tracker.TrackerExporterVersion
 import org.hisp.dhis.android.core.tracker.TrackerImporterVersion
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataEnqueable
@@ -55,7 +55,7 @@ abstract class EventPostBaseMockIntegrationShould : BaseMockIntegrationTestMetad
     private val event4Id = "event4Id"
 
     private lateinit var initSyncParams: SynchronizationSettings
-    private val syncStore = SynchronizationSettingStoreImpl(databaseAdapter)
+    private val syncStore: SynchronizationSettingStore = koin.get()
 
     @Before
     fun setUp() = runTest {
@@ -169,7 +169,7 @@ abstract class EventPostBaseMockIntegrationShould : BaseMockIntegrationTestMetad
         eventStore.insert(event3)
         eventStore.insert(event4)
 
-        val tedvStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
+        val tedvStore: TrackedEntityDataValueStore = koin.get()
         tedvStore.insert(dataValue1)
         tedvStore.insert(dataValue2)
         tedvStore.insert(dataValue3)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostBaseMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostBaseMockIntegrationShould.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityDataValueSamples
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.settings.SynchronizationSettings
+import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
 import org.hisp.dhis.android.core.tracker.TrackerExporterVersion
 import org.hisp.dhis.android.core.tracker.TrackerImporterVersion

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostCallRealIntegrationShould.kt
@@ -31,6 +31,7 @@ import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.helpers.UidGenerator
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl
 import org.hisp.dhis.android.core.common.State
@@ -40,9 +41,8 @@ import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.program.ProgramType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
 import org.junit.Before
-import java.util.*
+import java.util.Date
 
 class EventPostCallRealIntegrationShould : BaseRealIntegrationTest() {
     private lateinit var eventStore: EventStore
@@ -59,8 +59,8 @@ class EventPostCallRealIntegrationShould : BaseRealIntegrationTest() {
     @Before
     override fun setUp() {
         super.setUp()
-        eventStore = EventStoreImpl(d2.databaseAdapter())
-        trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(d2.databaseAdapter())
+        eventStore = koin.get()
+        trackedEntityDataValueStore = koin.get()
         val uidGenerator: UidGenerator = UidGeneratorImpl()
         eventUid1 = uidGenerator.generate()
         eventUid2 = uidGenerator.generate()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/BaseFileResourceRoutineIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/BaseFileResourceRoutineIntegrationShould.kt
@@ -29,23 +29,24 @@
 package org.hisp.dhis.android.core.fileresource.internal
 
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.category.internal.CategoryComboStoreImpl
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
-import org.hisp.dhis.android.core.dataset.internal.DataSetElementStoreImpl
-import org.hisp.dhis.android.core.dataset.internal.DataSetStoreImpl
-import org.hisp.dhis.android.core.datavalue.internal.DataValueStoreImpl
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
-import org.hisp.dhis.android.core.icon.internal.CustomIconStoreImpl
-import org.hisp.dhis.android.core.option.internal.OptionSetStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStageStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStoreImpl
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.category.internal.CategoryComboStore
+import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
+import org.hisp.dhis.android.core.dataset.internal.DataSetElementStore
+import org.hisp.dhis.android.core.dataset.internal.DataSetStore
+import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.event.internal.EventStore
+import org.hisp.dhis.android.core.icon.internal.CustomIconStore
+import org.hisp.dhis.android.core.option.internal.OptionSetStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
+import org.hisp.dhis.android.core.program.internal.ProgramStageStore
+import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataDispatcher
 import org.junit.After
 import org.junit.Before
@@ -53,29 +54,29 @@ import org.junit.Before
 internal open class BaseFileResourceRoutineIntegrationShould : BaseMockIntegrationTestMetadataDispatcher() {
 
     // Data stores
-    protected val eventStore = EventStoreImpl(databaseAdapter)
-    protected val trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
-    protected val trackedEntityAttributeValueStore = TrackedEntityAttributeValueStoreImpl(databaseAdapter)
-    protected val dataValueStore = DataValueStoreImpl(databaseAdapter)
-    protected val fileResourceStore = FileResourceStoreImpl(d2.databaseAdapter())
-    protected val customIconStore = CustomIconStoreImpl(d2.databaseAdapter())
-    private val optionSetStore = OptionSetStoreImpl(d2.databaseAdapter())
+    protected val eventStore: EventStore = koin.get()
+    protected val trackedEntityDataValueStore: TrackedEntityDataValueStore = koin.get()
+    protected val trackedEntityAttributeValueStore: TrackedEntityAttributeValueStore = koin.get()
+    protected val dataValueStore: DataValueStore = koin.get()
+    protected val fileResourceStore: FileResourceStore = koin.get()
+    protected val customIconStore: CustomIconStore = koin.get()
+    private val optionSetStore: OptionSetStore = koin.get()
 
     // Metadata stores
-    protected val categoryComboStore = CategoryComboStoreImpl(databaseAdapter)
+    protected val categoryComboStore: CategoryComboStore = koin.get()
 
-    protected val dataElementStore = DataElementStoreImpl(databaseAdapter)
-    protected val organisationUnitStore = OrganisationUnitStoreImpl(databaseAdapter)
+    protected val dataElementStore: DataElementStore = koin.get()
+    protected val organisationUnitStore: OrganisationUnitStore = koin.get()
 
-    protected val trackedEntityTypeStore = TrackedEntityTypeStoreImpl(databaseAdapter)
-    protected val trackedEntityAttributeStore = TrackedEntityAttributeStoreImpl(databaseAdapter)
-    protected val trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(databaseAdapter)
-    protected val enrollmentStore = EnrollmentStoreImpl(databaseAdapter)
-    protected val programStore = ProgramStoreImpl(databaseAdapter)
-    protected val programStageStore = ProgramStageStoreImpl(databaseAdapter)
+    protected val trackedEntityTypeStore: TrackedEntityTypeStore = koin.get()
+    protected val trackedEntityAttributeStore: TrackedEntityAttributeStore = koin.get()
+    protected val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
+    protected val enrollmentStore: EnrollmentStore = koin.get()
+    protected val programStore: ProgramStore = koin.get()
+    protected val programStageStore: ProgramStageStore = koin.get()
 
-    protected val dataSetStore = DataSetStoreImpl(databaseAdapter)
-    protected val dataSetElementStore = DataSetElementStoreImpl(databaseAdapter)
+    protected val dataSetStore: DataSetStore = koin.get()
+    protected val dataSetElementStore: DataSetElementStore = koin.get()
 
     @Before
     fun setUp() = runTest {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/OptionCallShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/OptionCallShould.kt
@@ -31,9 +31,10 @@ import androidx.test.runner.AndroidJUnit4
 import com.google.common.truth.Truth
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyCleanerImpl
-import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStoreImpl
+import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyEnqueable
 import org.junit.Before
 import org.junit.Test
@@ -107,7 +108,7 @@ class OptionCallShould : BaseMockIntegrationTestEmptyEnqueable() {
             }
             ForeignKeyCleanerImpl(
                 databaseAdapter,
-                ForeignKeyViolationStoreImpl(databaseAdapter),
+                koin.get<ForeignKeyViolationStore>(),
             ).cleanForeignKeyErrors()
             optionSets!!
         }
@@ -121,7 +122,7 @@ class OptionCallShould : BaseMockIntegrationTestEmptyEnqueable() {
                 options = optionCall.invoke()
             } catch (ignored: Exception) {
             }
-            ForeignKeyCleanerImpl(databaseAdapter, ForeignKeyViolationStoreImpl(databaseAdapter))
+            ForeignKeyCleanerImpl(databaseAdapter, koin.get<ForeignKeyViolationStore>())
                 .cleanForeignKeyErrors()
             options
         }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/OptionSetCallShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/OptionSetCallShould.kt
@@ -32,11 +32,12 @@ import com.google.common.truth.Truth
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyCleanerImpl
-import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStoreImpl
+import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyEnqueable
 import org.junit.Before
 import org.junit.Test
@@ -98,7 +99,7 @@ class OptionSetCallShould : BaseMockIntegrationTestEmptyEnqueable() {
                 optionSets = optionSetCall.invoke()
             } catch (ignored: Exception) {
             }
-            ForeignKeyCleanerImpl(databaseAdapter, ForeignKeyViolationStoreImpl(databaseAdapter))
+            ForeignKeyCleanerImpl(databaseAdapter, koin.get<ForeignKeyViolationStore>())
                 .cleanForeignKeyErrors()
             optionSets
         }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
@@ -31,21 +31,21 @@ import android.content.ContentValues
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo
 import org.hisp.dhis.android.core.category.CategoryComboTableInfo
 import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.core.data.organisationunit.OrganisationUnitSamples
 import org.hisp.dhis.android.core.dataset.DataSetTableInfo
 import org.hisp.dhis.android.core.dataset.internal.DataSetOrganisationUnitLinkHandler
-import org.hisp.dhis.android.core.dataset.internal.DataSetOrganisationUnitLinkStoreImpl
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.program.ProgramTableInfo
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
 import org.hisp.dhis.android.core.user.UserTableInfo
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkHandler
-import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStoreImpl
-import org.hisp.dhis.android.core.user.internal.UserStoreImpl
+import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
+import org.hisp.dhis.android.core.user.internal.UserStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyEnqueable
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.AfterClass
@@ -84,22 +84,20 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
         // inserting dataSets for creating OrgUnitDataSetLinks
         insertDataSet()
         val organisationUnitHandler = OrganisationUnitHandler(
-            OrganisationUnitStoreImpl(databaseAdapter),
-            UserOrganisationUnitLinkHandler(UserOrganisationUnitLinkStoreImpl(databaseAdapter)),
-            OrganisationUnitProgramLinkHandler(OrganisationUnitProgramLinkStoreImpl(databaseAdapter)),
-            DataSetOrganisationUnitLinkHandler(DataSetOrganisationUnitLinkStoreImpl(databaseAdapter)),
-            OrganisationUnitGroupHandler(OrganisationUnitGroupStoreImpl(databaseAdapter)),
-            OrganisationUnitOrganisationUnitGroupLinkHandler(
-                OrganisationUnitOrganisationUnitGroupLinkStoreImpl(databaseAdapter),
-            ),
+            koin.get(),
+            UserOrganisationUnitLinkHandler(koin.get()),
+            OrganisationUnitProgramLinkHandler(koin.get()),
+            DataSetOrganisationUnitLinkHandler(koin.get()),
+            OrganisationUnitGroupHandler(koin.get()),
+            OrganisationUnitOrganisationUnitGroupLinkHandler(koin.get()),
         )
         val organisationUnitCollectionCleaner = OrganisationUnitCollectionCleaner(databaseAdapter)
         organisationUnitCall = {
             OrganisationUnitCall(
                 organisationUnitNetworkHandler,
                 organisationUnitHandler,
-                UserOrganisationUnitLinkStoreImpl(databaseAdapter),
-                OrganisationUnitStoreImpl(databaseAdapter),
+                koin.get(),
+                koin.get(),
                 organisationUnitCollectionCleaner,
             ).download(user)
         }
@@ -124,7 +122,7 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
     @Test
     fun persist_organisation_unit_tree() = runTest {
         organisationUnitCall.invoke()
-        val organisationUnitStore = OrganisationUnitStoreImpl(databaseAdapter)
+        val organisationUnitStore: OrganisationUnitStore = koin.get()
         val dbAfroArabicClinic = organisationUnitStore.selectByUid(expectedAfroArabicClinic.uid())
         val dbAdonkiaCHP = organisationUnitStore.selectByUid(expectedAdonkiaCHP.uid())
 
@@ -135,7 +133,7 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
     @Test
     fun persist_organisation_unit_user_links() = runTest {
         organisationUnitCall.invoke()
-        val userOrganisationUnitStore = UserOrganisationUnitLinkStoreImpl(databaseAdapter)
+        val userOrganisationUnitStore: UserOrganisationUnitLinkStore = koin.get()
         val userOrganisationUnitLinks = userOrganisationUnitStore.selectAll()
         val linkOrganisationUnits: MutableSet<String> = HashSet(2)
 
@@ -156,7 +154,7 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
             d2.databaseAdapter().delete(ProgramTableInfo.TABLE_INFO.name())
             d2.databaseAdapter().delete(DataSetTableInfo.TABLE_INFO.name())
             d2.databaseAdapter().delete(CategoryComboTableInfo.TABLE_INFO.name())
-            UserStoreImpl(d2.databaseAdapter()).delete(userId)
+            koin.get<UserStore>().delete(userId)
         }
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/PeriodMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/PeriodMockIntegrationShould.kt
@@ -29,9 +29,9 @@ package org.hisp.dhis.android.core.period
 
 import com.google.common.truth.Truth
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.common.BaseIdentifiableObject
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.period.internal.PeriodStore
-import org.hisp.dhis.android.core.period.internal.PeriodStoreImpl
+import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 import java.text.ParseException
@@ -42,7 +42,7 @@ class PeriodMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     fun get_period_passing_period_type_and_a_date() {
         val period = d2.periodModule().periodHelper().blockingGetPeriodForPeriodTypeAndDate(
             PeriodType.BiWeekly,
-            BaseIdentifiableObject.DATE_FORMAT.parse("2019-07-08T12:24:25.319"),
+            "2019-07-08T12:24:25.319".toJavaDate()!!,
         )
         Truth.assertThat(period.periodId()).isEqualTo("2019BiW14")
     }
@@ -50,9 +50,9 @@ class PeriodMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     @Test
     @Throws(ParseException::class)
     fun create_period_in_database_if_not_exist() = runTest {
-        val periodStore: PeriodStore = PeriodStoreImpl(databaseAdapter)
+        val periodStore: PeriodStore = koin.get()
 
-        val date = BaseIdentifiableObject.DATE_FORMAT.parse("2010-12-24T12:24:25.319")
+        val date = "2010-12-24T12:24:25.319".toJavaDate()!!
 
         var periodInDb = periodStore.selectPeriodByTypeAndDate(PeriodType.Monthly, date)
         Truth.assertThat(periodInDb).isNull()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodHelperIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodHelperIntegrationShould.kt
@@ -31,12 +31,13 @@ import com.google.common.truth.Truth.assertThat
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.*
+import java.util.Date
 
 @RunWith(D2JunitRunner::class)
 class PeriodHelperIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
@@ -59,6 +60,6 @@ class PeriodHelperIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
 
         assertThat(periods.size).isEqualTo(1)
 
-        PeriodStoreImpl(databaseAdapter).delete()
+        koin.get<PeriodStore>().delete()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.program.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.category.CategoryComboTableInfo
 import org.hisp.dhis.android.core.category.internal.CreateCategoryComboUtils
 import org.hisp.dhis.android.core.data.program.ProgramRuleVariableSamples
@@ -38,7 +39,7 @@ import org.hisp.dhis.android.core.dataelement.CreateDataElementUtils
 import org.hisp.dhis.android.core.dataelement.DataElementTableInfo
 import org.hisp.dhis.android.core.program.CreateProgramStageUtils
 import org.hisp.dhis.android.core.program.ProgramStageTableInfo
-import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStoreImpl
+import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStore
 import org.hisp.dhis.android.core.trackedentity.CreateTrackedEntityAttributeUtils
 import org.hisp.dhis.android.core.trackedentity.CreateTrackedEntityUtils
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeTableInfo
@@ -55,7 +56,7 @@ class ProgramEndpointCallMockIntegrationShould : BaseMockIntegrationTestEmptyEnq
 
     @Test
     fun persist_program_when_call() = runTest {
-        val store = ProgramStoreImpl(databaseAdapter)
+        val store: ProgramStore = koin.get()
 
         assertThat(store.count()).isEqualTo(3)
         assertThat(store.selectByUid(PROGRAM_UID)!!.toBuilder().id(null).build())
@@ -64,7 +65,7 @@ class ProgramEndpointCallMockIntegrationShould : BaseMockIntegrationTestEmptyEnq
 
     @Test
     fun persist_program_rule_variables_on_call() = runTest {
-        val store = ProgramRuleVariableStoreImpl(databaseAdapter)
+        val store: ProgramRuleVariableStore = koin.get()
 
         assertThat(store.count()).isEqualTo(2)
         assertThat(store.selectByUid("omrL0gtPpDL")).isEqualTo(ProgramRuleVariableSamples.getHemoglobin())
@@ -72,7 +73,7 @@ class ProgramEndpointCallMockIntegrationShould : BaseMockIntegrationTestEmptyEnq
 
     @Test
     fun persist_program_tracker_entity_attributes_when_call() = runTest {
-        val store = ProgramTrackedEntityAttributeStoreImpl(databaseAdapter)
+        val store: ProgramTrackedEntityAttributeStore = koin.get()
 
         assertThat(store.count()).isEqualTo(2)
         assertThat(store.selectByUid("YhqgQ6Iy4c4"))
@@ -81,7 +82,7 @@ class ProgramEndpointCallMockIntegrationShould : BaseMockIntegrationTestEmptyEnq
 
     @Test
     fun not_persist_relationship_type_when_call() = runTest {
-        val store = RelationshipTypeStoreImpl(databaseAdapter)
+        val store: RelationshipTypeStore = koin.get()
         assertThat(store.count()).isEqualTo(0)
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseProgramIndicatorSQLExecutorIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/programindicatorengine/BaseProgramIndicatorSQLExecutorIntegrationShould.kt
@@ -33,29 +33,27 @@ import org.hisp.dhis.android.core.analytics.aggregated.internal.AnalyticsService
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorIntegrationShould
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.generator
 import org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator.BaseEvaluatorSamples.program
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.AggregationType
 import org.hisp.dhis.android.core.common.AnalyticsType
 import org.hisp.dhis.android.core.common.ObjectWithUid
-import org.hisp.dhis.android.core.constant.internal.ConstantStoreImpl
-import org.hisp.dhis.android.core.dataelement.internal.DataElementStoreImpl
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundaryType
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.programindicatorengine.BaseTrackerDataIntegrationHelper.Companion.`var`
 import org.hisp.dhis.android.core.program.programindicatorengine.internal.ProgramIndicatorSQLExecutor
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStoreImpl
 
 internal open class BaseProgramIndicatorSQLExecutorIntegrationShould : BaseEvaluatorIntegrationShould() {
 
     protected val programIndicatorEvaluator = ProgramIndicatorSQLExecutor(
-        ConstantStoreImpl(databaseAdapter),
-        DataElementStoreImpl(databaseAdapter),
-        TrackedEntityAttributeStoreImpl(databaseAdapter),
+        koin.get(),
+        koin.get(),
+        koin.get(),
         databaseAdapter,
     )
 
-    protected val helper = BaseTrackerDataIntegrationHelper(databaseAdapter)
+    protected val helper = BaseTrackerDataIntegrationHelper()
 
     protected suspend fun evaluateTeiCount(
         filter: String? = null,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManagerRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManagerRealIntegrationShould.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
 import org.hisp.dhis.android.core.arch.call.factories.internal.QueryCallFactory
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.category.CategoryCombo
 import org.hisp.dhis.android.core.category.CategoryComboTableInfo
 import org.hisp.dhis.android.core.common.Access
@@ -42,19 +43,16 @@ import org.hisp.dhis.android.core.data.utils.FillPropertiesTestUtils.FUTURE_DATE
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStoreImpl
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStore
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
 import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStoreImpl
+import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeReservedValueHandler
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeReservedValueQuery
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeReservedValueStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeReservedValueStoreImpl
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStoreImpl
 import org.junit.Before
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers
@@ -92,13 +90,11 @@ internal class TrackedEntityAttributeReservedValueManagerRealIntegrationShould :
     override fun setUp() = runTest {
         super.setUp()
         login()
-        store = TrackedEntityAttributeReservedValueStoreImpl(d2.databaseAdapter())
-        val organisationUnitStore: OrganisationUnitStore =
-            OrganisationUnitStoreImpl(d2.databaseAdapter())
-        val trackedEntityAttributeStore: TrackedEntityAttributeStore =
-            TrackedEntityAttributeStoreImpl(d2.databaseAdapter())
+        store = koin.get()
+        val organisationUnitStore: OrganisationUnitStore = koin.get()
+        val trackedEntityAttributeStore: TrackedEntityAttributeStore = koin.get()
         manager = d2.trackedEntityModule().reservedValueManager()
-        val handler = TrackedEntityAttributeReservedValueHandler(store as TrackedEntityAttributeReservedValueStoreImpl)
+        val handler = TrackedEntityAttributeReservedValueHandler(store)
         val trackedEntityAttributeReservedValues: MutableList<TrackedEntityAttributeReservedValue> =
             ArrayList()
         val reservedValueBuilder = TrackedEntityAttributeReservedValue.builder()
@@ -129,19 +125,19 @@ internal class TrackedEntityAttributeReservedValueManagerRealIntegrationShould :
         val program = Program.builder().uid(programUid)
             .categoryCombo(ObjectWithUid.create(categoryCombo.uid()))
             .access(Access.create(null, null, DataAccess.create(true, true))).build()
-        ProgramStoreImpl(d2.databaseAdapter()).insert(program)
+        koin.get<ProgramStore>().insert(program)
         val programTrackedEntityAttribute = ProgramTrackedEntityAttribute.builder()
             .uid("ptea_uid")
             .trackedEntityAttribute(ObjectWithUid.create(ownerUid))
             .program(ObjectWithUid.create(programUid))
             .build()
-        ProgramTrackedEntityAttributeStoreImpl(d2.databaseAdapter()).insert(
+        koin.get<ProgramTrackedEntityAttributeStore>().insert(
             programTrackedEntityAttribute,
         )
         val organisationUnitProgramLink =
             OrganisationUnitProgramLink.builder().organisationUnit(organisationUnitUid)
                 .program(programUid).build()
-        OrganisationUnitProgramLinkStoreImpl(d2.databaseAdapter()).insert(
+        koin.get<OrganisationUnitProgramLinkStore>().insert(
             organisationUnitProgramLink,
         )
         runBlocking {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/BasePayloadGeneratorMockIntegration.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/BasePayloadGeneratorMockIntegration.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import org.hisp.dhis.android.core.arch.call.executors.internal.D2CallExecutor
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.common.State
@@ -38,23 +39,20 @@ import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityInstanceSample
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.enrollment.EnrollmentInternalAccessor
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.internal.EventStore
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyCleanerImpl
-import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStoreImpl
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStageStoreImpl
+import org.hisp.dhis.android.core.maintenance.internal.ForeignKeyViolationStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
+import org.hisp.dhis.android.core.program.internal.ProgramStageStore
 import org.hisp.dhis.android.core.program.internal.ProgramStore
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
 import org.hisp.dhis.android.core.relationship.RelationshipConstraintType
 import org.hisp.dhis.android.core.relationship.RelationshipHelper
 import org.hisp.dhis.android.core.relationship.RelationshipItem
-import org.hisp.dhis.android.core.relationship.internal.RelationshipItemStoreImpl
-import org.hisp.dhis.android.core.relationship.internal.RelationshipStoreImpl
-import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStoreImpl
+import org.hisp.dhis.android.core.relationship.internal.RelationshipItemStore
+import org.hisp.dhis.android.core.relationship.internal.RelationshipStore
+import org.hisp.dhis.android.core.relationship.internal.RelationshipTypeStore
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceInternalAccessor
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType
@@ -81,10 +79,10 @@ open class BasePayloadGeneratorMockIntegration : BaseMockIntegrationTestMetadata
     }
 
     protected suspend fun storeTrackerData() {
-        val orgUnit = OrganisationUnitStoreImpl(databaseAdapter).selectFirst()!!
-        val teiType = TrackedEntityTypeStoreImpl(databaseAdapter).selectFirst()!!
+        val orgUnit = koin.get<OrganisationUnitStore>().selectFirst()!!
+        val teiType = koin.get<TrackedEntityTypeStore>().selectFirst()!!
         val program = d2.programModule().programs().one().blockingGet()!!
-        val programStage = ProgramStageStoreImpl(databaseAdapter).selectFirst()!!
+        val programStage = koin.get<ProgramStageStore>().selectFirst()!!
 
         val dataValue1 = TrackedEntityDataValueSamples.get().toBuilder()
             .syncState(State.TO_UPDATE)
@@ -209,9 +207,9 @@ open class BasePayloadGeneratorMockIntegration : BaseMockIntegrationTestMetadata
     }
 
     protected suspend fun storeSimpleTrackedEntityInstance(teiUid: String, state: State) {
-        val orgUnit = OrganisationUnitStoreImpl(databaseAdapter).selectFirst()
-        val teiType = TrackedEntityTypeStoreImpl(databaseAdapter).selectFirst()
-        TrackedEntityInstanceStoreImpl(databaseAdapter).insert(
+        val orgUnit = koin.get<OrganisationUnitStore>().selectFirst()
+        val teiType = koin.get<TrackedEntityTypeStore>().selectFirst()
+        koin.get<TrackedEntityInstanceStore>().insert(
             TrackedEntityInstanceSamples.get().toBuilder()
                 .uid(teiUid)
                 .trackedEntityType(teiType!!.uid())
@@ -237,28 +235,28 @@ open class BasePayloadGeneratorMockIntegration : BaseMockIntegrationTestMetadata
         from: RelationshipItem,
         to: RelationshipItem,
     ) {
-        val relationshipType = RelationshipTypeStoreImpl(databaseAdapter).selectFirst()
+        val relationshipType = koin.get<RelationshipTypeStore>().selectFirst()
         val executor = D2CallExecutor.create(databaseAdapter)
         executor.executeD2CallTransactionally<Unit> {
-            RelationshipStoreImpl(databaseAdapter).insert(
+            koin.get<RelationshipStore>().insert(
                 RelationshipSamples.get230(relationshipUid, from, to).toBuilder()
                     .relationshipType(relationshipType!!.uid())
                     .syncState(State.TO_POST)
                     .build(),
             )
-            RelationshipItemStoreImpl(databaseAdapter).insert(
+            koin.get<RelationshipItemStore>().insert(
                 from.toBuilder()
                     .relationship(ObjectWithUid.create(relationshipUid))
                     .relationshipItemType(RelationshipConstraintType.FROM)
                     .build(),
             )
-            RelationshipItemStoreImpl(databaseAdapter).insert(
+            koin.get<RelationshipItemStore>().insert(
                 to.toBuilder()
                     .relationship(ObjectWithUid.create(relationshipUid))
                     .relationshipItemType(RelationshipConstraintType.TO)
                     .build(),
             )
-            ForeignKeyCleanerImpl(databaseAdapter, ForeignKeyViolationStoreImpl(databaseAdapter))
+            ForeignKeyCleanerImpl(databaseAdapter, koin.get<ForeignKeyViolationStore>())
                 .cleanForeignKeyErrors()
         }
     }
@@ -285,13 +283,13 @@ open class BasePayloadGeneratorMockIntegration : BaseMockIntegrationTestMetadata
         @Throws(Exception::class)
         fun setUp() {
             setUpClass()
-            teiStore = TrackedEntityInstanceStoreImpl(databaseAdapter)
-            teiDataValueStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
-            teiAttributeValueStore = TrackedEntityAttributeValueStoreImpl(databaseAdapter)
-            eventStore = EventStoreImpl(databaseAdapter)
-            enrollmentStore = EnrollmentStoreImpl(databaseAdapter)
-            trackedEntityTypeStore = TrackedEntityTypeStoreImpl(databaseAdapter)
-            programStore = ProgramStoreImpl(databaseAdapter)
+            teiStore = koin.get()
+            teiDataValueStore = koin.get()
+            teiAttributeValueStore = koin.get()
+            eventStore = koin.get()
+            enrollmentStore = koin.get()
+            trackedEntityTypeStore = koin.get()
+            programStore = koin.get()
         }
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostCallRealIntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.trackedentity.internal
 import com.google.common.truth.Truth
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.arch.helpers.UidGenerator
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl
@@ -41,11 +42,9 @@ import org.hisp.dhis.android.core.enrollment.EnrollmentCreateProjection
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStoreImpl
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.event.internal.EventStore
-import org.hisp.dhis.android.core.event.internal.EventStoreImpl
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
@@ -92,11 +91,11 @@ class TrackedEntityInstancePostCallRealIntegrationShould : BaseRealIntegrationTe
     override fun setUp() {
         super.setUp()
 
-        trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(d2.databaseAdapter())
-        enrollmentStore = EnrollmentStoreImpl(d2.databaseAdapter())
-        eventStore = EventStoreImpl(d2.databaseAdapter())
-        trackedEntityAttributeValueStore = TrackedEntityAttributeValueStoreImpl(d2.databaseAdapter())
-        trackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(d2.databaseAdapter())
+        trackedEntityInstanceStore = koin.get()
+        enrollmentStore = koin.get()
+        eventStore = koin.get()
+        trackedEntityAttributeValueStore = koin.get()
+        trackedEntityDataValueStore = koin.get()
 
         uidGenerator = UidGeneratorImpl()
         orgUnitUid = "DiszpKrYNg8"

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
@@ -29,22 +29,27 @@ package org.hisp.dhis.android.core.trackedentity.search
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOperator
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem
-import org.hisp.dhis.android.core.common.*
+import org.hisp.dhis.android.core.common.AssignedUserMode
+import org.hisp.dhis.android.core.common.DateFilterPeriod
+import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
+import org.hisp.dhis.android.core.common.RelativePeriod
+import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
 class TrackedEntityInstanceLocalQueryHelperMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
-    private val trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(databaseAdapter)
+    private val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
 
     private val clockProvider = ClockProviderFactory.clockProvider
     private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider))

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/LogoutCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/LogoutCallRealIntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.user.internal
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.access.SqliteCheckerUtility
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStore
 import org.hisp.dhis.android.core.event.EventTableInfo
@@ -43,7 +44,7 @@ class LogoutCallRealIntegrationShould : BaseRealIntegrationTest() {
     @Before
     override fun setUp() {
         super.setUp()
-        authenticatedUserStore = AuthenticatedUserStoreImpl(d2.databaseAdapter())
+        authenticatedUserStore = koin.get()
     }
 
     // @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/mock/BaseMockIntegrationTestFullDispatcher.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/mock/BaseMockIntegrationTestFullDispatcher.kt
@@ -28,18 +28,19 @@
 package org.hisp.dhis.android.core.utils.integration.mock
 
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.data.datavalue.DataValueConflictSamples
 import org.hisp.dhis.android.core.data.imports.TrackerImportConflictSamples
 import org.hisp.dhis.android.core.data.maintenance.D2ErrorSamples
 import org.hisp.dhis.android.core.datastore.KeyValuePair
-import org.hisp.dhis.android.core.datastore.internal.LocalDataStoreStoreImpl
-import org.hisp.dhis.android.core.datavalue.internal.DataValueConflictStoreImpl
+import org.hisp.dhis.android.core.datastore.internal.LocalDataStoreStore
+import org.hisp.dhis.android.core.datavalue.internal.DataValueConflictStore
 import org.hisp.dhis.android.core.imports.ImportStatus
-import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStoreImpl
+import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
-import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStoreImpl
+import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStore
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.AfterClass
 import org.junit.BeforeClass
@@ -98,7 +99,7 @@ abstract class BaseMockIntegrationTestFullDispatcher : BaseMockIntegrationTest()
         }
 
         private suspend fun storeSomeD2Errors() {
-            val d2ErrorStore = D2ErrorStoreImpl(databaseAdapter)
+            val d2ErrorStore: D2ErrorStore = koin.get()
             d2ErrorStore.insert(D2ErrorSamples.get())
             d2ErrorStore.insert(
                 D2Error.builder()
@@ -112,7 +113,7 @@ abstract class BaseMockIntegrationTestFullDispatcher : BaseMockIntegrationTest()
         }
 
         private suspend fun storeSomeConflicts() {
-            val trackerImportConflictStore = TrackerImportConflictStoreImpl(databaseAdapter)
+            val trackerImportConflictStore: TrackerImportConflictStore = koin.get()
             trackerImportConflictStore.insert(
                 TrackerImportConflictSamples.get().toBuilder()
                     .trackedEntityInstance(null)
@@ -133,7 +134,7 @@ abstract class BaseMockIntegrationTestFullDispatcher : BaseMockIntegrationTest()
                     .build(),
             )
 
-            val dataValueConflictStore = DataValueConflictStoreImpl(databaseAdapter)
+            val dataValueConflictStore: DataValueConflictStore = koin.get()
 
             dataValueConflictStore.insert(DataValueConflictSamples.get())
             dataValueConflictStore.insert(
@@ -157,7 +158,7 @@ abstract class BaseMockIntegrationTestFullDispatcher : BaseMockIntegrationTest()
         }
 
         private suspend fun storeSomeKeyValuesInLocalDataStore() {
-            val dataStore = LocalDataStoreStoreImpl(databaseAdapter)
+            val dataStore: LocalDataStoreStore = koin.get()
 
             dataStore.insert(
                 KeyValuePair.builder()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/wipe/WipeDBCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/wipe/WipeDBCallMockIntegrationShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.wipe
 
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.data.database.DatabaseAssert.Companion.assertThatDatabase
 import org.hisp.dhis.android.core.data.datastore.KeyValuePairSamples
 import org.hisp.dhis.android.core.data.maps.MapLayerImageryProviderSamples
@@ -38,24 +39,24 @@ import org.hisp.dhis.android.core.data.tracker.importer.internal.TrackerJobObjec
 import org.hisp.dhis.android.core.data.usecase.stock.InternalStockUseCaseSamples
 import org.hisp.dhis.android.core.data.usecase.stock.InternalStockUseCaseTransactionSamples
 import org.hisp.dhis.android.core.datastore.KeyValuePair
-import org.hisp.dhis.android.core.datastore.internal.LocalDataStoreStoreImpl
+import org.hisp.dhis.android.core.datastore.internal.LocalDataStoreStore
 import org.hisp.dhis.android.core.datavalue.DataValueConflict
-import org.hisp.dhis.android.core.datavalue.internal.DataValueConflictStoreImpl
+import org.hisp.dhis.android.core.datavalue.internal.DataValueConflictStore
 import org.hisp.dhis.android.core.fileresource.FileResource
-import org.hisp.dhis.android.core.fileresource.internal.FileResourceStoreImpl
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceStore
 import org.hisp.dhis.android.core.imports.TrackerImportConflict
-import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStoreImpl
+import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
-import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStoreImpl
-import org.hisp.dhis.android.core.map.layer.internal.MapLayerImageryProviderStoreImpl
-import org.hisp.dhis.android.core.map.layer.internal.MapLayerStoreImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStoreImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStoreImpl
-import org.hisp.dhis.android.core.trackedentity.ownership.ProgramTempOwnerStoreImpl
-import org.hisp.dhis.android.core.tracker.importer.internal.TrackerJobObjectStoreImpl
-import org.hisp.dhis.android.core.usecase.stock.internal.StockUseCaseStoreImpl
-import org.hisp.dhis.android.core.usecase.stock.internal.StockUseCaseTransactionLinkStoreImpl
+import org.hisp.dhis.android.core.maintenance.internal.D2ErrorStore
+import org.hisp.dhis.android.core.map.layer.internal.MapLayerImageryProviderStore
+import org.hisp.dhis.android.core.map.layer.internal.MapLayerStore
+import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStore
+import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStore
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramTempOwnerStore
+import org.hisp.dhis.android.core.tracker.importer.internal.TrackerJobObjectStore
+import org.hisp.dhis.android.core.usecase.stock.internal.StockUseCaseStore
+import org.hisp.dhis.android.core.usecase.stock.internal.StockUseCaseTransactionLinkStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
@@ -95,43 +96,43 @@ class WipeDBCallMockIntegrationShould : BaseMockIntegrationTestEmptyDispatcher()
     }
 
     private suspend fun givenOthersInDatabase() {
-        D2ErrorStoreImpl(databaseAdapter).insert(
+        koin.get<D2ErrorStore>().insert(
             D2Error.builder()
                 .errorCode(D2ErrorCode.API_RESPONSE_PROCESS_ERROR)
                 .errorDescription("Sample error")
                 .build(),
         )
-        TrackerImportConflictStoreImpl(databaseAdapter).insert(TrackerImportConflict.builder().build())
-        FileResourceStoreImpl(databaseAdapter).insert(FileResource.builder().uid("uid").build())
-        TrackerJobObjectStoreImpl(databaseAdapter).insert(TrackerJobObjectSamples.get1())
-        DataValueConflictStoreImpl(databaseAdapter).insert(DataValueConflict.builder().build())
-        LocalDataStoreStoreImpl(databaseAdapter).insert(
+        koin.get<TrackerImportConflictStore>().insert(TrackerImportConflict.builder().build())
+        koin.get<FileResourceStore>().insert(FileResource.builder().uid("uid").build())
+        koin.get<TrackerJobObjectStore>().insert(TrackerJobObjectSamples.get1())
+        koin.get<DataValueConflictStore>().insert(DataValueConflict.builder().build())
+        koin.get<LocalDataStoreStore>().insert(
             KeyValuePair.builder()
                 .key("key1")
                 .value("value1")
                 .build(),
         )
-        LocalDataStoreStoreImpl(databaseAdapter).insert(
+        koin.get<LocalDataStoreStore>().insert(
             KeyValuePair.builder()
                 .key("key2")
                 .value("value2")
                 .build(),
         )
-        ProgramTempOwnerStoreImpl(databaseAdapter).insert(ProgramTempOwnerSamples.programTempOwner)
+        koin.get<ProgramTempOwnerStore>().insert(ProgramTempOwnerSamples.programTempOwner)
 
-        SMSConfigStoreImpl(databaseAdapter).insert(KeyValuePairSamples.keyValuePairSample)
-        SMSOngoingSubmissionStoreImpl(databaseAdapter).insert(SMSOngoingSubmissionSample.get)
+        koin.get<SMSConfigStore>().insert(KeyValuePairSamples.keyValuePairSample)
+        koin.get<SMSOngoingSubmissionStore>().insert(SMSOngoingSubmissionSample.get)
 
-        StockUseCaseStoreImpl(databaseAdapter).insert(
+        koin.get<StockUseCaseStore>().insert(
             InternalStockUseCaseSamples.get()
                 .toBuilder().uid("lxAQ7Zs9VYR").build(),
         )
-        StockUseCaseTransactionLinkStoreImpl(databaseAdapter).insert(
+        koin.get<StockUseCaseTransactionLinkStore>().insert(
             InternalStockUseCaseTransactionSamples.get()
                 .toBuilder().programUid("lxAQ7Zs9VYR").build(),
         )
 
-        MapLayerStoreImpl(databaseAdapter).insert(MapLayerSamples.get())
-        MapLayerImageryProviderStoreImpl(databaseAdapter).insert(MapLayerImageryProviderSamples.get())
+        koin.get<MapLayerStore>().insert(MapLayerSamples.get())
+        koin.get<MapLayerImageryProviderStore>().insert(MapLayerImageryProviderSamples.get())
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/wipe/WipeDBCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/wipe/WipeDBCallRealIntegrationShould.kt
@@ -30,9 +30,10 @@ package org.hisp.dhis.android.core.wipe
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.BaseRealIntegrationTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.data.database.DatabaseAssert.Companion.assertThatDatabase
 import org.hisp.dhis.android.core.event.internal.EventCallFactory.create
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStoreImpl
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 
 class WipeDBCallRealIntegrationShould : BaseRealIntegrationTest() {
     // @Test
@@ -75,7 +76,7 @@ class WipeDBCallRealIntegrationShould : BaseRealIntegrationTest() {
         d2.userModule().logIn(username, password, url).blockingGet()
         d2.metadataModule().blockingDownload()
         d2.trackedEntityModule().trackedEntityInstanceDownloader().limit(5).blockingDownload()
-        val trackedEntityInstanceStore = TrackedEntityInstanceStoreImpl(d2.databaseAdapter())
+        val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
         var hasTrackedEntities = trackedEntityInstanceStore.count() > 0
         assertThat(hasTrackedEntities).isTrue()
         d2.wipeModule().wipeData()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreObjectRepositoryMockIntegrationShould.kt
@@ -29,8 +29,9 @@ package org.hisp.dhis.android.testapp.datastore
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
-import org.hisp.dhis.android.core.datastore.internal.DataStoreEntryStoreImpl
+import org.hisp.dhis.android.core.datastore.internal.DataStoreEntryStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -77,7 +78,7 @@ class DataStoreObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
             .value("new_namespace", "new_key")
         repository.blockingSet("value")
 
-        DataStoreEntryStoreImpl(databaseAdapter)
+        koin.get<DataStoreEntryStore>()
             .updateWhere(repository.blockingGet()!!.toBuilder().syncState(State.ERROR).build())
 
         assertThat(repository.blockingExists()).isTrue()
@@ -88,7 +89,7 @@ class DataStoreObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
         assertThat(repository.blockingGet()!!.deleted()).isTrue()
         assertThat(repository.blockingGet()!!.syncState()).isEqualTo(State.TO_UPDATE)
 
-        DataStoreEntryStoreImpl(databaseAdapter)
+        koin.get<DataStoreEntryStore>()
             .deleteWhere(repository.blockingGet()!!)
     }
 
@@ -98,7 +99,7 @@ class DataStoreObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
             .value("new_namespace", "new_key")
         repository.blockingSet("value")
 
-        DataStoreEntryStoreImpl(databaseAdapter)
+        koin.get<DataStoreEntryStore>()
             .updateWhere(repository.blockingGet()!!.toBuilder().syncState(State.TO_UPDATE).build())
 
         repository.blockingDelete()
@@ -110,7 +111,7 @@ class DataStoreObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
         assertThat(repository.blockingGet()!!.deleted()).isFalse()
         assertThat(repository.blockingGet()!!.syncState()).isEqualTo(State.TO_UPDATE)
 
-        DataStoreEntryStoreImpl(databaseAdapter)
+        koin.get<DataStoreEntryStore>()
             .deleteWhere(repository.blockingGet()!!)
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datavalue/DataValueObjectRepositoryMockIntegrationShould.kt
@@ -29,9 +29,10 @@ package org.hisp.dhis.android.testapp.datavalue
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datavalue.DataValueObjectRepository
-import org.hisp.dhis.android.core.datavalue.internal.DataValueStoreImpl
+import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
@@ -84,7 +85,7 @@ class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
     fun set_state_to_delete_if_state_is_not_to_post() = runTest {
         val repository = objectRepository()
         repository.blockingSet("value")
-        DataValueStoreImpl(databaseAdapter).setState(repository.blockingGet()!!, State.ERROR)
+        dataValueStore().setState(repository.blockingGet()!!, State.ERROR)
 
         assertThat(repository.blockingExists()).isTrue()
         assertThat(repository.blockingGet()!!.syncState()).isEqualTo(State.ERROR)
@@ -99,7 +100,7 @@ class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
     fun set_not_deleted_when_updating_deleted_value() = runTest {
         val repository = objectRepository()
         repository.blockingSet("value")
-        DataValueStoreImpl(databaseAdapter).setState(repository.blockingGet()!!, State.TO_UPDATE)
+        dataValueStore().setState(repository.blockingGet()!!, State.TO_UPDATE)
         repository.blockingDelete()
 
         assertThat(repository.blockingGet()!!.deleted()).isTrue()
@@ -141,7 +142,7 @@ class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
         val repository = objectRepository()
         repository.blockingSet("test_value")
         repository.setComment("Hey!")
-        DataValueStoreImpl(databaseAdapter).setState(repository.blockingGet()!!, State.SYNCED)
+        dataValueStore().setState(repository.blockingGet()!!, State.SYNCED)
 
         repository.setComment("Hey!")
         assertThat(repository.blockingGet()!!.syncState()).isEqualTo(State.SYNCED)
@@ -150,7 +151,7 @@ class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
         assertThat(repository.blockingGet()!!.syncState()).isEqualTo(State.TO_UPDATE)
 
         // Set to TO_POST state to truly delete de data value
-        DataValueStoreImpl(databaseAdapter).setState(repository.blockingGet()!!, State.TO_POST)
+        dataValueStore().setState(repository.blockingGet()!!, State.TO_POST)
         repository.blockingDelete()
         assertThat(repository.blockingExists()).isFalse()
     }
@@ -164,5 +165,9 @@ class DataValueObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
                 "Gmbgme7z9BF",
                 "bRowv6yZOF2",
             )
+    }
+
+    private fun dataValueStore(): DataValueStore {
+        return koin.get<DataValueStore>()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/enrollment/EnrollmentObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/enrollment/EnrollmentObjectRepositoryMockIntegrationShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.testapp.enrollment
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.common.IdentifiableColumns
@@ -41,7 +42,7 @@ import org.hisp.dhis.android.core.enrollment.EnrollmentTableInfo
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Assert
 import org.junit.Test
@@ -51,7 +52,7 @@ class EnrollmentObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestF
     @Test
     fun update_organisation_unit() = runTest {
         val orgUnitUid = "new_org_unit"
-        OrganisationUnitStoreImpl(databaseAdapter).insert(OrganisationUnit.builder().uid(orgUnitUid).build())
+        koin.get<OrganisationUnitStore>().insert(OrganisationUnit.builder().uid(orgUnitUid).build())
 
         val repository = objectRepository()
 
@@ -59,7 +60,7 @@ class EnrollmentObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestF
         assertThat(repository.blockingGet()!!.organisationUnit()).isEqualTo(orgUnitUid)
 
         repository.blockingDelete()
-        OrganisationUnitStoreImpl(databaseAdapter).delete(orgUnitUid)
+        koin.get<OrganisationUnitStore>().delete(orgUnitUid)
     }
 
     @Test(expected = D2Error::class)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventObjectRepositoryMockIntegrationShould.kt
@@ -31,6 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.event.EventCreateProjection

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventObjectRepositoryMockIntegrationShould.kt
@@ -29,8 +29,8 @@ package org.hisp.dhis.android.testapp.event
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.category.CategoryOptionCombo
-import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStoreImpl
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.event.EventCreateProjection
@@ -39,7 +39,7 @@ import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Assert
 import org.junit.Test
@@ -49,7 +49,7 @@ class EventObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDi
     @Test
     fun update_organisation_unit() = runTest {
         val orgUnitUid = "new_org_unit"
-        OrganisationUnitStoreImpl(databaseAdapter).insert(
+        koin.get<OrganisationUnitStore>().insert(
             OrganisationUnit.builder().uid(orgUnitUid).build(),
         )
 
@@ -59,7 +59,7 @@ class EventObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDi
         assertThat(repository.blockingGet()!!.organisationUnit()).isEqualTo(orgUnitUid)
 
         repository.blockingDelete()
-        OrganisationUnitStoreImpl(databaseAdapter).delete(orgUnitUid)
+        koin.get<OrganisationUnitStore>().delete(orgUnitUid)
     }
 
     @Test(expected = D2Error::class)
@@ -186,7 +186,7 @@ class EventObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDi
     @Test
     fun update_attribute_option_combo() = runTest {
         val attributeOptionCombo = "new_att_opt_comb"
-        CategoryOptionComboStoreImpl(databaseAdapter)
+        koin.get<CategoryOptionComboStore>()
             .insert(CategoryOptionCombo.builder().uid(attributeOptionCombo).build())
 
         val repository = objectRepository()
@@ -196,7 +196,7 @@ class EventObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDi
             .isEqualTo(attributeOptionCombo)
 
         repository.delete()
-        CategoryOptionComboStoreImpl(databaseAdapter).delete(attributeOptionCombo)
+        koin.get<CategoryOptionComboStore>().delete(attributeOptionCombo)
     }
 
     @Test(expected = D2Error::class)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
@@ -30,9 +30,10 @@ package org.hisp.dhis.android.testapp.fileresource
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper.getFileResourceDirectory
 import org.hisp.dhis.android.core.data.fileresource.RandomGeneratedInputStream
-import org.hisp.dhis.android.core.fileresource.internal.FileResourceStoreImpl
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceStore
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil.writeInputStream
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
@@ -65,7 +66,7 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestEmptyDispatc
         assertThat(savedFile.exists()).isTrue()
 
         savedFile.delete()
-        FileResourceStoreImpl(databaseAdapter).delete(fileResource.uid()!!)
+        koin.get<FileResourceStore>().delete(fileResource.uid()!!)
     }
 
     private fun storeFile(): File {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould.kt
@@ -29,13 +29,12 @@ package org.hisp.dhis.android.testapp.trackedentity
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStoreImpl
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
@@ -130,13 +129,13 @@ class TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould : Bas
     }
 
     private suspend fun restoreTeiState(teiUid: String, syncState: State) {
-        val store = DhisAndroidSdkKoinContext.koin.get<TrackedEntityInstanceStore>()
+        val store = koin.get<TrackedEntityInstanceStore>()
         store.setAggregatedSyncState(teiUid, syncState)
         store.setSyncState(teiUid, syncState)
     }
 
     private suspend fun setDataValueState(value: TrackedEntityAttributeValue, syncState: State?) {
-        val store: TrackedEntityAttributeValueStore = TrackedEntityAttributeValueStoreImpl(databaseAdapter)
+        val store: TrackedEntityAttributeValueStore = koin.get()
         store.updateWhere(value.toBuilder().syncState(syncState).build())
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueObjectRepositoryMockIntegrationShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.testapp.trackedentity
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
@@ -36,7 +37,6 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValueObjec
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceCreateProjection
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceObjectRepository
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.After
 import org.junit.Before
@@ -145,7 +145,7 @@ class TrackedEntityAttributeValueObjectRepositoryMockIntegrationShould : BaseMoc
 
     companion object {
         suspend fun setDataValueState(value: TrackedEntityAttributeValue, syncState: State?) {
-            val store: TrackedEntityAttributeValueStore = TrackedEntityAttributeValueStoreImpl(databaseAdapter)
+            val store: TrackedEntityAttributeValueStore = koin.get()
             store.updateWhere(value.toBuilder().syncState(syncState).build())
         }
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityDataValueObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityDataValueObjectRepositoryMockIntegrationShould.kt
@@ -29,13 +29,13 @@ package org.hisp.dhis.android.testapp.trackedentity
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.querybuilders.internal.WhereClauseBuilder
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValueObjectRepository
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValueTableInfo
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStoreImpl
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.After
 import org.junit.Before
@@ -143,7 +143,7 @@ class TrackedEntityDataValueObjectRepositoryMockIntegrationShould : BaseMockInte
     }
 
     private suspend fun hardDeleteDataValue() {
-        val store: TrackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
+        val store: TrackedEntityDataValueStore = koin.get()
 
         store.deleteWhereIfExists(
             WhereClauseBuilder()
@@ -154,7 +154,7 @@ class TrackedEntityDataValueObjectRepositoryMockIntegrationShould : BaseMockInte
     }
 
     private suspend fun setDataValueStateToError(value: TrackedEntityDataValue) {
-        val store: TrackedEntityDataValueStore = TrackedEntityDataValueStoreImpl(databaseAdapter)
+        val store: TrackedEntityDataValueStore = koin.get()
         store.updateWhere(value.toBuilder().syncState(State.ERROR).build())
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityInstanceObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityInstanceObjectRepositoryMockIntegrationShould.kt
@@ -29,12 +29,13 @@ package org.hisp.dhis.android.testapp.trackedentity
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.Geometry
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceCreateProjection
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceObjectRepository
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
@@ -45,7 +46,7 @@ class TrackedEntityInstanceObjectRepositoryMockIntegrationShould : BaseMockInteg
     @Test
     fun update_organisation_unit() = runTest {
         val orgUnitUid = "new_org_unit"
-        OrganisationUnitStoreImpl(databaseAdapter).insert(OrganisationUnit.builder().uid(orgUnitUid).build())
+        koin.get<OrganisationUnitStore>().insert(OrganisationUnit.builder().uid(orgUnitUid).build())
 
         val repository = objectRepository()
 
@@ -53,7 +54,7 @@ class TrackedEntityInstanceObjectRepositoryMockIntegrationShould : BaseMockInteg
         assertThat(repository.blockingGet()!!.organisationUnit()).isEqualTo(orgUnitUid)
 
         repository.blockingDelete()
-        OrganisationUnitStoreImpl(databaseAdapter).delete(orgUnitUid)
+        koin.get<OrganisationUnitStore>().delete(orgUnitUid)
     }
 
     @Test(expected = D2Error::class)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityOnlineQueryCollectionRepositoryBaseIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntityOnlineQueryCollectionRepositoryBaseIntegrationShould.kt
@@ -29,8 +29,9 @@ package org.hisp.dhis.android.testapp.trackedentity.search
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.settings.SynchronizationSettings
-import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStoreImpl
+import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStore
 import org.hisp.dhis.android.core.tracker.TrackerExporterVersion
 import org.hisp.dhis.android.core.tracker.TrackerImporterVersion
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataEnqueable
@@ -51,7 +52,7 @@ abstract class TrackedEntityOnlineQueryCollectionRepositoryBaseIntegrationShould
     abstract val responseFile: String
 
     private lateinit var initSyncParams: SynchronizationSettings
-    private val syncStore = SynchronizationSettingStoreImpl(databaseAdapter)
+    private val syncStore: SynchronizationSettingStore = koin.get()
 
     @Before
     fun setUp() = runTest {

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/PerformanceHintsService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/PerformanceHintsService.kt
@@ -28,15 +28,11 @@
 package org.hisp.dhis.android.core.maintenance
 
 import kotlinx.coroutines.runBlocking
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.mapByParentUid
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
-import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStoreImpl
 import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.ProgramRule
-import org.hisp.dhis.android.core.program.internal.ProgramRuleStoreImpl
-import org.hisp.dhis.android.core.program.internal.ProgramStoreImpl
 
 class PerformanceHintsService internal constructor(
     private val organisationUnitStore: IdentifiableObjectStore<OrganisationUnit>,
@@ -75,21 +71,5 @@ class PerformanceHintsService internal constructor(
 
     fun areThereVulnerabilities(): Boolean {
         return this.areThereExcessiveOrganisationUnits() || areThereProgramsWithExcessiveProgramRules()
-    }
-
-    companion object {
-        operator fun invoke(
-            databaseAdapter: DatabaseAdapter,
-            organisationUnitThreshold: Int,
-            programRulesPerProgramThreshold: Int,
-        ): PerformanceHintsService {
-            return PerformanceHintsService(
-                OrganisationUnitStoreImpl(databaseAdapter),
-                ProgramStoreImpl(databaseAdapter),
-                ProgramRuleStoreImpl(databaseAdapter),
-                organisationUnitThreshold,
-                programRulesPerProgramThreshold,
-            )
-        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/MaintenanceModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/MaintenanceModuleImpl.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.maintenance.internal
 
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.DatabaseImportExport
 import org.hisp.dhis.android.core.maintenance.D2ErrorCollectionRepository
 import org.hisp.dhis.android.core.maintenance.ForeignKeyViolationCollectionRepository
@@ -37,7 +36,7 @@ import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class MaintenanceModuleImpl(
-    private val databaseAdapter: DatabaseAdapter,
+    private val performanceHintsServiceFactory: PerformanceHintsServiceFactory,
     private val foreignKeyViolations: ForeignKeyViolationCollectionRepository,
     private val d2Errors: D2ErrorCollectionRepository,
     private val databaseImportExport: DatabaseImportExport,
@@ -46,8 +45,7 @@ internal class MaintenanceModuleImpl(
         organisationUnitThreshold: Int,
         programRulesPerProgramThreshold: Int,
     ): PerformanceHintsService {
-        return PerformanceHintsService(
-            databaseAdapter,
+        return performanceHintsServiceFactory.getService(
             organisationUnitThreshold,
             programRulesPerProgramThreshold,
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/PerformanceHintsServiceFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/internal/PerformanceHintsServiceFactory.kt
@@ -25,39 +25,30 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.user.internal
+package org.hisp.dhis.android.core.maintenance.internal
 
-import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
-import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
-import org.hisp.dhis.android.core.data.user.UserSamples
-import org.hisp.dhis.android.core.user.User
-import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyEnqueable
-import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.hisp.dhis.android.core.maintenance.PerformanceHintsService
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
+import org.hisp.dhis.android.core.program.internal.ProgramRuleStore
+import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.koin.core.annotation.Singleton
 
-@OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(D2JunitRunner::class)
-class UserCallMockIntegrationShould : BaseMockIntegrationTestEmptyEnqueable() {
-
-    private lateinit var userStore: UserStore
-    private lateinit var userCall: suspend() -> User
-
-    @Before
-    fun setUp() {
-        userStore = koin.get()
-        userCall = { objects.d2DIComponent.internalModules.user.userCall.call() }
-    }
-
-    @Test
-    fun persist_user_in_database_when_call() = runTest {
-        dhis2MockServer.enqueueMockResponse("user/user38.json")
-        userCall.invoke()
-
-        assertThat(userStore.count()).isEqualTo(1)
-        assertThat(userStore.selectFirst()).isEqualTo(UserSamples.getUser())
+@Singleton
+internal class PerformanceHintsServiceFactory(
+    private val organisationUnitStore: OrganisationUnitStore,
+    private val programStore: ProgramStore,
+    private val programRuleStore: ProgramRuleStore,
+) {
+    fun getService(
+        organisationUnitThreshold: Int,
+        programRulesPerProgramThreshold: Int,
+    ): PerformanceHintsService {
+        return PerformanceHintsService(
+            organisationUnitStore,
+            programStore,
+            programRuleStore,
+            organisationUnitThreshold,
+            programRulesPerProgramThreshold,
+        )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/resource/internal/ResourceHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/resource/internal/ResourceHandler.kt
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.android.core.resource.internal
 
-import androidx.annotation.VisibleForTesting
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.koin.core.annotation.Singleton
 import java.util.Date
 
@@ -64,12 +62,5 @@ internal class ResourceHandler(private val resourceStore: ResourceStore) {
      */
     suspend fun getLastUpdated(type: Resource.Type): String? {
         return resourceStore.getLastUpdated(type)
-    }
-
-    companion object {
-        @VisibleForTesting
-        fun create(databaseAdapter: DatabaseAdapter): ResourceHandler {
-            return ResourceHandler(ResourceStoreImpl(databaseAdapter))
-        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/SmsDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/SmsDIModule.kt
@@ -28,15 +28,8 @@
 package org.hisp.dhis.android.core.sms
 
 import android.content.Context
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.sms.data.internal.DeviceStateRepositoryImpl
 import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.LocalDbRepositoryImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStore
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStoreImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSMetadataIdStore
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSMetadataIdStoreImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStore
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStoreImpl
 import org.hisp.dhis.android.core.sms.data.smsrepository.internal.SmsRepositoryImpl
 import org.hisp.dhis.android.core.sms.data.webapirepository.internal.MetadataNetworkHandler
 import org.hisp.dhis.android.core.sms.data.webapirepository.internal.WebApiRepositoryImpl
@@ -69,20 +62,5 @@ internal class SmsDIModule {
     @Singleton
     fun webApiRepository(networkHandler: MetadataNetworkHandler): WebApiRepository {
         return WebApiRepositoryImpl(networkHandler)
-    }
-
-    @Singleton
-    fun smsMetadataIdStore(databaseAdapter: DatabaseAdapter): SMSMetadataIdStore {
-        return SMSMetadataIdStoreImpl(databaseAdapter)
-    }
-
-    @Singleton
-    fun smsConfigStore(databaseAdapter: DatabaseAdapter): SMSConfigStore {
-        return SMSConfigStoreImpl(databaseAdapter)
-    }
-
-    @Singleton
-    fun smsOngoingSubmissionStore(databaseAdapter: DatabaseAdapter): SMSOngoingSubmissionStore {
-        return SMSOngoingSubmissionStoreImpl(databaseAdapter)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSConfigStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSConfigStoreImpl.kt
@@ -35,8 +35,10 @@ import org.hisp.dhis.android.core.arch.db.stores.binders.internal.WhereStatement
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStoreImpl
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.datastore.KeyValuePair
+import org.koin.core.annotation.Singleton
 
 @Suppress("MagicNumber")
+@Singleton
 internal class SMSConfigStoreImpl(
     databaseAdapter: DatabaseAdapter,
 ) : SMSConfigStore,

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataIdStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataIdStoreImpl.kt
@@ -33,8 +33,10 @@ import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinde
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.WhereStatementBinder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStoreImpl
+import org.koin.core.annotation.Singleton
 
 @Suppress("MagicNumber")
+@Singleton
 internal class SMSMetadataIdStoreImpl(
     databaseAdapter: DatabaseAdapter,
 ) : SMSMetadataIdStore,

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionStoreImpl.kt
@@ -32,8 +32,10 @@ import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementBinde
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.StatementWrapper
 import org.hisp.dhis.android.core.arch.db.stores.binders.internal.WhereStatementBinder
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStoreImpl
+import org.koin.core.annotation.Singleton
 
 @Suppress("MagicNumber")
+@Singleton
 internal class SMSOngoingSubmissionStoreImpl(
     databaseAdapter: DatabaseAdapter,
 ) : SMSOngoingSubmissionStore,

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/SystemInfoDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/SystemInfoDIModule.kt
@@ -27,62 +27,9 @@
  */
 package org.hisp.dhis.android.core.systeminfo
 
-import android.content.Context
-import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
-import org.hisp.dhis.android.core.sms.data.internal.DeviceStateRepositoryImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.LocalDbRepositoryImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStore
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSConfigStoreImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSMetadataIdStore
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSMetadataIdStoreImpl
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStore
-import org.hisp.dhis.android.core.sms.data.localdbrepository.internal.SMSOngoingSubmissionStoreImpl
-import org.hisp.dhis.android.core.sms.data.smsrepository.internal.SmsRepositoryImpl
-import org.hisp.dhis.android.core.sms.data.webapirepository.internal.MetadataNetworkHandler
-import org.hisp.dhis.android.core.sms.data.webapirepository.internal.WebApiRepositoryImpl
-import org.hisp.dhis.android.core.sms.domain.repository.SmsRepository
-import org.hisp.dhis.android.core.sms.domain.repository.WebApiRepository
-import org.hisp.dhis.android.core.sms.domain.repository.internal.DeviceStateRepository
-import org.hisp.dhis.android.core.sms.domain.repository.internal.LocalDbRepository
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
-import org.koin.core.annotation.Singleton
 
 @Module
 @ComponentScan
-internal class SystemInfoDIModule {
-    @Singleton
-    fun deviceStateRepository(context: Context): DeviceStateRepository {
-        return DeviceStateRepositoryImpl(context)
-    }
-
-    @Singleton
-    fun localDbRepository(impl: LocalDbRepositoryImpl): LocalDbRepository {
-        return impl
-    }
-
-    @Singleton
-    fun smsRepository(context: Context): SmsRepository {
-        return SmsRepositoryImpl(context)
-    }
-
-    @Singleton
-    fun webApiRepository(metadataNetworkHandler: MetadataNetworkHandler): WebApiRepository {
-        return WebApiRepositoryImpl(metadataNetworkHandler)
-    }
-
-    @Singleton
-    fun smsMetadataIdStore(databaseAdapter: DatabaseAdapter): SMSMetadataIdStore {
-        return SMSMetadataIdStoreImpl(databaseAdapter)
-    }
-
-    @Singleton
-    fun smsConfigStore(databaseAdapter: DatabaseAdapter): SMSConfigStore {
-        return SMSConfigStoreImpl(databaseAdapter)
-    }
-
-    @Singleton
-    fun smsOngoingSubmissionStore(databaseAdapter: DatabaseAdapter): SMSOngoingSubmissionStore {
-        return SMSOngoingSubmissionStoreImpl(databaseAdapter)
-    }
-}
+internal class SystemInfoDIModule

--- a/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionHandlerShould.kt
@@ -43,7 +43,7 @@ import org.mockito.kotlin.whenever
 
 @RunWith(JUnit4::class)
 class ProgramStageSectionHandlerShould {
-    private val programStageSectionStore: ProgramStageSectionStoreImpl = mock()
+    private val programStageSectionStore: ProgramStageSectionStore = mock()
     private val programStageSectionProgramIndicatorLinkHandler: ProgramStageSectionProgramIndicatorLinkHandler = mock()
     private val programStageSectionDataElementLinkHandler: ProgramStageSectionDataElementLinkHandler = mock()
     private val programStageSection: ProgramStageSection = mock()


### PR DESCRIPTION
Partially solves [ANDROSDK-2134](https://dhis2.atlassian.net/browse/ANDROSDK-2134).

It is very common to instantiate a store using the StoreImpl class and providing the databaseadapter. This won't work with Room anymore, so this way of instantiation has been replaced by picking the store from the Koin tree.

[ANDROSDK-2134]: https://dhis2.atlassian.net/browse/ANDROSDK-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ