### PR TITLE
fix: [ANDROSDK-2146] fix TEA reserved value not removing value from DB

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueStoreImpl.kt
@@ -78,6 +78,8 @@ internal class TrackedEntityAttributeReservedValueStoreImpl(
         val builder = WhereClauseBuilder().appendKeyStringValue(Columns.OWNER_UID, ownerUid)
         if (organisationUnit != null) {
             builder.appendKeyStringValue(Columns.ORGANISATION_UNIT, organisationUnit)
+        } else {
+            builder.appendIsNullValue(Columns.ORGANISATION_UNIT)
         }
         if (pattern != null) {
             builder.appendKeyStringValue(Columns.PATTERN, pattern)


### PR DESCRIPTION
This task fixes the issue where reserved values were not being popped from db due to the change in the database where all _ids were removed. Now, the null org unit case needs to be explicitly stated in the SQL statement to correctly fetch the reserved value.

A test for assessing this specific case has also been added

Related task [ANDROSDK-2146](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2146)

[ANDROSDK-2146]: https://dhis2.atlassian.net/browse/ANDROSDK-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ