### PR TITLE
chore: [ANDROSDK-2175] fix how table info and parent column names are passed to dao generator

### DIFF
--- a/annotations/src/main/java/org/hisp/dhis/android/annotations/ParentColumn.kt
+++ b/annotations/src/main/java/org/hisp/dhis/android/annotations/ParentColumn.kt
@@ -28,6 +28,6 @@
 
 package org.hisp.dhis.android.processor
 
-@Target(AnnotationTarget.CLASS)
+@Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.SOURCE)
-annotation class GenerateDaoQueries(val tableName: String = "", val parentColumnName: String = "")
+annotation class ParentColumn

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -12519,6 +12519,7 @@ public final class org/hisp/dhis/android/persistence/attribute/AttributeTableInf
 
 public final class org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12537,6 +12538,7 @@ public final class org/hisp/dhis/android/persistence/attribute/DataElementAttrib
 
 public final class org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12555,6 +12557,7 @@ public final class org/hisp/dhis/android/persistence/attribute/ProgramAttributeV
 
 public final class org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12573,6 +12576,7 @@ public final class org/hisp/dhis/android/persistence/attribute/ProgramStageAttri
 
 public final class org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12591,6 +12595,7 @@ public final class org/hisp/dhis/android/persistence/category/CategoryCategoryCo
 
 public final class org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12631,6 +12636,7 @@ public final class org/hisp/dhis/android/persistence/category/CategoryComboTable
 
 public final class org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12670,6 +12676,7 @@ public final class org/hisp/dhis/android/persistence/category/CategoryOptionComb
 
 public final class org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12851,6 +12858,7 @@ public final class org/hisp/dhis/android/persistence/dataelement/DataElementTabl
 
 public final class org/hisp/dhis/android/persistence/dataset/DataInputPeriodTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/DataInputPeriodTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12893,6 +12901,7 @@ public final class org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegi
 
 public final class org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandsLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandsLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12910,6 +12919,7 @@ public final class org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDa
 
 public final class org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12928,6 +12938,7 @@ public final class org/hisp/dhis/android/persistence/dataset/DataSetDataElementL
 
 public final class org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -12993,6 +13004,7 @@ public final class org/hisp/dhis/android/persistence/dataset/DataSetTableInfo$Co
 
 public final class org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/SectionDataElementLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13011,6 +13023,7 @@ public final class org/hisp/dhis/android/persistence/dataset/SectionDataElementL
 
 public final class org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13029,6 +13042,7 @@ public final class org/hisp/dhis/android/persistence/dataset/SectionGreyedFields
 
 public final class org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13438,6 +13452,7 @@ public final class org/hisp/dhis/android/persistence/imports/TrackerImportConfli
 
 public final class org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13513,6 +13528,7 @@ public final class org/hisp/dhis/android/persistence/indicator/IndicatorTypeTabl
 
 public final class org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13531,6 +13547,7 @@ public final class org/hisp/dhis/android/persistence/legendset/DataElementLegend
 
 public final class org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13596,6 +13613,7 @@ public final class org/hisp/dhis/android/persistence/legendset/LegendTableInfo$C
 
 public final class org/hisp/dhis/android/persistence/legendset/ProgramIndicatorLegendSetLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/legendset/ProgramIndicatorLegendSetLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13662,6 +13680,7 @@ public final class org/hisp/dhis/android/persistence/maintenance/ForeignKeyViola
 
 public final class org/hisp/dhis/android/persistence/map/MapLayerImageryProviderTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/map/MapLayerImageryProviderTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13732,6 +13751,7 @@ public final class org/hisp/dhis/android/persistence/note/NoteTableInfo$Columns$
 
 public final class org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/option/OptionGroupOptionLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13864,6 +13884,7 @@ public final class org/hisp/dhis/android/persistence/organisationunit/Organisati
 
 public final class org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13881,6 +13902,7 @@ public final class org/hisp/dhis/android/persistence/organisationunit/Organisati
 
 public final class org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -13950,6 +13972,7 @@ public final class org/hisp/dhis/android/persistence/period/PeriodTableInfo$Colu
 
 public final class org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14089,6 +14112,7 @@ public final class org/hisp/dhis/android/persistence/program/ProgramRuleVariable
 
 public final class org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14164,6 +14188,7 @@ public final class org/hisp/dhis/android/persistence/program/ProgramStageDataEle
 
 public final class org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14182,6 +14207,7 @@ public final class org/hisp/dhis/android/persistence/program/ProgramStageSection
 
 public final class org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14586,6 +14612,7 @@ public final class org/hisp/dhis/android/persistence/settings/AnalyticsDhisVisua
 
 public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiAttributeTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/settings/AnalyticsTeiAttributeTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14604,6 +14631,7 @@ public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiAttrib
 
 public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiDataElementTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/settings/AnalyticsTeiDataElementTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14623,6 +14651,7 @@ public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiDataEl
 
 public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiIndicatorTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/settings/AnalyticsTeiIndicatorTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14664,6 +14693,7 @@ public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiSettin
 
 public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONutritionDataTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONutritionDataTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14684,6 +14714,7 @@ public final class org/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONut
 
 public final class org/hisp/dhis/android/persistence/settings/CustomIntentAttributeTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/settings/CustomIntentAttributeTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -14701,6 +14732,7 @@ public final class org/hisp/dhis/android/persistence/settings/CustomIntentAttrib
 
 public final class org/hisp/dhis/android/persistence/settings/CustomIntentDataElementTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/settings/CustomIntentDataElementTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15111,6 +15143,7 @@ public final class org/hisp/dhis/android/persistence/trackedentity/ReservedValue
 
 public final class org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15351,6 +15384,7 @@ public final class org/hisp/dhis/android/persistence/trackedentity/TrackedEntity
 
 public final class org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15442,6 +15476,7 @@ public final class org/hisp/dhis/android/persistence/usecase/StockUseCaseTableIn
 
 public final class org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15518,6 +15553,7 @@ public final class org/hisp/dhis/android/persistence/user/UserGroupTableInfo$Col
 
 public final class org/hisp/dhis/android/persistence/user/UserOrganisationUnitTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/user/UserOrganisationUnitTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15595,6 +15631,7 @@ public final class org/hisp/dhis/android/persistence/user/UserTableInfo$Columns$
 
 public final class org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15672,6 +15709,7 @@ public final class org/hisp/dhis/android/persistence/valuetypedevicerendering/Va
 
 public final class org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDimensionTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/visualization/TrackerVisualizationDimensionTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }
@@ -15726,6 +15764,7 @@ public final class org/hisp/dhis/android/persistence/visualization/TrackerVisual
 
 public final class org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemTableInfo {
 	public static final field INSTANCE Lorg/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemTableInfo;
+	public static final field PARENT_COLUMN Ljava/lang/String;
 	public static final field TABLE_INFO Lorg/hisp/dhis/android/core/arch/db/tableinfos/TableInfo;
 	public static final field TABLE_NAME Ljava/lang/String;
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/AttributeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/AttributeDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.attribute
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AttributeTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AttributeDaoAux : IdentifiableObjectDao<AttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.attribute.DataElementAttributeValueLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataElementAttributeValueLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementDB
     primaryKeys = ["dataElement", "attribute"],
 )
 internal data class DataElementAttributeValueLinkDB(
-    val dataElement: String,
+    @ParentColumn val dataElement: String,
     val attribute: String,
     val value: String?,
 ) : EntityDB<DataElementAttributeValueLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.attribute
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataElementAttributeValueLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataElementAttributeValueLinkTableInfo.Columns.DATA_ELEMENT",
-)
+@GenerateDaoQueries
 internal interface DataElementAttributeValueLinkDaoAux : LinkDao<DataElementAttributeValueLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.attribute.ProgramAttributeValueLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "ProgramAttributeValueLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.program.ProgramDB
     primaryKeys = ["program", "attribute"],
 )
 internal data class ProgramAttributeValueLinkDB(
-    val program: String,
+    @ParentColumn val program: String,
     val attribute: String,
     val value: String?,
 ) : EntityDB<ProgramAttributeValueLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.attribute
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "ProgramAttributeValueLinkTableInfo.TABLE_NAME",
-    parentColumnName = "ProgramAttributeValueLinkTableInfo.Columns.PROGRAM",
-)
+@GenerateDaoQueries
 internal interface ProgramAttributeValueLinkDaoAux : LinkDao<ProgramAttributeValueLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.attribute.ProgramStageAttributeValueLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "ProgramStageAttributeValueLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.program.ProgramStageDB
     primaryKeys = ["programStage", "attribute"],
 )
 internal data class ProgramStageAttributeValueLinkDB(
-    val programStage: String,
+    @ParentColumn val programStage: String,
     val attribute: String,
     val value: String?,
 ) : EntityDB<ProgramStageAttributeValueLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.attribute
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "ProgramStageAttributeValueLinkTableInfo.TABLE_NAME",
-    parentColumnName = "ProgramStageAttributeValueLinkTableInfo.Columns.PROGRAM_STAGE",
-)
+@GenerateDaoQueries
 internal interface ProgramStageAttributeValueLinkDaoAux : LinkDao<ProgramStageAttributeValueLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.category.CategoryCategoryComboLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "CategoryCategoryComboLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 )
 internal data class CategoryCategoryComboLinkDB(
     val category: String,
-    val categoryCombo: String,
+    @ParentColumn val categoryCombo: String,
     val sortOrder: Int?,
 ) : EntityDB<CategoryCategoryComboLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryComboLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "CategoryCategoryComboLinkTableInfo.TABLE_NAME",
-    parentColumnName = "CategoryCategoryComboLinkTableInfo.Columns.CATEGORY_COMBO",
-)
+@GenerateDaoQueries
 internal interface CategoryCategoryComboLinkDaoAux : LinkDao<CategoryCategoryComboLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.category.CategoryCategoryOptionLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "CategoryCategoryOptionLink",
@@ -26,7 +27,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["category", "categoryOption"],
 )
 internal data class CategoryCategoryOptionLinkDB(
-    val category: String,
+    @ParentColumn val category: String,
     val categoryOption: String,
     val sortOrder: Int?,
 ) : EntityDB<CategoryCategoryOptionLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryCategoryOptionLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "CategoryCategoryOptionLinkTableInfo.TABLE_NAME",
-    parentColumnName = "CategoryCategoryOptionLinkTableInfo.Columns.CATEGORY",
-)
+@GenerateDaoQueries
 internal interface CategoryCategoryOptionLinkDaoAux : LinkDao<CategoryCategoryOptionLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryComboDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryComboDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "CategoryComboTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface CategoryComboDaoAux : IdentifiableObjectDao<CategoryComboDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "CategoryTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface CategoryDaoAux : IdentifiableObjectDao<CategoryDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.category.CategoryOptionComboCategoryOptionLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "CategoryOptionComboCategoryOptionLink",
@@ -26,7 +27,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["categoryOptionCombo", "categoryOption"],
 )
 internal data class CategoryOptionComboCategoryOptionLinkDB(
-    val categoryOptionCombo: String,
+    @ParentColumn val categoryOptionCombo: String,
     val categoryOption: String,
 ) : EntityDB<CategoryOptionComboCategoryOptionLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboCategoryOptionLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "CategoryOptionComboCategoryOptionLinkTableInfo.TABLE_NAME",
-    parentColumnName = "CategoryOptionComboCategoryOptionLinkTableInfo.Columns.CATEGORY_OPTION_COMBO",
-)
+@GenerateDaoQueries
 internal interface CategoryOptionComboCategoryOptionLinkDaoAux : LinkDao<CategoryOptionComboCategoryOptionLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionComboDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "CategoryOptionComboTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface CategoryOptionComboDaoAux : IdentifiableObjectDao<CategoryOptionComboDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "CategoryOptionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface CategoryOptionDaoAux : IdentifiableObjectDao<CategoryOptionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkDB.kt
@@ -7,6 +7,7 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.category.CategoryOptionOrganisationUnitLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "CategoryOptionOrganisationUnitLink",
@@ -31,7 +32,7 @@ internal data class CategoryOptionOrganisationUnitLinkDB(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")
     val id: Int = 0,
-    val categoryOption: String,
+    @ParentColumn val categoryOption: String,
     val organisationUnit: String?,
     val restriction: String?,
 ) : EntityDB<CategoryOptionOrganisationUnitLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/category/CategoryOptionOrganisationUnitLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.category
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "CategoryOptionOrganisationUnitLinkTableInfo.TABLE_NAME",
-    parentColumnName = "CategoryOptionOrganisationUnitLinkTableInfo.Columns.CATEGORY_OPTION",
-)
+@GenerateDaoQueries
 internal interface CategoryOptionOrganisationUnitLinkDaoAux : LinkDao<CategoryOptionOrganisationUnitLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/configuration/ConfigurationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/configuration/ConfigurationDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.configuration
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ConfigurationTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ConfigurationDaoAux : ObjectDao<ConfigurationDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/constant/ConstantDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/constant/ConstantDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.constant
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ConstantTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ConstantDaoAux : IdentifiableObjectDao<ConstantDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataapproval/DataApprovalDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataapproval/DataApprovalDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.dataapproval
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataApprovalTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataApprovalDaoAux : ObjectDao<DataApprovalDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.dataelement
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataElementTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataElementDaoAux : IdentifiableObjectDao<DataElementDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementOperandDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataelement/DataElementOperandDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.dataelement
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataElementOperandTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataElementOperandDaoAux : IdentifiableObjectDao<DataElementOperandDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodDB.kt
@@ -8,6 +8,7 @@ import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.period.PeriodDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataInputPeriod",
@@ -30,7 +31,7 @@ import org.hisp.dhis.android.persistence.period.PeriodDB
     primaryKeys = ["dataSet", "period", "openingDate", "closingDate"],
 )
 internal data class DataInputPeriodDB(
-    val dataSet: String,
+    @ParentColumn val dataSet: String,
     val period: String,
     val openingDate: String,
     val closingDate: String,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataInputPeriodTableInfo.TABLE_NAME",
-    parentColumnName = "DataInputPeriodTableInfo.Columns.DATA_SET",
-)
+@GenerateDaoQueries
 internal interface DataInputPeriodDaoAux : LinkDao<DataInputPeriodDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegistrationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompleteRegistrationDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitTableInfo
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataSetCompleteRegistrationTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataSetCompleteRegistrationDaoAux : ObjectDao<DataSetCompleteRegistrationDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandsLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandsLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.dataset.DataSetCompulsoryDataElementOperandLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementOperandDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataSetCompulsoryDataElementOperandsLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementOperandDB
     primaryKeys = ["dataSet", "dataElementOperand"],
 )
 internal data class DataSetCompulsoryDataElementOperandsLinkDB(
-    val dataSet: String,
+    @ParentColumn val dataSet: String,
     val dataElementOperand: String,
 ) : EntityDB<DataSetCompulsoryDataElementOperandLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandsLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetCompulsoryDataElementOperandsLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataSetCompulsoryDataElementOperandsLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataSetCompulsoryDataElementOperandsLinkTableInfo.Columns.DATA_SET",
-)
+@GenerateDaoQueries
 internal interface DataSetCompulsoryDataElementOperandsLinkDaoAux : LinkDao<DataSetCompulsoryDataElementOperandsLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataSetTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataSetDaoAux : IdentifiableObjectDao<DataSetDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkDB.kt
@@ -7,6 +7,7 @@ import org.hisp.dhis.android.core.dataset.DataSetElement
 import org.hisp.dhis.android.persistence.category.CategoryComboDB
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataSetDataElementLink",
@@ -36,7 +37,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementDB
     primaryKeys = ["dataSet", "dataElement"],
 )
 internal data class DataSetDataElementLinkDB(
-    val dataSet: String,
+    @ParentColumn val dataSet: String,
     val dataElement: String,
     val categoryCombo: String?,
 ) : EntityDB<DataSetElement> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetDataElementLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataSetDataElementLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataSetDataElementLinkTableInfo.Columns.DATA_SET",
-)
+@GenerateDaoQueries
 internal interface DataSetDataElementLinkDaoAux : LinkDao<DataSetDataElementLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.dataset.DataSetOrganisationUnitLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataSetOrganisationUnitLink",
@@ -28,7 +29,7 @@ import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitDB
 )
 internal data class DataSetOrganisationUnitLinkDB(
     val dataSet: String,
-    val organisationUnit: String,
+    @ParentColumn val organisationUnit: String,
 ) : EntityDB<DataSetOrganisationUnitLink> {
 
     override fun toDomain(): DataSetOrganisationUnitLink {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataSetOrganisationUnitLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataSetOrganisationUnitLinkTableInfo.Columns.ORGANISATION_UNIT",
-)
+@GenerateDaoQueries
 internal interface DataSetOrganisationUnitLinkDaoAux : LinkDao<DataSetOrganisationUnitLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "SectionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface SectionDaoAux : IdentifiableObjectDao<SectionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.dataset.SectionDataElementLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "SectionDataElementLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementDB
     primaryKeys = ["section", "dataElement"],
 )
 internal data class SectionDataElementLinkDB(
-    val section: String,
+    @ParentColumn val section: String,
     val dataElement: String,
     val sortOrder: Int?,
 ) : EntityDB<SectionDataElementLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionDataElementLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "SectionDataElementLinkTableInfo.TABLE_NAME",
-    parentColumnName = "SectionDataElementLinkTableInfo.Columns.SECTION",
-)
+@GenerateDaoQueries
 internal interface SectionDataElementLinkDaoAux : LinkDao<SectionDataElementLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkDB.kt
@@ -6,6 +6,7 @@ import org.hisp.dhis.android.core.dataset.SectionGreyedFieldsLink
 import org.hisp.dhis.android.persistence.category.CategoryOptionComboDB
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementOperandDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "SectionGreyedFieldsLink",
@@ -35,7 +36,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementOperandDB
     primaryKeys = ["section", "dataElementOperand", "categoryOptionCombo"],
 )
 internal data class SectionGreyedFieldsLinkDB(
-    val section: String,
+    @ParentColumn val section: String,
     val dataElementOperand: String,
     val categoryOptionCombo: String,
 ) : EntityDB<SectionGreyedFieldsLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionGreyedFieldsLinkDaoAux.kt
@@ -32,10 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "SectionGreyedFieldsLinkTableInfo.TABLE_NAME",
-    parentColumnName = "SectionGreyedFieldsLinkTableInfo.Columns.SECTION",
-)
+@GenerateDaoQueries
 internal interface SectionGreyedFieldsLinkDaoAux : LinkDao<SectionGreyedFieldsLinkDB> {
 
     @Query(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.dataset.internal.SectionIndicatorLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.indicator.IndicatorDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "SectionIndicatorLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.indicator.IndicatorDB
     primaryKeys = ["section", "indicator"],
 )
 internal data class SectionIndicatorLinkDB(
-    val section: String,
+    @ParentColumn val section: String,
     val indicator: String,
 ) : EntityDB<SectionIndicatorLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.dataset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "SectionIndicatorLinkTableInfo.TABLE_NAME",
-    parentColumnName = "SectionIndicatorLinkTableInfo.Columns.SECTION",
-)
+@GenerateDaoQueries
 internal interface SectionIndicatorLinkDaoAux : LinkDao<SectionIndicatorLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datastore/DataStoreDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datastore/DataStoreDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataStoreTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataStoreDaoAux : ObjectDao<DataStoreDB> {
     @Query(
         """UPDATE DataStore 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datastore/LocalDataStoreDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datastore/LocalDataStoreDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.datastore
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "LocalDataStoreTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface LocalDataStoreDaoAux : ObjectDao<LocalDataStoreDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueConflictDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueConflictDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataValueConflictTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataValueConflictDaoAux : ObjectDao<DataValueConflictDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.datavalue
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataValueTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataValueDaoAux : ObjectDao<DataValueDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/domain/AggregatedDataSyncDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/domain/AggregatedDataSyncDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.domain
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AggregatedDataSyncTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AggregatedDataSyncDaoAux : ObjectDao<AggregatedDataSyncDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/enrollment/EnrollmentDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/enrollment/EnrollmentDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableDeletableDataObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "EnrollmentTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface EnrollmentDaoAux : IdentifiableDeletableDataObjectDao<EnrollmentDB> {
     @Query(
         """UPDATE Enrollment

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableDeletableDataObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "EventTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface EventDaoAux : IdentifiableDeletableDataObjectDao<EventDB> {
     @Query(
         """UPDATE Event

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDataFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventDataFilterDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.event
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "EventDataFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface EventDataFilterDaoAux : ObjectDao<EventDataFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventFilterDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.event
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "EventFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface EventFilterDaoAux : IdentifiableObjectDao<EventFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceSyncTableInfo.Columns
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "EventSyncTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface EventSyncDaoAux : ObjectDao<EventSyncDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/expressiondimensionitem/ExpressionDimensionItemDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/expressiondimensionitem/ExpressionDimensionItemDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.expressiondimensionitem
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ExpressionDimensionItemTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ExpressionDimensionItemDaoAux : IdentifiableObjectDao<ExpressionDimensionItemDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/fileresource/FileResourceDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/fileresource/FileResourceDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.fileresource
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableDataObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "FileResourceTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface FileResourceDaoAux : IdentifiableDataObjectDao<FileResourceDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/icon/CustomIconDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/icon/CustomIconDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.icon
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "CustomIconTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface CustomIconDaoAux : ObjectDao<CustomIconDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/imports/TrackerImportConflictDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/imports/TrackerImportConflictDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackerImportConflictTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackerImportConflictDaoAux : ObjectDao<TrackerImportConflictDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.indicator.DataSetIndicatorLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataset.DataSetDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataSetIndicatorLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataset.DataSetDB
     primaryKeys = ["dataSet", "indicator"],
 )
 internal data class DataSetIndicatorLinkDB(
-    val dataSet: String,
+    @ParentColumn val dataSet: String,
     val indicator: String,
 ) : EntityDB<DataSetIndicatorLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.indicator
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataSetIndicatorLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataSetIndicatorLinkTableInfo.Columns.DATA_SET",
-)
+@GenerateDaoQueries
 internal interface DataSetIndicatorLinkDaoAux : LinkDao<DataSetIndicatorLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/indicator/IndicatorDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/indicator/IndicatorDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.indicator
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "IndicatorTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface IndicatorDaoAux : IdentifiableObjectDao<IndicatorDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/indicator/IndicatorTypeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/indicator/IndicatorTypeDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.indicator
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "IndicatorTypeTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface IndicatorTypeDaoAux : IdentifiableObjectDao<IndicatorTypeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.legendset.DataElementLegendSetLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataElementLegendSetLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementDB
     primaryKeys = ["dataElement", "legendSet"],
 )
 internal data class DataElementLegendSetLinkDB(
-    val dataElement: String,
+    @ParentColumn val dataElement: String,
     val legendSet: String,
     val sortOrder: Int?,
 ) : EntityDB<DataElementLegendSetLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.legendset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataElementLegendSetLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataElementLegendSetLinkTableInfo.Columns.DATA_ELEMENT",
-)
+@GenerateDaoQueries
 internal interface DataElementLegendSetLinkDaoAux : LinkDao<DataElementLegendSetLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.legendset.IndicatorLegendSetLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.indicator.IndicatorDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "IndicatorLegendSetLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.indicator.IndicatorDB
     primaryKeys = ["indicator", "legendSet"],
 )
 internal data class IndicatorLegendSetLinkDB(
-    val indicator: String,
+    @ParentColumn val indicator: String,
     val legendSet: String,
     val sortOrder: Int?,
 ) : EntityDB<IndicatorLegendSetLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/IndicatorLegendSetLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.legendset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "IndicatorLegendSetLinkTableInfo.TABLE_NAME",
-    parentColumnName = "IndicatorLegendSetLinkTableInfo.Columns.INDICATOR",
-)
+@GenerateDaoQueries
 internal interface IndicatorLegendSetLinkDaoAux : LinkDao<IndicatorLegendSetLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/LegendDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/LegendDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.legendset
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "LegendTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface LegendDaoAux : IdentifiableObjectDao<LegendDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/LegendSetDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/LegendSetDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.legendset
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "LegendSetTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface LegendSetDaoAux : IdentifiableObjectDao<LegendSetDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/ProgramIndicatorLegendSetLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/ProgramIndicatorLegendSetLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.legendset.ProgramIndicatorLegendSetLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramIndicatorDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "ProgramIndicatorLegendSetLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.program.ProgramIndicatorDB
     primaryKeys = ["programIndicator", "legendSet"],
 )
 internal data class ProgramIndicatorLegendSetLinkDB(
-    val programIndicator: String,
+    @ParentColumn val programIndicator: String,
     val legendSet: String,
     val sortOrder: Int?,
 ) : EntityDB<ProgramIndicatorLegendSetLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/ProgramIndicatorLegendSetLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/ProgramIndicatorLegendSetLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.legendset
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "ProgramIndicatorLegendSetLinkTableInfo.TABLE_NAME",
-    parentColumnName = "ProgramIndicatorLegendSetLinkTableInfo.Columns.PROGRAM_INDICATOR",
-)
+@GenerateDaoQueries
 internal interface ProgramIndicatorLegendSetLinkDaoAux : LinkDao<ProgramIndicatorLegendSetLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.maintenance
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "D2ErrorTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface D2ErrorDaoAux : ObjectDao<D2ErrorDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/ForeignKeyViolationDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.maintenance
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ForeignKeyViolationTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ForeignKeyViolationDaoAux : ObjectDao<ForeignKeyViolationDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.map
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "MapLayerTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface MapLayerDaoAux : IdentifiableObjectDao<MapLayerDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.map.layer.MapLayerImageryProvider
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "MapLayerImageryProvider",
@@ -19,7 +20,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["mapLayer", "attribution"],
 )
 internal data class MapLayerImageryProviderDB(
-    val mapLayer: String,
+    @ParentColumn val mapLayer: String,
     val attribution: String,
     val coverageAreas: MapLayerImageryProviderAreaDB?,
 ) : EntityDB<MapLayerImageryProvider> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerImageryProviderDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.map
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "MapLayerImageryProviderTableInfo.TABLE_NAME",
-    parentColumnName = "MapLayerImageryProviderTableInfo.Columns.MAP_LAYER",
-)
+@GenerateDaoQueries
 internal interface MapLayerImageryProviderDaoAux : LinkDao<MapLayerImageryProviderDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "NoteTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface NoteDaoAux : IdentifiableObjectDao<NoteDB> {
 
     @Query(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.option
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "OptionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface OptionDaoAux : IdentifiableObjectDao<OptionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.option
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "OptionGroupTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface OptionGroupDaoAux : IdentifiableObjectDao<OptionGroupDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.option.OptionGroupOptionLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "OptionGroupOptionLink",
@@ -26,7 +27,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["optionGroup", "option"],
 )
 internal data class OptionGroupOptionLinkDB(
-    val optionGroup: String,
+    @ParentColumn val optionGroup: String,
     val option: String,
 ) : EntityDB<OptionGroupOptionLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.option
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "OptionGroupOptionLinkTableInfo.TABLE_NAME",
-    parentColumnName = "OptionGroupOptionLinkTableInfo.Columns.OPTION_GROUP",
-)
+@GenerateDaoQueries
 internal interface OptionGroupOptionLinkDaoAux : LinkDao<OptionGroupOptionLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionSetDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.option
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "OptionSetTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface OptionSetDaoAux : IdentifiableObjectDao<OptionSetDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.organisationunit
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "OrganisationUnitTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface OrganisationUnitDaoAux : IdentifiableObjectDao<OrganisationUnitDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitGroupDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitGroupDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.organisationunit
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "OrganisationUnitGroupTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface OrganisationUnitGroupDaoAux : IdentifiableObjectDao<OrganisationUnitGroupDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitLevelDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitLevelDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.organisationunit
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "OrganisationUnitLevelTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface OrganisationUnitLevelDaoAux : IdentifiableObjectDao<OrganisationUnitLevelDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitOrganisationUnitGroupLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "OrganisationUnitOrganisationUnitGroupLink",
@@ -26,7 +27,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["organisationUnit", "organisationUnitGroup"],
 )
 internal data class OrganisationUnitOrganisationUnitGroupLinkDB(
-    val organisationUnit: String,
+    @ParentColumn val organisationUnit: String,
     val organisationUnitGroup: String,
 ) : EntityDB<OrganisationUnitOrganisationUnitGroupLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitOrganisationUnitGroupLinkDaoAux.kt
@@ -31,9 +31,6 @@ package org.hisp.dhis.android.persistence.organisationunit
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "OrganisationUnitOrganisationUnitGroupLinkTableInfo.TABLE_NAME",
-    parentColumnName = "OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT",
-)
+@GenerateDaoQueries
 internal interface OrganisationUnitOrganisationUnitGroupLinkDaoAux :
     LinkDao<OrganisationUnitOrganisationUnitGroupLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "OrganisationUnitProgramLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.program.ProgramDB
     primaryKeys = ["organisationUnit", "program"],
 )
 internal data class OrganisationUnitProgramLinkDB(
-    val organisationUnit: String,
+    @ParentColumn val organisationUnit: String,
     val program: String,
 ) : EntityDB<OrganisationUnitProgramLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitProgramLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.organisationunit
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "OrganisationUnitProgramLinkTableInfo.TABLE_NAME",
-    parentColumnName = "OrganisationUnitProgramLinkTableInfo.Columns.ORGANISATION_UNIT",
-)
+@GenerateDaoQueries
 internal interface OrganisationUnitProgramLinkDaoAux : LinkDao<OrganisationUnitProgramLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/period/PeriodDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.period
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "PeriodTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface PeriodDaoAux : ObjectDao<PeriodDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryDB.kt
@@ -6,6 +6,7 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundaryType
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "AnalyticsPeriodBoundary",
@@ -21,7 +22,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["programIndicator", "boundaryTarget", "analyticsPeriodBoundaryType"],
 )
 internal data class AnalyticsPeriodBoundaryDB(
-    val programIndicator: String,
+    @ParentColumn val programIndicator: String,
     val boundaryTarget: String,
     val analyticsPeriodBoundaryType: String,
     val offsetPeriods: Int?,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/AnalyticsPeriodBoundaryDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "AnalyticsPeriodBoundaryTableInfo.TABLE_NAME",
-    parentColumnName = "AnalyticsPeriodBoundaryTableInfo.Columns.PROGRAM_INDICATOR",
-)
+@GenerateDaoQueries
 internal interface AnalyticsPeriodBoundaryDaoAux : LinkDao<AnalyticsPeriodBoundaryDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramDaoAux : IdentifiableObjectDao<ProgramDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramIndicatorDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramIndicatorTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramIndicatorDaoAux : IdentifiableObjectDao<ProgramIndicatorDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleActionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramRuleActionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramRuleActionDaoAux : IdentifiableObjectDao<ProgramRuleActionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramRuleTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramRuleDaoAux : IdentifiableObjectDao<ProgramRuleDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleVariableDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramRuleVariableDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramRuleVariableTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramRuleVariableDaoAux : IdentifiableObjectDao<ProgramRuleVariableDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.program.ProgramSectionAttributeLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "ProgramSectionAttributeLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeDB
     primaryKeys = ["programSection", "attribute"],
 )
 internal data class ProgramSectionAttributeLinkDB(
-    val programSection: String,
+    @ParentColumn val programSection: String,
     val attribute: String,
     val sortOrder: Int?,
 ) : EntityDB<ProgramSectionAttributeLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionAttributeLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "ProgramSectionAttributeLinkTableInfo.TABLE_NAME",
-    parentColumnName = "ProgramSectionAttributeLinkTableInfo.Columns.PROGRAM_SECTION",
-)
+@GenerateDaoQueries
 internal interface ProgramSectionAttributeLinkDaoAux : LinkDao<ProgramSectionAttributeLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramSectionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramSectionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramSectionDaoAux : IdentifiableObjectDao<ProgramSectionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramStageTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramStageDaoAux : IdentifiableObjectDao<ProgramStageDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDataElementDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageDataElementDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramStageDataElementTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramStageDataElementDaoAux : IdentifiableObjectDao<ProgramStageDataElementDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramStageSectionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramStageSectionDaoAux : IdentifiableObjectDao<ProgramStageSectionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.program.ProgramStageSectionDataElementLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "ProgramStageSectionDataElementLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataelement.DataElementDB
     primaryKeys = ["programStageSection", "dataElement"],
 )
 internal data class ProgramStageSectionDataElementLinkDB(
-    val programStageSection: String,
+    @ParentColumn val programStageSection: String,
     val dataElement: String,
     val sortOrder: Int,
 ) : EntityDB<ProgramStageSectionDataElementLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionDataElementLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "ProgramStageSectionDataElementLinkTableInfo.TABLE_NAME",
-    parentColumnName = "ProgramStageSectionDataElementLinkTableInfo.Columns.PROGRAM_STAGE_SECTION",
-)
+@GenerateDaoQueries
 internal interface ProgramStageSectionDataElementLinkDaoAux : LinkDao<ProgramStageSectionDataElementLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.program.ProgramStageSectionProgramIndicatorLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "ProgramStageSectionProgramIndicatorLink",
@@ -26,7 +27,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["programStageSection", "programIndicator"],
 )
 internal data class ProgramStageSectionProgramIndicatorLinkDB(
-    val programStageSection: String,
+    @ParentColumn val programStageSection: String,
     val programIndicator: String,
 ) : EntityDB<ProgramStageSectionProgramIndicatorLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramStageSectionProgramIndicatorLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "ProgramStageSectionProgramIndicatorLinkTableInfo.TABLE_NAME",
-    parentColumnName = "ProgramStageSectionProgramIndicatorLinkTableInfo.Columns.PROGRAM_STAGE_SECTION",
-)
+@GenerateDaoQueries
 internal interface ProgramStageSectionProgramIndicatorLinkDaoAux : LinkDao<ProgramStageSectionProgramIndicatorLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/program/ProgramTrackedEntityAttributeDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.program
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramTrackedEntityAttributeTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramTrackedEntityAttributeDaoAux : IdentifiableObjectDao<ProgramTrackedEntityAttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/programstageworkinglist/ProgramStageWorkingListAttributeValueFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/programstageworkinglist/ProgramStageWorkingListAttributeValueFilterDaoAux.kt
@@ -31,6 +31,6 @@ package org.hisp.dhis.android.persistence.programstageworkinglist
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramStageWorkingListAttributeValueFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramStageWorkingListAttributeValueFilterDaoAux :
     ObjectDao<ProgramStageWorkingListAttributeValueFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/programstageworkinglist/ProgramStageWorkingListDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/programstageworkinglist/ProgramStageWorkingListDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.programstageworkinglist
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramStageWorkingListTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramStageWorkingListDaoAux : IdentifiableObjectDao<ProgramStageWorkingListDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/programstageworkinglist/ProgramStageWorkingListEventDataFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/programstageworkinglist/ProgramStageWorkingListEventDataFilterDaoAux.kt
@@ -31,6 +31,6 @@ package org.hisp.dhis.android.persistence.programstageworkinglist
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramStageWorkingListEventDataFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramStageWorkingListEventDataFilterDaoAux :
     ObjectDao<ProgramStageWorkingListEventDataFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipConstraintDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipConstraintDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.relationship
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "RelationshipConstraintTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface RelationshipConstraintDaoAux : ObjectDao<RelationshipConstraintDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.relationship
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableDeletableDataObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "RelationshipTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface RelationshipDaoAux : IdentifiableDeletableDataObjectDao<RelationshipDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipItemDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipItemDaoAux.kt
@@ -33,7 +33,7 @@ import androidx.room.RoomRawQuery
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "RelationshipItemTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface RelationshipItemDaoAux : ObjectDao<RelationshipItemDB> {
     @RawQuery
     fun getRelationshipRow(query: RoomRawQuery): List<RelationshipRow>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipTypeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/relationship/RelationshipTypeDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.relationship
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "RelationshipTypeTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface RelationshipTypeDaoAux : IdentifiableObjectDao<RelationshipTypeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/resource/ResourceDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/resource/ResourceDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.resource.internal.Resource
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ResourceTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ResourceDaoAux : ObjectDao<ResourceDB> {
 
     @Query(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsDhisVisualizationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsDhisVisualizationDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AnalyticsDhisVisualizationTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AnalyticsDhisVisualizationDaoAux : ObjectDao<AnalyticsDhisVisualizationDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiAttributeDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiAttributeDB.kt
@@ -6,6 +6,7 @@ import org.hisp.dhis.android.core.settings.AnalyticsTeiAttribute
 import org.hisp.dhis.android.core.settings.WHONutritionComponent
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "AnalyticsTeiAttribute",
@@ -28,7 +29,7 @@ import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeDB
     primaryKeys = ["teiSetting", "attribute"],
 )
 internal data class AnalyticsTeiAttributeDB(
-    val teiSetting: String,
+    @ParentColumn val teiSetting: String,
     val whoComponent: String?,
     val attribute: String,
 ) : EntityDB<AnalyticsTeiAttribute> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiAttributeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiAttributeDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "AnalyticsTeiAttributeTableInfo.TABLE_NAME",
-    parentColumnName = "AnalyticsTeiAttributeTableInfo.Columns.TEI_SETTING",
-)
+@GenerateDaoQueries
 internal interface AnalyticsTeiAttributeDaoAux : LinkDao<AnalyticsTeiAttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiDataElementDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiDataElementDB.kt
@@ -7,6 +7,7 @@ import org.hisp.dhis.android.core.settings.WHONutritionComponent
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataelement.DataElementDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "AnalyticsTeiDataElement",
@@ -36,7 +37,7 @@ import org.hisp.dhis.android.persistence.program.ProgramStageDB
     primaryKeys = ["teiSetting", "dataElement"],
 )
 internal data class AnalyticsTeiDataElementDB(
-    val teiSetting: String,
+    @ParentColumn val teiSetting: String,
     val whoComponent: String?,
     val programStage: String?,
     val dataElement: String,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiDataElementDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiDataElementDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "AnalyticsTeiDataElementTableInfo.TABLE_NAME",
-    parentColumnName = "AnalyticsTeiDataElementTableInfo.Columns.TEI_SETTING",
-)
+@GenerateDaoQueries
 internal interface AnalyticsTeiDataElementDaoAux : LinkDao<AnalyticsTeiDataElementDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiIndicatorDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiIndicatorDB.kt
@@ -7,6 +7,7 @@ import org.hisp.dhis.android.core.settings.WHONutritionComponent
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramIndicatorDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "AnalyticsTeiIndicator",
@@ -36,7 +37,7 @@ import org.hisp.dhis.android.persistence.program.ProgramStageDB
     primaryKeys = ["teiSetting", "indicator"],
 )
 internal data class AnalyticsTeiIndicatorDB(
-    val teiSetting: String,
+    @ParentColumn val teiSetting: String,
     val whoComponent: String?,
     val programStage: String?,
     val indicator: String,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiIndicatorDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiIndicatorDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "AnalyticsTeiIndicatorTableInfo.TABLE_NAME",
-    parentColumnName = "AnalyticsTeiIndicatorTableInfo.Columns.TEI_SETTING",
-)
+@GenerateDaoQueries
 internal interface AnalyticsTeiIndicatorDaoAux : LinkDao<AnalyticsTeiIndicatorDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AnalyticsTeiSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AnalyticsTeiSettingDaoAux : ObjectDao<AnalyticsTeiSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONutritionDataDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONutritionDataDB.kt
@@ -8,6 +8,7 @@ import org.hisp.dhis.android.core.settings.AnalyticsTeiWHONutritionGenderValues
 import org.hisp.dhis.android.core.settings.WHONutritionChartType
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "AnalyticsTeiWHONutritionData",
@@ -30,7 +31,7 @@ import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeDB
     primaryKeys = ["teiSetting", "genderAttribute"],
 )
 internal data class AnalyticsTeiWHONutritionDataDB(
-    val teiSetting: String,
+    @ParentColumn val teiSetting: String,
     val chartType: String?,
     val genderAttribute: String,
     val genderFemale: String?,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONutritionDataDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/AnalyticsTeiWHONutritionDataDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "AnalyticsTeiWHONutritionDataTableInfo.TABLE_NAME",
-    parentColumnName = "AnalyticsTeiWHONutritionDataTableInfo.Columns.TEI_SETTING",
-)
+@GenerateDaoQueries
 internal interface AnalyticsTeiWHONutritionDataDaoAux : LinkDao<AnalyticsTeiWHONutritionDataDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentAttributeDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentAttributeDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.settings.CustomIntentAttribute
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "CustomIntentAttribute",
@@ -20,7 +21,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 )
 internal data class CustomIntentAttributeDB(
     val uid: String,
-    val customIntentUid: String,
+    @ParentColumn val customIntentUid: String,
 ) : EntityDB<CustomIntentAttribute> {
 
     override fun toDomain(): CustomIntentAttribute {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentAttributeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentAttributeDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "CustomIntentAttributeTableInfo.TABLE_NAME",
-    parentColumnName = "CustomIntentAttributeTableInfo.Columns.CUSTOM_INTENT_UID",
-)
+@GenerateDaoQueries
 internal interface CustomIntentAttributeDaoAux : LinkDao<CustomIntentAttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "CustomIntentTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface CustomIntentDaoAux : IdentifiableObjectDao<CustomIntentDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDataElementDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDataElementDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.settings.CustomIntentDataElement
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "CustomIntentDataElement",
@@ -20,7 +21,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 )
 internal data class CustomIntentDataElementDB(
     val uid: String,
-    val customIntentUid: String,
+    @ParentColumn val customIntentUid: String,
 ) : EntityDB<CustomIntentDataElement> {
 
     override fun toDomain(): CustomIntentDataElement {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDataElementDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/CustomIntentDataElementDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "CustomIntentDataElementTableInfo.TABLE_NAME",
-    parentColumnName = "CustomIntentDataElementTableInfo.Columns.CUSTOM_INTENT_UID",
-)
+@GenerateDaoQueries
 internal interface CustomIntentDataElementDaoAux : LinkDao<CustomIntentDataElementDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/DataSetConfigurationSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/DataSetConfigurationSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataSetConfigurationSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataSetConfigurationSettingDaoAux : ObjectDao<DataSetConfigurationSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/DataSetSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/DataSetSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "DataSetSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface DataSetSettingDaoAux : ObjectDao<DataSetSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/FilterSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/FilterSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "FilterSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface FilterSettingDaoAux : ObjectDao<FilterSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/GeneralSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/GeneralSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "GeneralSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface GeneralSettingDaoAux : ObjectDao<GeneralSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/LatestAppVersionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/LatestAppVersionDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "LatestAppVersionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface LatestAppVersionDaoAux : ObjectDao<LatestAppVersionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/ProgramConfigurationSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/ProgramConfigurationSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramConfigurationSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramConfigurationSettingDaoAux : ObjectDao<ProgramConfigurationSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/ProgramSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/ProgramSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramSettingDaoAux : ObjectDao<ProgramSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/SynchronizationSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/SynchronizationSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "SynchronizationSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface SynchronizationSettingDaoAux : ObjectDao<SynchronizationSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/SystemSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/SystemSettingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "SystemSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface SystemSettingDaoAux : ObjectDao<SystemSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/UserSettingsDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/UserSettingsDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.settings
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "UserSettingsTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface UserSettingsDaoAux : ObjectDao<UserSettingsDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSConfigDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSConfigDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "SMSConfigTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface SMSConfigDaoAux : ObjectDao<SMSConfigDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSOngoingSubmissionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSOngoingSubmissionDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "SMSOngoingSubmissionTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface SMSOngoingSubmissionDaoAux : ObjectDao<SMSOngoingSubmissionDB> {
 
     @Query(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/systeminfo/SystemInfoDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/systeminfo/SystemInfoDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.systeminfo
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "SystemInfoTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface SystemInfoDaoAux : ObjectDao<SystemInfoDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/AttributeValueFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/AttributeValueFilterDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AttributeValueFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AttributeValueFilterDaoAux : ObjectDao<AttributeValueFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramOwnerDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramOwnerDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramOwnerTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramOwnerDaoAux : ObjectDao<ProgramOwnerDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramTempOwnerDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramTempOwnerDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ProgramTempOwnerTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ProgramTempOwnerDaoAux : ObjectDao<ProgramTempOwnerDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ReservedValueSettingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ReservedValueSettingDaoAux.kt
@@ -31,6 +31,6 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ReservedValueSettingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ReservedValueSettingDaoAux :
     IdentifiableObjectDao<ReservedValueSettingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityAttributeTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityAttributeDaoAux : IdentifiableObjectDao<TrackedEntityAttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeLegendSetLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.legendset.LegendSetDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "TrackedEntityAttributeLegendSetLink",
@@ -28,7 +29,7 @@ import org.hisp.dhis.android.persistence.legendset.LegendSetDB
 )
 internal data class TrackedEntityAttributeLegendSetLinkDB(
 
-    val trackedEntityAttribute: String,
+    @ParentColumn val trackedEntityAttribute: String,
     val legendSet: String,
     val sortOrder: Int?,
 ) : EntityDB<TrackedEntityAttributeLegendSetLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeLegendSetLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "TrackedEntityAttributeLegendSetLinkTableInfo.TABLE_NAME",
-    parentColumnName = "TrackedEntityAttributeLegendSetLinkTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE",
-)
+@GenerateDaoQueries
 internal interface TrackedEntityAttributeLegendSetLinkDaoAux : LinkDao<TrackedEntityAttributeLegendSetLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityAttributeReservedValueTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityAttributeReservedValueDaoAux : ObjectDao<TrackedEntityAttributeReservedValueDB> {
 
     @Query(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.persistence.program.ProgramTrackedEntityAttributeTableInfo
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityAttributeValueTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAttributeValueDB> {
     @Query(
         """UPDATE TrackedEntityAttributeValue 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityDataValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityDataValueDaoAux.kt
@@ -34,7 +34,7 @@ import org.hisp.dhis.android.persistence.event.EventTableInfo
 import org.hisp.dhis.android.persistence.program.ProgramStageDataElementTableInfo
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityDataValueTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityDataValueDaoAux : ObjectDao<TrackedEntityDataValueDB> {
 
     @Query(

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.common.IdentifiableColumns
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableDeletableDataObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityInstanceTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityInstanceDaoAux : IdentifiableDeletableDataObjectDao<TrackedEntityInstanceDB> {
     @Query(
         """UPDATE TrackedEntityInstance

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceEventFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceEventFilterDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityInstanceEventFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityInstanceEventFilterDaoAux : ObjectDao<TrackedEntityInstanceEventFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceFilterDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceFilterDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityInstanceFilterTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityInstanceFilterDaoAux : IdentifiableObjectDao<TrackedEntityInstanceFilterDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDaoAux.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceSyncTableInfo.Columns
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityInstanceSyncTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityInstanceSyncDaoAux : ObjectDao<TrackedEntityInstanceSyncDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeAttribute
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "TrackedEntityTypeAttribute",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["trackedEntityType", "trackedEntityAttribute"],
 )
 internal data class TrackedEntityTypeAttributeDB(
-    val trackedEntityType: String,
+    @ParentColumn val trackedEntityType: String,
     val trackedEntityAttribute: String,
     val displayInList: Boolean?,
     val mandatory: Boolean?,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeAttributeDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "TrackedEntityTypeAttributeTableInfo.TABLE_NAME",
-    parentColumnName = "TrackedEntityTypeAttributeTableInfo.Columns.TRACKED_ENTITY_TYPE",
-)
+@GenerateDaoQueries
 internal interface TrackedEntityTypeAttributeDaoAux : LinkDao<TrackedEntityTypeAttributeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityTypeDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackedEntityTypeTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackedEntityTypeDaoAux : IdentifiableObjectDao<TrackedEntityTypeDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDaoAux.kt
@@ -32,7 +32,7 @@ import androidx.room.Query
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackerJobObjectTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackerJobObjectDaoAux : ObjectDao<TrackerJobObjectDB> {
     @Query(
         """

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.usecase
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "StockUseCaseTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface StockUseCaseDaoAux : IdentifiableObjectDao<StockUseCaseDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.usecase.stock.InternalStockUseCaseTransaction
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "StockUseCaseTransaction",
@@ -19,7 +20,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["programUid", "transactionType"],
 )
 internal data class StockUseCaseTransactionDB(
-    val programUid: String,
+    @ParentColumn val programUid: String,
     val sortOrder: Int?,
     val transactionType: String,
     val distributedTo: String?,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/usecase/StockUseCaseTransactionLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.usecase
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "StockUseCaseTransactionTableInfo.TABLE_NAME",
-    parentColumnName = "StockUseCaseTransactionTableInfo.Columns.PROGRAM_UID",
-)
+@GenerateDaoQueries
 internal interface StockUseCaseTransactionLinkDaoAux : LinkDao<StockUseCaseTransactionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthenticatedUserDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthenticatedUserDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.user
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AuthenticatedUserTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AuthenticatedUserDaoAux : ObjectDao<AuthenticatedUserDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/AuthorityDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.user
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "AuthorityTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface AuthorityDaoAux : ObjectDao<AuthorityDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.user
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "UserTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface UserDaoAux : IdentifiableObjectDao<UserDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserGroupDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.user
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "UserGroupTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface UserGroupDaoAux : IdentifiableObjectDao<UserGroupDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDB.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.user.UserOrganisationUnitLink
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "UserOrganisationUnit",
@@ -21,7 +22,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 internal data class UserOrganisationUnitDB(
     val user: String,
     val organisationUnit: String,
-    val organisationUnitScope: String,
+    @ParentColumn val organisationUnitScope: String,
     val root: Boolean?,
     val userAssigned: Boolean?,
 ) : EntityDB<UserOrganisationUnitLink> {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.user
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "UserOrganisationUnitTableInfo.TABLE_NAME",
-    parentColumnName = "UserOrganisationUnitTableInfo.Columns.ORGANISATION_UNIT_SCOPE",
-)
+@GenerateDaoQueries
 internal interface UserOrganisationUnitDaoAux : LinkDao<UserOrganisationUnitDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserRoleDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.user
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "UserRoleTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface UserRoleDaoAux : IdentifiableObjectDao<UserRoleDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.validation.DataSetValidationRuleLink
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataset.DataSetDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "DataSetValidationRuleLink",
@@ -27,7 +28,7 @@ import org.hisp.dhis.android.persistence.dataset.DataSetDB
     primaryKeys = ["dataSet", "validationRule"],
 )
 internal data class DataSetValidationRuleLinkDB(
-    val dataSet: String,
+    @ParentColumn val dataSet: String,
     val validationRule: String,
 ) : EntityDB<DataSetValidationRuleLink> {
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/DataSetValidationRuleLinkDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.validation
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "DataSetValidationRuleLinkTableInfo.TABLE_NAME",
-    parentColumnName = "DataSetValidationRuleLinkTableInfo.Columns.DATA_SET",
-)
+@GenerateDaoQueries
 internal interface DataSetValidationRuleLinkDaoAux : LinkDao<DataSetValidationRuleLinkDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/validation/ValidationRuleDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.validation
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ValidationRuleTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ValidationRuleDaoAux : IdentifiableObjectDao<ValidationRuleDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/valuetypedevicerendering/ValueTypeDeviceRenderingDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/valuetypedevicerendering/ValueTypeDeviceRenderingDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.valuetypedevicerendering
 import org.hisp.dhis.android.persistence.common.daos.ObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "ValueTypeDeviceRenderingTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface ValueTypeDeviceRenderingDaoAux : ObjectDao<ValueTypeDeviceRenderingDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.visualization
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "TrackerVisualizationTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface TrackerVisualizationDaoAux : IdentifiableObjectDao<TrackerVisualizationDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDimensionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDimensionDB.kt
@@ -10,6 +10,7 @@ import org.hisp.dhis.android.persistence.common.ObjectWithUidListDB
 import org.hisp.dhis.android.persistence.common.toDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 import org.hisp.dhis.android.persistence.program.ProgramStageDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "TrackerVisualizationDimension",
@@ -39,7 +40,7 @@ import org.hisp.dhis.android.persistence.program.ProgramStageDB
     primaryKeys = ["trackerVisualization", "dimension"],
 )
 internal data class TrackerVisualizationDimensionDB(
-    val trackerVisualization: String,
+    @ParentColumn val trackerVisualization: String,
     val position: String,
     val dimension: String,
     val dimensionType: String?,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDimensionDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/TrackerVisualizationDimensionDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.visualization
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "TrackerVisualizationDimensionTableInfo.TABLE_NAME",
-    parentColumnName = "TrackerVisualizationDimensionTableInfo.Columns.TRACKER_VISUALIZATION",
-)
+@GenerateDaoQueries
 internal interface TrackerVisualizationDimensionDaoAux : LinkDao<TrackerVisualizationDimensionDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDaoAux.kt
@@ -31,5 +31,5 @@ package org.hisp.dhis.android.persistence.visualization
 import org.hisp.dhis.android.persistence.common.daos.IdentifiableObjectDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(tableName = "VisualizationTableInfo.TABLE_NAME")
+@GenerateDaoQueries
 internal interface VisualizationDaoAux : IdentifiableObjectDao<VisualizationDB>

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDB.kt
@@ -5,6 +5,7 @@ import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.visualization.LayoutPosition
 import org.hisp.dhis.android.core.visualization.VisualizationDimensionItem
 import org.hisp.dhis.android.persistence.common.EntityDB
+import org.hisp.dhis.android.processor.ParentColumn
 
 @Entity(
     tableName = "VisualizationDimensionItem",
@@ -20,7 +21,7 @@ import org.hisp.dhis.android.persistence.common.EntityDB
     primaryKeys = ["visualization", "dimensionItem"],
 )
 internal data class VisualizationDimensionItemDB(
-    val visualization: String,
+    @ParentColumn val visualization: String,
     val position: String,
     val dimension: String,
     val dimensionItem: String,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/visualization/VisualizationDimensionItemDaoAux.kt
@@ -31,8 +31,5 @@ package org.hisp.dhis.android.persistence.visualization
 import org.hisp.dhis.android.persistence.common.daos.LinkDao
 import org.hisp.dhis.android.processor.GenerateDaoQueries
 
-@GenerateDaoQueries(
-    tableName = "VisualizationDimensionItemTableInfo.TABLE_NAME",
-    parentColumnName = "VisualizationDimensionItemTableInfo.Columns.VISUALIZATION",
-)
+@GenerateDaoQueries
 internal interface VisualizationDimensionItemDaoAux : LinkDao<VisualizationDimensionItemDB>

--- a/processor/src/main/java/org/hisp/dhis/android/processor/DaoQueriesProcessor.kt
+++ b/processor/src/main/java/org/hisp/dhis/android/processor/DaoQueriesProcessor.kt
@@ -36,35 +36,76 @@ class DaoQueriesProcessor(
         symbols.forEach { symbol ->
             logger.info("Processing DAO: ${symbol.qualifiedName?.asString()}")
 
-            val tableName = symbol.annotations.firstNotNullOfOrNull { annotation ->
-                if (annotation.shortName.asString() == GenerateDaoQueries::class.simpleName &&
+            // Extract annotation parameters
+            val annotation = symbol.annotations.firstOrNull { annotation ->
+                annotation.shortName.asString() == GenerateDaoQueries::class.simpleName &&
                     annotation.annotationType.resolve().declaration.qualifiedName?.asString() == GenerateDaoQueries::class.qualifiedName
-                ) {
-                    annotation.arguments.find { arg -> arg.name?.asString() == "tableName" }?.value as? String
-                } else {
-                    null
-                }
-            }?.takeIf { it.isNotBlank() }
-
-            val parentColumnName = symbol.annotations.firstNotNullOfOrNull { annotation ->
-                if (annotation.shortName.asString() == GenerateDaoQueries::class.simpleName &&
-                    annotation.annotationType.resolve().declaration.qualifiedName?.asString() == GenerateDaoQueries::class.qualifiedName
-                ) {
-                    annotation.arguments.find { arg -> arg.name?.asString() == "parentColumnName" }?.value as? String
-                } else {
-                    null
-                }
-            }?.takeIf { it.isNotBlank() }
-
-            if (tableName == null) {
-                logger.error(
-                    "Could not extract a valid, non-blank 'tableName' String from @GenerateDaoQueries for ${symbol.qualifiedName?.asString()}. ",
-                    symbol
-                )
-                return@forEach
             }
 
-            logger.info("Successfully extracted tableName: '$tableName' for ${symbol.qualifiedName?.asString()}")
+            val explicitTableName = annotation?.arguments
+                ?.find { arg -> arg.name?.asString() == "tableName" }
+                ?.value as? String
+
+            val explicitParentColumnName = annotation?.arguments
+                ?.find { arg -> arg.name?.asString() == "parentColumnName" }
+                ?.value as? String
+
+            // Infer table name if not explicitly provided
+            val tableName = if (explicitTableName.isNullOrBlank()) {
+                // Extract the entity type from the DAO's generic parameter
+                val entityType = symbol.superTypes
+                    .firstOrNull()
+                    ?.resolve()
+                    ?.arguments
+                    ?.firstOrNull()
+                    ?.type
+                    ?.resolve()
+                    ?.declaration as? KSClassDeclaration
+
+                if (entityType == null) {
+                    logger.error(
+                        "Could not infer tableName for ${symbol.qualifiedName?.asString()}. " +
+                            "Either provide an explicit tableName parameter or ensure the DAO has a generic type parameter.",
+                        symbol
+                    )
+                    return@forEach
+                }
+
+                // Convert EntityDB -> EntityTableInfo.TABLE_NAME
+                val entityName = entityType.simpleName.asString().removeSuffix("DB")
+                val tableInfoName = "${entityName}TableInfo.TABLE_NAME"
+                logger.info("Inferred tableName: '$tableInfoName' from entity type: ${entityType.simpleName.asString()}")
+                tableInfoName
+            } else {
+                logger.info("Using explicit tableName: '$explicitTableName'")
+                explicitTableName
+            }
+
+            // Infer parent column name if not explicitly provided (for LinkDao)
+            val parentColumnName = if (explicitParentColumnName.isNullOrBlank()) {
+                // Extract the entity type from the DAO's generic parameter
+                val entityType = symbol.superTypes
+                    .firstOrNull()
+                    ?.resolve()
+                    ?.arguments
+                    ?.firstOrNull()
+                    ?.type
+                    ?.resolve()
+                    ?.declaration as? KSClassDeclaration
+
+                if (entityType != null) {
+                    // Convert EntityDB -> EntityTableInfo.PARENT_COLUMN
+                    val entityName = entityType.simpleName.asString().removeSuffix("DB")
+                    val parentColumnRef = "${entityName}TableInfo.PARENT_COLUMN"
+                    logger.info("Inferred parentColumnName: '$parentColumnRef' from entity type: ${entityType.simpleName.asString()}")
+                    parentColumnRef
+                } else {
+                    null
+                }
+            } else {
+                logger.info("Using explicit parentColumnName: '$explicitParentColumnName'")
+                explicitParentColumnName
+            }
 
             val superInterfaceSimpleNames = symbol.superTypes
                 .map { it.resolve() } // Resolves each KSTypeReference to KSType


### PR DESCRIPTION
This PR fixes how these parameters are passed to the dao generator. Instead of having to pass a hardcoded string with the path, the dao processing scripts infers the table name and parent column from the TABLE INFO files. For this, a new annotation has been added to mark the parent columns from the link entities so the entity processor can use it and  print it in the generate table info file.

Related task [ANDROSDK-2175](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2175)

[ANDROSDK-2175]: https://dhis2.atlassian.net/browse/ANDROSDK-2175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ