### PR TITLE
fix: [ANDROSDK-2188] Fix failing date-filter tests by converting server dates to local timezone

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/enrollment/EnrollmentCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/enrollment/EnrollmentCollectionRepositoryMockIntegrationShould.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.testapp.enrollment
 
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClient
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClientAsString
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.State
@@ -81,7 +83,7 @@ class EnrollmentCollectionRepositoryMockIntegrationShould : BaseMockIntegrationT
     @Test
     fun filter_by_created() {
         val enrollments = d2.enrollmentModule().enrollments()
-            .byCreated().eq("2019-01-10T13:40:28.322".toJavaDate())
+            .byCreated().eq(convertServerToClient("2019-01-10T13:40:28.322"))
             .blockingGet()
 
         assertThat(enrollments.size).isEqualTo(1)
@@ -90,7 +92,7 @@ class EnrollmentCollectionRepositoryMockIntegrationShould : BaseMockIntegrationT
     @Test
     fun filter_by_last_updated() {
         val enrollments = d2.enrollmentModule().enrollments()
-            .byLastUpdated().eq("2019-01-10T13:40:28.718".toJavaDate())
+            .byLastUpdated().eq(convertServerToClient("2019-01-10T13:40:28.718"))
             .blockingGet()
 
         assertThat(enrollments.size).isEqualTo(1)
@@ -99,7 +101,7 @@ class EnrollmentCollectionRepositoryMockIntegrationShould : BaseMockIntegrationT
     @Test
     fun filter_by_created_as_client() {
         val enrollments = d2.enrollmentModule().enrollments()
-            .byCreatedAtClient().eq("2018-01-08T13:40:28.718")
+            .byCreatedAtClient().eq(convertServerToClientAsString("2018-01-08T13:40:28.718"))
             .blockingGet()
 
         assertThat(enrollments.size).isEqualTo(1)
@@ -108,7 +110,7 @@ class EnrollmentCollectionRepositoryMockIntegrationShould : BaseMockIntegrationT
     @Test
     fun filter_by_last_updated_as_client() {
         val enrollments = d2.enrollmentModule().enrollments()
-            .byLastUpdatedAtClient().eq("2018-01-11T13:40:28.718")
+            .byLastUpdatedAtClient().eq(convertServerToClientAsString("2018-01-11T13:40:28.718"))
             .blockingGet()
 
         assertThat(enrollments.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventCollectionRepositoryMockIntegrationShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.testapp.event
 
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClient
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.State
@@ -70,7 +71,7 @@ class EventCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
     @Test
     fun filter_by_created() {
         val events = d2.eventModule().events()
-            .byCreated().eq("2017-08-07T15:47:25.959".toJavaDate())
+            .byCreated().eq(convertServerToClient("2017-08-07T15:47:25.959"))
             .blockingGet()
 
         assertThat(events.size).isEqualTo(1)
@@ -79,7 +80,7 @@ class EventCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
     @Test
     fun filter_by_last_updated() {
         val events = d2.eventModule().events()
-            .byLastUpdated().eq("2019-01-01T22:26:39.094".toJavaDate())
+            .byLastUpdated().eq(convertServerToClient("2019-01-01T22:26:39.094"))
             .blockingGet()
 
         assertThat(events.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould.kt
@@ -30,7 +30,7 @@ package org.hisp.dhis.android.testapp.trackedentity
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
-import org.hisp.dhis.android.core.common.BaseIdentifiableObject
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClient
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
@@ -67,10 +67,9 @@ class TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould : Bas
     @Test
     @Throws(ParseException::class)
     fun filter_by_created() {
-        val date = BaseIdentifiableObject.DATE_FORMAT.parse("2019-01-10T13:40:28.000")
         val trackedEntityAttributeValues =
             d2.trackedEntityModule().trackedEntityAttributeValues()
-                .byCreated().eq(date)
+                .byCreated().eq(convertServerToClient("2019-01-10T13:40:28.000"))
                 .blockingGet()
         assertThat(trackedEntityAttributeValues.size).isEqualTo(1)
     }
@@ -78,9 +77,8 @@ class TrackedEntityAttributeValueCollectionRepositoryMockIntegrationShould : Bas
     @Test
     @Throws(ParseException::class)
     fun filter_by_last_updated() {
-        val date = BaseIdentifiableObject.DATE_FORMAT.parse("2018-01-10T13:40:28.000")
         val trackedEntityAttributeValues = d2.trackedEntityModule().trackedEntityAttributeValues()
-            .byLastUpdated().eq(date)
+            .byLastUpdated().eq(convertServerToClient("2018-01-10T13:40:28.000"))
             .blockingGet()
         assertThat(trackedEntityAttributeValues.size).isEqualTo(1)
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityCollectionRepositoryMockIntegrationShould.kt
@@ -29,10 +29,11 @@ package org.hisp.dhis.android.testapp.trackedentity
 
 import com.google.common.collect.Lists
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClient
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClientAsString
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.core.common.State
-import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -56,7 +57,7 @@ class TrackedEntityCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
     @Test
     fun filter_by_created() {
         val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstances()
-            .byCreated().eq("2019-01-10T13:40:27.987".toJavaDate())
+            .byCreated().eq(convertServerToClient("2019-01-10T13:40:27.987"))
             .blockingGet()
 
         assertThat(trackedEntityInstances.size).isEqualTo(1)
@@ -65,7 +66,7 @@ class TrackedEntityCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
     @Test
     fun filter_by_lastUpdated() {
         val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstances()
-            .byLastUpdated().eq("2018-01-10T13:40:28.592".toJavaDate())
+            .byLastUpdated().eq(convertServerToClient("2018-01-10T13:40:28.592"))
             .blockingGet()
 
         assertThat(trackedEntityInstances.size).isEqualTo(1)
@@ -74,7 +75,7 @@ class TrackedEntityCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
     @Test
     fun filter_by_created_at_client() {
         val trackedEntityInstances = d2.trackedEntityModule().trackedEntityInstances()
-            .byCreatedAtClient().eq("2019-01-22T18:38:15.845")
+            .byCreatedAtClient().eq(convertServerToClientAsString("2019-01-22T18:38:15.845"))
             .blockingGet()
 
         assertThat(trackedEntityInstances.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityDataValueCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/TrackedEntityDataValueCollectionRepositoryMockIntegrationShould.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.testapp.trackedentity
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter.convertServerToClient
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Ignore
 import org.junit.Test
@@ -53,7 +53,7 @@ class TrackedEntityDataValueCollectionRepositoryMockIntegrationShould : BaseMock
     @Test
     fun filter_by_created() {
         val trackedEntityDataValues = d2.trackedEntityModule().trackedEntityDataValues()
-            .byCreated().eq("2015-02-28T12:05:00.333".toJavaDate())
+            .byCreated().eq(convertServerToClient("2015-02-28T12:05:00.333"))
             .blockingGet()
 
         assertThat(trackedEntityDataValues.size).isEqualTo(1)
@@ -62,7 +62,7 @@ class TrackedEntityDataValueCollectionRepositoryMockIntegrationShould : BaseMock
     @Test
     fun filter_by_last_updated() {
         val trackedEntityDataValues = d2.trackedEntityModule().trackedEntityDataValues()
-            .byLastUpdated().eq("2015-02-28T12:05:00.222".toJavaDate())
+            .byLastUpdated().eq(convertServerToClient("2015-02-28T12:05:00.222"))
             .blockingGet()
 
         assertThat(trackedEntityDataValues.size).isEqualTo(1)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/DateTimezoneConverter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/DateTimezoneConverter.kt
@@ -86,4 +86,16 @@ internal object DateTimezoneConverter {
             fromInstant.toJavaDate()
         }
     }
+
+    /**
+     * Converts a date from server timezone to client timezone.
+     * Uses the cached server timezone from ServerTimezoneManager.
+     *
+     * @param dateString The date string in server timezone
+     * @return Date as String converted to client timezone context
+     */
+    fun convertServerToClientAsString(dateString: String?): String? {
+        val convertedDate = convertServerToClient(dateString)
+        return convertedDate?.let { DateUtils.DATE_FORMAT.format(it) }
+    }
 }


### PR DESCRIPTION
This PR updates multiple integration tests that rely on filtering by date fields (`created`, `lastUpdated`, and client equivalents). Previously, the tests compared raw server timestamps directly against values stored in the local timezone, which caused failures on devices configured with non-UTC timezones.

To ensure consistent behavior across environments, date comparisons in tests now use `convertServerToClient(...)` or `convertServerToClientAsString(...)`, aligning filter input with the timezone-converted values stored in the database.

- Tests now pass regardless of device timezone
- Timezone conversion behavior continues to be validated
- No behavior changes in production code
