### PR TITLE
chore: [ANDROSDK-2148] Update custom intents response model in network layer

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/network/settings/CustomIntentResponseDataExtraDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/settings/CustomIntentResponseDataExtraDTO.kt
@@ -29,15 +29,20 @@
 package org.hisp.dhis.android.network.settings
 
 import kotlinx.serialization.Serializable
-import org.hisp.dhis.android.core.settings.CustomIntentResponseData
+import org.hisp.dhis.android.core.settings.CustomIntentResponseDataExtra
+import org.hisp.dhis.android.core.settings.CustomIntentResponseExtraType
 
 @Serializable
-internal data class CustomIntentResponseDataDTO(
-    val extras: List<CustomIntentResponseDataExtraDTO>,
+internal data class CustomIntentResponseDataExtraDTO(
+    val extraName: String,
+    val extraType: String,
+    val key: String?,
 ) {
-    fun toDomain(): CustomIntentResponseData {
-        return CustomIntentResponseData.builder()
-            .extras(extras.map { it.toDomain() })
+    fun toDomain(): CustomIntentResponseDataExtra {
+        return CustomIntentResponseDataExtra.builder()
+            .extraName(extraName)
+            .extraType(CustomIntentResponseExtraType.valueOf(extraType))
+            .key(key)
             .build()
     }
 }

--- a/core/src/sharedTest/resources/settings/custom_intents.json
+++ b/core/src/sharedTest/resources/settings/custom_intents.json
@@ -41,8 +41,18 @@
       },
       "response": {
         "data": {
-          "argument": "registration",
-          "path": "guid"
+          "extras": [
+            {
+              "extraName": "registration",
+              "extraType": "OBJECT",
+              "key": "guid"
+            },
+            {
+              "extraName": "otherExtra",
+              "extraType": "STRING",
+              "key": "otherKey"
+            }
+          ]
         }
       }
     },
@@ -82,8 +92,13 @@
       },
       "response": {
         "data": {
-          "argument": "registration",
-          "path": "guid"
+          "extras": [
+            {
+              "extraName": "registration",
+              "extraType": "BOOLEAN",
+              "key": "guid"
+            }
+          ]
         }
       }
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
@@ -52,5 +52,9 @@ class CustomIntentsShould : CoreObjectShould("settings/custom_intents.json") {
         assertThat(firstCustomIntent.request()?.arguments()?.get(0)?.value()).isEqualTo("project one")
         assertThat(firstCustomIntent.response()?.data()?.extras()?.get(0)?.extraName()).isEqualTo("registration")
         assertThat(firstCustomIntent.response()?.data()?.extras()?.get(0)?.key()).isEqualTo("guid")
+        assertThat(firstCustomIntent.response()?.data()?.extras()?.get(1)?.extraName()).isEqualTo("otherExtra")
+        assertThat(firstCustomIntent.response()?.data()?.extras()?.get(1)?.extraType()).isEqualTo(
+            CustomIntentResponseExtraType.STRING,
+        )
     }
 }


### PR DESCRIPTION
This tasks updates the response object of the custom intents configuration to allow multiple extras. The change allows to download the new updated version of custom intents from the server. However the changes will need to be manually crafted there using the DataStore editor since the ASWA doesn't currently support these changes. This latter task can be followed [here](https://dhis2.atlassian.net/browse/DHIS2-19954)


Related task [ANDROSDK-2148](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2148)

[ANDROSDK-2148]: https://dhis2.atlassian.net/browse/ANDROSDK-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ