### PR TITLE
feat: [ANDROSDK-2205] Add program owners to TEI search item objects

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11149,14 +11149,15 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 }
 
 public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem : org/hisp/dhis/android/core/common/ObjectWithUidInterface {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Z
 	public final fun component11 ()Z
 	public final fun component12 ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;
 	public final fun component13 ()Ljava/lang/String;
 	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/util/Date;
 	public final fun component4 ()Ljava/util/Date;
@@ -11165,8 +11166,8 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 	public final fun component7 ()Lorg/hisp/dhis/android/core/common/Geometry;
 	public final fun component8 ()Lorg/hisp/dhis/android/core/common/State;
 	public final fun component9 ()Lorg/hisp/dhis/android/core/common/State;
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lorg/hisp/dhis/android/core/common/Geometry;Lorg/hisp/dhis/android/core/common/State;Lorg/hisp/dhis/android/core/common/State;ZZLorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAggregatedSyncState ()Lorg/hisp/dhis/android/core/common/State;
 	public final fun getAttributeValues ()Ljava/util/List;
@@ -11178,6 +11179,7 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 	public final fun getLastUpdated ()Ljava/util/Date;
 	public final fun getLastUpdatedAtClient ()Ljava/util/Date;
 	public final fun getOrganisationUnit ()Ljava/lang/String;
+	public final fun getProgramOwners ()Ljava/util/List;
 	public final fun getSyncState ()Lorg/hisp/dhis/android/core/common/State;
 	public final fun getType ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityType;
 	public final fun getUid ()Ljava/lang/String;
@@ -11217,6 +11219,19 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper {
 	public static final field INSTANCE Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper;
 	public final fun toTrackedEntityInstance (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstance;
+}
+
+public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemProgramOwner {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemProgramOwner;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemProgramOwner;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemProgramOwner;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOwnerOrgUnit ()Ljava/lang/String;
+	public final fun getProgram ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.testapp.trackedentity.search
 
-import android.util.Log
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -102,16 +102,6 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
     }
 
     @Test
-    fun find_by_in_data_value() {
-        val trackedEntityInstances = d2.trackedEntityModule().trackedEntitySearch()
-            .byProgram().eq("IpHINAT79UW")
-            .byDataValue("g9eOBujte1U").`in`(listOf("false"))
-            .blockingGet()
-
-        assertThat(trackedEntityInstances.size).isEqualTo(1)
-    }
-
-    @Test
     fun should_return_program_owners() {
         val trackedEntity = d2.trackedEntityModule().trackedEntitySearch()
             .uid("nWrB0TfWlvh")
@@ -122,5 +112,15 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
         assertThat(trackedEntity.programOwners!!.size).isEqualTo(1)
         assertThat(trackedEntity.programOwners[0].program).isEqualTo("IpHINAT79UW")
         assertThat(trackedEntity.programOwners[0].ownerOrgUnit).isEqualTo("DiszpKrYNg8")
+    }
+
+    @Test
+    fun find_by_in_data_value() {
+        val trackedEntityInstances = d2.trackedEntityModule().trackedEntitySearch()
+            .byProgram().eq("IpHINAT79UW")
+            .byDataValue("g9eOBujte1U").`in`(listOf("false"))
+            .blockingGet()
+
+        assertThat(trackedEntityInstances.size).isEqualTo(1)
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.testapp.trackedentity.search
 
+import android.util.Log
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
@@ -108,8 +109,7 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
             .blockingGet()
 
         assertThat(trackedEntity).isNotNull()
-        assertThat(trackedEntity!!.programOwners).isNotNull()
-        assertThat(trackedEntity.programOwners!!.size).isEqualTo(1)
+        assertThat(trackedEntity!!.programOwners!!).isNotNull()
         assertThat(trackedEntity.programOwners[0].program).isEqualTo("IpHINAT79UW")
         assertThat(trackedEntity.programOwners[0].ownerOrgUnit).isEqualTo("DiszpKrYNg8")
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/trackedentity/search/TrackedEntitySearchCollectionRepositoryMockIntegrationShould.kt
@@ -98,7 +98,7 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
 
         assertThat(trackedEntity).isNotNull()
         assertThat(trackedEntity!!.attributeValues!![0].attribute).isEqualTo("cejWyOfXge6")
-        assertThat(trackedEntity.attributeValues!![1].attribute).isEqualTo("aejWyOfXge6")
+        assertThat(trackedEntity.attributeValues[1].attribute).isEqualTo("aejWyOfXge6")
     }
 
     @Test
@@ -109,5 +109,18 @@ class TrackedEntitySearchCollectionRepositoryMockIntegrationShould :
             .blockingGet()
 
         assertThat(trackedEntityInstances.size).isEqualTo(1)
+    }
+
+    @Test
+    fun should_return_program_owners() {
+        val trackedEntity = d2.trackedEntityModule().trackedEntitySearch()
+            .uid("nWrB0TfWlvh")
+            .blockingGet()
+
+        assertThat(trackedEntity).isNotNull()
+        assertThat(trackedEntity!!.programOwners).isNotNull()
+        assertThat(trackedEntity.programOwners!!.size).isEqualTo(1)
+        assertThat(trackedEntity.programOwners[0].program).isEqualTo("IpHINAT79UW")
+        assertThat(trackedEntity.programOwners[0].ownerOrgUnit).isEqualTo("DiszpKrYNg8")
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -213,7 +213,7 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
 
     internal companion object {
         internal const val TRACKED_ENTITY_ATTRIBUTE_VALUES = "attributes"
-        private const val PROGRAM_OWNERS = "programOwners"
+        internal const val PROGRAM_OWNERS = "programOwners"
 
         val childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance> = mapOf(
             TRACKED_ENTITY_ATTRIBUTE_VALUES to TrackedEntityAttributeValueChildrenAppender::create,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -35,6 +35,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMod
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceCollectionRepository.Companion.PROGRAM_OWNERS
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceCollectionRepository.Companion.TRACKED_ENTITY_ATTRIBUTE_VALUES
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
@@ -115,7 +116,7 @@ internal class TrackedEntityInstanceQueryDataFetcher(
         val instances = store.selectRawQuery(sqlQuery)
         returnedUidsOffline.addAll(instances.map { it.uid() })
 
-        return appendAttributes(instances).map {
+        return appendChildren(instances).map {
             Result.Success(it)
         }
     }
@@ -207,13 +208,14 @@ internal class TrackedEntityInstanceQueryDataFetcher(
         }
     }
 
-    private suspend fun appendAttributes(withoutChildren: List<TrackedEntityInstance>): List<TrackedEntityInstance> {
+    private suspend fun appendChildren(withoutChildren: List<TrackedEntityInstance>): List<TrackedEntityInstance> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             withoutChildren,
             childrenAppenders,
             ChildrenSelection(
                 setOf(
                     TRACKED_ENTITY_ATTRIBUTE_VALUES,
+                    PROGRAM_OWNERS,
                 ),
             ),
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItem.kt
@@ -50,6 +50,7 @@ data class TrackedEntitySearchItem(
     val type: TrackedEntityType,
     val header: String? = null,
     val attributeValues: List<TrackedEntitySearchItemAttribute>? = emptyList(),
+    val programOwners: List<TrackedEntitySearchItemProgramOwner>? = emptyList(),
 
 ) : ObjectWithUidInterface {
     override fun uid(): String = uid

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper.kt
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.core.trackedentity.search
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityType
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwner
 
 object TrackedEntitySearchItemHelper {
     internal fun from(
@@ -47,6 +48,7 @@ object TrackedEntitySearchItemHelper {
             organisationUnit = i.organisationUnit(),
             geometry = i.geometry(),
             attributeValues = fromAttributes(attributes, i.trackedEntityAttributeValues()),
+            programOwners = fromProgramOwners(i.programOwners()),
             syncState = i.syncState(),
             aggregatedSyncState = i.aggregatedSyncState(),
             deleted = i.deleted() ?: false,
@@ -78,6 +80,17 @@ object TrackedEntitySearchItemHelper {
         return attributes.map { attribute ->
             from(attribute, attributeValues)
         }
+    }
+
+    private fun fromProgramOwners(
+        programOwners: List<ProgramOwner>?,
+    ): List<TrackedEntitySearchItemProgramOwner> {
+        return programOwners?.map { owner ->
+            TrackedEntitySearchItemProgramOwner(
+                program = owner.program(),
+                ownerOrgUnit = owner.ownerOrgUnit(),
+            )
+        } ?: emptyList()
     }
 
     private fun from(

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemProgramOwner.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemProgramOwner.kt
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.trackedentity.search
+
+data class TrackedEntitySearchItemProgramOwner(
+    val program: String,
+    val ownerOrgUnit: String,
+)


### PR DESCRIPTION
Include program ownership information in `TrackedEntitySearchItem` results. Previously, program owners were only available when querying `TrackedEntityInstance` directly with `withProgramOwners()`.
Now the search repository automatically includes them, allowing access ownership data directly from search results.