### PR TITLE
chore: [ANDROSDK-2173] Handle FileResource status when posting files

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceInternalAccessor.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceInternalAccessor.kt
@@ -32,6 +32,10 @@ internal object FileResourceInternalAccessor {
         return fileResource.storageStatus()?.let { it == FileResourceStorageStatus.STORED } ?: true
     }
 
+    fun storageStatus(fileResource: FileResource): FileResourceStorageStatus {
+        return fileResource.storageStatus() ?: FileResourceStorageStatus.NONE
+    }
+
     fun insertStorageStatus(
         builder: FileResource.Builder,
         storageStatus: FileResourceStorageStatus,

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifier.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifier.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifier.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifier.kt
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.fileresource.internal
+
+import android.util.Log
+import kotlinx.coroutines.delay
+import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
+import org.hisp.dhis.android.core.fileresource.FileResourceInternalAccessor
+import org.hisp.dhis.android.core.fileresource.FileResourceStorageStatus
+import org.hisp.dhis.android.core.fileresource.internal.FileResourcePostCall.Companion.TAG
+import org.koin.core.annotation.Singleton
+import kotlin.math.pow
+
+/**
+ * Verifies the storage status of uploaded FileResources in batch to ensure they are STORED
+ * before being used in data values. This prevents issues with files being wrongly assigned
+ * when they are posted without waiting for the STORED status.
+ *
+ */
+@Singleton
+internal class FileResourceStorageStatusVerifier(
+    private val fileResourceNetworkHandler: FileResourceNetworkHandler,
+    private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
+) {
+
+    /**
+     * Verifies the storage status of multiple file resources in batch.
+     *
+     * @param fileResourceUids List of file resource UIDs to verify
+     * @param maxAttempts Maximum number of polling attempts per file (default: 30)
+     * @param delayMs Delay in milliseconds between polling attempts (default: 1000ms)
+     * @param batchSize Number of files to verify in parallel (default: 10)
+     * @return Map of file resource UID to verification result (true if STORED, false otherwise)
+     */
+    suspend fun verifyStorageStatusBatch(
+        fileResourceUids: List<String>,
+        maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+        delayMs: Long = DEFAULT_DELAY_MS,
+        batchSize: Int = DEFAULT_BATCH_SIZE,
+    ): Map<String, FileResourceVerificationResult> {
+        if (fileResourceUids.isEmpty()) {
+            return emptyMap()
+        }
+
+        Log.d(TAG, "Starting batch verification for ${fileResourceUids.size} file resources")
+
+        val results = mutableMapOf<String, FileResourceVerificationResult>()
+        val pendingUids = fileResourceUids.toMutableSet()
+
+        for (attempt in 1..maxAttempts) {
+            if (pendingUids.isEmpty()) {
+                break
+            }
+
+            Log.d(TAG, "Verification attempt $attempt/$maxAttempts for ${pendingUids.size} pending files")
+
+            // Process in batches to avoid overwhelming the server
+            val currentBatch = pendingUids.take(batchSize)
+            val batchResults = verifyBatch(currentBatch)
+
+            batchResults.forEach { (uid, result) ->
+                when (result.status) {
+                    FileResourceStorageStatus.STORED -> {
+                        results[uid] = result
+                        pendingUids.remove(uid)
+                        Log.d(TAG, "File resource $uid is STORED")
+                    }
+                    FileResourceStorageStatus.FAILED -> {
+                        results[uid] = result
+                        pendingUids.remove(uid)
+                        Log.w(TAG, "File resource $uid FAILED to store")
+                    }
+                    FileResourceStorageStatus.PENDING -> {
+                        // Keep in pending list for next attempt
+                        Log.d(TAG, "File resource $uid still PENDING")
+                    }
+                    FileResourceStorageStatus.NONE -> {
+                        // Treat as pending
+                        Log.d(TAG, "File resource $uid has status NONE")
+                    }
+                }
+            }
+
+            // If there are still pending files and we haven't reached max attempts, wait before next poll
+            if (pendingUids.isNotEmpty() && attempt < maxAttempts) {
+                delay((delayMs * (2.0.pow(attempt) - 1)).toLong())
+            }
+        }
+
+        // Mark remaining pending files as timed out
+        pendingUids.forEach { uid ->
+            results[uid] = FileResourceVerificationResult(
+                uid = uid,
+                status = FileResourceStorageStatus.PENDING,
+                isVerified = false,
+                timedOut = true,
+            )
+            Log.w(TAG, "File resource $uid timed out after $maxAttempts attempts")
+        }
+
+        val storedCount = results.count { it.value.isVerified }
+        val failedCount = results.count { it.value.status == FileResourceStorageStatus.FAILED }
+        val timedOutCount = results.count { it.value.timedOut }
+
+        Log.i(
+            TAG,
+            "Batch verification complete: $storedCount stored, $failedCount failed, $timedOutCount timed out",
+        )
+
+        return results
+    }
+
+    /**
+     * Verifies a single batch of file resources.
+     */
+    private suspend fun verifyBatch(uids: List<String>): Map<String, FileResourceVerificationResult> {
+        return uids.associateWith { uid ->
+            verifyFileResource(uid)
+        }
+    }
+
+    /**
+     * Verifies a single file resource by fetching its current status from the server.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun verifyFileResource(uid: String): FileResourceVerificationResult {
+        return try {
+            val fileResource = coroutineAPICallExecutor.wrap(storeError = false) {
+                fileResourceNetworkHandler.getFileResource(uid)
+            }.getOrThrow()
+
+            val status = FileResourceInternalAccessor.storageStatus(fileResource)
+            val isStored = FileResourceInternalAccessor.isStored(fileResource)
+
+            FileResourceVerificationResult(
+                uid = uid,
+                status = status,
+                isVerified = isStored,
+                timedOut = false,
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Error verifying file resource $uid: ${e.message}", e)
+            FileResourceVerificationResult(
+                uid = uid,
+                status = FileResourceStorageStatus.FAILED,
+                isVerified = false,
+                timedOut = false,
+            )
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_MAX_ATTEMPTS = 30
+        private const val DEFAULT_DELAY_MS = 1000L
+        private const val DEFAULT_BATCH_SIZE = 10
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUploadResult.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUploadResult.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUploadResult.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUploadResult.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.fileresource.internal
+
+import org.hisp.dhis.android.core.fileresource.FileResource
+
+/**
+ * Result of a file resource upload operation.
+ *
+ * @property originalFileResource The original file resource before upload
+ * @property uploadedUid The UID assigned by the server after upload (null if upload failed)
+ * @property value The associated value (DataValue, AttributeValue, or EventValue)
+ * @property success True if upload was successful
+ */
+internal data class FileResourceUploadResult(
+    val originalFileResource: FileResource,
+    val uploadedUid: String?,
+    val value: FileResourceValue,
+    val success: Boolean,
+)

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceVerificationResult.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceVerificationResult.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceVerificationResult.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceVerificationResult.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.fileresource.internal
+
+import org.hisp.dhis.android.core.fileresource.FileResourceStorageStatus
+
+/**
+ * Result of file resource storage status verification.
+ *
+ * @property uid The file resource UID
+ * @property status The current storage status
+ * @property isVerified True if the file is stored and verified
+ * @property timedOut True if verification timed out
+ */
+internal data class FileResourceVerificationResult(
+    val uid: String,
+    val status: FileResourceStorageStatus,
+    val isVerified: Boolean,
+    val timedOut: Boolean,
+)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/OldTrackerImporterFileResourcesPostCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/OldTrackerImporterFileResourcesPostCall.kt
@@ -34,17 +34,23 @@ import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.FileResourceDataDomainType
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceHelper
 import org.hisp.dhis.android.core.fileresource.internal.FileResourcePostCall
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceStorageStatusVerifier
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceUploadResult
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceValue
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceVerificationResult
 import org.hisp.dhis.android.core.imports.internal.ItemsWithFileResources
 import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceInternalAccessor
 import org.koin.core.annotation.Singleton
 
 @Singleton
+@Suppress("TooManyFunctions")
 internal class OldTrackerImporterFileResourcesPostCall internal constructor(
     private val fileResourcePostCall: FileResourcePostCall,
     private val fileResourceHelper: FileResourceHelper,
+    private val fileResourceStorageStatusVerifier: FileResourceStorageStatusVerifier,
 ) {
 
     suspend fun uploadTrackedEntityFileResources(
@@ -83,23 +89,25 @@ internal class OldTrackerImporterFileResourcesPostCall internal constructor(
         trackedEntityInstance: TrackedEntityInstance,
         fileResources: List<FileResource>,
     ): Pair<TrackedEntityInstance, List<String>> {
-        val uploadedFileResources = mutableListOf<String>()
-        val updatedAttributes = trackedEntityInstance.trackedEntityAttributeValues()?.map { attributeValue ->
-            fileResourceHelper.findAttributeFileResource(attributeValue, fileResources)?.let { fileResource ->
-                val fValue = FileResourceValue.AttributeValue(attributeValue.trackedEntityAttribute()!!)
-                val newUid = fileResourcePostCall.uploadFileResource(fileResource, fValue)?.also {
-                    uploadedFileResources.add(it)
-                }
-                attributeValue.toBuilder().value(newUid).build()
-            } ?: attributeValue
-        }
+        val attributeUploadResults = uploadAttributeFileResources(trackedEntityInstance, fileResources)
+        val enrollmentResults = uploadEnrollmentFileResources(trackedEntityInstance, fileResources)
 
-        val updatedEnrollments = TrackedEntityInstanceInternalAccessor.accessEnrollments(trackedEntityInstance)
-            .map { enrollment ->
-                uploadEnrollment(enrollment, fileResources)
-                    .also { uploadedFileResources.addAll(it.second) }
-                    .first
-            }
+        val verificationResults = verifyAllUploadedFiles(attributeUploadResults, enrollmentResults)
+        updateVerifiedAttributeValues(attributeUploadResults, verificationResults)
+
+        val uploadedFileResources = mutableListOf<String>()
+        val updatedAttributes = buildUpdatedAttributes(
+            trackedEntityInstance,
+            fileResources,
+            attributeUploadResults,
+            verificationResults,
+            uploadedFileResources,
+        )
+        val updatedEnrollments = buildUpdatedEnrollments(
+            enrollmentResults,
+            verificationResults,
+            uploadedFileResources,
+        )
 
         return Pair(
             TrackedEntityInstanceInternalAccessor
@@ -110,21 +118,123 @@ internal class OldTrackerImporterFileResourcesPostCall internal constructor(
         )
     }
 
+    private suspend fun uploadAttributeFileResources(
+        trackedEntityInstance: TrackedEntityInstance,
+        fileResources: List<FileResource>,
+    ): List<FileResourceUploadResult> {
+        val uploadResults = mutableListOf<FileResourceUploadResult>()
+        trackedEntityInstance.trackedEntityAttributeValues()?.forEach { attributeValue ->
+            fileResourceHelper.findAttributeFileResource(attributeValue, fileResources)?.let { fileResource ->
+                val fValue = FileResourceValue.AttributeValue(attributeValue.trackedEntityAttribute()!!)
+                val uploadResult = fileResourcePostCall.uploadFileResourceWithoutUpdate(fileResource, fValue)
+                uploadResults.add(uploadResult)
+            }
+        }
+        return uploadResults
+    }
+
+    private suspend fun uploadEnrollmentFileResources(
+        trackedEntityInstance: TrackedEntityInstance,
+        fileResources: List<FileResource>,
+    ): List<Pair<Enrollment, List<String>>> {
+        return TrackedEntityInstanceInternalAccessor.accessEnrollments(trackedEntityInstance)
+            .map { enrollment -> uploadEnrollment(enrollment, fileResources) }
+    }
+
+    private suspend fun verifyAllUploadedFiles(
+        attributeUploadResults: List<FileResourceUploadResult>,
+        enrollmentResults: List<Pair<Enrollment, List<String>>>,
+    ): Map<String, FileResourceVerificationResult> {
+        val allUidsToVerify = mutableListOf<String>()
+        allUidsToVerify.addAll(attributeUploadResults.mapNotNull { it.uploadedUid })
+        enrollmentResults.forEach { allUidsToVerify.addAll(it.second) }
+
+        return if (allUidsToVerify.isNotEmpty()) {
+            fileResourceStorageStatusVerifier.verifyStorageStatusBatch(allUidsToVerify)
+        } else {
+            emptyMap()
+        }
+    }
+
+    private suspend fun updateVerifiedAttributeValues(
+        attributeUploadResults: List<FileResourceUploadResult>,
+        verificationResults: Map<String, FileResourceVerificationResult>,
+    ) {
+        attributeUploadResults.forEach { uploadResult ->
+            val uploadedUid = uploadResult.uploadedUid ?: return@forEach
+            val verificationResult = verificationResults[uploadedUid]
+            if (verificationResult?.isVerified == true) {
+                fileResourcePostCall.updateValueAfterVerification(
+                    uploadResult.originalFileResource,
+                    uploadedUid,
+                    uploadResult.value,
+                )
+            }
+        }
+    }
+
+    private suspend fun buildUpdatedAttributes(
+        trackedEntityInstance: TrackedEntityInstance,
+        fileResources: List<FileResource>,
+        attributeUploadResults: List<FileResourceUploadResult>,
+        verificationResults: Map<String, FileResourceVerificationResult>,
+        uploadedFileResources: MutableList<String>,
+    ): List<TrackedEntityAttributeValue>? {
+        return trackedEntityInstance.trackedEntityAttributeValues()?.map { attributeValue ->
+            fileResourceHelper.findAttributeFileResource(attributeValue, fileResources)?.let { fileResource ->
+                val uploadResult = attributeUploadResults.find {
+                    it.originalFileResource.uid() == fileResource.uid()
+                }
+                val newUid = getVerifiedUidForAttribute(uploadResult, verificationResults, uploadedFileResources)
+                attributeValue.toBuilder().value(newUid).build()
+            } ?: attributeValue
+        }
+    }
+
+    private fun getVerifiedUidForAttribute(
+        uploadResult: FileResourceUploadResult?,
+        verificationResults: Map<String, FileResourceVerificationResult>,
+        uploadedFileResources: MutableList<String>,
+    ): String? {
+        val uploadedUid = uploadResult?.uploadedUid ?: return null
+        val verificationResult = verificationResults[uploadedUid]
+        return if (verificationResult?.isVerified == true) {
+            uploadedFileResources.add(uploadedUid)
+            uploadedUid
+        } else {
+            null
+        }
+    }
+
+    private fun buildUpdatedEnrollments(
+        enrollmentResults: List<Pair<Enrollment, List<String>>>,
+        verificationResults: Map<String, FileResourceVerificationResult>,
+        uploadedFileResources: MutableList<String>,
+    ): List<Enrollment> {
+        return enrollmentResults.map { (enrollment, fileResourceUids) ->
+            fileResourceUids.forEach { uid ->
+                val verificationResult = verificationResults[uid]
+                if (verificationResult?.isVerified == true) {
+                    uploadedFileResources.add(uid)
+                }
+            }
+            enrollment
+        }
+    }
+
     private suspend fun uploadEnrollment(
         enrollment: Enrollment,
         fileResources: List<FileResource>,
     ): Pair<Enrollment, List<String>> {
-        val uploadedFileResources = mutableListOf<String>()
-        val updatedEvents = EnrollmentInternalAccessor.accessEvents(enrollment)
-            .map { event ->
-                uploadEvent(event, fileResources)
-                    .also { uploadedFileResources.addAll(it.second) }
-                    .first
-            }
+        val eventResults = EnrollmentInternalAccessor.accessEvents(enrollment)
+            .map { event -> uploadEvent(event, fileResources) }
+
+        val allUploadedUids = eventResults.flatMap { it.second }
+        val updatedEvents = eventResults.map { it.first }
 
         return Pair(
             EnrollmentInternalAccessor.insertEvents(enrollment.toBuilder(), updatedEvents).build(),
-            uploadedFileResources,
+            allUploadedUids,
         )
     }
 
@@ -132,20 +242,33 @@ internal class OldTrackerImporterFileResourcesPostCall internal constructor(
         event: Event,
         fileResources: List<FileResource>,
     ): Pair<Event, List<String>> {
-        val uploadedFileResources = mutableListOf<String>()
-        val updatedDataValues = event.trackedEntityDataValues()?.map { dataValue ->
+        // Upload file resources without updating values
+        val uploadResults = mutableListOf<FileResourceUploadResult>()
+        event.trackedEntityDataValues()?.forEach { dataValue ->
             fileResourceHelper.findDataValueFileResource(dataValue, fileResources)?.let { fileResource ->
                 val fValue = FileResourceValue.EventValue(dataValue.dataElement()!!)
-                val newUid = fileResourcePostCall.uploadFileResource(fileResource, fValue)?.also {
-                    uploadedFileResources.add(it)
+                val uploadResult = fileResourcePostCall.uploadFileResourceWithoutUpdate(fileResource, fValue)
+                uploadResults.add(uploadResult)
+            }
+        }
+
+        // Collect uploaded UIDs (verification will be done at TEI level)
+        val uploadedUids = uploadResults.mapNotNull { it.uploadedUid }
+
+        // Build event with uploaded UIDs (values will be updated after verification)
+        val updatedDataValues = event.trackedEntityDataValues()?.map { dataValue ->
+            fileResourceHelper.findDataValueFileResource(dataValue, fileResources)?.let { fileResource ->
+                val uploadResult = uploadResults.find {
+                    it.originalFileResource.uid() == fileResource.uid()
                 }
+                val newUid = uploadResult?.uploadedUid
                 dataValue.toBuilder().value(newUid).build()
             } ?: dataValue
         }
 
         return Pair(
             event.toBuilder().trackedEntityDataValues(updatedDataValues).build(),
-            uploadedFileResources,
+            uploadedUids,
         )
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifierShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifierShould.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifierShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStorageStatusVerifierShould.kt
@@ -1,0 +1,248 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.fileresource.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.api.executors.internal.APICallErrorCatcher
+import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.fileresource.FileResource
+import org.hisp.dhis.android.core.fileresource.FileResourceInternalAccessor
+import org.hisp.dhis.android.core.fileresource.FileResourceStorageStatus
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(JUnit4::class)
+class FileResourceStorageStatusVerifierShould {
+
+    private val fileResourceNetworkHandler: FileResourceNetworkHandler = mock()
+
+    // Fake implementation that just executes the block
+    private val coroutineAPICallExecutor = object : CoroutineAPICallExecutor {
+        override suspend fun <P> wrap(
+            storeError: Boolean,
+            acceptedErrorCodes: List<Int>?,
+            errorCatcher: APICallErrorCatcher?,
+            errorClassParser: ((body: String) -> P)?,
+            block: suspend () -> P,
+        ): Result<P, D2Error> {
+            return try {
+                Result.Success(block())
+            } catch (e: D2Error) {
+                Result.Failure(e)
+            } catch (e: Exception) {
+                Result.Failure(
+                    D2Error.builder()
+                        .errorCode(D2ErrorCode.API_UNSUCCESSFUL_RESPONSE)
+                        .errorDescription(e.message ?: "Unknown error")
+                        .build(),
+                )
+            }
+        }
+
+        override suspend fun <P> wrapTransactionallyRoom(
+            cleanForeignKeyErrors: Boolean,
+            block: suspend () -> P,
+        ): P = block()
+    }
+
+    private lateinit var verifier: FileResourceStorageStatusVerifier
+
+    @Before
+    fun setUp() {
+        verifier = FileResourceStorageStatusVerifier(
+            fileResourceNetworkHandler,
+            coroutineAPICallExecutor,
+        )
+    }
+
+    @Test
+    fun `return empty map when no UIDs provided`() = runTest {
+        val result = verifier.verifyStorageStatusBatch(emptyList())
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `verify single file resource with STORED status`() = runTest {
+        val uid = "test-uid-1"
+        val fileResourceBuilder = FileResource.builder().uid(uid)
+        val fileResource = FileResourceInternalAccessor.insertStorageStatus(
+            fileResourceBuilder,
+            FileResourceStorageStatus.STORED,
+        ).build()
+
+        whenever(fileResourceNetworkHandler.getFileResource(uid))
+            .thenReturn(fileResource)
+
+        val result = verifier.verifyStorageStatusBatch(listOf(uid), maxAttempts = 1)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[uid]?.isVerified).isTrue()
+        assertThat(result[uid]?.status).isEqualTo(FileResourceStorageStatus.STORED)
+        assertThat(result[uid]?.timedOut).isFalse()
+    }
+
+    @Test
+    fun `verify multiple file resources with STORED status`() = runTest {
+        val uid1 = "test-uid-1"
+        val uid2 = "test-uid-2"
+        val uid3 = "test-uid-3"
+
+        val fileResource1 = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uid1),
+            FileResourceStorageStatus.STORED,
+        ).build()
+
+        val fileResource2 = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uid2),
+            FileResourceStorageStatus.STORED,
+        ).build()
+
+        val fileResource3 = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uid3),
+            FileResourceStorageStatus.STORED,
+        ).build()
+
+        whenever(fileResourceNetworkHandler.getFileResource(uid1)).thenReturn(fileResource1)
+        whenever(fileResourceNetworkHandler.getFileResource(uid2)).thenReturn(fileResource2)
+        whenever(fileResourceNetworkHandler.getFileResource(uid3)).thenReturn(fileResource3)
+
+        val result = verifier.verifyStorageStatusBatch(listOf(uid1, uid2, uid3), maxAttempts = 1)
+
+        assertThat(result).hasSize(3)
+        assertThat(result[uid1]?.isVerified).isTrue()
+        assertThat(result[uid2]?.isVerified).isTrue()
+        assertThat(result[uid3]?.isVerified).isTrue()
+    }
+
+    @Test
+    fun `mark file resource as FAILED when status is FAILED`() = runTest {
+        val uid = "test-uid-failed"
+        val fileResource = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uid),
+            FileResourceStorageStatus.FAILED,
+        ).build()
+
+        whenever(fileResourceNetworkHandler.getFileResource(uid))
+            .thenReturn(fileResource)
+
+        val result = verifier.verifyStorageStatusBatch(listOf(uid), maxAttempts = 1)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[uid]?.isVerified).isFalse()
+        assertThat(result[uid]?.status).isEqualTo(FileResourceStorageStatus.FAILED)
+        assertThat(result[uid]?.timedOut).isFalse()
+    }
+
+    @Test
+    fun `mark file resource as timed out when PENDING after max attempts`() = runTest {
+        val uid = "test-uid-pending"
+        val fileResource = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uid),
+            FileResourceStorageStatus.PENDING,
+        ).build()
+
+        whenever(fileResourceNetworkHandler.getFileResource(uid))
+            .thenReturn(fileResource)
+
+        val result = verifier.verifyStorageStatusBatch(
+            listOf(uid),
+            maxAttempts = 2,
+            delayMs = 10,
+        )
+
+        assertThat(result).hasSize(1)
+        assertThat(result[uid]?.isVerified).isFalse()
+        assertThat(result[uid]?.status).isEqualTo(FileResourceStorageStatus.PENDING)
+        assertThat(result[uid]?.timedOut).isTrue()
+    }
+
+    @Test
+    fun `handle mixed statuses correctly`() = runTest {
+        val uidStored = "test-uid-stored"
+        val uidFailed = "test-uid-failed"
+        val uidPending = "test-uid-pending"
+
+        val fileResourceStored = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uidStored),
+            FileResourceStorageStatus.STORED,
+        ).build()
+
+        val fileResourceFailed = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uidFailed),
+            FileResourceStorageStatus.FAILED,
+        ).build()
+
+        val fileResourcePending = FileResourceInternalAccessor.insertStorageStatus(
+            FileResource.builder().uid(uidPending),
+            FileResourceStorageStatus.PENDING,
+        ).build()
+
+        whenever(fileResourceNetworkHandler.getFileResource(uidStored)).thenReturn(fileResourceStored)
+        whenever(fileResourceNetworkHandler.getFileResource(uidFailed)).thenReturn(fileResourceFailed)
+        whenever(fileResourceNetworkHandler.getFileResource(uidPending)).thenReturn(fileResourcePending)
+
+        val result = verifier.verifyStorageStatusBatch(
+            listOf(uidStored, uidFailed, uidPending),
+            maxAttempts = 1,
+        )
+
+        assertThat(result).hasSize(3)
+        assertThat(result[uidStored]?.isVerified).isTrue()
+        assertThat(result[uidFailed]?.isVerified).isFalse()
+        assertThat(result[uidFailed]?.status).isEqualTo(FileResourceStorageStatus.FAILED)
+        assertThat(result[uidPending]?.isVerified).isFalse()
+        assertThat(result[uidPending]?.timedOut).isTrue()
+    }
+
+    @Test
+    fun `handle network errors gracefully`() = runTest {
+        val uid = "test-uid-error"
+        val error = D2Error.builder()
+            .errorCode(D2ErrorCode.API_UNSUCCESSFUL_RESPONSE)
+            .errorDescription("Network error")
+            .build()
+
+        whenever(fileResourceNetworkHandler.getFileResource(uid))
+            .thenAnswer { throw error }
+
+        val result = verifier.verifyStorageStatusBatch(listOf(uid), maxAttempts = 1)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[uid]?.isVerified).isFalse()
+        assertThat(result[uid]?.status).isEqualTo(FileResourceStorageStatus.FAILED)
+    }
+}


### PR DESCRIPTION
This PR implements batch verification for file resource storage status to prevent issues with files being wrongly assigned when posted without waiting for the STORED status.

**Key changes:**
- Added FileResourceStorageStatusVerifier with exponential backoff retry mechanism for batch verification
- Refactored file upload flows DataValueFileResourcePostCall, OldTrackerImporterFileResourcesPostCall and TrackerImporterFileResourcesPostCall to upload files first, verify in batch, then update values only for verified files
- Extracted helper functions to reduce complexity and improve code maintainability
- Added comprehensive test suite with 7 test cases covering various verification scenarios
- Introduced FileResourceUploadResult and FileResourceVerificationResult data classes to track upload and verification states

Related task: [ANDROSDK-2173](https://dhis2.atlassian.net/browse/ANDROSDK-2173)

[ANDROSDK-2173]: https://dhis2.atlassian.net/browse/ANDROSDK-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ