### PR TITLE
chore: [ANDROSDK-2151] Add byFilterUids() and byFilter() to TEI and Event Downloaders

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10343,22 +10343,6 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public abstract fun uids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 }
 
-public class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$QueryParams {
-	public static final field LIMIT Ljava/lang/String;
-	public static final field LIMIT_BY_ORGUNIT Ljava/lang/String;
-	public static final field LIMIT_BY_PROGRAM Ljava/lang/String;
-	public static final field ORG_UNITS Ljava/lang/String;
-	public static final field ORG_UNIT_MODE Ljava/lang/String;
-	public static final field OVERWRITE Ljava/lang/String;
-	public static final field PROGRAM Ljava/lang/String;
-	public static final field PROGRAM_END_DATE Ljava/lang/String;
-	public static final field PROGRAM_START_DATE Ljava/lang/String;
-	public static final field PROGRAM_STATUS Ljava/lang/String;
-	public static final field TRACKED_ENTITY_TYPE Ljava/lang/String;
-	public static final field UID Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public abstract interface class org/hisp/dhis/android/core/program/programindicatorengine/ProgramIndicatorEngine {
 	public abstract fun getEnrollmentProgramIndicatorValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun getEventProgramIndicatorValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6871,6 +6871,8 @@ public class org/hisp/dhis/android/core/event/EventDataFilterTableInfo$Columns :
 
 public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
+	public final fun byEventFilter (Lorg/hisp/dhis/android/core/event/EventFilter;)Lorg/hisp/dhis/android/core/event/EventDownloader;
+	public final fun byFilterUids ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
@@ -10311,6 +10313,8 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public static final field DEFAULT_LIMIT Ljava/lang/Integer;
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun eventFilter ()Lorg/hisp/dhis/android/core/event/EventFilter;
+	public abstract fun filterUids ()Ljava/util/List;
 	public abstract fun limit ()Ljava/lang/Integer;
 	public abstract fun limitByOrgunit ()Ljava/lang/Boolean;
 	public abstract fun limitByProgram ()Ljava/lang/Boolean;
@@ -10319,9 +10323,11 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public abstract fun overwrite ()Ljava/lang/Boolean;
 	public abstract fun program ()Ljava/lang/String;
 	public abstract fun programEndDate ()Ljava/util/Date;
+	public abstract fun programStageWorkingList ()Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingList;
 	public abstract fun programStartDate ()Ljava/util/Date;
 	public abstract fun programStatus ()Lorg/hisp/dhis/android/core/settings/EnrollmentScope;
 	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun trackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter;
 	public abstract fun trackedEntityType ()Ljava/lang/String;
 	public abstract fun uids ()Ljava/util/List;
 }
@@ -10329,6 +10335,8 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder {
 	public fun <init> ()V
 	public abstract fun build ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams;
+	public abstract fun eventFilter (Lorg/hisp/dhis/android/core/event/EventFilter;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun filterUids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limit (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limitByOrgunit (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limitByProgram (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
@@ -10337,8 +10345,10 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public abstract fun overwrite (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun program (Ljava/lang/String;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun programEndDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun programStageWorkingList (Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingList;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun programStartDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun programStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun trackedEntityInstanceFilter (Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun trackedEntityType (Ljava/lang/String;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun uids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 }
@@ -13728,8 +13738,11 @@ public abstract class org/hisp/dhis/android/core/trackedentity/internal/ObjectWi
 
 public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
+	public final fun byFilterUids ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
+	public final fun byProgramStageWorkingList (Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingList;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byProgramStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
+	public final fun byTrackedEntityInstanceFilter (Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6872,7 +6872,7 @@ public class org/hisp/dhis/android/core/event/EventDataFilterTableInfo$Columns :
 public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
 	public final fun byEventFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
-	public final fun byFilterUids ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
+	public final fun byFilterUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
@@ -13738,7 +13738,7 @@ public abstract class org/hisp/dhis/android/core/trackedentity/internal/ObjectWi
 
 public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
-	public final fun byFilterUids ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
+	public final fun byFilterUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byProgramStageWorkingList ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byProgramStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6869,10 +6869,10 @@ public class org/hisp/dhis/android/core/event/EventDataFilterTableInfo$Columns :
 	public fun all ()[Ljava/lang/String;
 }
 
-public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseRepositoryImpl {
+public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
-	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/UnwrappedEqInFilterConnector;
+	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
@@ -10307,11 +10307,10 @@ public final class org/hisp/dhis/android/core/program/SectionRenderingType : jav
 	public static fun values ()[Lorg/hisp/dhis/android/core/program/SectionRenderingType;
 }
 
-public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams {
+public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams : org/hisp/dhis/android/core/arch/repositories/scope/BaseScope {
 	public static final field DEFAULT_LIMIT Ljava/lang/Integer;
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public static fun fromRepositoryScope (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams;
 	public abstract fun limit ()Ljava/lang/Integer;
 	public abstract fun limitByOrgunit ()Ljava/lang/Boolean;
 	public abstract fun limitByProgram ()Ljava/lang/Boolean;
@@ -13743,11 +13742,11 @@ public abstract class org/hisp/dhis/android/core/trackedentity/internal/ObjectWi
 	public abstract fun response (Lorg/hisp/dhis/android/core/common/ObjectWithUid;)Lorg/hisp/dhis/android/core/trackedentity/internal/ObjectWithUidWebResponse$Builder;
 }
 
-public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseRepositoryImpl {
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
 	public final fun byProgramStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
-	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/UnwrappedEqInFilterConnector;
+	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3093,7 +3093,7 @@ public final class org/hisp/dhis/android/core/arch/repositories/filters/internal
 
 public final class org/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector {
 	public final fun eq (Ljava/lang/Object;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
-	public final fun in (Ljava/util/List;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
+	public final fun in (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun in ([Ljava/lang/Object;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6871,7 +6871,7 @@ public class org/hisp/dhis/android/core/event/EventDataFilterTableInfo$Columns :
 
 public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
-	public final fun byEventFilter (Lorg/hisp/dhis/android/core/event/EventFilter;)Lorg/hisp/dhis/android/core/event/EventDownloader;
+	public final fun byEventFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byFilterUids ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
@@ -10313,7 +10313,7 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public static final field DEFAULT_LIMIT Ljava/lang/Integer;
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public abstract fun eventFilter ()Lorg/hisp/dhis/android/core/event/EventFilter;
+	public abstract fun eventFilters ()Ljava/util/List;
 	public abstract fun filterUids ()Ljava/util/List;
 	public abstract fun limit ()Ljava/lang/Integer;
 	public abstract fun limitByOrgunit ()Ljava/lang/Boolean;
@@ -10323,11 +10323,11 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public abstract fun overwrite ()Ljava/lang/Boolean;
 	public abstract fun program ()Ljava/lang/String;
 	public abstract fun programEndDate ()Ljava/util/Date;
-	public abstract fun programStageWorkingList ()Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingList;
+	public abstract fun programStageWorkingLists ()Ljava/util/List;
 	public abstract fun programStartDate ()Ljava/util/Date;
 	public abstract fun programStatus ()Lorg/hisp/dhis/android/core/settings/EnrollmentScope;
 	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public abstract fun trackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter;
+	public abstract fun trackedEntityInstanceFilters ()Ljava/util/List;
 	public abstract fun trackedEntityType ()Ljava/lang/String;
 	public abstract fun uids ()Ljava/util/List;
 }
@@ -10335,7 +10335,7 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder {
 	public fun <init> ()V
 	public abstract fun build ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams;
-	public abstract fun eventFilter (Lorg/hisp/dhis/android/core/event/EventFilter;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun eventFilters (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun filterUids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limit (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limitByOrgunit (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
@@ -10345,10 +10345,10 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public abstract fun overwrite (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun program (Ljava/lang/String;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun programEndDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public abstract fun programStageWorkingList (Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingList;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun programStageWorkingLists (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun programStartDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun programStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public abstract fun trackedEntityInstanceFilter (Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
+	public abstract fun trackedEntityInstanceFilters (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun trackedEntityType (Ljava/lang/String;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun uids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 }
@@ -13739,10 +13739,10 @@ public abstract class org/hisp/dhis/android/core/trackedentity/internal/ObjectWi
 public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
 	public final fun blockingDownload ()V
 	public final fun byFilterUids ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
-	public final fun byProgramStageWorkingList (Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingList;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
+	public final fun byProgramStageWorkingList ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byProgramStatus (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
-	public final fun byTrackedEntityInstanceFilter (Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
+	public final fun byTrackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector.kt
@@ -35,8 +35,8 @@ internal constructor(private val repositoryFactory: ScopedRepositoryFilterFactor
         return repositoryFactory.updated(value?.let { listOf(it) } ?: emptyList())
     }
 
-    fun `in`(values: List<T>): R {
-        return repositoryFactory.updated(values)
+    fun `in`(values: Collection<T>): R {
+        return repositoryFactory.updated(values.toList())
     }
 
     @SafeVarargs

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -87,4 +87,12 @@ class EventDownloader internal constructor(
         connectorFactory.eqConnector<Int> { limit ->
             params.toBuilder().limit(limit).build()
         }.eq(limit)
+
+    fun byFilterUids(): ListFilterConnector<EventDownloader, String> =
+        connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
+
+    fun byEventFilter(filter: EventFilter): EventDownloader =
+        connectorFactory.eqConnector<EventFilter> { eventFilter ->
+            params.toBuilder().eventFilter(eventFilter).build()
+        }.eq(filter)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -69,14 +69,22 @@ class EventDownloader internal constructor(
         connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
     fun byProgramUid(programUid: String): EventDownloader =
-        EventDownloader(call, params.toBuilder().program(programUid).build())
+        connectorFactory.eqConnector<String> { programUid ->
+            params.toBuilder().program(programUid).build()
+        }.eq(programUid)
 
     fun limitByOrgunit(limitByOrgunit: Boolean): EventDownloader =
-        EventDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
+        connectorFactory.eqConnector<Boolean> { limitByOrgunit ->
+            params.toBuilder().limitByOrgunit(limitByOrgunit).build()
+        }.eq(limitByOrgunit)
 
     fun limitByProgram(limitByProgram: Boolean): EventDownloader =
-        EventDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
+        connectorFactory.eqConnector<Boolean> { limitByProgram ->
+            params.toBuilder().limitByProgram(limitByProgram).build()
+        }.eq(limitByProgram)
 
     fun limit(limit: Int): EventDownloader =
-        EventDownloader(call, params.toBuilder().limit(limit).build())
+        connectorFactory.eqConnector<Int> { limit ->
+            params.toBuilder().limit(limit).build()
+        }.eq(limit)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -91,8 +91,8 @@ class EventDownloader internal constructor(
     fun byFilterUids(): ListFilterConnector<EventDownloader, String> =
         connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
 
-    fun byEventFilter(filter: EventFilter): EventDownloader =
-        connectorFactory.eqConnector<EventFilter> { eventFilter ->
-            params.toBuilder().eventFilter(eventFilter).build()
-        }.eq(filter)
+    fun byEventFilters(filters: List<EventFilter>): EventDownloader =
+        connectorFactory.listConnector { eventFilters ->
+            params.toBuilder().eventFilters(eventFilters).build()
+        }.`in`(filters)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -91,8 +91,8 @@ class EventDownloader internal constructor(
     fun byFilterUids(): ListFilterConnector<EventDownloader, String> =
         connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
 
-    fun byEventFilters(filters: List<EventFilter>): EventDownloader =
+    fun byEventFilter(): ListFilterConnector<EventDownloader, EventFilter> =
         connectorFactory.listConnector { eventFilters ->
             params.toBuilder().eventFilters(eventFilters).build()
-        }.`in`(filters)
+        }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -29,24 +29,24 @@ package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
 import kotlinx.coroutines.rx2.asObservable
-import org.hisp.dhis.android.core.arch.repositories.collection.internal.BaseRepositoryImpl
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.UnwrappedEqInFilterConnector
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
 import org.hisp.dhis.android.core.event.internal.EventDownloadCall
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
-import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams.QueryParams
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
 @Singleton
 class EventDownloader internal constructor(
-    scope: RepositoryScope,
-    private val callFactory: EventDownloadCall,
-) : BaseRepositoryImpl<EventDownloader>(
-    scope,
-    FilterConnectorFactory(scope) { s: RepositoryScope -> EventDownloader(s, callFactory) },
-) {
+    private val call: EventDownloadCall,
+    private val params: ProgramDataDownloadParams,
+) : BaseRepository {
+
+    private val connectorFactory: ScopedFilterConnectorFactory<EventDownloader, ProgramDataDownloadParams> =
+        ScopedFilterConnectorFactory { params ->
+            EventDownloader(call, params)
+        }
 
     /**
      * Downloads and persists Events from the server. Only instances in capture scope are downloaded.
@@ -58,31 +58,25 @@ class EventDownloader internal constructor(
      * @return -
      */
     fun download(): Observable<TrackerD2Progress> {
-        val params = ProgramDataDownloadParams.fromRepositoryScope(scope)
-        return callFactory.download(params).asObservable()
+        return call.download(params).asObservable()
     }
 
     fun blockingDownload() {
         download().blockingSubscribe()
     }
 
-    fun byUid(): UnwrappedEqInFilterConnector<EventDownloader> {
-        return cf.unwrappedEqIn(QueryParams.UID)
-    }
+    fun byUid(): ListFilterConnector<EventDownloader, String> =
+        connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
-    fun byProgramUid(programUid: String): EventDownloader {
-        return cf.baseString(QueryParams.PROGRAM).eq(programUid)
-    }
+    fun byProgramUid(programUid: String): EventDownloader =
+        EventDownloader(call, params.toBuilder().program(programUid).build())
 
-    fun limitByOrgunit(limitByOrgunit: Boolean): EventDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_ORGUNIT).eq(limitByOrgunit)
-    }
+    fun limitByOrgunit(limitByOrgunit: Boolean): EventDownloader =
+        EventDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
 
-    fun limitByProgram(limitByProgram: Boolean): EventDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_PROGRAM).eq(limitByProgram)
-    }
+    fun limitByProgram(limitByProgram: Boolean): EventDownloader =
+        EventDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
 
-    fun limit(limit: Int): EventDownloader {
-        return cf.integer(QueryParams.LIMIT).eq(limit)
-    }
+    fun limit(limit: Int): EventDownloader =
+        EventDownloader(call, params.toBuilder().limit(limit).build())
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -88,7 +88,7 @@ class EventDownloader internal constructor(
             params.toBuilder().limit(limit).build()
         }.eq(limit)
 
-    fun byFilterUids(): ListFilterConnector<EventDownloader, String> =
+    fun byFilterUid(): ListFilterConnector<EventDownloader, String> =
         connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
 
     fun byEventFilter(): ListFilterConnector<EventDownloader, EventFilter> =

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
@@ -28,9 +28,16 @@
 
 package org.hisp.dhis.android.core.program
 
+import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Module
 
 @Module
 @ComponentScan
-internal class ProgramDIModule
+internal class ProgramDIModule {
+
+    @Factory
+    fun programDataDownloadParams(): ProgramDataDownloadParams = ProgramDataDownloadParams.builder().build()
+
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramDIModule.kt
@@ -39,5 +39,4 @@ internal class ProgramDIModule {
 
     @Factory
     fun programDataDownloadParams(): ProgramDataDownloadParams = ProgramDataDownloadParams.builder().build()
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -134,7 +134,8 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
 
         public abstract Builder filterUids(List<String> filterUids);
 
-        public abstract Builder trackedEntityInstanceFilters(List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
+        public abstract Builder trackedEntityInstanceFilters(
+                List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
 
         public abstract Builder programStageWorkingLists(List<ProgramStageWorkingList> programStageWorkingLists);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -119,19 +119,4 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
 
         public abstract ProgramDataDownloadParams build();
     }
-
-    public static class QueryParams {
-        public static final String UID = "uid";
-        public static final String PROGRAM = "program";
-        public static final String PROGRAM_STATUS = "programStatus";
-        public static final String PROGRAM_START_DATE = "programStartDate";
-        public static final String PROGRAM_END_DATE = "programEndDate";
-        public static final String ORG_UNITS = "ou";
-        public static final String ORG_UNIT_MODE = "ouMode";
-        public static final String TRACKED_ENTITY_TYPE = "trackedEntityType";
-        public static final String LIMIT_BY_ORGUNIT = "limitByOrgunit";
-        public static final String LIMIT_BY_PROGRAM = "limitByProgram";
-        public static final String LIMIT = "limit";
-        public static final String OVERWRITE = "overwrite";
-    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -35,7 +35,9 @@ import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.arch.repositories.scope.BaseScope;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode;
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList;
 import org.hisp.dhis.android.core.settings.EnrollmentScope;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter;
 
 import java.util.Collections;
 import java.util.Date;
@@ -82,6 +84,15 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
     @NonNull
     public abstract Boolean overwrite();
 
+    @Nullable
+    public abstract List<String> filterUids();
+
+    @Nullable
+    public abstract TrackedEntityInstanceFilter trackedEntityInstanceFilter();
+
+    @Nullable
+    public abstract ProgramStageWorkingList programStageWorkingList();
+
     public static Builder builder() {
         return new AutoValue_ProgramDataDownloadParams.Builder()
                 .overwrite(false)
@@ -116,6 +127,12 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
         public abstract Builder limit(Integer limit);
 
         public abstract Builder overwrite(Boolean overwrite);
+
+        public abstract Builder filterUids(List<String> filterUids);
+
+        public abstract Builder trackedEntityInstanceFilter(TrackedEntityInstanceFilter trackedEntityInstanceFilter);
+
+        public abstract Builder programStageWorkingList(ProgramStageWorkingList programStageWorkingList);
 
         public abstract ProgramDataDownloadParams build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -34,6 +34,7 @@ import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.arch.repositories.scope.BaseScope;
+import org.hisp.dhis.android.core.event.EventFilter;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode;
 import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList;
 import org.hisp.dhis.android.core.settings.EnrollmentScope;
@@ -93,6 +94,9 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
     @Nullable
     public abstract ProgramStageWorkingList programStageWorkingList();
 
+    @Nullable
+    public abstract EventFilter eventFilter();
+
     public static Builder builder() {
         return new AutoValue_ProgramDataDownloadParams.Builder()
                 .overwrite(false)
@@ -133,6 +137,8 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
         public abstract Builder trackedEntityInstanceFilter(TrackedEntityInstanceFilter trackedEntityInstanceFilter);
 
         public abstract Builder programStageWorkingList(ProgramStageWorkingList programStageWorkingList);
+
+        public abstract Builder eventFilter(EventFilter eventFilter);
 
         public abstract ProgramDataDownloadParams build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -89,13 +89,13 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
     public abstract List<String> filterUids();
 
     @Nullable
-    public abstract TrackedEntityInstanceFilter trackedEntityInstanceFilter();
+    public abstract List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters();
 
     @Nullable
-    public abstract ProgramStageWorkingList programStageWorkingList();
+    public abstract List<ProgramStageWorkingList> programStageWorkingLists();
 
     @Nullable
-    public abstract EventFilter eventFilter();
+    public abstract List<EventFilter> eventFilters();
 
     public static Builder builder() {
         return new AutoValue_ProgramDataDownloadParams.Builder()
@@ -134,11 +134,11 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
 
         public abstract Builder filterUids(List<String> filterUids);
 
-        public abstract Builder trackedEntityInstanceFilter(TrackedEntityInstanceFilter trackedEntityInstanceFilter);
+        public abstract Builder trackedEntityInstanceFilters(List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
 
-        public abstract Builder programStageWorkingList(ProgramStageWorkingList programStageWorkingList);
+        public abstract Builder programStageWorkingLists(List<ProgramStageWorkingList> programStageWorkingLists);
 
-        public abstract Builder eventFilter(EventFilter eventFilter);
+        public abstract Builder eventFilters(List<EventFilter> eventFilters);
 
         public abstract ProgramDataDownloadParams build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -33,9 +33,7 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.UnwrappedEqInFilterConnector;
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope;
-import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem;
+import org.hisp.dhis.android.core.arch.repositories.scope.BaseScope;
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode;
 import org.hisp.dhis.android.core.settings.EnrollmentScope;
 
@@ -44,7 +42,7 @@ import java.util.Date;
 import java.util.List;
 
 @AutoValue
-public abstract class ProgramDataDownloadParams {
+public abstract class ProgramDataDownloadParams implements BaseScope {
 
     public static final Integer DEFAULT_LIMIT = 500;
 
@@ -83,37 +81,6 @@ public abstract class ProgramDataDownloadParams {
 
     @NonNull
     public abstract Boolean overwrite();
-
-    public static ProgramDataDownloadParams fromRepositoryScope(RepositoryScope scope) {
-        Builder builder = builder();
-        for (RepositoryScopeFilterItem item : scope.filters()) {
-            switch (item.key()) {
-                case QueryParams.UID:
-                    builder.uids(UnwrappedEqInFilterConnector.getValueList(item.value()));
-                    break;
-                case QueryParams.PROGRAM:
-                    builder.program(item.value());
-                    break;
-                case QueryParams.LIMIT_BY_ORGUNIT:
-                    builder.limitByOrgunit(item.value().equals("1"));
-                    break;
-                case QueryParams.LIMIT_BY_PROGRAM:
-                    builder.limitByProgram(item.value().equals("1"));
-                    break;
-                case QueryParams.LIMIT:
-                    builder.limit(Integer.parseInt(item.value()));
-                    break;
-                case QueryParams.PROGRAM_STATUS:
-                    builder.programStatus(EnrollmentScope.valueOf(item.value()));
-                    break;
-                case QueryParams.OVERWRITE:
-                    builder.overwrite(item.value().equals("1"));
-                    break;
-                default:
-            }
-        }
-        return builder.build();
-    }
 
     public static Builder builder() {
         return new AutoValue_ProgramDataDownloadParams.Builder()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -70,19 +70,29 @@ class TrackedEntityInstanceDownloader internal constructor(
         connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
     fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().program(programUid).build())
+        connectorFactory.eqConnector<String> { programUid ->
+            params.toBuilder().program(programUid).build()
+        }.eq(programUid)
 
     fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
+        connectorFactory.eqConnector<Boolean> { limitByOrgunit ->
+            params.toBuilder().limitByOrgunit(limitByOrgunit).build()
+        }.eq(limitByOrgunit)
 
     fun limitByProgram(limitByProgram: Boolean): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
+        connectorFactory.eqConnector<Boolean> { limitByProgram ->
+            params.toBuilder().limitByProgram(limitByProgram).build()
+        }.eq(limitByProgram)
 
     fun limit(limit: Int): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().limit(limit).build())
+        connectorFactory.eqConnector<Int> { limit ->
+            params.toBuilder().limit(limit).build()
+        }.eq(limit)
 
     fun byProgramStatus(status: EnrollmentScope): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().programStatus(status).build())
+        connectorFactory.eqConnector<EnrollmentScope> { status ->
+            params.toBuilder().programStatus(status).build()
+        }.eq(status)
 
     /**
      * If true, it overwrites existing TEIs in the device with the TEIs returned from the server. It does not modify
@@ -92,5 +102,7 @@ class TrackedEntityInstanceDownloader internal constructor(
      * @return the new repository
      */
     fun overwrite(overwrite: Boolean): TrackedEntityInstanceDownloader =
-        TrackedEntityInstanceDownloader(call, params.toBuilder().overwrite(overwrite).build())
+        connectorFactory.eqConnector<Boolean> { overwrite ->
+            params.toBuilder().overwrite(overwrite).build()
+        }.eq(overwrite)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -33,7 +33,9 @@ import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
 import org.hisp.dhis.android.core.settings.EnrollmentScope
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
@@ -105,4 +107,18 @@ class TrackedEntityInstanceDownloader internal constructor(
         connectorFactory.eqConnector<Boolean> { overwrite ->
             params.toBuilder().overwrite(overwrite).build()
         }.eq(overwrite)
+
+    fun byFilterUids(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
+        connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
+
+    fun byTrackedEntityInstanceFilter(filter: TrackedEntityInstanceFilter): TrackedEntityInstanceDownloader =
+        connectorFactory.eqConnector<TrackedEntityInstanceFilter> { trackedEntityInstanceFilter ->
+            params.toBuilder().trackedEntityInstanceFilter(trackedEntityInstanceFilter).build()
+        }.eq(filter)
+
+    fun byProgramStageWorkingList(workingList: ProgramStageWorkingList): TrackedEntityInstanceDownloader =
+        connectorFactory.eqConnector<ProgramStageWorkingList> { programStageWorkingList ->
+            params.toBuilder().programStageWorkingList(programStageWorkingList).build()
+        }.eq(workingList)
+
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -29,29 +29,25 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.rx2.asObservable
-import org.hisp.dhis.android.core.arch.repositories.collection.internal.BaseRepositoryImpl
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.UnwrappedEqInFilterConnector
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
-import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams.QueryParams
 import org.hisp.dhis.android.core.settings.EnrollmentScope
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
 @Singleton
 class TrackedEntityInstanceDownloader internal constructor(
-    scope: RepositoryScope,
-    private val downloadCall: TrackedEntityInstanceDownloadCall,
-) : BaseRepositoryImpl<TrackedEntityInstanceDownloader>(
-    scope,
-    FilterConnectorFactory(scope) { s: RepositoryScope ->
-        TrackedEntityInstanceDownloader(
-            s,
-            downloadCall,
-        )
-    },
-) {
+    private val call: TrackedEntityInstanceDownloadCall,
+    private val params: ProgramDataDownloadParams,
+) : BaseRepository {
+
+    private val connectorFactory
+            : ScopedFilterConnectorFactory<TrackedEntityInstanceDownloader, ProgramDataDownloadParams> =
+        ScopedFilterConnectorFactory { params ->
+            TrackedEntityInstanceDownloader(call, params)
+        }
 
     /**
      * Downloads and persists TrackedEntityInstances from the server. Only instances in capture scope are downloaded.
@@ -63,37 +59,31 @@ class TrackedEntityInstanceDownloader internal constructor(
      * @return An Observable that notifies about the progress.
      */
     fun download(): Observable<TrackerD2Progress> {
-        val params = ProgramDataDownloadParams.fromRepositoryScope(scope)
-        return downloadCall.download(params).asObservable()
+        return call.download(params).asObservable()
     }
 
     fun blockingDownload() {
         download().blockingSubscribe()
     }
 
-    fun byUid(): UnwrappedEqInFilterConnector<TrackedEntityInstanceDownloader> {
-        return cf.unwrappedEqIn(QueryParams.UID)
-    }
+    fun byUid(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
+        connectorFactory.listConnector { uids -> params.toBuilder().uids(uids).build() }
 
-    fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader {
-        return cf.baseString(QueryParams.PROGRAM).eq(programUid)
-    }
+    fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().program(programUid).build())
 
-    fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_ORGUNIT).eq(limitByOrgunit)
-    }
 
-    fun limitByProgram(limitByProgram: Boolean): TrackedEntityInstanceDownloader {
-        return cf.bool(QueryParams.LIMIT_BY_PROGRAM).eq(limitByProgram)
-    }
+    fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())
 
-    fun limit(limit: Int): TrackedEntityInstanceDownloader {
-        return cf.integer(QueryParams.LIMIT).eq(limit)
-    }
+    fun limitByProgram(limitByProgram: Boolean): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().limitByProgram(limitByProgram).build())
 
-    fun byProgramStatus(status: EnrollmentScope): TrackedEntityInstanceDownloader {
-        return cf.baseString(QueryParams.PROGRAM_STATUS).eq(status.toString())
-    }
+    fun limit(limit: Int): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().limit(limit).build())
+
+    fun byProgramStatus(status: EnrollmentScope): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().programStatus(status).build())
 
     /**
      * If true, it overwrites existing TEIs in the device with the TEIs returned from the server. It does not modify
@@ -102,7 +92,6 @@ class TrackedEntityInstanceDownloader internal constructor(
      * @param overwrite True to overwrite
      * @return the new repository
      */
-    fun overwrite(overwrite: Boolean): TrackedEntityInstanceDownloader {
-        return cf.bool(QueryParams.OVERWRITE).eq(overwrite)
-    }
+    fun overwrite(overwrite: Boolean): TrackedEntityInstanceDownloader =
+        TrackedEntityInstanceDownloader(call, params.toBuilder().overwrite(overwrite).build())
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -112,13 +112,13 @@ class TrackedEntityInstanceDownloader internal constructor(
     fun byFilterUids(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
         connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
 
-    fun byTrackedEntityInstanceFilter(filter: TrackedEntityInstanceFilter): TrackedEntityInstanceDownloader =
-        connectorFactory.eqConnector<TrackedEntityInstanceFilter> { trackedEntityInstanceFilter ->
-            params.toBuilder().trackedEntityInstanceFilter(trackedEntityInstanceFilter).build()
-        }.eq(filter)
+    fun byTrackedEntityInstanceFilters(filters: List<TrackedEntityInstanceFilter>): TrackedEntityInstanceDownloader =
+        connectorFactory.listConnector { teiFilters ->
+            params.toBuilder().trackedEntityInstanceFilters(teiFilters).build()
+        }.`in`(filters)
 
-    fun byProgramStageWorkingList(workingList: ProgramStageWorkingList): TrackedEntityInstanceDownloader =
-        connectorFactory.eqConnector<ProgramStageWorkingList> { programStageWorkingList ->
-            params.toBuilder().programStageWorkingList(programStageWorkingList).build()
-        }.eq(workingList)
+    fun byProgramStageWorkingLists(workingLists: List<ProgramStageWorkingList>): TrackedEntityInstanceDownloader =
+        connectorFactory.listConnector { programStageWorkingLists ->
+            params.toBuilder().programStageWorkingLists(programStageWorkingLists).build()
+        }.`in`(workingLists)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -40,6 +40,7 @@ import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
 @Singleton
+@Suppress("TooManyFunctions")
 class TrackedEntityInstanceDownloader internal constructor(
     private val call: TrackedEntityInstanceDownloadCall,
     private val params: ProgramDataDownloadParams,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -43,8 +43,8 @@ class TrackedEntityInstanceDownloader internal constructor(
     private val params: ProgramDataDownloadParams,
 ) : BaseRepository {
 
-    private val connectorFactory
-            : ScopedFilterConnectorFactory<TrackedEntityInstanceDownloader, ProgramDataDownloadParams> =
+    private val connectorFactory:
+        ScopedFilterConnectorFactory<TrackedEntityInstanceDownloader, ProgramDataDownloadParams> =
         ScopedFilterConnectorFactory { params ->
             TrackedEntityInstanceDownloader(call, params)
         }
@@ -71,7 +71,6 @@ class TrackedEntityInstanceDownloader internal constructor(
 
     fun byProgramUid(programUid: String): TrackedEntityInstanceDownloader =
         TrackedEntityInstanceDownloader(call, params.toBuilder().program(programUid).build())
-
 
     fun limitByOrgunit(limitByOrgunit: Boolean): TrackedEntityInstanceDownloader =
         TrackedEntityInstanceDownloader(call, params.toBuilder().limitByOrgunit(limitByOrgunit).build())

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -109,7 +109,7 @@ class TrackedEntityInstanceDownloader internal constructor(
             params.toBuilder().overwrite(overwrite).build()
         }.eq(overwrite)
 
-    fun byFilterUids(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
+    fun byFilterUid(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
         connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
 
     fun byTrackedEntityInstanceFilter(): ListFilterConnector<

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -120,5 +120,4 @@ class TrackedEntityInstanceDownloader internal constructor(
         connectorFactory.eqConnector<ProgramStageWorkingList> { programStageWorkingList ->
             params.toBuilder().programStageWorkingList(programStageWorkingList).build()
         }.eq(workingList)
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -112,13 +112,16 @@ class TrackedEntityInstanceDownloader internal constructor(
     fun byFilterUids(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =
         connectorFactory.listConnector { filterUids -> params.toBuilder().filterUids(filterUids).build() }
 
-    fun byTrackedEntityInstanceFilters(filters: List<TrackedEntityInstanceFilter>): TrackedEntityInstanceDownloader =
+    fun byTrackedEntityInstanceFilter(): ListFilterConnector<
+        TrackedEntityInstanceDownloader,
+        TrackedEntityInstanceFilter,
+        > =
         connectorFactory.listConnector { teiFilters ->
             params.toBuilder().trackedEntityInstanceFilters(teiFilters).build()
-        }.`in`(filters)
+        }
 
-    fun byProgramStageWorkingLists(workingLists: List<ProgramStageWorkingList>): TrackedEntityInstanceDownloader =
+    fun byProgramStageWorkingList(): ListFilterConnector<TrackedEntityInstanceDownloader, ProgramStageWorkingList> =
         connectorFactory.listConnector { programStageWorkingLists ->
             params.toBuilder().programStageWorkingLists(programStageWorkingLists).build()
-        }.`in`(workingLists)
+        }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -29,7 +29,6 @@
 package org.hisp.dhis.android.core.event
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.event.internal.EventDownloadCall
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.junit.Before

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -101,7 +101,7 @@ class EventDownloaderShould {
     @Test
     fun should_parse_event_filter_params() {
         val eventFilter: EventFilter = mock()
-        downloader.byEventFilters(listOf(eventFilter)).download()
+        downloader.byEventFilter().eq(eventFilter).download()
 
         verify(call).download(paramsCapture.capture())
         val params = paramsCapture.firstValue

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -73,4 +73,39 @@ class EventDownloaderShould {
         assertThat(params.uids()[1]).isEqualTo("uid1")
         assertThat(params.uids()[2]).isEqualTo("uid2")
     }
+
+    @Test
+    fun should_parse_filter_uid_eq_params() {
+        downloader.byFilterUids().eq("filterUid").download()
+
+        verify(call).download(paramsCapture.capture())
+        val params = paramsCapture.firstValue
+
+        assertThat(params.filterUids()?.size).isEqualTo(1)
+        assertThat(params.filterUids()?.get(0)).isEqualTo("filterUid")
+    }
+
+    @Test
+    fun should_parse_filter_uid_in_params() {
+        downloader.byFilterUids().`in`("filterUid0", "filterUid1", "filterUid2").download()
+
+        verify(call).download(paramsCapture.capture())
+        val params = paramsCapture.firstValue
+
+        assertThat(params.filterUids()?.size).isEqualTo(3)
+        assertThat(params.filterUids()?.get(0)).isEqualTo("filterUid0")
+        assertThat(params.filterUids()?.get(1)).isEqualTo("filterUid1")
+        assertThat(params.filterUids()?.get(2)).isEqualTo("filterUid2")
+    }
+
+    @Test
+    fun should_parse_event_filter_params() {
+        val eventFilter: EventFilter = mock()
+        downloader.byEventFilter(eventFilter).download()
+
+        verify(call).download(paramsCapture.capture())
+        val params = paramsCapture.firstValue
+
+        assertThat(params.eventFilter()).isEqualTo(eventFilter)
+    }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -101,11 +101,11 @@ class EventDownloaderShould {
     @Test
     fun should_parse_event_filter_params() {
         val eventFilter: EventFilter = mock()
-        downloader.byEventFilter(eventFilter).download()
+        downloader.byEventFilters(listOf(eventFilter)).download()
 
         verify(call).download(paramsCapture.capture())
         val params = paramsCapture.firstValue
 
-        assertThat(params.eventFilter()).isEqualTo(eventFilter)
+        assertThat(params.eventFilters()).isEqualTo(listOf(eventFilter))
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -42,11 +42,13 @@ class EventDownloaderShould {
 
     private val paramsCapture: KArgumentCaptor<ProgramDataDownloadParams> = argumentCaptor()
 
+    private lateinit var params: ProgramDataDownloadParams
     private lateinit var downloader: EventDownloader
 
     @Before
     fun setUp() {
-        downloader = EventDownloader(RepositoryScope.empty(), call)
+        params = ProgramDataDownloadParams.builder().build()
+        downloader = EventDownloader(call, params)
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -76,7 +76,7 @@ class EventDownloaderShould {
 
     @Test
     fun should_parse_filter_uid_eq_params() {
-        downloader.byFilterUids().eq("filterUid").download()
+        downloader.byFilterUid().eq("filterUid").download()
 
         verify(call).download(paramsCapture.capture())
         val params = paramsCapture.firstValue
@@ -87,7 +87,7 @@ class EventDownloaderShould {
 
     @Test
     fun should_parse_filter_uid_in_params() {
-        downloader.byFilterUids().`in`("filterUid0", "filterUid1", "filterUid2").download()
+        downloader.byFilterUid().`in`("filterUid0", "filterUid1", "filterUid2").download()
 
         verify(call).download(paramsCapture.capture())
         val params = paramsCapture.firstValue

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -129,7 +129,7 @@ class TrackedEntityInstanceDownloaderShould {
     @Test
     fun should_parse_tracked_entity_instance_filter_params() {
         val trackedEntityInstanceFilter: TrackedEntityInstanceFilter = mock()
-        downloader.byTrackedEntityInstanceFilters(listOf(trackedEntityInstanceFilter)).download()
+        downloader.byTrackedEntityInstanceFilter().eq(trackedEntityInstanceFilter).download()
 
         verify(call).download(paramsCapture.capture())
 
@@ -141,7 +141,8 @@ class TrackedEntityInstanceDownloaderShould {
     fun should_parse_program_stage_working_list_params() {
         val programStageWorkingList1: ProgramStageWorkingList = mock()
         val programStageWorkingList2: ProgramStageWorkingList = mock()
-        downloader.byProgramStageWorkingLists(listOf(programStageWorkingList1, programStageWorkingList2)).download()
+        downloader.byProgramStageWorkingList().`in`(listOf(programStageWorkingList1, programStageWorkingList2))
+            .download()
 
         verify(call).download(paramsCapture.capture())
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -104,7 +104,7 @@ class TrackedEntityInstanceDownloaderShould {
 
     @Test
     fun should_parse_filter_uid_eq_params() {
-        downloader.byFilterUids().eq("filterUid").download()
+        downloader.byFilterUid().eq("filterUid").download()
 
         verify(call).download(paramsCapture.capture())
 
@@ -115,7 +115,7 @@ class TrackedEntityInstanceDownloaderShould {
 
     @Test
     fun should_parse_filter_uid_in_params() {
-        downloader.byFilterUids().`in`("filterUid0", "filterUid1", "filterUid2").download()
+        downloader.byFilterUid().`in`("filterUid0", "filterUid1", "filterUid2").download()
 
         verify(call).download(paramsCapture.capture())
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.settings.EnrollmentScope
 import org.junit.Before
@@ -42,15 +41,17 @@ import org.mockito.kotlin.verify
 
 @RunWith(JUnit4::class)
 class TrackedEntityInstanceDownloaderShould {
-    private val callFactory: TrackedEntityInstanceDownloadCall = mock()
+    private val call: TrackedEntityInstanceDownloadCall = mock()
 
     private val paramsCapture: KArgumentCaptor<ProgramDataDownloadParams> = argumentCaptor()
 
+    private lateinit var params: ProgramDataDownloadParams
     private lateinit var downloader: TrackedEntityInstanceDownloader
 
     @Before
     fun setUp() {
-        downloader = TrackedEntityInstanceDownloader(RepositoryScope.empty(), callFactory)
+        params = ProgramDataDownloadParams.builder().build()
+        downloader = TrackedEntityInstanceDownloader(call, params)
     }
 
     @Test
@@ -64,7 +65,7 @@ class TrackedEntityInstanceDownloaderShould {
             .overwrite(true)
             .download()
 
-        verify(callFactory).download(paramsCapture.capture())
+        verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
         assertThat(params.program()).isEqualTo("program-uid")
@@ -79,7 +80,7 @@ class TrackedEntityInstanceDownloaderShould {
     fun should_parse_uid_eq_params() {
         downloader.byUid().eq("uid").download()
 
-        verify(callFactory).download(paramsCapture.capture())
+        verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
         assertThat(params.uids().size).isEqualTo(1)
@@ -90,7 +91,7 @@ class TrackedEntityInstanceDownloaderShould {
     fun should_parse_uid_in_params() {
         downloader.byUid().`in`("uid0", "uid1", "uid2").download()
 
-        verify(callFactory).download(paramsCapture.capture())
+        verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
         assertThat(params.uids().size).isEqualTo(3)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -29,7 +29,9 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
 import org.hisp.dhis.android.core.settings.EnrollmentScope
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -98,5 +100,51 @@ class TrackedEntityInstanceDownloaderShould {
         assertThat(params.uids()[0]).isEqualTo("uid0")
         assertThat(params.uids()[1]).isEqualTo("uid1")
         assertThat(params.uids()[2]).isEqualTo("uid2")
+    }
+
+    @Test
+    fun should_parse_filter_uid_eq_params() {
+        downloader.byFilterUids().eq("filterUid").download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.filterUids()?.size).isEqualTo(1)
+        assertThat(params.filterUids()?.get(0)).isEqualTo("filterUid")
+    }
+
+    @Test
+    fun should_parse_filter_uid_in_params() {
+        downloader.byFilterUids().`in`("filterUid0", "filterUid1", "filterUid2").download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.filterUids()?.size).isEqualTo(3)
+        assertThat(params.filterUids()?.get(0)).isEqualTo("filterUid0")
+        assertThat(params.filterUids()?.get(1)).isEqualTo("filterUid1")
+        assertThat(params.filterUids()?.get(2)).isEqualTo("filterUid2")
+    }
+
+    @Test
+    fun should_parse_tracked_entity_instance_filter_params() {
+        val trackedEntityInstanceFilter: TrackedEntityInstanceFilter = mock()
+        downloader.byTrackedEntityInstanceFilter(trackedEntityInstanceFilter).download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.trackedEntityInstanceFilter()).isEqualTo(trackedEntityInstanceFilter)
+    }
+
+    @Test
+    fun should_parse_program_stage_working_list_params() {
+        val programStageWorkingList: ProgramStageWorkingList = mock()
+        downloader.byProgramStageWorkingList(programStageWorkingList).download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.programStageWorkingList()).isEqualTo(programStageWorkingList)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -129,22 +129,24 @@ class TrackedEntityInstanceDownloaderShould {
     @Test
     fun should_parse_tracked_entity_instance_filter_params() {
         val trackedEntityInstanceFilter: TrackedEntityInstanceFilter = mock()
-        downloader.byTrackedEntityInstanceFilter(trackedEntityInstanceFilter).download()
+        downloader.byTrackedEntityInstanceFilters(listOf(trackedEntityInstanceFilter)).download()
 
         verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
-        assertThat(params.trackedEntityInstanceFilter()).isEqualTo(trackedEntityInstanceFilter)
+        assertThat(params.trackedEntityInstanceFilters()).isEqualTo(listOf(trackedEntityInstanceFilter))
     }
 
     @Test
     fun should_parse_program_stage_working_list_params() {
-        val programStageWorkingList: ProgramStageWorkingList = mock()
-        downloader.byProgramStageWorkingList(programStageWorkingList).download()
+        val programStageWorkingList1: ProgramStageWorkingList = mock()
+        val programStageWorkingList2: ProgramStageWorkingList = mock()
+        downloader.byProgramStageWorkingLists(listOf(programStageWorkingList1, programStageWorkingList2)).download()
 
         verify(call).download(paramsCapture.capture())
 
         val params = paramsCapture.firstValue
-        assertThat(params.programStageWorkingList()).isEqualTo(programStageWorkingList)
+        assertThat(params.programStageWorkingLists())
+            .isEqualTo(listOf(programStageWorkingList1, programStageWorkingList2))
     }
 }


### PR DESCRIPTION
Implements `byFilterUids()` and `byFilter()` in `TrackedEntityInstanceDownloader` and `EventDownloader`, supporting `in` and `eq` operators.
Includes support for `TrackedEntityInstanceFilter`, `ProgramStageWorkingList`, and `EventFilter`.
`DownloadCall` implementation will be handled separately.