### PR TITLE
fix: [ANDROSDK-2204] Database export doesn't include recent changes

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1672,6 +1672,7 @@ public abstract interface class org/hisp/dhis/android/core/arch/db/access/BaseDa
 public abstract interface class org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter {
 	public abstract fun activate (Lorg/hisp/dhis/android/core/arch/db/access/internal/AppDatabase;Ljava/lang/String;)V
 	public abstract fun beginNewTransaction ()Lorg/hisp/dhis/android/core/arch/db/access/Transaction;
+	public abstract fun checkpointWAL (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun close ()V
 	public abstract fun deactivate ()V
 	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/DatabaseAdapter.kt
@@ -75,4 +75,10 @@ interface DatabaseAdapter {
     fun getCurrentDatabase(): AppDatabase
 
     fun getVersion(): Int
+
+    /**
+     * Forces a WAL checkpoint to consolidate pending changes to the main database file.
+     * This should be called before exporting the database to ensure all changes are included.
+     */
+    suspend fun checkpointWAL()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseImportExportImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseImportExportImpl.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.arch.db.access.internal
 
 import android.content.Context
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.DatabaseExportMetadata
 import org.hisp.dhis.android.core.arch.db.access.DatabaseImportExport
 import org.hisp.dhis.android.core.arch.helpers.DateUtils.getCurrentTimeAndDate
@@ -54,6 +55,7 @@ internal class DatabaseImportExportImpl(
     private val userModule: UserModule,
     private val credentialsStore: CredentialsSecureStore,
     private val databaseExport: BaseDatabaseExport,
+    private val databaseAdapter: DatabaseAdapter,
 ) : DatabaseImportExport {
 
     companion object {
@@ -150,6 +152,9 @@ internal class DatabaseImportExportImpl(
 
         val databaseName = userConfiguration.databaseName()
         val databaseFile = getDatabaseFile(databaseName)
+
+        // Force WAL checkpoint to ensure all pending changes are written to the database file
+        databaseAdapter.checkpointWAL()
 
         if (userConfiguration.encrypted()) {
             databaseExport.decryptAndCopyTo(userConfiguration, copiedDatabase)

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseAdapter.kt
@@ -297,4 +297,14 @@ internal class RoomDatabaseAdapter(
         checkReady()
         return database?.openHelper?.readableDatabase?.version!!
     }
+
+    override suspend fun checkpointWAL() {
+        checkReady()
+        // Execute checkpoint without a transaction to avoid blocking
+        database!!.useWriterConnection { transactor ->
+            transactor.usePrepared("PRAGMA wal_checkpoint(PASSIVE);") { statement ->
+                statement.step()
+            }
+        }
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomDatabaseAdapter.kt
@@ -300,7 +300,6 @@ internal class RoomDatabaseAdapter(
 
     override suspend fun checkpointWAL() {
         checkReady()
-        // Execute checkpoint without a transaction to avoid blocking
         database!!.useWriterConnection { transactor ->
             transactor.usePrepared("PRAGMA wal_checkpoint(PASSIVE);") { statement ->
                 statement.step()


### PR DESCRIPTION
This PR adds a db checkpoint before performing the export, which makes sure recent changes are added to the saved database.

Related task: [ANDROSDK-2204](https://dhis2.atlassian.net/browse/ANDROSDK-2204)

[ANDROSDK-2204]: https://dhis2.atlassian.net/browse/ANDROSDK-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ