### PR TITLE
fix: [ANDROSDK-2142] Simplify multipart Content-Disposition header to include only filename

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourcePostCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourcePostCall.kt
@@ -98,7 +98,7 @@ internal class FileResourcePostCall(
                     key = "file",
                     value = file.readBytes(),
                     headers = Headers.build {
-                        append(HttpHeaders.ContentDisposition, "form-data; name=\"file\"; filename=\"$fileName\"")
+                        append(HttpHeaders.ContentDisposition, "filename=\"$fileName\"")
                         append(HttpHeaders.ContentType, type)
                     },
                 )


### PR DESCRIPTION
By manually setting the full `form-data; name="file"; filename="…"` header we were duplicating the `name="file"` portion, causing malformed multipart requests. Ktor already injects that fragment, so we only need to append the `filename` parameter.

Ktor docs: [Upload a file in client requests](https://ktor.io/docs/client-requests.html#upload_file)