### PR TITLE
fix: [ANDROSDK-2214] Handle break-the-glass for DHIS2 v42 servers returning 404

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceCallNewMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceCallNewMockIntegrationShould.kt
@@ -48,6 +48,7 @@ class TrackedEntityInstanceCallNewMockIntegrationShould : TrackedEntityInstanceC
         "trackedentity/new_tracker_importer_tracked_entity_with_removed_data_single.json"
     override val teiWithRelationshipFile = "trackedentity/new_tracker_importer_tracked_entity_with_relationship.json"
     override val teiAsRelationshipFile = teiFile
+    override val teiWithSearchOnlyOrgUnitFile = "trackedentity/glass/glass_v42_tei_without_program.json"
 
     override fun parseTrackedEntityInstance(file: String): TrackedEntityInstance {
         val expectedEventsResponseJson = ResourcesFileReader().getStringFromFile(file)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceCallOldMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceCallOldMockIntegrationShould.kt
@@ -47,6 +47,7 @@ class TrackedEntityInstanceCallOldMockIntegrationShould : TrackedEntityInstanceC
     override val teiWithRemovedDataFile = "trackedentity/tracked_entity_instance_with_removed_data_single.json"
     override val teiWithRelationshipFile = "trackedentity/tracked_entity_instances_with_relationship.json"
     override val teiAsRelationshipFile = teiCollectionFile
+    override val teiWithSearchOnlyOrgUnitFile = "trackedentity/glass/glass_v42_tei_without_program_old.json"
 
     override fun parseTrackedEntityInstance(file: String): TrackedEntityInstance {
         val expectedEventsResponseJson = ResourcesFileReader().getStringFromFile(file)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceCallErrorCatcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceCallErrorCatcher.kt
@@ -49,9 +49,10 @@ internal class TrackedEntityInstanceCallErrorCatcher : APICallErrorCatcher {
             parsed.httpStatusCode() == HttpsURLConnection.HTTP_CONFLICT ||
             parsed.httpStatusCode() == HttpsURLConnection.HTTP_FORBIDDEN
         ) {
-            when (parsed.message()) {
-                "OWNERSHIP_ACCESS_DENIED" -> D2ErrorCode.OWNERSHIP_ACCESS_DENIED
-                "PROGRAM_ACCESS_CLOSED" -> D2ErrorCode.PROGRAM_ACCESS_CLOSED
+            val message = parsed.message()
+            when {
+                message.contains("OWNERSHIP_ACCESS_DENIED") -> D2ErrorCode.OWNERSHIP_ACCESS_DENIED
+                message.contains("PROGRAM_ACCESS_CLOSED") -> D2ErrorCode.PROGRAM_ACCESS_CLOSED
                 else -> null
             }
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -27,11 +27,13 @@
  */
 package org.hisp.dhis.android.core.trackedentity.internal
 
+import io.ktor.http.HttpStatusCode
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
@@ -40,10 +42,12 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryCollectionRepository
 import org.hisp.dhis.android.core.tracker.exporter.TrackerAPIQuery
 import org.hisp.dhis.android.core.tracker.exporter.TrackerDownloadCall
+import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterBreakTheGlassHelper
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
+@Suppress("LongParameterList")
 internal class TrackedEntityInstanceDownloadCall(
     userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
     systemInfoModuleDownloader: SystemInfoModuleDownloader,
@@ -54,6 +58,7 @@ internal class TrackedEntityInstanceDownloadCall(
     private val persistenceCallFactory: TrackedEntityInstancePersistenceCallFactory,
     private val lastUpdatedManager: TrackedEntityInstanceLastUpdatedManager,
     private val teiQueryCollectionRepository: TrackedEntityInstanceQueryCollectionRepository,
+    private val breakTheGlassHelper: TrackerImporterBreakTheGlassHelper,
 ) : TrackerDownloadCall<TrackedEntityInstance, TrackerQueryBundle>(
     userOrganisationUnitLinkStore,
     systemInfoModuleDownloader,
@@ -133,18 +138,67 @@ internal class TrackedEntityInstanceDownloadCall(
         useEntityEndpoint: Boolean,
         query: TrackerAPIQuery,
     ): Result<TrackedEntityInstance?, D2Error> {
-        return if (useEntityEndpoint) {
-            coroutineCallExecutor.wrap(
-                storeError = true,
-                errorCatcher = TrackedEntityInstanceCallErrorCatcher(),
-            ) {
-                trackerCallFactory.getTrackedEntityCall().getEntityCall(uid, query)
-            }
-        } else {
+        if (!useEntityEndpoint) {
             val collectionQuery = query.copy(uids = listOf(uid))
-            coroutineCallExecutor.wrap(storeError = true) {
+            return coroutineCallExecutor.wrap(storeError = true) {
                 trackerCallFactory.getTrackedEntityCall().getCollectionCall(collectionQuery)
             }.map { it.items.firstOrNull() }
+        }
+
+        val result = coroutineCallExecutor.wrap(
+            storeError = true,
+            errorCatcher = TrackedEntityInstanceCallErrorCatcher(),
+        ) {
+            trackerCallFactory.getTrackedEntityCall().getEntityCall(uid, query)
+        }
+
+        return when {
+            result is Result.Success -> result
+            result is Result.Failure &&
+                result.failure.errorCode() == D2ErrorCode.OWNERSHIP_ACCESS_DENIED -> result
+            result is Result.Failure &&
+                result.failure.errorCode() == D2ErrorCode.PROGRAM_ACCESS_CLOSED -> result
+            result is Result.Failure && result.failure.httpErrorCode() == HttpStatusCode.NotFound.value -> {
+                checkOwnershipOnNotFound(uid, query)
+            }
+            else -> result
+        }
+    }
+
+    private suspend fun checkOwnershipOnNotFound(
+        uid: String,
+        query: TrackerAPIQuery,
+    ): Result<TrackedEntityInstance?, D2Error> {
+        val program = query.commonParams.program ?: return Result.Success(null)
+
+        val queryWithoutProgram = TrackerAPIQuery(
+            commonParams = query.commonParams.copy(program = null),
+        )
+
+        val teiResult = coroutineCallExecutor.wrap(storeError = false) {
+            trackerCallFactory.getTrackedEntityCall().getEntityCall(uid, queryWithoutProgram)
+        }
+
+        return when (teiResult) {
+            is Result.Failure -> Result.Success(null)
+            is Result.Success -> {
+                val tei = teiResult.value
+                val programOwner = tei.programOwners()?.find { it.program() == program }
+
+                if (programOwner != null &&
+                    breakTheGlassHelper.isProtectedInSearchScope(program, programOwner.ownerOrgUnit())
+                ) {
+                    Result.Failure(
+                        D2Error.builder()
+                            .errorCode(D2ErrorCode.OWNERSHIP_ACCESS_DENIED)
+                            .errorDescription("OWNERSHIP_ACCESS_DENIED")
+                            .httpErrorCode(HttpStatusCode.NotFound.value)
+                            .build(),
+                    )
+                } else {
+                    Result.Success(null)
+                }
+            }
         }
     }
 

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_protected_tei_failure_403.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_protected_tei_failure_403.json
@@ -2,6 +2,6 @@
   "httpStatus": "Forbidden",
   "httpStatusCode": 403,
   "status": "ERROR",
-  "message": "User has no read access to organisation unit",
+  "message": "OWNERSHIP_ACCESS_DENIED",
   "errorCode": "E1006"
 }

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_protected_tei_failure_403.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_protected_tei_failure_403.json
@@ -1,0 +1,7 @@
+{
+  "httpStatus": "Forbidden",
+  "httpStatusCode": 403,
+  "status": "ERROR",
+  "message": "User has no read access to organisation unit",
+  "errorCode": "E1006"
+}

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_v42_not_found.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_v42_not_found.json
@@ -1,0 +1,7 @@
+{
+  "httpStatus": "Not Found",
+  "httpStatusCode": 404,
+  "status": "ERROR",
+  "message": "TrackedEntity with id PgmUFEQYZdt could not be found.",
+  "errorCode": "E1005"
+}

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program.json
@@ -1,0 +1,28 @@
+{
+  "trackedEntity": "PgmUFEQYZdt",
+  "trackedEntityType": "nEenWmSyUEp",
+  "createdAt": "2014-06-06T20:44:21.375",
+  "createdAtClient": "2014-06-06T20:44:21.375",
+  "updatedAt": "2015-10-15T11:32:27.242",
+  "orgUnit": "SearchOnlyOrgUnit",
+  "inactive": false,
+  "deleted": false,
+  "potentialDuplicate": false,
+  "relationships": [],
+  "attributes": [
+    {
+      "attribute": "cejWyOfXge6",
+      "createdAt": "2017-12-12T07:35:11.366",
+      "updatedAt": "2017-12-12T07:35:12.904",
+      "value": "1972-11-08"
+    }
+  ],
+  "enrollments": [],
+  "programOwners": [
+    {
+      "orgUnit": "SearchOnlyOrgUnit",
+      "trackedEntity": "PgmUFEQYZdt",
+      "program": "lxAQ7Zs9VYR"
+    }
+  ]
+}

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program_old.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program_old.json
@@ -1,0 +1,25 @@
+{
+  "trackedEntityInstance": "PgmUFEQYZdt",
+  "trackedEntityType": "nEenWmSyUEp",
+  "created": "2014-06-06T20:44:21.375",
+  "lastUpdated": "2015-10-15T11:32:27.242",
+  "orgUnit": "SearchOnlyOrgUnit",
+  "deleted": false,
+  "relationships": [],
+  "attributes": [
+    {
+      "attribute": "cejWyOfXge6",
+      "created": "2017-12-12T07:35:11.366",
+      "lastUpdated": "2017-12-12T07:35:12.904",
+      "value": "1972-11-08"
+    }
+  ],
+  "enrollments": [],
+  "programOwners": [
+    {
+      "ownerOrgUnit": "SearchOnlyOrgUnit",
+      "program": "lxAQ7Zs9VYR",
+      "trackedEntityInstance": "PgmUFEQYZdt"
+    }
+  ]
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelperShould.kt
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.tracker.importer.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStore
+import org.hisp.dhis.android.core.program.AccessLevel
+import org.hisp.dhis.android.core.program.Program
+import org.hisp.dhis.android.core.program.internal.ProgramStore
+import org.hisp.dhis.android.core.trackedentity.ownership.OwnershipManagerImpl
+import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(JUnit4::class)
+class TrackerImporterBreakTheGlassHelperShould {
+
+    private val conflictStore: TrackerImportConflictStore = mock()
+    private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
+    private val enrollmentStore: EnrollmentStore = mock()
+    private val programStore: ProgramStore = mock()
+    private val ownershipManagerImpl: OwnershipManagerImpl = mock()
+
+    private lateinit var helper: TrackerImporterBreakTheGlassHelper
+
+    private val programUid = "program_uid"
+    private val orgUnitUid = "orgunit_uid"
+
+    @Before
+    fun setUp() {
+        helper = TrackerImporterBreakTheGlassHelper(
+            conflictStore,
+            userOrganisationUnitLinkStore,
+            enrollmentStore,
+            programStore,
+            ownershipManagerImpl,
+        )
+    }
+
+    @Test
+    fun return_true_when_program_is_protected_and_orgunit_is_not_capture_scope() = runTest {
+        mockProtectedProgram()
+        mockNotCaptureScope()
+
+        val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun return_false_when_program_is_protected_but_orgunit_is_in_capture_scope() = runTest {
+        mockProtectedProgram()
+        mockCaptureScope()
+
+        val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun return_false_when_program_is_open_and_orgunit_is_not_capture_scope() = runTest {
+        mockOpenProgram()
+        mockNotCaptureScope()
+
+        val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun return_false_when_program_is_open_and_orgunit_is_capture_scope() = runTest {
+        mockOpenProgram()
+        mockCaptureScope()
+
+        val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun return_false_when_program_is_null() = runTest {
+        val result = helper.isProtectedInSearchScope(null, orgUnitUid)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun return_false_when_orgunit_is_null() = runTest {
+        mockProtectedProgram()
+
+        val result = helper.isProtectedInSearchScope(programUid, null)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun return_false_when_both_are_null() = runTest {
+        val result = helper.isProtectedInSearchScope(null, null)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun return_false_when_program_not_found() = runTest {
+        whenever(programStore.selectByUid(programUid)).doReturn(null)
+        mockNotCaptureScope()
+
+        val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
+
+        assertThat(result).isFalse()
+    }
+
+    private suspend fun mockProtectedProgram() {
+        val program = Program.builder()
+            .uid(programUid)
+            .accessLevel(AccessLevel.PROTECTED)
+            .build()
+        whenever(programStore.selectByUid(programUid)).doReturn(program)
+    }
+
+    private suspend fun mockOpenProgram() {
+        val program = Program.builder()
+            .uid(programUid)
+            .accessLevel(AccessLevel.OPEN)
+            .build()
+        whenever(programStore.selectByUid(programUid)).doReturn(program)
+    }
+
+    private suspend fun mockCaptureScope() {
+        whenever(userOrganisationUnitLinkStore.isCaptureScope(orgUnitUid)).doReturn(true)
+    }
+
+    private suspend fun mockNotCaptureScope() {
+        whenever(userOrganisationUnitLinkStore.isCaptureScope(orgUnitUid)).doReturn(false)
+    }
+}


### PR DESCRIPTION
In DHIS2 v42+, the endpoint `/tracker/trackedEntities/{uid}?program={programUid}` returns 404 instead of 403 to hide ownership information from unauthorized users.

Now the SDK detects break-the-glass scenarios when a 404 is returned:
1. When a 404 is received with a program filter, makes a second request without the program.
2. Checks whether the TEI includes a programOwner for the requested program.
3. Verifies whether the owner org unit is within `SEARCH` scope but not within `CAPTURE` scope.
4. If these conditions are met, return an `OWNERSHIP_ACCESS_DENIED` error to trigger the break-the-glass flow.

This is fully backward-compatible with older servers that still return 403.