### PR TITLE
chore: [ANDROSDK-2150] Refactor EventDownloader and TrackedEntityInstanceDownloader to use ProgramDataDownloadParams

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10343,22 +10343,6 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public abstract fun uids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 }
 
-public class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$QueryParams {
-	public static final field LIMIT Ljava/lang/String;
-	public static final field LIMIT_BY_ORGUNIT Ljava/lang/String;
-	public static final field LIMIT_BY_PROGRAM Ljava/lang/String;
-	public static final field ORG_UNITS Ljava/lang/String;
-	public static final field ORG_UNIT_MODE Ljava/lang/String;
-	public static final field OVERWRITE Ljava/lang/String;
-	public static final field PROGRAM Ljava/lang/String;
-	public static final field PROGRAM_END_DATE Ljava/lang/String;
-	public static final field PROGRAM_START_DATE Ljava/lang/String;
-	public static final field PROGRAM_STATUS Ljava/lang/String;
-	public static final field TRACKED_ENTITY_TYPE Ljava/lang/String;
-	public static final field UID Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public abstract interface class org/hisp/dhis/android/core/program/programindicatorengine/ProgramIndicatorEngine {
 	public abstract fun getEnrollmentProgramIndicatorValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun getEventProgramIndicatorValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6869,10 +6869,10 @@ public class org/hisp/dhis/android/core/event/EventDataFilterTableInfo$Columns :
 	public fun all ()[Ljava/lang/String;
 }
 
-public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseRepositoryImpl {
+public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
-	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/UnwrappedEqInFilterConnector;
+	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
@@ -10307,11 +10307,10 @@ public final class org/hisp/dhis/android/core/program/SectionRenderingType : jav
 	public static fun values ()[Lorg/hisp/dhis/android/core/program/SectionRenderingType;
 }
 
-public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams {
+public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams : org/hisp/dhis/android/core/arch/repositories/scope/BaseScope {
 	public static final field DEFAULT_LIMIT Ljava/lang/Integer;
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public static fun fromRepositoryScope (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams;
 	public abstract fun limit ()Ljava/lang/Integer;
 	public abstract fun limitByOrgunit ()Ljava/lang/Boolean;
 	public abstract fun limitByProgram ()Ljava/lang/Boolean;
@@ -13743,11 +13742,11 @@ public abstract class org/hisp/dhis/android/core/trackedentity/internal/ObjectWi
 	public abstract fun response (Lorg/hisp/dhis/android/core/common/ObjectWithUid;)Lorg/hisp/dhis/android/core/trackedentity/internal/ObjectWithUidWebResponse$Builder;
 }
 
-public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseRepositoryImpl {
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
 	public final fun byProgramStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
-	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/UnwrappedEqInFilterConnector;
+	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3093,7 +3093,7 @@ public final class org/hisp/dhis/android/core/arch/repositories/filters/internal
 
 public final class org/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector {
 	public final fun eq (Ljava/lang/Object;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
-	public final fun in (Ljava/util/List;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
+	public final fun in (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun in ([Ljava/lang/Object;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector.kt
@@ -35,8 +35,8 @@ internal constructor(private val repositoryFactory: ScopedRepositoryFilterFactor
         return repositoryFactory.updated(value?.let { listOf(it) } ?: emptyList())
     }
 
-    fun `in`(values: List<T>): R {
-        return repositoryFactory.updated(values)
+    fun `in`(values: Collection<T>): R {
+        return repositoryFactory.updated(values.toList())
     }
 
     @SafeVarargs

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -69,14 +69,22 @@ class EventDownloader internal constructor(
         connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
     fun byProgramUid(programUid: String): EventDownloader =
-        EventDownloader(call, params.toBuilder().program(programUid).build())
+        connectorFactory.eqConnector<String> { programUid ->
+            params.toBuilder().program(programUid).build()
+        }.eq(programUid)
 
     fun limitByOrgunit(limitByOrgunit: Boolean): EventDownloader =
-        EventDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
+        connectorFactory.eqConnector<Boolean> { limitByOrgunit ->
+            params.toBuilder().limitByOrgunit(limitByOrgunit).build()
+        }.eq(limitByOrgunit)
 
     fun limitByProgram(limitByProgram: Boolean): EventDownloader =
-        EventDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
+        connectorFactory.eqConnector<Boolean> { limitByProgram ->
+            params.toBuilder().limitByProgram(limitByProgram).build()
+        }.eq(limitByProgram)
 
     fun limit(limit: Int): EventDownloader =
-        EventDownloader(call, params.toBuilder().limit(limit).build())
+        connectorFactory.eqConnector<Int> { limit ->
+            params.toBuilder().limit(limit).build()
+        }.eq(limit)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -29,24 +29,24 @@ package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
 import kotlinx.coroutines.rx2.asObservable
-import org.hisp.dhis.android.core.arch.repositories.collection.internal.BaseRepositoryImpl
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.UnwrappedEqInFilterConnector
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
 import org.hisp.dhis.android.core.event.internal.EventDownloadCall
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
-import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams.QueryParams
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
 @Singleton
 class EventDownloader internal constructor(
-    scope: RepositoryScope,
-    private val callFactory: EventDownloadCall,
-) : BaseRepositoryImpl<EventDownloader>(
-    scope,
-    FilterConnectorFactory(scope) { s: RepositoryScope -> EventDownloader(s, callFactory) },
-) {
+    private val call: EventDownloadCall,
+    private val params: ProgramDataDownloadParams,
+) : BaseRepository {
+
+    private val connectorFactory: ScopedFilterConnectorFactory<EventDownloader, ProgramDataDownloadParams> =
+        ScopedFilterConnectorFactory { params ->
+            EventDownloader(call, params)
+        }
 
     /**
      * Downloads and persists Events from the server. Only instances in capture scope are downloaded.
@@ -58,31 +58,25 @@ class EventDownloader internal constructor(
      * @return -
      */
     fun download(): Observable<TrackerD2Progress> {
-        val params = ProgramDataDownloadParams.fromRepositoryScope(scope)
-        return callFactory.download(params).asObservable()
+        return call.download(params).asObservable()
     }
 
     fun blockingDownload() {
         download().blockingSubscribe()
     }
 
-    fun byUid(): UnwrappedEqInFilterConnector<EventDownloader> {
-        return cf.unwrappedEqIn(QueryParams.UID)
-    }
+    fun byUid(): ListFilterConnector<EventDownloader, String> =
+        connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
-    fun byProgramUid(programUid: String): EventDownloader {
-        return cf.baseString(QueryParams.PROGRAM).eq(programUid)
-    }
+    fun byProgramUid(programUid: String): EventDownloader =
+        EventDownloader(call, params.toBuilder().program(programUid).build())
 
-    fun limitByOrgunit(limitByOrgunit: Boolean): EventDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_ORGUNIT).eq(limitByOrgunit)
-    }
+    fun limitByOrgunit(limitByOrgunit: Boolean): EventDownloader =
+        EventDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
 
-    fun limitByProgram(limitByProgram: Boolean): EventDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_PROGRAM).eq(limitByProgram)
-    }
+    fun limitByProgram(limitByProgram: Boolean): EventDownloader =
+        EventDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
 
-    fun limit(limit: Int): EventDownloader {
-        return cf.integer(QueryParams.LIMIT).eq(limit)
-    }
+    fun limit(limit: Int): EventDownloader =
+        EventDownloader(call, params.toBuilder().limit(limit).build())
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
@@ -28,9 +28,16 @@
 
 package org.hisp.dhis.android.core.program
 
+import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 
 @Module
 @ComponentScan
-internal class ProgramDIModule
+internal class ProgramDIModule {
+
+    @Factory
+    fun programDataDownloadParams(): ProgramDataDownloadParams = ProgramDataDownloadParams.builder().build()
+
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
@@ -39,5 +39,4 @@ internal class ProgramDIModule {
 
     @Factory
     fun programDataDownloadParams(): ProgramDataDownloadParams = ProgramDataDownloadParams.builder().build()
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -119,19 +119,4 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
 
         public abstract ProgramDataDownloadParams build();
     }
-
-    public static class QueryParams {
-        public static final String UID = "uid";
-        public static final String PROGRAM = "program";
-        public static final String PROGRAM_STATUS = "programStatus";
-        public static final String PROGRAM_START_DATE = "programStartDate";
-        public static final String PROGRAM_END_DATE = "programEndDate";
-        public static final String ORG_UNITS = "ou";
-        public static final String ORG_UNIT_MODE = "ouMode";
-        public static final String TRACKED_ENTITY_TYPE = "trackedEntityType";
-        public static final String LIMIT_BY_ORGUNIT = "limitByOrgunit";
-        public static final String LIMIT_BY_PROGRAM = "limitByProgram";
-        public static final String LIMIT = "limit";
-        public static final String OVERWRITE = "overwrite";
-    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -33,9 +33,7 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.UnwrappedEqInFilterConnector;
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope;
-import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem;
+import org.hisp.dhis.android.core.arch.repositories.scope.BaseScope;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode;
 import org.hisp.dhis.android.core.settings.EnrollmentScope;
 
@@ -44,7 +42,7 @@ import java.util.Date;
 import java.util.List;
 
 @AutoValue
-public abstract class ProgramDataDownloadParams {
+public abstract class ProgramDataDownloadParams implements BaseScope {
 
     public static final Integer DEFAULT_LIMIT = 500;
 
@@ -83,37 +81,6 @@ public abstract class ProgramDataDownloadParams {
 
     @NonNull
     public abstract Boolean overwrite();
-
-    public static ProgramDataDownloadParams fromRepositoryScope(RepositoryScope scope) {
-        Builder builder = builder();
-        for (RepositoryScopeFilterItem item : scope.filters()) {
-            switch (item.key()) {
-                case QueryParams.UID:
-                    builder.uids(UnwrappedEqInFilterConnector.getValueList(item.value()));
-                    break;
-                case QueryParams.PROGRAM:
-                    builder.program(item.value());
-                    break;
-                case QueryParams.LIMIT_BY_ORGUNIT:
-                    builder.limitByOrgunit(item.value().equals("1"));
-                    break;
-                case QueryParams.LIMIT_BY_PROGRAM:
-                    builder.limitByProgram(item.value().equals("1"));
-                    break;
-                case QueryParams.LIMIT:
-                    builder.limit(Integer.parseInt(item.value()));
-                    break;
-                case QueryParams.PROGRAM_STATUS:
-                    builder.programStatus(EnrollmentScope.valueOf(item.value()));
-                    break;
-                case QueryParams.OVERWRITE:
-                    builder.overwrite(item.value().equals("1"));
-                    break;
-                default:
-            }
-        }
-        return builder.build();
-    }
 
     public static Builder builder() {
         return new AutoValue_ProgramDataDownloadParams.Builder()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -70,19 +70,29 @@ class TrackedEntityInstanceDownloader internal constructor(
         connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
     fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().program(programUid).build())
+        connectorFactory.eqConnector<String> { programUid ->
+            params.toBuilder().program(programUid).build()
+        }.eq(programUid)
 
     fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
+        connectorFactory.eqConnector<Boolean> { limitByOrgunit ->
+            params.toBuilder().limitByOrgunit(limitByOrgunit).build()
+        }.eq(limitByOrgunit)
 
     fun limitByProgram(limitByProgram: Boolean): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
+        connectorFactory.eqConnector<Boolean> { limitByProgram ->
+            params.toBuilder().limitByProgram(limitByProgram).build()
+        }.eq(limitByProgram)
 
     fun limit(limit: Int): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().limit(limit).build())
+        connectorFactory.eqConnector<Int> { limit ->
+            params.toBuilder().limit(limit).build()
+        }.eq(limit)
 
     fun byProgramStatus(status: EnrollmentScope): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().programStatus(status).build())
+        connectorFactory.eqConnector<EnrollmentScope> { status ->
+            params.toBuilder().programStatus(status).build()
+        }.eq(status)
 
     /**
      * If true, it overwrites existing TEIs in the device with the TEIs returned from the server. It does not modify
@@ -92,5 +102,7 @@ class TrackedEntityInstanceDownloader internal constructor(
      * @return the new repository
      */
     fun overwrite(overwrite: Boolean): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().overwrite(overwrite).build())
+        connectorFactory.eqConnector<Boolean> { overwrite ->
+            params.toBuilder().overwrite(overwrite).build()
+        }.eq(overwrite)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -29,29 +29,25 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.rx2.asObservable
-import org.hisp.dhis.android.core.arch.repositories.collection.internal.BaseRepositoryImpl
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.UnwrappedEqInFilterConnector
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
-import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams.QueryParams
 import org.hisp.dhis.android.core.settings.EnrollmentScope
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
 @Singleton
 class TrackedEntityInstanceDownloader internal constructor(
-    scope: RepositoryScope,
-    private val downloadCall: TrackedEntityInstanceDownloadCall,
-) : BaseRepositoryImpl<TrackedEntityInstanceDownloader>(
-    scope,
-    FilterConnectorFactory(scope) { s: RepositoryScope ->
-        TrackedEntityInstanceDownloader(
-            s,
-            downloadCall,
-        )
-    },
-) {
+    private val call: TrackedEntityInstanceDownloadCall,
+    private val params: ProgramDataDownloadParams,
+) : BaseRepository {
+
+    private val connectorFactory
+            : ScopedFilterConnectorFactory<TrackedEntityInstanceDownloader, ProgramDataDownloadParams> =
+        ScopedFilterConnectorFactory { params ->
+            TrackedEntityInstanceDownloader(call, params)
+        }
 
     /**
      * Downloads and persists TrackedEntityInstances from the server. Only instances in capture scope are downloaded.
@@ -63,37 +59,31 @@ class TrackedEntityInstanceDownloader internal constructor(
      * @return An Observable that notifies about the progress.
      */
     fun download(): Observable<TrackerD2Progress> {
-        val params = ProgramDataDownloadParams.fromRepositoryScope(scope)
-        return downloadCall.download(params).asObservable()
+        return call.download(params).asObservable()
     }
 
     fun blockingDownload() {
         download().blockingSubscribe()
     }
 
-    fun byUid(): UnwrappedEqInFilterConnector<TrackedEntityInstanceDownloader> {
-        return cf.unwrappedEqIn(QueryParams.UID)
-    }
+    fun byUid(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
+        connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
-    fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader {
-        return cf.baseString(QueryParams.PROGRAM).eq(programUid)
-    }
+    fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().program(programUid).build())
 
-    fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_ORGUNIT).eq(limitByOrgunit)
-    }
 
-    fun limitByProgram(limitByProgram: Boolean): TrackedEntityInstanceDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_PROGRAM).eq(limitByProgram)
-    }
+    fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
 
-    fun limit(limit: Int): TrackedEntityInstanceDownloader {
-        return cf.integer(QueryParams.LIMIT).eq(limit)
-    }
+    fun limitByProgram(limitByProgram: Boolean): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
 
-    fun byProgramStatus(status: EnrollmentScope): TrackedEntityInstanceDownloader {
-        return cf.baseString(QueryParams.PROGRAM_STATUS).eq(status.toString())
-    }
+    fun limit(limit: Int): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().limit(limit).build())
+
+    fun byProgramStatus(status: EnrollmentScope): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().programStatus(status).build())
 
     /**
      * If true, it overwrites existing TEIs in the device with the TEIs returned from the server. It does not modify
@@ -102,7 +92,6 @@ class TrackedEntityInstanceDownloader internal constructor(
      * @param overwrite True to overwrite
      * @return the new repository
      */
-    fun overwrite(overwrite: Boolean): TrackedEntityInstanceDownloader {
-        return cf.bool(QueryParams.OVERWRITE).eq(overwrite)
-    }
+    fun overwrite(overwrite: Boolean): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().overwrite(overwrite).build())
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -43,8 +43,8 @@ class TrackedEntityInstanceDownloader internal constructor(
     private val params: ProgramDataDownloadParams,
 ) : BaseRepository {
 
-    private val connectorFactory
-            : ScopedFilterConnectorFactory<TrackedEntityInstanceDownloader, ProgramDataDownloadParams> =
+    private val connectorFactory:
+        ScopedFilterConnectorFactory<TrackedEntityInstanceDownloader, ProgramDataDownloadParams> =
         ScopedFilterConnectorFactory { params ->
             TrackedEntityInstanceDownloader(call, params)
         }
@@ -71,7 +71,6 @@ class TrackedEntityInstanceDownloader internal constructor(
 
     fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader =
         TrackedEntityInstanceDownloader(call, params.toBuilder().program(programUid).build())
-
 
     fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader =
         TrackedEntityInstanceDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -29,7 +29,6 @@
 package org.hisp.dhis.android.core.event
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.event.internal.EventDownloadCall
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.junit.Before

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -42,11 +42,13 @@ class EventDownloaderShould {
 
     private val paramsCapture: KArgumentCaptor<ProgramDataDownloadParams> = argumentCaptor()
 
+    private lateinit var params: ProgramDataDownloadParams
     private lateinit var downloader: EventDownloader
 
     @Before
     fun setUp() {
-        downloader = EventDownloader(RepositoryScope.empty(), call)
+        params = ProgramDataDownloadParams.builder().build()
+        downloader = EventDownloader(call, params)
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.settings.EnrollmentScope
 import org.junit.Before
@@ -42,15 +41,17 @@ import org.mockito.kotlin.verify
 
 @RunWith(JUnit4::class)
 class TrackedEntityInstanceDownloaderShould {
-    private val callFactory: TrackedEntityInstanceDownloadCall = mock()
+    private val call: TrackedEntityInstanceDownloadCall = mock()
 
     private val paramsCapture: KArgumentCaptor<ProgramDataDownloadParams> = argumentCaptor()
 
+    private lateinit var params: ProgramDataDownloadParams
     private lateinit var downloader: TrackedEntityInstanceDownloader
 
     @Before
     fun setUp() {
-        downloader = TrackedEntityInstanceDownloader(RepositoryScope.empty(), callFactory)
+        params = ProgramDataDownloadParams.builder().build()
+        downloader = TrackedEntityInstanceDownloader(call, params)
     }
 
     @Test
@@ -64,7 +65,7 @@ class TrackedEntityInstanceDownloaderShould {
             .overwrite(true)
             .download()
 
-        verify(callFactory).download(paramsCapture.capture())
+        verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
         assertThat(params.program()).isEqualTo("program-uid")
@@ -79,7 +80,7 @@ class TrackedEntityInstanceDownloaderShould {
     fun should_parse_uid_eq_params() {
         downloader.byUid().eq("uid").download()
 
-        verify(callFactory).download(paramsCapture.capture())
+        verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
         assertThat(params.uids().size).isEqualTo(1)
@@ -90,7 +91,7 @@ class TrackedEntityInstanceDownloaderShould {
     fun should_parse_uid_in_params() {
         downloader.byUid().`in`("uid0", "uid1", "uid2").download()
 
-        verify(callFactory).download(paramsCapture.capture())
+        verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
         assertThat(params.uids().size).isEqualTo(3)


### PR DESCRIPTION
**Description**
Refactors `EventDownloader` and `TrackedEntityInstanceDownloader` to use the custom scope `ProgramDataDownloadParams` instead of `RepositoryScope`.

### Main changes

* Replaced `BaseRepositoryImpl` with `BaseRepository` + `ScopedFilterConnectorFactory`.
* Updated filter methods (`byUid`, `byProgramUid`, `limit`, etc.) to build params directly.
* Removed `fromRepositoryScope()` from `ProgramDataDownloadParams`.
* Adjusted unit tests and updated API dump.

This enables storing full objects as filters and prepares the SDK for upcoming sync improvements.