### PR TITLE
fix: [ANDROSDK-2166] Do not send created and lastUpdated in datavalue post

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6824,6 +6824,7 @@ public final class org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer {
 	public final fun setDhis2Dispatcher ()V
 	public final fun setRequestDispatcher ()V
 	public final fun shutdown ()V
+	public final fun takeLastRequest ()Lokhttp3/mockwebserver/RecordedRequest;
 	public final fun takeRequest ()Lokhttp3/mockwebserver/RecordedRequest;
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.kt
@@ -41,6 +41,7 @@ import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 @Suppress("TooManyFunctions")
 class Dhis2MockServer(private val fileReader: IFileReader, port: Int) {
@@ -425,6 +426,16 @@ class Dhis2MockServer(private val fileReader: IFileReader, port: Int) {
     @Throws(InterruptedException::class)
     fun takeRequest(): RecordedRequest {
         return server.takeRequest()
+    }
+
+    fun takeLastRequest(): RecordedRequest? {
+        var lastRequest: RecordedRequest? = null
+
+        do {
+            lastRequest = server.takeRequest(1, TimeUnit.SECONDS) ?: break
+        } while (true)
+
+        return lastRequest
     }
 
     fun addResponse(

--- a/core/src/main/java/org/hisp/dhis/android/network/datavalue/DataValueDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/datavalue/DataValueDTO.kt
@@ -77,8 +77,8 @@ internal fun DataValue.toDto(): DataValueDTO {
         attributeOptionCombo = this.attributeOptionCombo()!!,
         value = this.value(),
         storedBy = this.storedBy(),
-        created = this.created()?.let { DateUtils.DATE_FORMAT.format(it) },
-        lastUpdated = this.lastUpdated()?.let { DateUtils.DATE_FORMAT.format(it) },
+        created = null,
+        lastUpdated = null,
         comment = this.comment(),
         followup = this.followUp(),
     )


### PR DESCRIPTION
[ANDROSDK-2166](https://dhis2.atlassian.net/browse/ANDROSDK-2166).

Removes the properties `created` and `lastUpdated` from dataValue post payload.