### PR TITLE
chore: [ANDROSDK-2153] Implement download by filters in the DownloadCall

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10997,13 +10997,17 @@ public class org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSyncCo
 public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle : org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle {
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
+	public abstract fun programStageWorkingLists ()Ljava/util/List;
 	public abstract fun programStatus ()Lorg/hisp/dhis/android/core/enrollment/EnrollmentStatus;
+	public abstract fun trackedEntityInstanceFilters ()Ljava/util/List;
 }
 
 public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder : org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle$Builder {
 	public fun <init> ()V
 	public abstract fun build ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle;
+	public abstract fun programStageWorkingLists (Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
 	public abstract fun programStatus (Lorg/hisp/dhis/android/core/enrollment/EnrollmentStatus;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
+	public abstract fun trackedEntityInstanceFilters (Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
 }
 
 public abstract interface class org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManager {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -8173,7 +8173,6 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun eventFilters ()Ljava/util/List;
-	public abstract fun filterUids ()Ljava/util/List;
 	public fun hasProgramOrFilters ()Z
 	public abstract fun limit ()Ljava/lang/Integer;
 	public abstract fun limitByOrgunit ()Ljava/lang/Boolean;
@@ -8196,7 +8195,6 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public fun <init> ()V
 	public abstract fun build ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams;
 	public abstract fun eventFilters (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
-	public abstract fun filterUids (Ljava/util/List;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limit (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limitByOrgunit (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun limitByProgram (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -5496,6 +5496,7 @@ public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/d
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun getEventFilterCollectionRepository ()Lorg/hisp/dhis/android/core/event/EventFilterCollectionRepository;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByProgram (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
@@ -8173,6 +8174,7 @@ public abstract class org/hisp/dhis/android/core/program/internal/ProgramDataDow
 	public static fun builder ()Lorg/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams$Builder;
 	public abstract fun eventFilters ()Ljava/util/List;
 	public abstract fun filterUids ()Ljava/util/List;
+	public fun hasProgramOrFilters ()Z
 	public abstract fun limit ()Ljava/lang/Integer;
 	public abstract fun limitByOrgunit ()Ljava/lang/Boolean;
 	public abstract fun limitByProgram ()Ljava/lang/Boolean;
@@ -10946,6 +10948,8 @@ public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEnti
 	public final fun byTrackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun getProgramStageWorkingListObjectRepository ()Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListCollectionRepository;
+	public final fun getTrackedEntityInstanceFilterCollectionRepository ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCollectionRepository;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun limitByProgram (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/executors/internal/CoroutineAPICallExecutorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/executors/internal/CoroutineAPICallExecutorImpl.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.api.executors.internal
 
-import androidx.room.immediateTransaction
+import androidx.room.deferredTransaction
 import androidx.room.useWriterConnection
 import io.ktor.client.plugins.ClientRequestException
 import org.hisp.dhis.android.core.arch.api.internal.D2HttpException
@@ -127,7 +127,7 @@ internal class CoroutineAPICallExecutorImpl(
     ): P {
         return try {
             databaseAdapter.getCurrentDatabase().useWriterConnection { transactor ->
-                transactor.immediateTransaction {
+                transactor.deferredTransaction {
                     block().also { successfulTransactionRoom(cleanForeignKeyErrors) }
                 }
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/executors/internal/CoroutineAPICallExecutorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/executors/internal/CoroutineAPICallExecutorImpl.kt
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.api.executors.internal
 
-import androidx.room.deferredTransaction
+import androidx.room.immediateTransaction
 import androidx.room.useWriterConnection
 import io.ktor.client.plugins.ClientRequestException
 import org.hisp.dhis.android.core.arch.api.internal.D2HttpException
@@ -127,7 +127,7 @@ internal class CoroutineAPICallExecutorImpl(
     ): P {
         return try {
             databaseAdapter.getCurrentDatabase().useWriterConnection { transactor ->
-                transactor.deferredTransaction {
+                transactor.immediateTransaction {
                     block().also { successfulTransactionRoom(cleanForeignKeyErrors) }
                 }
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutor.kt
@@ -48,6 +48,7 @@ internal class D2CallExecutor(
         .errorComponent(D2ErrorComponent.SDK)
 
     @Throws(D2Error::class)
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun <C> executeD2Call(call: suspend () -> C): C {
         try {
             return call()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutor.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.core.arch.call.executors.internal
 
 import android.util.Log
-import androidx.room.deferredTransaction
+import androidx.room.immediateTransaction
 import androidx.room.useWriterConnection
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
@@ -77,7 +77,7 @@ internal class D2CallExecutor(
     private suspend fun <C> innerExecuteD2CallTransactionally(call: suspend () -> C): C {
         return try {
             databaseAdapter.getCurrentDatabase().useWriterConnection { transactor ->
-                transactor.deferredTransaction {
+                transactor.immediateTransaction {
                     call()
                 }
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutorInterface.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/executors/internal/D2CallExecutorInterface.kt
@@ -30,4 +30,5 @@ package org.hisp.dhis.android.core.arch.call.executors.internal
 
 internal interface D2CallExecutorInterface {
     suspend fun <C> executeD2CallTransactionally(call: suspend () -> C): C
+    suspend fun <C> executeD2Call(call: suspend () -> C): C
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalNoResourceSyncCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalNoResourceSyncCallProcessor.kt
@@ -38,7 +38,7 @@ internal class TransactionalNoResourceSyncCallProcessor<O>(
 ) : CallProcessor<O> {
     @Throws(D2Error::class)
     override suspend fun process(objectList: List<O>) {
-        create(databaseAdapter).executeD2CallTransactionally {
+        create(databaseAdapter).executeD2Call {
             handler.handleMany(objectList)
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalResourceSyncCallProcessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/processors/internal/TransactionalResourceSyncCallProcessor.kt
@@ -40,7 +40,7 @@ internal class TransactionalResourceSyncCallProcessor<O>(
 ) : CallProcessor<O> {
     @Throws(D2Error::class)
     override suspend fun process(objectList: List<O>) {
-        create(data.databaseAdapter).executeD2CallTransactionally {
+        create(data.databaseAdapter).executeD2Call {
             handler.handleMany(objectList)
             data.handleResource(resourceType)
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -129,7 +129,8 @@ internal class EventDownloadCall internal constructor(
         program: String?,
         orgunitUid: String?,
         limit: Int,
-    ): TrackerAPIQuery {
+    ): TrackerAPIQuery? {
+        if (bundle.eventFilters()?.isEmpty() == true) return null
         val eventUidsByFilters: List<String> = getEventUidsByFilters(bundle.eventFilters())
 
         return TrackerAPIQuery(

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -144,6 +144,6 @@ internal class EventDownloadCall internal constructor(
     }
 
     private fun getEventUidsByFilters(eventFilters: List<EventFilter>?): List<String> = eventFilters?.flatMap {
-        eventQueryCollectionRepository.byEventFilterObject().eq(it).blockingGetUids() // Add online only
+        eventQueryCollectionRepository.byEventFilterObject().eq(it).blockingGetUids() // Do in another task
     } ?: emptyList()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -130,18 +130,25 @@ internal class EventDownloadCall internal constructor(
         orgunitUid: String?,
         limit: Int,
     ): TrackerAPIQuery? {
-        if (bundle.eventFilters()?.isEmpty() == true) return null
-        val eventUidsByFilters: List<String> = getEventUidsByFilters(bundle.eventFilters())
+        val eventUids = if (bundle.eventFilters() != null) {
+            val filteredUids = getEventUidsByFilters(bundle.eventFilters())
 
-        return TrackerAPIQuery(
-            commonParams = bundle.commonParams().copy(
-                program = program,
-                limit = limit,
-            ),
-            lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
-            orgUnit = orgunitUid,
-            uids = eventUidsByFilters,
-        )
+            filteredUids.takeIf { it.isNotEmpty() }
+        } else {
+            emptyList()
+        }
+
+        return eventUids?.let {
+            TrackerAPIQuery(
+                commonParams = bundle.commonParams().copy(
+                    program = program,
+                    limit = limit,
+                ),
+                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
+                orgUnit = orgunitUid,
+                uids = eventUids.distinct(),
+            )
+        }
     }
 
     private fun getEventUidsByFilters(eventFilters: List<EventFilter>?): List<String> = eventFilters?.flatMap {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundle.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundle.java
@@ -28,12 +28,20 @@
 
 package org.hisp.dhis.android.core.event.internal;
 
+import androidx.annotation.Nullable;
+
 import com.google.auto.value.AutoValue;
 
+import org.hisp.dhis.android.core.event.EventFilter;
 import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle;
+
+import java.util.List;
 
 @AutoValue
 abstract class EventQueryBundle extends BaseTrackerQueryBundle {
+
+    @Nullable
+    public abstract List<EventFilter> eventFilters();
 
     static Builder builder() {
         return new AutoValue_EventQueryBundle.Builder();
@@ -41,6 +49,9 @@ abstract class EventQueryBundle extends BaseTrackerQueryBundle {
 
     @AutoValue.Builder
     abstract static class Builder extends BaseTrackerQueryBundle.Builder<Builder> {
+
+        abstract Builder eventFilters(List<EventFilter> eventFilters);
+
         abstract EventQueryBundle build();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactory.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.event.internal
 
+import org.hisp.dhis.android.core.event.EventFilterCollectionRepository
 import org.hisp.dhis.android.core.program.ProgramType
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.program.internal.ProgramStore
@@ -42,6 +43,7 @@ internal class EventQueryBundleFactory(
     programSettingsObjectRepository: ProgramSettingsObjectRepository,
     lastUpdatedManager: EventLastUpdatedManager,
     commonHelper: TrackerQueryFactoryCommonHelper,
+    eventFilterCollectionRepository: EventFilterCollectionRepository,
 ) : TrackerQueryFactory<EventQueryBundle, EventSync>(
     programStore,
     programSettingsObjectRepository,
@@ -51,6 +53,6 @@ internal class EventQueryBundleFactory(
     { params: ProgramDataDownloadParams,
             programSettings: ProgramSettings?,
         ->
-        EventQueryBundleInternalFactory(commonHelper, params, programSettings)
+        EventQueryBundleInternalFactory(commonHelper, params, programSettings, eventFilterCollectionRepository)
     },
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -64,7 +64,7 @@ internal class EventQueryBundleInternalFactory(
         ) { it?.eventDateDownload() }
 
         val eventFilters = (params.eventFilters() ?: emptyList()).plus(
-            eventFilterCollectionRepository.byUid().`in`(params.filterUids()).blockingGet()
+            eventFilterCollectionRepository.byUid().`in`(params.filterUids()).blockingGet(),
         )
 
         val programSettingFilters = eventFilterCollectionRepository.byUid()
@@ -74,7 +74,10 @@ internal class EventQueryBundleInternalFactory(
             .eventFilters(eventFilters.takeIf { it.isNotEmpty() } ?: programSettingFilters)
             .commonParams(commonParams)
 
-        return commonHelper.divideByOrgUnits(commonParams.orgUnitsBeforeDivision, commonParams.hasLimitByOrgUnit) {
+        return commonHelper.divideByOrgUnits(
+            commonParams.orgUnitsBeforeDivision,
+            commonParams.hasLimitByOrgUnit,
+        ) {
             builder.orgUnits(it).build()
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -64,11 +64,16 @@ internal class EventQueryBundleInternalFactory(
         ) { it?.eventDateDownload() }
 
         val eventFilters = (params.eventFilters() ?: emptyList()).plus(
-            eventFilterCollectionRepository.byUid().`in`(params.filterUids()).blockingGet(),
+            eventFilterCollectionRepository
+                .byUid().`in`(params.filterUids())
+                .withEventDataFilters()
+                .blockingGet(),
         )
 
-        val programSettingFilters = eventFilterCollectionRepository.byUid()
-            .`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() }).blockingGet()
+        val programSettingFilters = eventFilterCollectionRepository
+            .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })
+            .withEventDataFilters()
+            .blockingGet()
 
         val builder = EventQueryBundle.builder()
             .eventFilters(eventFilters.takeIf { it.isNotEmpty() } ?: programSettingFilters)

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -63,7 +63,7 @@ internal class EventQueryBundleInternalFactory(
             orgUnitByLimitExtractor,
         ) { it?.eventDateDownload() }
 
-        val eventFilters = params.eventFilters()?.plus(
+        val eventFilters = (params.eventFilters() ?: emptyList()).plus(
             eventFilterCollectionRepository.byUid().`in`(params.filterUids()).blockingGet()
         )
 
@@ -71,7 +71,7 @@ internal class EventQueryBundleInternalFactory(
             .`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() }).blockingGet()
 
         val builder = EventQueryBundle.builder()
-            .eventFilters(eventFilters ?: programSettingFilters)
+            .eventFilters(eventFilters.takeIf { it.isNotEmpty() } ?: programSettingFilters)
             .commonParams(commonParams)
 
         return commonHelper.divideByOrgUnits(commonParams.orgUnitsBeforeDivision, commonParams.hasLimitByOrgUnit) {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -63,12 +63,7 @@ internal class EventQueryBundleInternalFactory(
             orgUnitByLimitExtractor,
         ) { it?.eventDateDownload() }
 
-        val eventFilters = (params.eventFilters() ?: emptyList()).plus(
-            eventFilterCollectionRepository
-                .byUid().`in`(params.filterUids())
-                .withEventDataFilters()
-                .blockingGet(),
-        )
+        val eventFilters = (params.eventFilters() ?: emptyList())
 
         val programSettingFilters = eventFilterCollectionRepository
             .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -180,6 +180,12 @@ class EventQueryCollectionRepository internal constructor(
         }
     }
 
+    internal fun byEventFilterObject(): EqFilterConnector<EventQueryCollectionRepository, EventFilter> {
+        return connectorFactory.eqConnector { eventFilter ->
+            EventQueryRepositoryScopeHelper.addEventFilter(scope, eventFilter!!)
+        }
+    }
+
     /**
      * Filter by sync status.
      * <br></br>**IMPORTANT:** using this filter forces **offlineOnly** mode.

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitModuleDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitModuleDownloader.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.organisationunit.internal
 
-import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.dataset.internal.DataSetOrganisationUnitLinkCleaner
 import org.hisp.dhis.android.core.program.internal.ProgramOrganisationUnitLinkCleaner
 import org.hisp.dhis.android.core.user.User
@@ -39,7 +38,6 @@ internal class OrganisationUnitModuleDownloader(
     private val organisationUnitCall: OrganisationUnitCall,
     private val userCall: UserCall,
     private val organisationUnitLevelEndpointCall: OrganisationUnitLevelEndpointCall,
-    private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     private val dataSetLinkCleaner: DataSetOrganisationUnitLinkCleaner,
     private val programLinkCleaner: ProgramOrganisationUnitLinkCleaner,
 ) {

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitModuleDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitModuleDownloader.kt
@@ -49,11 +49,9 @@ internal class OrganisationUnitModuleDownloader(
     }
 
     suspend fun refreshOrganisationUnits() {
-        coroutineAPICallExecutor.wrapTransactionallyRoom(cleanForeignKeyErrors = true) {
-            val user = userCall.call()
-            downloadMetadata(user)
-            cleanLinksFromDB()
-        }
+        val user = userCall.call()
+        downloadMetadata(user)
+        cleanLinksFromDB()
     }
 
     private suspend fun cleanLinksFromDB() {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -86,9 +86,6 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
     public abstract Boolean overwrite();
 
     @Nullable
-    public abstract List<String> filterUids();
-
-    @Nullable
     public abstract List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters();
 
     @Nullable
@@ -131,8 +128,6 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
         public abstract Builder limit(Integer limit);
 
         public abstract Builder overwrite(Boolean overwrite);
-
-        public abstract Builder filterUids(List<String> filterUids);
 
         public abstract Builder trackedEntityInstanceFilters(
                 List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -146,8 +146,8 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
 
     public boolean hasProgramOrFilters() {
         return program() != null ||
-                (programStageWorkingLists() != null && !programStageWorkingLists().isEmpty()) ||
-                (trackedEntityInstanceFilters() != null && !trackedEntityInstanceFilters().isEmpty()) ||
-                (eventFilters() != null && !eventFilters().isEmpty());
+                programStageWorkingLists() != null && !programStageWorkingLists().isEmpty() ||
+                trackedEntityInstanceFilters() != null && !trackedEntityInstanceFilters().isEmpty() ||
+                eventFilters() != null && !eventFilters().isEmpty();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.java
@@ -143,4 +143,11 @@ public abstract class ProgramDataDownloadParams implements BaseScope {
 
         public abstract ProgramDataDownloadParams build();
     }
+
+    public boolean hasProgramOrFilters() {
+        return program() != null ||
+                (programStageWorkingLists() != null && !programStageWorkingLists().isEmpty()) ||
+                (trackedEntityInstanceFilters() != null && !trackedEntityInstanceFilters().isEmpty()) ||
+                (eventFilters() != null && !eventFilters().isEmpty());
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -155,7 +155,12 @@ internal class TrackedEntityInstanceDownloadCall(
         program: String?,
         orgunitUid: String?,
         limit: Int,
-    ): TrackerAPIQuery {
+    ): TrackerAPIQuery? {
+        if (
+            bundle.trackedEntityInstanceFilters()?.isEmpty() == true &&
+            bundle.programStageWorkingLists()?.isEmpty() == true
+        ) return null
+
         val teiUids = getTeiUidsByFilter(bundle.trackedEntityInstanceFilters()) +
             getTeiUidsByWorkingList(bundle.programStageWorkingLists())
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -173,13 +173,13 @@ internal class TrackedEntityInstanceDownloadCall(
 
     private fun getTeiUidsByFilter(trackedEntityInstanceFilters: List<TrackedEntityInstanceFilter>?): List<String> {
         return trackedEntityInstanceFilters?.flatMap {
-            teiQueryCollectionRepository.byTrackedEntityInstanceFilterObject().eq(it).blockingGetUids()
+            teiQueryCollectionRepository.byTrackedEntityInstanceFilterObject().eq(it).onlineOnly().blockingGetUids()
         } ?: emptyList()
     }
 
     private fun getTeiUidsByWorkingList(programStageWorkingLists: List<ProgramStageWorkingList>?): List<String> {
         return programStageWorkingLists?.flatMap {
-            teiQueryCollectionRepository.byProgramStageWorkingListObject().eq(it).blockingGetUids()
+            teiQueryCollectionRepository.byProgramStageWorkingListObject().eq(it).onlineOnly().blockingGetUids()
         } ?: emptyList()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -98,31 +98,35 @@ internal class TrackedEntityInstanceDownloadCall(
             programStatus = bundle.programStatus(),
         )
 
-        for (uid in bundle.commonParams().uids) {
-            try {
-                val useEntityEndpoint = teiQuery.commonParams.program != null
+        val useEntityEndpoint = teiQuery.commonParams.program != null
 
+        try {
+            val teisList = mutableListOf<TrackedEntityInstance>()
+
+            for (uid in bundle.commonParams().uids) {
                 val tei = querySingleTei(uid, useEntityEndpoint, teiQuery).getOrThrow()
 
                 if (tei != null) {
-                    val persistParams = IdentifiableDataHandlerParams(
-                        hasAllAttributes = !useEntityEndpoint,
-                        overwrite = overwrite,
-                        asRelationship = false,
-                        program = teiQuery.commonParams.program,
-                    )
-
-                    persistItems(listOf(tei), persistParams, relatives)
-
+                    teisList.add(tei)
                     result.count++
                 }
-            } catch (d2Error: D2Error) {
-                result.successfulSync = false
-                if (result.d2Error == null) {
-                    result.d2Error = d2Error
-                }
             }
+
+            if (teisList.isNotEmpty()) {
+                val persistParams = IdentifiableDataHandlerParams(
+                    hasAllAttributes = !useEntityEndpoint,
+                    overwrite = overwrite,
+                    asRelationship = false,
+                    program = teiQuery.commonParams.program,
+                )
+
+                persistItems(teisList, persistParams, relatives)
+            }
+        } catch (d2Error: D2Error) {
+            result.successfulSync = false
+            result.d2Error = d2Error
         }
+
         return result
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -156,24 +156,30 @@ internal class TrackedEntityInstanceDownloadCall(
         orgunitUid: String?,
         limit: Int,
     ): TrackerAPIQuery? {
-        if (
-            bundle.trackedEntityInstanceFilters()?.isEmpty() == true &&
-            bundle.programStageWorkingLists()?.isEmpty() == true
-        ) return null
+        val teiUids = if (
+            bundle.trackedEntityInstanceFilters() != null ||
+            bundle.programStageWorkingLists() != null
+        ) {
+            val filteredUids = getTeiUidsByFilter(bundle.trackedEntityInstanceFilters()) +
+                getTeiUidsByWorkingList(bundle.programStageWorkingLists())
 
-        val teiUids = getTeiUidsByFilter(bundle.trackedEntityInstanceFilters()) +
-            getTeiUidsByWorkingList(bundle.programStageWorkingLists())
+            filteredUids.takeIf { it.isNotEmpty() }
+        } else {
+            emptyList()
+        }
 
-        return TrackerAPIQuery(
-            commonParams = bundle.commonParams().copy(
-                program = program,
-                limit = limit,
-            ),
-            programStatus = bundle.programStatus(),
-            lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
-            orgUnit = orgunitUid,
-            uids = teiUids.distinct(),
-        )
+        return teiUids?.let {
+            TrackerAPIQuery(
+                commonParams = bundle.commonParams().copy(
+                    program = program,
+                    limit = limit,
+                ),
+                programStatus = bundle.programStatus(),
+                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
+                orgUnit = orgunitUid,
+                uids = teiUids.distinct(),
+            )
+        }
     }
 
     private fun getTeiUidsByFilter(trackedEntityInstanceFilters: List<TrackedEntityInstanceFilter>?): List<String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -163,7 +163,7 @@ internal class TrackedEntityInstanceDownloadCall(
             programStatus = bundle.programStatus(),
             lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
             orgUnit = orgunitUid,
-            uids = teiUids,
+            uids = teiUids.distinct(),
         )
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -57,7 +57,7 @@ class TrackedEntityInstanceDownloader internal constructor(
                 call,
                 params,
                 programStageWorkingListObjectRepository,
-                trackedEntityInstanceFilterCollectionRepository
+                trackedEntityInstanceFilterCollectionRepository,
             )
         }
 
@@ -135,7 +135,6 @@ class TrackedEntityInstanceDownloader internal constructor(
                 teiFilters.takeIf { it.isNotEmpty() }?.let { trackedEntityInstanceFilters(it) }
                 build()
             }
-
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -130,12 +130,10 @@ class TrackedEntityInstanceDownloader internal constructor(
                 .withTrackedEntityInstanceEventFilters()
                 .withAttributeValueFilters()
                 .blockingGet()
-            if (wl.isNotEmpty()) {
-                params.toBuilder().programStageWorkingLists(wl).build()
-            } else if (teiFilters.isNotEmpty()) {
-                params.toBuilder().trackedEntityInstanceFilters(teiFilters).build()
-            } else {
-                params
+            params.toBuilder().run {
+                wl.takeIf { it.isNotEmpty() }?.let { programStageWorkingLists(it) }
+                teiFilters.takeIf { it.isNotEmpty() }?.let { trackedEntityInstanceFilters(it) }
+                build()
             }
 
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.java
@@ -60,9 +60,11 @@ public abstract class TrackerQueryBundle extends BaseTrackerQueryBundle {
 
         public abstract Builder programStatus(EnrollmentStatus programStatus);
 
-        public abstract Builder trackedEntityInstanceFilters(List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
+        public abstract Builder trackedEntityInstanceFilters(
+                List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
 
-        public abstract Builder programStageWorkingLists(List<ProgramStageWorkingList> programStageWorkingLists);
+        public abstract Builder programStageWorkingLists(
+                List<ProgramStageWorkingList> programStageWorkingLists);
 
         public abstract TrackerQueryBundle build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.java
@@ -33,13 +33,23 @@ import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus;
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList;
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter;
 import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle;
+
+import java.util.List;
 
 @AutoValue
 public abstract class TrackerQueryBundle extends BaseTrackerQueryBundle {
 
     @Nullable
     public abstract EnrollmentStatus programStatus();
+
+    @Nullable
+    public abstract List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters();
+
+    @Nullable
+    public abstract List<ProgramStageWorkingList> programStageWorkingLists();
 
     public static Builder builder() {
         return new AutoValue_TrackerQueryBundle.Builder();
@@ -49,6 +59,10 @@ public abstract class TrackerQueryBundle extends BaseTrackerQueryBundle {
     public abstract static class Builder extends BaseTrackerQueryBundle.Builder<Builder> {
 
         public abstract Builder programStatus(EnrollmentStatus programStatus);
+
+        public abstract Builder trackedEntityInstanceFilters(List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
+
+        public abstract Builder programStageWorkingLists(List<ProgramStageWorkingList> programStageWorkingLists);
 
         public abstract TrackerQueryBundle build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleFactory.kt
@@ -30,8 +30,10 @@ package org.hisp.dhis.android.core.trackedentity.internal
 import org.hisp.dhis.android.core.program.ProgramType
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingListCollectionRepository
 import org.hisp.dhis.android.core.settings.ProgramSettings
 import org.hisp.dhis.android.core.settings.ProgramSettingsObjectRepository
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilterCollectionRepository
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -40,6 +42,8 @@ internal class TrackerQueryBundleFactory(
     programSettingsObjectRepository: ProgramSettingsObjectRepository,
     lastUpdatedManager: TrackedEntityInstanceLastUpdatedManager,
     commonHelper: TrackerQueryFactoryCommonHelper,
+    programStageWorkingListObjectRepository: ProgramStageWorkingListCollectionRepository,
+    trackedEntityInstanceFilterCollectionRepository: TrackedEntityInstanceFilterCollectionRepository
 ) : TrackerQueryFactory<TrackerQueryBundle, TrackedEntityInstanceSync>(
     programStore,
     programSettingsObjectRepository,
@@ -49,6 +53,12 @@ internal class TrackerQueryBundleFactory(
     { params: ProgramDataDownloadParams,
             programSettings: ProgramSettings?,
         ->
-        TrackerQueryBundleInternalFactory(commonHelper, params, programSettings)
+        TrackerQueryBundleInternalFactory(
+            commonHelper,
+            params,
+            programSettings,
+            programStageWorkingListObjectRepository,
+            trackedEntityInstanceFilterCollectionRepository,
+        )
     },
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleFactory.kt
@@ -43,7 +43,7 @@ internal class TrackerQueryBundleFactory(
     lastUpdatedManager: TrackedEntityInstanceLastUpdatedManager,
     commonHelper: TrackerQueryFactoryCommonHelper,
     programStageWorkingListObjectRepository: ProgramStageWorkingListCollectionRepository,
-    trackedEntityInstanceFilterCollectionRepository: TrackedEntityInstanceFilterCollectionRepository
+    trackedEntityInstanceFilterCollectionRepository: TrackedEntityInstanceFilterCollectionRepository,
 ) : TrackerQueryFactory<TrackerQueryBundle, TrackedEntityInstanceSync>(
     programStore,
     programSettingsObjectRepository,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -39,7 +39,7 @@ internal class TrackerQueryBundleInternalFactory(
     params: ProgramDataDownloadParams,
     programSettings: ProgramSettings?,
     val programStageWorkingListObjectRepository: ProgramStageWorkingListCollectionRepository,
-    val trackedEntityInstanceFilterCollectionRepository: TrackedEntityInstanceFilterCollectionRepository
+    val trackedEntityInstanceFilterCollectionRepository: TrackedEntityInstanceFilterCollectionRepository,
 ) : TrackerQueryInternalFactory<TrackerQueryBundle>(commonHelper, params, programSettings) {
 
     override suspend fun queryInternal(
@@ -70,13 +70,13 @@ internal class TrackerQueryBundleInternalFactory(
             (params.programStageWorkingLists() ?: emptyList()).plus(
                 programStageWorkingListObjectRepository
                     .byUid().`in`(params.filterUids())
-                    .blockingGet()
+                    .blockingGet(),
             )
 
         val trackedEntityInstanceFilters = (params.trackedEntityInstanceFilters() ?: emptyList()).plus(
             trackedEntityInstanceFilterCollectionRepository
                 .byUid().`in`(params.filterUids())
-                .blockingGet()
+                .blockingGet(),
         )
 
         val programStageWorkingListsSettings = programStageWorkingListObjectRepository
@@ -87,14 +87,17 @@ internal class TrackerQueryBundleInternalFactory(
             .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })
             .blockingGet()
 
-
         val builder = TrackerQueryBundle.builder()
             .commonParams(commonParams)
             .programStatus(programStatus)
-            .programStageWorkingLists(programStageWorkingLists.takeIf { it.isNotEmpty() }
-                ?: programStageWorkingListsSettings)
-            .trackedEntityInstanceFilters(trackedEntityInstanceFilters.takeIf { it.isNotEmpty() }
-                ?: trackedEntityInstanceFiltersSettings)
+            .programStageWorkingLists(
+                programStageWorkingLists.takeIf { it.isNotEmpty() }
+                    ?: programStageWorkingListsSettings,
+            )
+            .trackedEntityInstanceFilters(
+                trackedEntityInstanceFilters.takeIf { it.isNotEmpty() }
+                    ?: trackedEntityInstanceFiltersSettings,
+            )
 
         return commonHelper.divideByOrgUnits(
             commonParams.orgUnitsBeforeDivision,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -67,17 +67,11 @@ internal class TrackerQueryBundleInternalFactory(
         val programStatus = getProgramStatus(params, programSettings, programUid)
 
         val programStageWorkingLists =
-            (params.programStageWorkingLists() ?: emptyList()).plus(
-                programStageWorkingListObjectRepository
-                    .byUid().`in`(params.filterUids())
-                    .blockingGet(),
-            )
+            (params.programStageWorkingLists()?.filter { it.program().uid() == programUid } ?: emptyList())
 
-        val trackedEntityInstanceFilters = (params.trackedEntityInstanceFilters() ?: emptyList()).plus(
-            trackedEntityInstanceFilterCollectionRepository
-                .byUid().`in`(params.filterUids())
-                .blockingGet(),
-        )
+        val trackedEntityInstanceFilters =
+            (params.trackedEntityInstanceFilters()?.filter { it.program()?.uid() == programUid } ?: emptyList())
+
         val filters = programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() }
 
         val programStageWorkingListsSettings = filters.takeIf { !it.isNullOrEmpty() }?.let {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -78,18 +78,23 @@ internal class TrackerQueryBundleInternalFactory(
                 .byUid().`in`(params.filterUids())
                 .blockingGet(),
         )
+        val filters = programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() }
 
-        val programStageWorkingListsSettings = programStageWorkingListObjectRepository
-            .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })
-            .withAttributeValueFilters()
-            .withDataFilters()
-            .blockingGet()
+        val programStageWorkingListsSettings = filters.takeIf { !it.isNullOrEmpty() }?.let {
+            programStageWorkingListObjectRepository
+                .byUid().`in`(it)
+                .withAttributeValueFilters()
+                .withDataFilters()
+                .blockingGet()
+        }
 
-        val trackedEntityInstanceFiltersSettings = trackedEntityInstanceFilterCollectionRepository
-            .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })
-            .withTrackedEntityInstanceEventFilters()
-            .withAttributeValueFilters()
-            .blockingGet()
+        val trackedEntityInstanceFiltersSettings = filters.takeIf { !it.isNullOrEmpty() }?.let {
+            trackedEntityInstanceFilterCollectionRepository
+                .byUid().`in`(it)
+                .withTrackedEntityInstanceEventFilters()
+                .withAttributeValueFilters()
+                .blockingGet()
+        }
 
         val builder = TrackerQueryBundle.builder()
             .commonParams(commonParams)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -81,10 +81,14 @@ internal class TrackerQueryBundleInternalFactory(
 
         val programStageWorkingListsSettings = programStageWorkingListObjectRepository
             .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })
+            .withAttributeValueFilters()
+            .withDataFilters()
             .blockingGet()
 
         val trackedEntityInstanceFiltersSettings = trackedEntityInstanceFilterCollectionRepository
             .byUid().`in`(programSettings?.specificSettings()?.get(programUid)?.filters()?.map { it.uid() })
+            .withTrackedEntityInstanceEventFilters()
+            .withAttributeValueFilters()
             .blockingGet()
 
         val builder = TrackerQueryBundle.builder()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
@@ -374,6 +374,16 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
         }
     }
 
+    internal fun byTrackedEntityInstanceFilterObject(): EqFilterConnector<R, TrackedEntityInstanceFilter> {
+        return connectorFactory.eqConnector { teiFilter: TrackedEntityInstanceFilter? ->
+            val filter = filtersRepository
+                .withTrackedEntityInstanceEventFilters()
+                .withAttributeValueFilters()
+                .uid(teiFilter?.uid()).blockingGet()
+            scopeHelper.addTrackedEntityInstanceFilter(scope, filter!!)
+        }
+    }
+
     /**
      * Apply the filters defined in a [ProgramStageWorkingList]. It will overwrite previous filters in case
      * they overlap. In the same way, they could be overwritten by subsequent filters.
@@ -386,6 +396,16 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
                 .withDataFilters()
                 .withAttributeValueFilters()
                 .uid(id).blockingGet()
+            scopeHelper.addProgramStageWorkingList(scope, workingList!!)
+        }
+    }
+
+    internal fun byProgramStageWorkingListObject(): EqFilterConnector<R, ProgramStageWorkingList> {
+        return connectorFactory.eqConnector { workingList: ProgramStageWorkingList? ->
+            val workingList = workingListRepository
+                .withDataFilters()
+                .withAttributeValueFilters()
+                .uid(workingList?.uid()).blockingGet()
             scopeHelper.addProgramStageWorkingList(scope, workingList!!)
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
@@ -376,11 +376,7 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
 
     internal fun byTrackedEntityInstanceFilterObject(): EqFilterConnector<R, TrackedEntityInstanceFilter> {
         return connectorFactory.eqConnector { teiFilter: TrackedEntityInstanceFilter? ->
-            val filter = filtersRepository
-                .withTrackedEntityInstanceEventFilters()
-                .withAttributeValueFilters()
-                .uid(teiFilter?.uid()).blockingGet()
-            scopeHelper.addTrackedEntityInstanceFilter(scope, filter!!)
+            scopeHelper.addTrackedEntityInstanceFilter(scope, teiFilter!!)
         }
     }
 
@@ -402,10 +398,6 @@ abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constru
 
     internal fun byProgramStageWorkingListObject(): EqFilterConnector<R, ProgramStageWorkingList> {
         return connectorFactory.eqConnector { workingList: ProgramStageWorkingList? ->
-            val workingList = workingListRepository
-                .withDataFilters()
-                .withAttributeValueFilters()
-                .uid(workingList?.uid()).blockingGet()
             scopeHelper.addProgramStageWorkingList(scope, workingList!!)
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -186,13 +186,17 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                 if (bundleResult.bundleCount < bundle.commonParams().limit) {
                     val trackerQuery = getQuery(bundle, bundleProgram.program, orgUnitUid, limit)
 
-                    val result = getItemsForOrgUnitProgramCombination(
-                        trackerQuery,
-                        limit,
-                        bundleProgram.itemCount,
-                        params.overwrite(),
-                        relatives,
-                    )
+                    val result = if (trackerQuery != null) {
+                        getItemsForOrgUnitProgramCombination(
+                            trackerQuery,
+                            limit,
+                            bundleProgram.itemCount,
+                            params.overwrite(),
+                            relatives,
+                        )
+                    } else {
+                        ItemsWithPagingResult(0, true, null, false)
+                    }
 
                     bundleResult.bundleCount += result.count
                     bundleProgram.itemCount += result.count
@@ -387,5 +391,5 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         program: String?,
         orgunitUid: String?,
         limit: Int,
-    ): TrackerAPIQuery
+    ): TrackerAPIQuery?
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -56,7 +56,6 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     private val relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
 ) {
-
     fun download(params: ProgramDataDownloadParams): Flow<TrackerD2Progress> = channelFlow {
         val progressManager = TrackerD2ProgressManager(null)
         if (userOrganisationUnitLinkStore.count() == 0) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserCall.kt
@@ -45,10 +45,7 @@ internal class UserCall(
             coroutineAPICallExecutor.wrap {
                 networkHandler.getUser()
             }.getOrThrow()
-
-        coroutineAPICallExecutor.wrapTransactionallyRoom(cleanForeignKeyErrors = false) {
-            userHandler.handle(user)
-        }
+        userHandler.handle(user)
         return user
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
@@ -162,7 +162,6 @@ class EventQueryBundleFactoryShould {
         assertThat(query.eventFilters()?.first()).isEqualTo(f1)
     }
 
-
     @Test
     fun get_event_date_if_defined() = runTest {
         val settings = ProgramSetting.builder().uid(p1).eventDateDownload(DownloadPeriod.LAST_3_MONTHS).build()

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
@@ -29,13 +29,20 @@ package org.hisp.dhis.android.core.event.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
+import org.hisp.dhis.android.core.event.EventFilter
+import org.hisp.dhis.android.core.event.EventFilterCollectionRepository
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.resource.internal.ResourceHandler
-import org.hisp.dhis.android.core.settings.*
+import org.hisp.dhis.android.core.settings.DownloadPeriod
+import org.hisp.dhis.android.core.settings.LimitScope
+import org.hisp.dhis.android.core.settings.ProgramSetting
+import org.hisp.dhis.android.core.settings.ProgramSettings
+import org.hisp.dhis.android.core.settings.ProgramSettingsObjectRepository
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryFactoryCommonHelper
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.junit.Assert.fail
@@ -57,10 +64,17 @@ class EventQueryBundleFactoryShould {
     private val lastUpdatedManager: EventLastUpdatedManager = mock()
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
     private val organisationUnitProgramLinkLinkStore: OrganisationUnitProgramLinkStore = mock()
+    private val eventFilterCollectionRepository: EventFilterCollectionRepository = mock()
+    private val connectorEvent: StringFilterConnector<EventFilterCollectionRepository> = mock()
 
     private val p1 = "program1"
     private val p2 = "program2"
     private val p3 = "program3"
+    private val f1 = EventFilter.builder()
+        .uid("filter1")
+        .program(p1)
+        .build()
+
     private val ou1 = "ou1"
     private val ou1c1 = "ou1.1"
     private val ou2 = "ou2"
@@ -84,6 +98,10 @@ class EventQueryBundleFactoryShould {
 
         whenever(programSettingsObjectRepository.blockingGet()).thenReturn(programSettings)
 
+        whenever(eventFilterCollectionRepository.byUid()).thenReturn(connectorEvent)
+        whenever(connectorEvent.`in`(null)).thenReturn(eventFilterCollectionRepository)
+        whenever(eventFilterCollectionRepository.blockingGet()).thenReturn(emptyList())
+
         val commonHelper = TrackerQueryFactoryCommonHelper(
             userOrganisationUnitLinkStore,
             organisationUnitProgramLinkLinkStore,
@@ -93,6 +111,7 @@ class EventQueryBundleFactoryShould {
             programSettingsObjectRepository,
             lastUpdatedManager,
             commonHelper,
+            eventFilterCollectionRepository,
         )
     }
 
@@ -131,6 +150,18 @@ class EventQueryBundleFactoryShould {
             }
         }
     }
+
+    @Test
+    fun single_query_if_event_filter_provided_by_user() = runTest {
+        val params = ProgramDataDownloadParams.builder().limit(5000)
+            .eventFilters(listOf(f1)).build()
+        val queries = bundleFactory.getQueries(params)
+        assertThat(queries.size).isEqualTo(1)
+        val query = queries.first()
+        assertThat(query.eventFilters()?.size).isEqualTo(1)
+        assertThat(query.eventFilters()?.first()).isEqualTo(f1)
+    }
+
 
     @Test
     fun get_event_date_if_defined() = runTest {

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
@@ -69,7 +69,6 @@ class TrackedEntityInstanceQueryFactoryShould {
     private val teiFilterCollectionRepository: TrackedEntityInstanceFilterCollectionRepository = mock()
     private val connectorTei: StringFilterConnector<TrackedEntityInstanceFilterCollectionRepository> = mock()
 
-
     private val p1 = "program1"
     private val p2 = "program2"
     private val p3 = "program3"
@@ -118,7 +117,6 @@ class TrackedEntityInstanceQueryFactoryShould {
         whenever(teiFilterCollectionRepository.byUid()).thenReturn(connectorTei)
         whenever(connectorTei.`in`(null)).thenReturn(teiFilterCollectionRepository)
         whenever(teiFilterCollectionRepository.blockingGet()).thenReturn(emptyList())
-
 
         val commonHelper = TrackerQueryFactoryCommonHelper(
             userOrganisationUnitLinkStore,

--- a/core/src/test/java/org/hisp/dhis/android/core/wipe/internal/WipeModuleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/wipe/internal/WipeModuleShould.kt
@@ -92,4 +92,8 @@ internal class FakeD2CallExecutor : D2CallExecutorInterface {
     override suspend fun <C> executeD2CallTransactionally(call: suspend () -> C): C {
         return call()
     }
+
+    override suspend fun <C> executeD2Call(call: suspend () -> C): C {
+        return call()
+    }
 }


### PR DESCRIPTION
This PR enables downloading teis and events using used passed working lists, events and filters as parameters.

Other transaction related issues have been addressed; nested transactions have been simplified.

Related task [ANDROSDK-2153](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2153)

[ANDROSDK-2153]: https://dhis2.atlassian.net/browse/ANDROSDK-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ