### PR TITLE
fix: [ANDROSDK-2206] Continue tracker download if working list result is empty

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCallEnqueableMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCallEnqueableMockIntegrationShould.kt
@@ -77,9 +77,9 @@ class TrackedEntityInstanceDownloadCallEnqueableMockIntegrationShould : BaseMock
                     .program(ObjectWithUid.create("IpHINAT79UW"))
                     .programStage(ObjectWithUid.create("dBwrot7S421"))
                     .programStageQueryCriteria(
-                        ProgramStageQueryCriteria.builder().eventStatus(EventStatus.OVERDUE).build()
+                        ProgramStageQueryCriteria.builder().eventStatus(EventStatus.OVERDUE).build(),
                     )
-                    .build()
+                    .build(),
             ).blockingDownload()
 
         val existingTeisInDB = d2.trackedEntityModule().trackedEntityInstances().blockingGet()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCallEnqueableMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCallEnqueableMockIntegrationShould.kt
@@ -29,6 +29,10 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.event.EventStatus
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageQueryCriteria
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestMetadataEnqueable
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.After
@@ -57,6 +61,30 @@ class TrackedEntityInstanceDownloadCallEnqueableMockIntegrationShould : BaseMock
         val existingTeisInDB = d2.trackedEntityModule().trackedEntityInstances().blockingGet()
 
         assertThat(existingTeisInDB).isNotEmpty()
+    }
+
+    @Test
+    fun should_continue_on_empty_page_from_working_list() {
+        val programTeis = "trackedentity/new_tracker_importer_tracked_entities_empty.json"
+
+        dhis2MockServer.enqueueSystemInfoResponse()
+        dhis2MockServer.enqueueMockResponse(programTeis)
+
+        d2.trackedEntityModule().trackedEntityInstanceDownloader()
+            .byProgramStageWorkingList().eq(
+                ProgramStageWorkingList.builder()
+                    .uid("aprI6ATr9RW")
+                    .program(ObjectWithUid.create("IpHINAT79UW"))
+                    .programStage(ObjectWithUid.create("dBwrot7S421"))
+                    .programStageQueryCriteria(
+                        ProgramStageQueryCriteria.builder().eventStatus(EventStatus.OVERDUE).build()
+                    )
+                    .build()
+            ).blockingDownload()
+
+        val existingTeisInDB = d2.trackedEntityModule().trackedEntityInstances().blockingGet()
+
+        assertThat(existingTeisInDB).isEmpty()
     }
 
     @After

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -211,7 +211,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
                     progressManager.updateProgramSyncStatus(bundleProgram.program, syncStatus)
 
-                    if (result.emptyProgram || !result.successfulSync) {
+                    if (result.exhaustedProgram || !result.successfulSync) {
                         bundleResult.bundleOrgUnitPrograms[orgUnitUid] = bundlePrograms
                             .filter { it.program != bundleProgram.program }
                             .toMutableList()
@@ -277,7 +277,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         relatives: RelationshipItemRelatives,
     ): ItemsWithPagingResult {
         var downloadedItemsForCombination = 0
-        var emptyProgram = false
+        var exhaustedProgram = false
 
         val callPages: List<TrackerDownloadCallPage<T>> =
             if (query.uids.isNotEmpty()) {
@@ -323,16 +323,16 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
             downloadedItemsForCombination += itemsToPersist.size
 
             if (items.size < callPage.query.pageSize) {
-                emptyProgram = true
+                exhaustedProgram = true
                 break
             }
         }
 
         if (downloadedItemsForCombination < combinationLimit) {
-            emptyProgram = true
+            exhaustedProgram = true
         }
 
-        return ItemsWithPagingResult(downloadedItemsForCombination, true, null, emptyProgram)
+        return ItemsWithPagingResult(downloadedItemsForCombination, true, null, exhaustedProgram)
     }
 
     private fun getItemsToPersist(paging: Paging, pageItems: List<T>): List<T> {
@@ -370,7 +370,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         var count: Int,
         var successfulSync: Boolean,
         var d2Error: D2Error?,
-        var emptyProgram: Boolean,
+        var exhaustedProgram: Boolean,
     )
 
     protected class ItemsByProgramCount(val program: String, var itemCount: Int)

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -195,7 +195,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                             relatives,
                         )
                     } else {
-                        ItemsWithPagingResult(0, true, null, false)
+                        ItemsWithPagingResult(0, true, null, true)
                     }
 
                     bundleResult.bundleCount += result.count

--- a/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities_empty.json
+++ b/core/src/sharedTest/resources/trackedentity/new_tracker_importer_tracked_entities_empty.json
@@ -1,0 +1,6 @@
+{
+  "page": 1,
+  "pageSize": 50,
+  "instances": [
+  ]
+}


### PR DESCRIPTION
[ANDROSDK-2206](https://dhis2.atlassian.net/browse/ANDROSDK-2206).

In tracker download based on working lists, there is an initial query to get the list of uids passing the filter. If this query returns an empty result, the SDK does not perform any other request to the server, but it doesn't mark the program as exhausted and tries to download it in the following iteration, which results again in an empty list.

There is a refactor from "emptyProgram" to "exhaustedProgram" to make it more accurate. 

[ANDROSDK-2206]: https://dhis2.atlassian.net/browse/ANDROSDK-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ