### PR TITLE
chore: [ANDROSDK-2181] make Dao methods temporarily blocking to improve performance

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
@@ -32,7 +32,6 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.user.User
-import org.junit.Test
 
 class MetadataCallRealIntegrationShould : BaseRealIntegrationTest() {
     /**
@@ -58,9 +57,9 @@ class MetadataCallRealIntegrationShould : BaseRealIntegrationTest() {
     // It depends on a live server to operate and the login is hardcoded here.
     // Uncomment in order to quickly test changes vs a real server, but keep it uncommented after.
 
-    @Test
+//    @Test
     fun response_successful_on_sync_meta_data_once() {
-        d2.userModule().logIn(username, password, "https://play.im.dhis2.org/stable-2-42-2").blockingGet()
+        d2.userModule().logIn(username, password, url).blockingGet()
 
         d2.metadataModule().blockingDownload()
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
@@ -32,6 +32,7 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.user.User
+import org.junit.Test
 
 class MetadataCallRealIntegrationShould : BaseRealIntegrationTest() {
     /**
@@ -57,9 +58,9 @@ class MetadataCallRealIntegrationShould : BaseRealIntegrationTest() {
     // It depends on a live server to operate and the login is hardcoded here.
     // Uncomment in order to quickly test changes vs a real server, but keep it uncommented after.
 
-//    @Test
+    @Test
     fun response_successful_on_sync_meta_data_once() {
-        d2.userModule().logIn(username, password, url).blockingGet()
+        d2.userModule().logIn(username, password, "https://play.im.dhis2.org/stable-2-42-2").blockingGet()
 
         d2.metadataModule().blockingDownload()
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseRoomMigrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseRoomMigrationShould.kt
@@ -172,9 +172,9 @@ class DatabaseRoomMigrationShould {
                 FINAL_DB_VERSION,
                 migratedRoomDb.openHelper.readableDatabase.version,
             )
-            println("Room abrió y validó con éxito MIGRATED_DB_NAME.")
+            println("Room database opened and validated successfully with MIGRATED_DB_NAME.")
         } catch (e: IllegalStateException) {
-            println("Error al validar el esquema de la base de datos migrada por Room: ${e.message}")
+            println("Error validating the schema of the database migrated by Room: ${e.message}")
             throw e
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/D2Dao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/D2Dao.kt
@@ -42,29 +42,29 @@ import org.hisp.dhis.android.persistence.common.SchemaRow
 internal interface D2Dao {
 
     @RawQuery
-    suspend fun intRawQuery(sqlRawQuery: RoomRawQuery): Int
+    fun intRawQuery(sqlRawQuery: RoomRawQuery): Int
 
     @RawQuery
-    suspend fun stringListRawQuery(query: SupportSQLiteQuery): List<String>
+    fun stringListRawQuery(query: SupportSQLiteQuery): List<String>
 
     @RawQuery
-    suspend fun stringRawQuery(query: RoomRawQuery): String
+    fun stringRawQuery(query: RoomRawQuery): String
 
     @RawQuery
-    suspend fun queryStringValue(query: SupportSQLiteQuery): String?
+    fun queryStringValue(query: SupportSQLiteQuery): String?
 
     @TypeConverters(StateTypeConverter::class)
     @RawQuery
-    suspend fun getTypedSyncStates(query: SupportSQLiteQuery): List<State>
+    fun getTypedSyncStates(query: SupportSQLiteQuery): List<State>
 
     @RawQuery
-    suspend fun getCodeMigration133DataValue(query: SupportSQLiteQuery): List<DatabaseCodeMigration133DataValue>
+    fun getCodeMigration133DataValue(query: SupportSQLiteQuery): List<DatabaseCodeMigration133DataValue>
 
     @Query("SELECT name, sql FROM sqlite_master ORDER BY name")
-    suspend fun getSchemaRows(): List<SchemaRow>
+    fun getSchemaRows(): List<SchemaRow>
 
     @RawQuery
-    suspend fun getTableInfo(query: SupportSQLiteQuery): List<PragmaTableInfoRow>
+    fun getTableInfo(query: SupportSQLiteQuery): List<PragmaTableInfoRow>
 }
 
 internal data class PragmaTableInfoRow(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDataObjectDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDataObjectDao.kt
@@ -38,5 +38,5 @@ internal interface IdentifiableDataObjectDao<P : EntityDB<*>> :
     IdentifiableDataObjectDaoQueryFallbacks {
 
     @RawQuery
-    suspend fun stateRawQuery(query: RoomRawQuery): State?
+    fun stateRawQuery(query: RoomRawQuery): State?
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDataObjectDaoQueryFallbacks.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDataObjectDaoQueryFallbacks.kt
@@ -31,7 +31,7 @@ package org.hisp.dhis.android.persistence.common.daos
 import org.hisp.dhis.android.core.common.State
 
 internal interface IdentifiableDataObjectDaoQueryFallbacks {
-    suspend fun setSyncState(uid: String, state: State): Int
-    suspend fun setSyncState(uids: List<String>, state: State): Int
-    suspend fun setSyncStateIfUploading(uid: String, newstate: State, updateState: State): Int
+    fun setSyncState(uid: String, state: State): Int
+    fun setSyncState(uids: List<String>, state: State): Int
+    fun setSyncStateIfUploading(uid: String, newstate: State, updateState: State): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDeletableDataObjectDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDeletableDataObjectDao.kt
@@ -38,5 +38,5 @@ internal interface IdentifiableDeletableDataObjectDao<P : EntityDB<*>> :
     IdentifiableDeletableDataObjectDaoQueryFallbacks {
 
     @RawQuery
-    suspend fun stateListRawQuery(query: RoomRawQuery): List<State>
+    fun stateListRawQuery(query: RoomRawQuery): List<State>
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDeletableDataObjectDaoQueryFallbacks.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableDeletableDataObjectDaoQueryFallbacks.kt
@@ -31,6 +31,6 @@ package org.hisp.dhis.android.persistence.common.daos
 import org.hisp.dhis.android.core.common.State
 
 internal interface IdentifiableDeletableDataObjectDaoQueryFallbacks {
-    suspend fun setDeleted(uid: String): Int
-    suspend fun deleteWhere(uid: String, deleted: Boolean, state: State): Int
+    fun setDeleted(uid: String): Int
+    fun deleteWhere(uid: String, deleted: Boolean, state: State): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableObjectDaoQueryFallbacks.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/IdentifiableObjectDaoQueryFallbacks.kt
@@ -29,5 +29,5 @@
 package org.hisp.dhis.android.persistence.common.daos
 
 internal fun interface IdentifiableObjectDaoQueryFallbacks {
-    suspend fun delete(uid: String): Int
+    fun delete(uid: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/LinkDaoQueryFallbacks.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/LinkDaoQueryFallbacks.kt
@@ -29,6 +29,6 @@
 package org.hisp.dhis.android.persistence.common.daos
 
 internal interface LinkDaoQueryFallbacks {
-    suspend fun deleteLinksForMasterUid(parentUid: String): Int
-    suspend fun deleteLinksForMasterUid(): Int
+    fun deleteLinksForMasterUid(parentUid: String): Int
+    fun deleteLinksForMasterUid(): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/ObjectDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/ObjectDao.kt
@@ -41,32 +41,32 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 internal interface ObjectDao<P : EntityDB<*>> : ReadableDao<P>, ObjectDaoQueryFallbacks {
 
     @Insert(onConflict = OnConflictStrategy.ABORT)
-    suspend fun insert(entity: P): Long
+    fun insert(entity: P): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(entities: Collection<P>): LongArray
+    fun insert(entities: Collection<P>): LongArray
 
     @Update
-    suspend fun update(entity: P): Int
+    fun update(entity: P): Int
 
     @Update
-    suspend fun update(entities: Collection<P>): Int
+    fun update(entities: Collection<P>): Int
 
     @Upsert
-    suspend fun upsert(entity: P): Long
+    fun upsert(entity: P): Long
 
     @Upsert
-    suspend fun upsert(entities: Collection<P>): LongArray
+    fun upsert(entities: Collection<P>): LongArray
 
     @Delete
-    suspend fun delete(entity: P): Int
+    fun delete(entity: P): Int
 
     @Delete
-    suspend fun delete(entities: Collection<P>): Int
+    fun delete(entities: Collection<P>): Int
 
     @RawQuery
-    suspend fun objectRawQuery(query: RoomRawQuery): P?
+    fun objectRawQuery(query: RoomRawQuery): P?
 
     @RawQuery
-    suspend fun stringListRawQuery(query: RoomRawQuery): List<String>
+    fun stringListRawQuery(query: RoomRawQuery): List<String>
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/ObjectDaoQueryFallbacks.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/ObjectDaoQueryFallbacks.kt
@@ -29,5 +29,5 @@
 package org.hisp.dhis.android.persistence.common.daos
 
 internal fun interface ObjectDaoQueryFallbacks {
-    suspend fun deleteAllRows(): Int
+    fun deleteAllRows(): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/ReadableDao.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/daos/ReadableDao.kt
@@ -35,13 +35,13 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 internal interface ReadableDao<P : EntityDB<*>> {
 
     @RawQuery
-    suspend fun objectListRawQuery(sqlRawQuery: RoomRawQuery): List<P>
+    fun objectListRawQuery(sqlRawQuery: RoomRawQuery): List<P>
 
     @RawQuery
-    suspend fun intRawQuery(sqlRawQuery: RoomRawQuery): Int
+    fun intRawQuery(sqlRawQuery: RoomRawQuery): Int
 
     @RawQuery
-    suspend fun groupCountListRawQuery(sqlRawQuery: RoomRawQuery): List<GroupCount>
+    fun groupCountListRawQuery(sqlRawQuery: RoomRawQuery): List<GroupCount>
 }
 
 internal data class GroupCount(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegistrationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegistrationDaoAux.kt
@@ -49,7 +49,7 @@ internal interface DataSetCompleteRegistrationDaoAux : ObjectDao<DataSetComplete
           AND ${DataSetCompleteRegistrationTableInfo.Columns.SYNC_STATE} = :syncedStateValue
     """,
     )
-    suspend fun removeNotPresentAndSynced(
+    fun removeNotPresentAndSynced(
         dataSetUids: Collection<String>,
         periodIds: Collection<String>,
         orgUnitPathQuery: String, // pass this as  "%$rootOrgunitUid%"

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkDaoAux.kt
@@ -44,5 +44,5 @@ internal interface SectionGreyedFieldsLinkDaoAux : LinkDao<SectionGreyedFieldsLi
         WHERE ${SectionGreyedFieldsLinkTableInfo.Columns.SECTION} = :sectionUid
     """,
     )
-    suspend fun deleteBySectionUid(sectionUid: String): Int
+    fun deleteBySectionUid(sectionUid: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datastore/DataStoreDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datastore/DataStoreDaoAux.kt
@@ -40,7 +40,7 @@ internal interface DataStoreDaoAux : ObjectDao<DataStoreDB> {
         WHERE ${DataStoreTableInfo.Columns.NAMESPACE} = :namespace 
         AND `${DataStoreTableInfo.Columns.KEY}` = :key;""",
     )
-    suspend fun setSyncState(state: String, namespace: String, key: String)
+    fun setSyncState(state: String, namespace: String, key: String)
 
     @Query(
         """UPDATE DataStore 
@@ -49,7 +49,7 @@ internal interface DataStoreDaoAux : ObjectDao<DataStoreDB> {
         AND `${DataStoreTableInfo.Columns.KEY}` = :key 
         AND ${DataStoreTableInfo.Columns.SYNC_STATE} = 'UPLOADING';""",
     )
-    suspend fun setStateIfUploading(state: String, namespace: String, key: String)
+    fun setStateIfUploading(state: String, namespace: String, key: String)
 
     @Query(
         """
@@ -58,7 +58,7 @@ internal interface DataStoreDaoAux : ObjectDao<DataStoreDB> {
           AND ${DataStoreTableInfo.Columns.SYNC_STATE} IN (:syncStates) 
     """,
     )
-    suspend fun deleteByNamespaceAndSyncStates(
+    fun deleteByNamespaceAndSyncStates(
         namespace: String,
         syncStates: List<String>,
     ): Int
@@ -71,7 +71,7 @@ internal interface DataStoreDaoAux : ObjectDao<DataStoreDB> {
           AND `${DataStoreTableInfo.Columns.KEY}` NOT IN (:keysToKeep) 
     """,
     )
-    suspend fun deleteByNamespaceSyncStatesAndNotInKeys(
+    fun deleteByNamespaceSyncStatesAndNotInKeys(
         namespace: String,
         syncStates: List<String>,
         keysToKeep: List<String>,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueConflictDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueConflictDaoAux.kt
@@ -44,7 +44,7 @@ internal interface DataValueConflictDaoAux : ObjectDao<DataValueConflictDB> {
           AND ${DataValueConflictTableInfo.Columns.ORG_UNIT} = :organisationUnit
     """,
     )
-    suspend fun deleteDataValueConflict(
+    fun deleteDataValueConflict(
         attributeOptionCombo: String,
         categoryOptionCombo: String,
         dataElement: String,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
@@ -36,7 +36,6 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import net.zetetic.database.DatabaseErrorHandler
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
@@ -36,6 +36,7 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import net.zetetic.database.DatabaseErrorHandler
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
@@ -72,6 +73,7 @@ internal class RoomDatabaseManager(
         Log.d(TAG, "createInMemoryDatabase called. Setting up PRAGMA foreign_keys=OFF.")
         val database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onOpen(db: SupportSQLiteDatabase) {
                     super.onOpen(db)
@@ -88,6 +90,7 @@ internal class RoomDatabaseManager(
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .addMigrations(*ALL_MIGRATIONS.toTypedArray())
             .build()
         databaseAdapter.activate(database, databaseName)
@@ -98,6 +101,7 @@ internal class RoomDatabaseManager(
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .build()
         databaseAdapter.activate(database, databaseName)
         return databaseAdapter

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
@@ -116,6 +116,7 @@ internal class RoomDatabaseManager(
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setQueryExecutor(singleThreadExecutor)
             .setTransactionExecutor(singleThreadExecutor)
+            .allowMainThreadQueries()
             .addMigrations(*ALL_MIGRATIONS.toTypedArray())
             .openHelperFactory(factory)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
@@ -36,6 +36,7 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import net.zetetic.database.DatabaseErrorHandler
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
@@ -72,6 +73,7 @@ internal class RoomDatabaseManager(
         Log.d(TAG, "createInMemoryDatabase called. Setting up PRAGMA foreign_keys=OFF.")
         val database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onOpen(db: SupportSQLiteDatabase) {
                     super.onOpen(db)
@@ -88,6 +90,7 @@ internal class RoomDatabaseManager(
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .addMigrations(*ALL_MIGRATIONS.toTypedArray())
             .build()
         databaseAdapter.activate(database, databaseName)
@@ -97,6 +100,7 @@ internal class RoomDatabaseManager(
     override fun createOrOpenUnencryptedDatabaseWithoutMigration(databaseName: String): DatabaseAdapter {
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .build()
         databaseAdapter.activate(database, databaseName)
         return databaseAdapter

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
@@ -179,6 +179,6 @@ internal class RoomDatabaseManager(
 
 internal class LoggingErrorHandler(private val tag: String) : DatabaseErrorHandler {
     override fun onCorruption(dbObj: net.zetetic.database.sqlcipher.SQLiteDatabase?, exception: SQLiteException?) {
-        Log.e(tag, "¡CORRUPCIÓN DETECTADA! DB Path: ${dbObj?.path}")
+        Log.e(tag, "CORRUPTION DETECTED! DB Path: ${dbObj?.path}")
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseManager.kt
@@ -36,6 +36,7 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import net.zetetic.database.DatabaseErrorHandler
 import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
@@ -72,6 +73,7 @@ internal class RoomDatabaseManager(
         Log.d(TAG, "createInMemoryDatabase called. Setting up PRAGMA foreign_keys=OFF.")
         val database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onOpen(db: SupportSQLiteDatabase) {
                     super.onOpen(db)
@@ -88,6 +90,7 @@ internal class RoomDatabaseManager(
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .addMigrations(*ALL_MIGRATIONS.toTypedArray())
             .build()
         databaseAdapter.activate(database, databaseName)
@@ -98,6 +101,7 @@ internal class RoomDatabaseManager(
         val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
             .setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .allowMainThreadQueries()
             .build()
         databaseAdapter.activate(database, databaseName)
         return databaseAdapter
@@ -118,6 +122,7 @@ internal class RoomDatabaseManager(
             .setQueryCallback({ sqlQuery, bindArgs ->
                 println("SQL Query: $sqlQuery SQL Args: $bindArgs")
             }, Executors.newSingleThreadExecutor())
+            .allowMainThreadQueries()
             .build()
         databaseAdapter.activate(database, databaseName)
         return databaseAdapter

--- a/core/src/main/java/org/hisp/dhis/android/persistence/enrollment/EnrollmentDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/enrollment/EnrollmentDaoAux.kt
@@ -40,7 +40,7 @@ internal interface EnrollmentDaoAux : IdentifiableDeletableDataObjectDao<Enrollm
         SET ${EnrollmentTableInfo.Columns.AGGREGATED_SYNC_STATE} = :state
         WHERE ${IdentifiableColumns.UID} = :uid;""",
     )
-    suspend fun setAggregatedSyncState(state: String, uid: String): Int
+    fun setAggregatedSyncState(state: String, uid: String): Int
 
     @Query(
         """
@@ -48,5 +48,5 @@ internal interface EnrollmentDaoAux : IdentifiableDeletableDataObjectDao<Enrollm
         WHERE ${EnrollmentTableInfo.Columns.UID} IN (:enrollmentUids)
     """,
     )
-    suspend fun deleteByUids(enrollmentUids: List<String>): Int
+    fun deleteByUids(enrollmentUids: List<String>): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDaoAux.kt
@@ -40,5 +40,5 @@ internal interface EventDaoAux : IdentifiableDeletableDataObjectDao<EventDB> {
         SET ${EventTableInfo.Columns.AGGREGATED_SYNC_STATE} = :state
         WHERE ${IdentifiableColumns.UID} = :uid;""",
     )
-    suspend fun setAggregatedSyncState(state: String, uid: String): Int
+    fun setAggregatedSyncState(state: String, uid: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDaoAux.kt
@@ -42,7 +42,7 @@ internal interface EventSyncDaoAux : ObjectDao<EventSyncDB> {
         AND ${Columns.PROGRAM} = :programUid
     """,
     )
-    suspend fun deleteByProgram(programUid: String, organisationUnitIdsHash: Int): Int
+    fun deleteByProgram(programUid: String, organisationUnitIdsHash: Int): Int
 
     @Query(
         """
@@ -51,5 +51,5 @@ internal interface EventSyncDaoAux : ObjectDao<EventSyncDB> {
         AND ${Columns.PROGRAM} IS NULL
     """,
     )
-    suspend fun deleteByNullProgram(organisationUnitIdsHash: Int): Int
+    fun deleteByNullProgram(organisationUnitIdsHash: Int): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/imports/TrackerImportConflictDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/imports/TrackerImportConflictDaoAux.kt
@@ -41,7 +41,7 @@ internal interface TrackerImportConflictDaoAux : ObjectDao<TrackerImportConflict
           AND ${TrackerImportConflictTableInfo.Columns.TABLE_REFERENCE} = :tableName
     """,
     )
-    suspend fun deleteEventConflict(uid: String, tableName: String): Int
+    fun deleteEventConflict(uid: String, tableName: String): Int
 
     @Query(
         """
@@ -50,7 +50,7 @@ internal interface TrackerImportConflictDaoAux : ObjectDao<TrackerImportConflict
           AND ${TrackerImportConflictTableInfo.Columns.TABLE_REFERENCE} = :tableName
     """,
     )
-    suspend fun deleteEnrollmentConflict(uid: String, tableName: String): Int
+    fun deleteEnrollmentConflict(uid: String, tableName: String): Int
 
     @Query(
         """
@@ -59,5 +59,5 @@ internal interface TrackerImportConflictDaoAux : ObjectDao<TrackerImportConflict
           AND ${TrackerImportConflictTableInfo.Columns.TABLE_REFERENCE} = :tableName
     """,
     )
-    suspend fun deleteTrackedEntityConflict(uid: String, tableName: String): Int
+    fun deleteTrackedEntityConflict(uid: String, tableName: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDaoAux.kt
@@ -41,7 +41,7 @@ internal interface NoteDaoAux : IdentifiableObjectDao<NoteDB> {
         WHERE ${NoteTableInfo.Columns.ENROLLMENT} = :enrollmentUid
     """,
     )
-    suspend fun deleteNotesByEnrollment(enrollmentUid: String): Int
+    fun deleteNotesByEnrollment(enrollmentUid: String): Int
 
     @Query(
         """
@@ -49,5 +49,5 @@ internal interface NoteDaoAux : IdentifiableObjectDao<NoteDB> {
         WHERE ${NoteTableInfo.Columns.EVENT} = :eventUid
     """,
     )
-    suspend fun deleteNotesByEvent(eventUid: String): Int
+    fun deleteNotesByEvent(eventUid: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorDaoAux.kt
@@ -41,5 +41,5 @@ internal interface ProgramIndicatorDaoAux : IdentifiableObjectDao<ProgramIndicat
         WHERE ${IdentifiableColumns.UID} IN (:uids)
     """,
     )
-    suspend fun deleteByUids(uids: List<String>)
+    fun deleteByUids(uids: List<String>)
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipItemDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipItemDaoAux.kt
@@ -36,7 +36,7 @@ import org.hisp.dhis.android.processor.GenerateDaoQueries
 @GenerateDaoQueries(tableName = "RelationshipItemTableInfo.TABLE_NAME")
 internal interface RelationshipItemDaoAux : ObjectDao<RelationshipItemDB> {
     @RawQuery
-    suspend fun getRelationshipRow(query: RoomRawQuery): List<RelationshipRow>
+    fun getRelationshipRow(query: RoomRawQuery): List<RelationshipRow>
 }
 
 internal data class RelationshipRow(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/resource/ResourceDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/resource/ResourceDaoAux.kt
@@ -42,5 +42,5 @@ internal interface ResourceDaoAux : ObjectDao<ResourceDB> {
         WHERE ${ResourceTableInfo.Columns.RESOURCE_TYPE} = :type
         """,
     )
-    suspend fun deleteResource(type: Resource.Type): Int
+    fun deleteResource(type: Resource.Type): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsDhisVisualizationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsDhisVisualizationDaoAux.kt
@@ -41,5 +41,5 @@ internal interface AnalyticsDhisVisualizationDaoAux : ObjectDao<AnalyticsDhisVis
           AND ${AnalyticsDhisVisualizationTableInfo.Columns.UID} NOT IN (:uidsToKeep)
     """,
     )
-    suspend fun deleteByTypeAndUidNotIn(typeName: String, uidsToKeep: List<String>): Int
+    fun deleteByTypeAndUidNotIn(typeName: String, uidsToKeep: List<String>): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSConfigDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSConfigDaoAux.kt
@@ -40,5 +40,5 @@ internal interface SMSConfigDaoAux : ObjectDao<SMSConfigDB> {
         WHERE `${SMSConfigTableInfo.Columns.KEY}` = :keyName 
         """,
     )
-    suspend fun deleteByKeyName(keyName: String): Int
+    fun deleteByKeyName(keyName: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSOngoingSubmissionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSOngoingSubmissionDaoAux.kt
@@ -41,5 +41,5 @@ internal interface SMSOngoingSubmissionDaoAux : ObjectDao<SMSOngoingSubmissionDB
         WHERE ${SMSOngoingSubmissionTableInfo.Columns.SUBMISSION_ID} = :submissionId
     """,
     )
-    suspend fun deleteSubmissionIfExists(submissionId: Int)
+    fun deleteSubmissionIfExists(submissionId: Int)
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueDaoAux.kt
@@ -46,7 +46,7 @@ internal interface TrackedEntityAttributeReservedValueDaoAux : ObjectDao<Tracked
             AND ${TrackedEntityAttributeReservedValueTableInfo.Columns.TEMPORAL_VALIDITY_DATE} IS NOT NULL)
         """,
     )
-    suspend fun deleteExpired(serverDateAsString: String): Int
+    fun deleteExpired(serverDateAsString: String): Int
 
     @Query(
         """
@@ -55,5 +55,5 @@ internal interface TrackedEntityAttributeReservedValueDaoAux : ObjectDao<Tracked
         AND ${TrackedEntityAttributeReservedValueTableInfo.Columns.PATTERN} != :pattern
         """,
     )
-    suspend fun deleteIfOutdatedPattern(ownerUid: String, pattern: String)
+    fun deleteIfOutdatedPattern(ownerUid: String, pattern: String)
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
@@ -40,7 +40,7 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
         SET ${TrackedEntityAttributeValueTableInfo.Columns.SYNC_STATE} = :state 
         WHERE ${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_INSTANCE} = :uid""",
     )
-    suspend fun setSyncStateByInstance(state: String, uid: String)
+    fun setSyncStateByInstance(state: String, uid: String)
 
     @Query(
         """
@@ -50,7 +50,7 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
             NOT IN (:trackedEntityAttributeUids)
     """,
     )
-    suspend fun deleteByInstanceAndNotInAttributes(
+    fun deleteByInstanceAndNotInAttributes(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUids: List<String>,
     ): Int
@@ -68,7 +68,7 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
           )
     """,
     )
-    suspend fun deleteByInstanceAndNotInProgramAttributes(
+    fun deleteByInstanceAndNotInProgramAttributes(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUids: List<String>,
         programUid: String,
@@ -91,7 +91,7 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
           )
     """,
     )
-    suspend fun deleteByInstanceAndNotInAccessibleAttributes(
+    fun deleteByInstanceAndNotInAccessibleAttributes(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUids: List<String>,
         programUids: List<String>,
@@ -105,7 +105,7 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
           AND ${TrackedEntityAttributeValueTableInfo.Columns.VALUE} IS NULL
     """,
     )
-    suspend fun removeDeletedAttributeValuesByInstance(
+    fun removeDeletedAttributeValuesByInstance(
         trackedEntityInstanceUid: String,
     ): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityDataValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityDataValueDaoAux.kt
@@ -42,7 +42,7 @@ internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataVal
         SET ${TrackedEntityDataValueTableInfo.Columns.SYNC_STATE} = :state 
         WHERE ${TrackedEntityDataValueTableInfo.Columns.EVENT} = :uid;""",
     )
-    suspend fun setSyncStateByEvent(uid: String, state: String)
+    fun setSyncStateByEvent(uid: String, state: String)
 
     @Query(
         """
@@ -51,7 +51,7 @@ internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataVal
           AND ${TrackedEntityDataValueTableInfo.Columns.DATA_ELEMENT} NOT IN (:dataElementUids)
     """,
     )
-    suspend fun deleteByEventAndNotInDataElements(
+    fun deleteByEventAndNotInDataElements(
         eventUid: String,
         dataElementUids: List<String>,
     ): Int
@@ -63,7 +63,7 @@ internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataVal
           AND ${TrackedEntityDataValueTableInfo.Columns.DATA_ELEMENT} = :dataElementUid
     """,
     )
-    suspend fun deleteByEventAndDataElement(
+    fun deleteByEventAndDataElement(
         eventUid: String,
         dataElementUid: String,
     ): Int
@@ -74,7 +74,7 @@ internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataVal
         WHERE ${TrackedEntityDataValueTableInfo.Columns.EVENT} = :eventUid
     """,
     )
-    suspend fun deleteByEvent(eventUid: String): Int
+    fun deleteByEvent(eventUid: String): Int
 
     @Query(
         """
@@ -83,7 +83,7 @@ internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataVal
           AND ${TrackedEntityDataValueTableInfo.Columns.VALUE} IS NULL 
     """,
     )
-    suspend fun removeDeletedDataValuesByEvent(
+    fun removeDeletedDataValuesByEvent(
         eventUid: String,
     ): Int
 
@@ -101,5 +101,5 @@ internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataVal
           )
     """,
     )
-    suspend fun removeUnassignedDataValuesByEvent(eventUid: String): Int
+    fun removeUnassignedDataValuesByEvent(eventUid: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDaoAux.kt
@@ -40,5 +40,5 @@ internal interface TrackedEntityInstanceDaoAux : IdentifiableDeletableDataObject
         SET ${TrackedEntityInstanceTableInfo.Columns.AGGREGATED_SYNC_STATE} = :state
         WHERE ${IdentifiableColumns.UID} = :uid;""",
     )
-    suspend fun setAggregatedSyncState(state: String, uid: String): Int
+    fun setAggregatedSyncState(state: String, uid: String): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDaoAux.kt
@@ -42,7 +42,7 @@ internal interface TrackedEntityInstanceSyncDaoAux : ObjectDao<TrackedEntityInst
         AND ${Columns.PROGRAM} = :programUid
     """,
     )
-    suspend fun deleteByProgram(programUid: String, organisationUnitIdsHash: Int): Int
+    fun deleteByProgram(programUid: String, organisationUnitIdsHash: Int): Int
 
     @Query(
         """
@@ -51,5 +51,5 @@ internal interface TrackedEntityInstanceSyncDaoAux : ObjectDao<TrackedEntityInst
         AND ${Columns.PROGRAM} IS NULL
     """,
     )
-    suspend fun deleteByNullProgram(organisationUnitIdsHash: Int): Int
+    fun deleteByNullProgram(organisationUnitIdsHash: Int): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDaoAux.kt
@@ -40,5 +40,5 @@ internal interface TrackerJobObjectDaoAux : ObjectDao<TrackerJobObjectDB> {
         WHERE ${TrackerJobObjectTableInfo.Columns.JOB_UID} = :jobUid
     """,
     )
-    suspend fun deleteByJobUid(jobUid: String): Int
+    fun deleteByJobUid(jobUid: String): Int
 }

--- a/processor/src/main/java/org/hisp/dhis/android/processor/DaoQueriesProcessor.kt
+++ b/processor/src/main/java/org/hisp/dhis/android/processor/DaoQueriesProcessor.kt
@@ -67,18 +67,18 @@ class DaoQueriesProcessor(
             logger.info("Successfully extracted tableName: '$tableName' for ${symbol.qualifiedName?.asString()}")
 
             val superInterfaceSimpleNames = symbol.superTypes
-                .map { it.resolve() } // Resuelve cada KSTypeReference a KSType
-                .filterNot { it.isError } // Filtra los que son KSErrorType
-                .mapNotNull { ksType -> // Para los restantes (no error)
+                .map { it.resolve() } // Resolves each KSTypeReference to KSType
+                .filterNot { it.isError } // Filters out KSErrorType instances
+                .mapNotNull { ksType -> // For the remaining (non-error) types
                     (ksType.declaration as? KSClassDeclaration)?.simpleName?.asString()
-                    // Intenta castear la declaración a KSClassDeclaration y luego obtén el simpleName
-                    // Si el casteo falla o simpleName es null, mapNotNull lo omitirá
+                    // Attempts to cast the declaration to KSClassDeclaration and then get the simpleName
+                    // If the cast fails or simpleName is null, mapNotNull will omit it
                 }
                 .toList()
 
             logger.info("DAO ${symbol.qualifiedName?.asString()} (resolved) super interface simple names: $superInterfaceSimpleNames")
 
-            // o si hay jerarquías más profundas que necesitas inspeccionar.
+            // or if there are deeper hierarchies you need to inspect.
             val baseInterfaceType: String? = when {
                 superInterfaceSimpleNames.any { it == "ObjectDao" } -> "ObjectDao"
                 superInterfaceSimpleNames.any { it == "IdentifiableDeletableDataObjectDao" } -> "IdentifiableDeletableDataObjectDao"
@@ -209,7 +209,7 @@ class DaoQueriesProcessor(
             "    override fun deleteWhere(uid: String, deleted: Boolean, state: State): Int\n\n"
     }
 
-    // Operador de extensión para escribir Strings fácilmente en OutputStream
+    // Extension operator to easily write Strings to OutputStream
     private operator fun OutputStream.plusAssign(str: String) {
         this.write(str.toByteArray())
     }

--- a/processor/src/main/java/org/hisp/dhis/android/processor/DaoQueriesProcessor.kt
+++ b/processor/src/main/java/org/hisp/dhis/android/processor/DaoQueriesProcessor.kt
@@ -169,44 +169,44 @@ class DaoQueriesProcessor(
 
     private fun buildObjectDaoQueries(tableName: String): String {
         return "    @Query(\"DELETE FROM ${'$'}{${tableName}}\")\n" +
-            "    override suspend fun deleteAllRows(): Int\n\n"
+            "    override fun deleteAllRows(): Int\n\n"
     }
 
     private fun buildIdentifiableObjectDaoQueries(tableName: String): String {
         return buildObjectDaoQueries(tableName) +
             "    @Query(\"DELETE FROM ${'$'}{${tableName}} WHERE uid = :uid\")\n" +
-            "    override suspend fun delete(uid: String): Int\n\n"
+            "    override fun delete(uid: String): Int\n\n"
     }
 
     private fun buildLinkDaoQueries(tableName: String, parentColumnName: String): String {
         return buildObjectDaoQueries(tableName) +
             "    @Query(\"DELETE FROM ${'$'}{${tableName}} WHERE ${'$'}{${parentColumnName}} = :parentUid\")\n" +
-            "    override suspend fun deleteLinksForMasterUid(parentUid: String): Int\n\n" +
+            "    override fun deleteLinksForMasterUid(parentUid: String): Int\n\n" +
             "    @Query(\"DELETE FROM ${'$'}{${tableName}}\")" +
-            "    override suspend fun deleteLinksForMasterUid(): Int"
+            "    override fun deleteLinksForMasterUid(): Int"
     }
 
     private fun buildIdentifiableDataObjectDaoQueries(tableName: String): String {
         return buildIdentifiableObjectDaoQueries(tableName) +
             "    @Query(\"UPDATE ${'$'}{${tableName}} SET ${'$'}{DataColumns.SYNC_STATE} = :state WHERE " +
             "${'$'}{IdentifiableColumns.UID} = :uid\")\n" +
-            "    override suspend fun setSyncState(uid: String, state: State): Int\n\n" +
+            "    override fun setSyncState(uid: String, state: State): Int\n\n" +
             "    @Query(\"UPDATE ${'$'}{${tableName}} SET ${'$'}{DataColumns.SYNC_STATE} = :state WHERE " +
             "${'$'}{IdentifiableColumns.UID} IN (:uids)\")\n" +
-            "    override suspend fun setSyncState(uids: List<String>, state: State): Int\n\n" +
+            "    override fun setSyncState(uids: List<String>, state: State): Int\n\n" +
             "    @Query(\"UPDATE ${'$'}{${tableName}} SET ${'$'}{DataColumns.SYNC_STATE} = :newstate WHERE " +
             "${'$'}{IdentifiableColumns.UID} = :uid AND ${'$'}{DataColumns.SYNC_STATE} = :updateState\")\n" +
-            "    override suspend fun setSyncStateIfUploading(uid: String, newstate: State, updateState: State): Int\n\n"
+            "    override fun setSyncStateIfUploading(uid: String, newstate: State, updateState: State): Int\n\n"
     }
 
     private fun buildIdentifiableDeletableDataObjectDaoQueries(tableName: String): String {
         return buildIdentifiableDataObjectDaoQueries(tableName) +
             "    @Query(\"UPDATE ${'$'}{${tableName}} SET ${'$'}{DeletableDataColumns.DELETED} = 1 " +
             "WHERE ${'$'}{IdentifiableColumns.UID} = :uid\")\n" +
-            "    override suspend fun setDeleted(uid: String): Int\n\n" +
+            "    override fun setDeleted(uid: String): Int\n\n" +
             "    @Query(\"DELETE FROM ${'$'}{${tableName}} WHERE ${'$'}{DataColumns.SYNC_STATE} = :state AND " +
             "${'$'}{IdentifiableColumns.UID} = :uid AND ${'$'}{DeletableDataColumns.DELETED} = :deleted\")\n" +
-            "    override suspend fun deleteWhere(uid: String, deleted: Boolean, state: State): Int\n\n"
+            "    override fun deleteWhere(uid: String, deleted: Boolean, state: State): Int\n\n"
     }
 
     // Operador de extensión para escribir Strings fácilmente en OutputStream


### PR DESCRIPTION
There's been found a way to partially restore the previous performance of the db by performing blocking transactions directly over the db DAOs.  