### PR TITLE
 chore: [ANDROSDK-2189] Make TrackerConflictHelper tests locale-agnostic

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/BaseTrackerConflictMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/BaseTrackerConflictMockIntegrationShould.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.testapp.tracker.importer
 
-import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.tracker.importer.internal.ImporterError
@@ -58,7 +57,7 @@ internal abstract class BaseTrackerConflictMockIntegrationShould : BaseMockInteg
     @Test
     fun generate_correct_display_descriptions_for_error() = runTest {
         val trackerConflictHelper = TrackerConflictHelper(
-            InstrumentationRegistry.getInstrumentation().context,
+            LocaleTestUtils.createEnglishContext(d2.context()),
             objects.d2DIComponent.interpreterSelector,
         )
         val trackerImportConflict = trackerConflictHelper.getConflictBuilder(errorReport).build()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/LocaleTestUtils.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/LocaleTestUtils.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.testapp.tracker.importer
+
+import android.content.Context
+import java.util.Locale
+
+internal object LocaleTestUtils {
+
+    /**
+     * Wraps a context with a specific locale configuration.
+     * This is useful for testing localized content in a device-agnostic way.
+     *
+     * @param context The base context to wrap
+     * @param locale The desired locale (defaults to English US)
+     * @return A new context configured with the specified locale
+     */
+    fun wrapContextWithLocale(context: Context, locale: Locale = Locale.ENGLISH): Context {
+        val configuration = context.resources.configuration
+        configuration.setLocale(locale)
+        return context.createConfigurationContext(configuration)
+    }
+
+    fun createEnglishContext(context: Context): Context {
+        return wrapContextWithLocale(context, Locale.ENGLISH)
+    }
+}

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/TrackerConflictHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/tracker/importer/TrackerConflictHelperMockIntegrationShould.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.testapp.tracker.importer
 
-import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.tracker.importer.internal.JobValidationError
@@ -41,7 +40,7 @@ class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDi
     @Test
     fun generate_correct_display_descriptions_if_passing_correct_error_report() = runTest {
         val trackerImportConflict = TrackerConflictHelper(
-            InstrumentationRegistry.getInstrumentation().context,
+            LocaleTestUtils.createEnglishContext(d2.context()),
             objects.d2DIComponent.interpreterSelector,
         ).getConflictBuilder(errorReport).build()
         assertThat(trackerImportConflict.displayDescription())
@@ -54,7 +53,7 @@ class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDi
     @Test
     fun return_default_message_when_passing_wrong_error_report() = runTest {
         val trackerImportConflict = TrackerConflictHelper(
-            InstrumentationRegistry.getInstrumentation().context,
+            LocaleTestUtils.createEnglishContext(d2.context()),
             objects.d2DIComponent.interpreterSelector,
         ).getConflictBuilder(wrongCodeErrorReport).build()
         assertThat(trackerImportConflict.displayDescription())
@@ -64,7 +63,7 @@ class TrackerConflictHelperMockIntegrationShould : BaseMockIntegrationTestFullDi
     @Test
     fun generate_correct_display_descriptions_for_E1000_error() = runTest {
         val trackerImportConflict = TrackerConflictHelper(
-            InstrumentationRegistry.getInstrumentation().context,
+            LocaleTestUtils.createEnglishContext(d2.context()),
             objects.d2DIComponent.interpreterSelector,
         ).getConflictBuilder(errorReportE1000).build()
         assertThat(trackerImportConflict.displayDescription())


### PR DESCRIPTION
Tests were failing on devices configured with non-English locales due to localized error messages. This update enforces an English locale during `TrackerConflictHelper` integration tests to ensure predictable assertions.