### PR TITLE
fix: [ANDROSDK-2164] Call handler event if the object list is empty 

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalNoResourceSyncCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalNoResourceSyncCallProcessor.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.call.processors.internal
 
-import org.hisp.dhis.android.core.arch.call.executors.internal.D2CallExecutor
+import org.hisp.dhis.android.core.arch.call.executors.internal.D2CallExecutor.Companion.create
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.Handler
 import org.hisp.dhis.android.core.maintenance.D2Error
@@ -38,10 +38,8 @@ internal class TransactionalNoResourceSyncCallProcessor<O>(
 ) : CallProcessor<O> {
     @Throws(D2Error::class)
     override fun process(objectList: List<O>) {
-        if (objectList.isNotEmpty()) {
-            D2CallExecutor.create(databaseAdapter).executeD2CallTransactionally<Unit> {
-                handler.handleMany(objectList)
-            }
+        create(databaseAdapter).executeD2CallTransactionally {
+            handler.handleMany(objectList)
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalResourceSyncCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalResourceSyncCallProcessor.kt
@@ -40,11 +40,9 @@ internal class TransactionalResourceSyncCallProcessor<O>(
 ) : CallProcessor<O> {
     @Throws(D2Error::class)
     override fun process(objectList: List<O>) {
-        if (objectList.isNotEmpty()) {
-            create(data.databaseAdapter).executeD2CallTransactionally<Unit>({
-                handler.handleMany(objectList)
-                data.handleResource(resourceType)
-            })
+        create(data.databaseAdapter).executeD2CallTransactionally {
+            handler.handleMany(objectList)
+            data.handleResource(resourceType)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-dhis2AndroidSdkVersion = "1.12.1-SNAPSHOT"
-dhis2AndroidSdkCode = "298"
+dhis2AndroidSdkVersion = "1.12.1.1-SNAPSHOT"
+dhis2AndroidSdkCode = "299"
 
 gradle = "8.6.1"
 kotlin = "2.0.20"

--- a/scripts/config_jenkins.init
+++ b/scripts/config_jenkins.init
@@ -1,6 +1,6 @@
 build_time_average=120
 polling_interval=10
-browserstack_device_list="\"Google Pixel 4-10.0\""
+browserstack_device_list="\"Google Pixel 7-13.0\""
 browserstack_video=false
 browserstack_local=false
 browserstack_deviceLogs=true


### PR DESCRIPTION
This PR is a hotfix to unblock the metadata synchronization in a specific configuration (check [this ticket](https://dhis2.atlassian.net/browse/ANDROSDK-2164))