### PR TITLE
feat: [DO-NOT-MERGE] [ANDROSDK-2043-3] Remove unused CustomIntentContext variables

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentContext.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentContext.kt
@@ -29,7 +29,5 @@
 package org.hisp.dhis.android.core.settings
 
 data class CustomIntentContext(
-    val programUid: String? = null,
-    val programStageUid: String? = null,
     val orgunitUid: String? = null,
 )


### PR DESCRIPTION
Do not merge until [this PR](https://github.com/dhis2/dhis2-android-capture-app/pull/4398) is merged.