### PR TITLE
fix: [ANDROSDK-2192] sanitize login config url call

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/ServerUrlParser.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/ServerUrlParser.kt
@@ -69,10 +69,14 @@ internal object ServerUrlParser {
     }
 
     fun trimAndRemoveTrailingSlash(url: String?): String? {
-        return url?.trim()?.replace('\\', '/')?.trimEnd('/')
+        return sanitizeUrl(url)?.trimEnd('/')
+    }
+
+    fun sanitizeUrl(url: String?): String? {
+        return url?.trim()?.replace('\\', '/')
     }
 
     fun removeTrailingApi(url: String): String {
-        return url.trimEnd('/').removeSuffix("/api")
+        return trimAndRemoveTrailingSlash(url)!!.removeSuffix("/api")
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.server.internal
 
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.configuration.internal.ServerUrlParser
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.server.LoginConfig
@@ -45,11 +46,12 @@ internal class LoginConfigCall(
     private val networkHandler: LoginConfigNetworkHandler,
 ) {
     suspend fun checkServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
-        val loginConfig = tryLoginConfig(serverUrl)
+        val sanitizedUrl = ServerUrlParser.trimAndRemoveTrailingSlash(serverUrl)!!
+        val loginConfig = tryLoginConfig(sanitizedUrl)
 
         return when (loginConfig) {
             is Result.Success<LoginConfig, D2Error> -> loginConfig
-            is Result.Failure<LoginConfig, D2Error> -> tryPing(serverUrl)
+            is Result.Failure<LoginConfig, D2Error> -> tryPing(sanitizedUrl)
         }
     }
 


### PR DESCRIPTION
Related Task [ANDROSDK-2192](https://dhis2.atlassian.net/browse/ANDROSDK-2192)

[ANDROSDK-2192]: https://dhis2.atlassian.net/browse/ANDROSDK-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ