### PR TITLE
fix: [ANDROSDK-2213] Enrollment trackedEntity attributes are incorrectly marked as SYNCED

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackerImporterPayloadGeneratorMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackerImporterPayloadGeneratorMockIntegrationShould.kt
@@ -30,7 +30,13 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.common.State
+import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
+import org.hisp.dhis.android.core.tracker.importer.internal.JobReportEnrollmentHandler
+import org.hisp.dhis.android.core.tracker.importer.internal.JobReportTrackedEntityHandler
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -80,5 +86,129 @@ class NewTrackerImporterPayloadGeneratorMockIntegrationShould : BasePayloadGener
         val event2 = eventStore.selectByUid(singleEventId)!!
         val payload2 = newTrackerPayloadGenerator.getEventPayload(listOf(event2))
         assertThat(payload2.updated.events.first().trackedEntityDataValues?.size).isEqualTo(0)
+    }
+
+    @Test
+    fun mark_only_type_attributes_as_synced_when_te_succeeds() = runTest {
+        storeTrackerData()
+        val trackedEntity = teiStore.selectByUid(teiId)!!
+
+        // Get stores from Koin
+        val trackedEntityTypeAttributeStore: TrackedEntityTypeAttributeStore = koin.get()
+
+        // Get type attributes
+        val typeAttributes = trackedEntityTypeAttributeStore
+            .getForTrackedEntityType(trackedEntity.trackedEntityType()!!)
+            .mapNotNull { it.trackedEntityAttribute()?.uid() }
+
+        // Get initial attribute values before sync
+        val attributeValuesBefore = teiAttributeValueStore.queryByTrackedEntityInstance(teiId)
+        val initialStates = attributeValuesBefore.associate {
+            it.trackedEntityAttribute()!! to it.syncState()
+        }
+
+        // Simulate TE success: mark only type attributes as SYNCED
+        val handler: JobReportTrackedEntityHandler = koin.get()
+        handler.handleSyncedEntity(teiId)
+
+        // Assert: Only type attributes should be SYNCED
+        val allAttributeValues = teiAttributeValueStore.queryByTrackedEntityInstance(teiId)
+
+        allAttributeValues.forEach { attrValue ->
+            val attrUid = attrValue.trackedEntityAttribute()!!
+            if (typeAttributes.contains(attrUid)) {
+                // Type attributes should be SYNCED
+                assertThat(attrValue.syncState()).isEqualTo(State.SYNCED)
+            } else {
+                // Non-type attributes should keep their original state
+                assertThat(attrValue.syncState()).isEqualTo(initialStates[attrUid])
+            }
+        }
+    }
+
+    @Test
+    fun mark_only_program_attributes_as_synced_when_enrollment_succeeds() = runTest {
+        storeTrackerData()
+        val enrollment = enrollmentStore.selectByUid(enrollment1Id)!!
+        val teiUid = enrollment.trackedEntityInstance()!!
+        val programUid = enrollment.program()!!
+
+        // Get store from Koin
+        val programTrackedEntityAttributeStore: ProgramTrackedEntityAttributeStore = koin.get()
+
+        // Get program attribute UIDs
+        val programAttributes = programTrackedEntityAttributeStore
+            .selectAll()
+            .filter { it.program()?.uid() == programUid }
+            .mapNotNull { it.trackedEntityAttribute()?.uid() }
+
+        // Skip test if no program attributes are configured in test data
+        if (programAttributes.isEmpty()) {
+            return@runTest
+        }
+
+        // Get initial attribute values before sync
+        val attributeValuesBefore = teiAttributeValueStore.queryByTrackedEntityInstance(teiUid)
+        val initialStates = attributeValuesBefore.associate {
+            it.trackedEntityAttribute()!! to it.syncState()
+        }
+
+        // Simulate enrollment success: mark only program attributes as SYNCED
+        val handler: JobReportEnrollmentHandler = koin.get()
+        handler.handleObject(enrollment1Id, State.SYNCED)
+
+        // Assert: Program attributes should be SYNCED
+        val allAttributeValues = teiAttributeValueStore.queryByTrackedEntityInstance(teiUid)
+
+        allAttributeValues.forEach { attrValue ->
+            val attrUid = attrValue.trackedEntityAttribute()!!
+            if (programAttributes.contains(attrUid)) {
+                assertThat(attrValue.syncState()).isEqualTo(State.SYNCED)
+            } else {
+                // Non-program attributes should keep their state (unless they were also synced by TE handler)
+                // This test focuses on enrollment handler behavior
+            }
+        }
+    }
+
+    @Test
+    fun not_mark_program_attributes_as_synced_when_only_te_succeeds_and_enrollment_fails() = runTest {
+        storeTrackerData()
+        val trackedEntity = teiStore.selectByUid(teiId)!!
+
+        // Get type attributes
+        val trackedEntityTypeAttributeStore: TrackedEntityTypeAttributeStore = koin.get()
+        val typeAttributeUids = trackedEntityTypeAttributeStore
+            .getForTrackedEntityType(trackedEntity.trackedEntityType()!!)
+            .mapNotNull { it.trackedEntityAttribute()?.uid() }
+
+        // Create a program-only attribute (not in type attributes)
+        val programOnlyAttrUid = "programOnlyAttr123"
+
+        // Insert the attribute first (to satisfy foreign key constraint)
+        val trackedEntityAttributeStore: TrackedEntityAttributeStore = koin.get()
+        val programOnlyAttribute = TrackedEntityAttribute.builder()
+            .uid(programOnlyAttrUid)
+            .build()
+        trackedEntityAttributeStore.insert(programOnlyAttribute)
+
+        // Now insert the attribute value
+        val programOnlyAttrValue = TrackedEntityAttributeValue.builder()
+            .trackedEntityInstance(teiId)
+            .trackedEntityAttribute(programOnlyAttrUid)
+            .value("test value")
+            .syncState(State.TO_POST)
+            .build()
+        teiAttributeValueStore.insert(programOnlyAttrValue)
+
+        // Simulate what the handler does: mark only TYPE attributes as SYNCED
+        teiAttributeValueStore.setSyncStateByAttributes(teiId, typeAttributeUids, State.SYNCED)
+
+        // Assert: Program-only attribute should NOT be SYNCED
+        val afterSync = teiAttributeValueStore.queryByTrackedEntityInstance(teiId)
+            .find { it.trackedEntityAttribute() == programOnlyAttrUid }
+
+        assertThat(afterSync).isNotNull()
+        assertThat(afterSync!!.syncState()).isEqualTo(State.TO_POST)
     }
 }

--- a/core/src/main/assets/migrations/178.sql
+++ b/core/src/main/assets/migrations/178.sql
@@ -1,3 +1,6 @@
 # Rename eventStatus property to status on EventFilter class (ANDROSDK-2208)
 
-ALTER TABLE EventFilter RENAME COLUMN eventStatus TO status;
+ALTER TABLE EventFilter RENAME TO EventFilter_Old;
+CREATE TABLE EventFilter(uid TEXT NOT NULL, code TEXT, name TEXT, displayName TEXT, created TEXT, lastUpdated TEXT, program TEXT NOT NULL, programStage TEXT, description TEXT, followUp INTEGER, organisationUnit TEXT, ouMode TEXT, assignedUserMode TEXT, orderProperty TEXT, displayColumnOrder TEXT, events TEXT, status TEXT, eventDate TEXT, dueDate TEXT, lastUpdatedDate TEXT, completedDate TEXT, PRIMARY KEY(uid), FOREIGN KEY(program) REFERENCES Program(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(programStage) REFERENCES ProgramStage(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(organisationUnit) REFERENCES OrganisationUnit(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED);
+INSERT INTO EventFilter(uid, code, name, displayName, created, lastUpdated, program, programStage, description, followUp, organisationUnit, ouMode, assignedUserMode, orderProperty, displayColumnOrder, events, status, eventDate, dueDate, lastUpdatedDate, completedDate) SELECT uid, code, name, displayName, created, lastUpdated, program, programStage, description, followUp, organisationUnit, ouMode, assignedUserMode, orderProperty, displayColumnOrder, events, eventStatus, eventDate, dueDate, lastUpdatedDate, completedDate FROM EventFilter_Old;
+DROP TABLE EventFilter_Old;

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStore.kt
@@ -50,7 +50,10 @@ internal interface TrackedEntityAttributeValueStore : ObjectWithoutUidStore<Trac
         programs: List<String>,
     )
 
-    suspend fun removeDeletedAttributeValuesByInstance(trackedEntityInstanceUid: String)
+    suspend fun removeDeletedAttributeValuesByInstanceAndAttributes(
+        trackedEntityInstanceUid: String,
+        attributeUids: List<String>,
+    )
 
     suspend fun setSyncStateByInstance(trackedEntityInstanceUid: String, syncState: State)
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStore.kt
@@ -53,4 +53,10 @@ internal interface TrackedEntityAttributeValueStore : ObjectWithoutUidStore<Trac
     suspend fun removeDeletedAttributeValuesByInstance(trackedEntityInstanceUid: String)
 
     suspend fun setSyncStateByInstance(trackedEntityInstanceUid: String, syncState: State)
+
+    suspend fun setSyncStateByAttributes(
+        trackedEntityInstanceUid: String,
+        attributeUids: List<String>,
+        syncState: State,
+    )
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportEnrollmentHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportEnrollmentHandler.kt
@@ -89,7 +89,7 @@ internal class JobReportEnrollmentHandler internal constructor(
             val whereClause = WhereClauseBuilder()
                 .appendKeyStringValue(ProgramTrackedEntityAttributeTableInfo.Columns.PROGRAM, programUid)
                 .build()
-            
+
             val programAttributeUids = programTrackedEntityAttributeStore.selectStringColumnsWhereClause(
                 ProgramTrackedEntityAttributeTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE,
                 whereClause,

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportEnrollmentHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportEnrollmentHandler.kt
@@ -96,7 +96,15 @@ internal class JobReportEnrollmentHandler internal constructor(
             )
 
             if (programAttributeUids.isNotEmpty()) {
-                trackedEntityAttributeValueStore.setSyncStateByAttributes(teiUid, programAttributeUids, State.SYNCED)
+                trackedEntityAttributeValueStore.setSyncStateByAttributes(
+                    teiUid,
+                    programAttributeUids,
+                    State.SYNCED,
+                )
+                trackedEntityAttributeValueStore.removeDeletedAttributeValuesByInstanceAndAttributes(
+                    teiUid,
+                    programAttributeUids,
+                )
             }
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportEnrollmentHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportEnrollmentHandler.kt
@@ -33,9 +33,11 @@ import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStore
 import org.hisp.dhis.android.core.note.internal.NoteStore
+import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
 import org.hisp.dhis.android.core.relationship.Relationship
 import org.hisp.dhis.android.core.relationship.RelationshipHelper
 import org.hisp.dhis.android.core.relationship.internal.RelationshipStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
 import org.hisp.dhis.android.persistence.note.NoteTableInfo
@@ -47,6 +49,8 @@ internal class JobReportEnrollmentHandler internal constructor(
     private val enrollmentStore: EnrollmentStore,
     private val conflictStore: TrackerImportConflictStore,
     private val conflictHelper: TrackerConflictHelper,
+    private val trackedEntityAttributeValueStore: TrackedEntityAttributeValueStore,
+    private val programTrackedEntityAttributeStore: ProgramTrackedEntityAttributeStore,
     relationshipStore: RelationshipStore,
 ) : JobReportTypeHandler(relationshipStore) {
 
@@ -69,9 +73,26 @@ internal class JobReportEnrollmentHandler internal constructor(
 
         if (state == State.SYNCED && (handleAction == HandleAction.Update || handleAction == HandleAction.Insert)) {
             handleEnrollmentNotes(uid, state)
+            handleSyncedEnrollmentAttributes(uid)
         }
 
         return handleAction
+    }
+
+    private suspend fun handleSyncedEnrollmentAttributes(enrollmentUid: String) {
+        val enrollment = enrollmentStore.selectByUid(enrollmentUid)
+        val teiUid = enrollment?.trackedEntityInstance()
+        val programUid = enrollment?.program()
+
+        if (teiUid != null && programUid != null) {
+            val programAttributes = programTrackedEntityAttributeStore.selectAll()
+                .filter { it.program()?.uid() == programUid }
+                .mapNotNull { it.trackedEntityAttribute()?.uid() }
+
+            if (programAttributes.isNotEmpty()) {
+                trackedEntityAttributeValueStore.setSyncStateByAttributes(teiUid, programAttributes, State.SYNCED)
+            }
+        }
     }
 
     override suspend fun storeConflict(errorReport: JobValidationError) {

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTrackedEntityHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTrackedEntityHandler.kt
@@ -87,9 +87,8 @@ internal class JobReportTrackedEntityHandler internal constructor(
 
             if (tetAttributes.isNotEmpty()) {
                 trackedEntityAttributeValueStore.setSyncStateByAttributes(uid, tetAttributes, State.SYNCED)
+                trackedEntityAttributeValueStore.removeDeletedAttributeValuesByInstanceAndAttributes(uid, tetAttributes)
             }
         }
-
-        trackedEntityAttributeValueStore.removeDeletedAttributeValuesByInstance(uid)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTrackedEntityHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTrackedEntityHandler.kt
@@ -35,6 +35,7 @@ import org.hisp.dhis.android.core.relationship.RelationshipHelper
 import org.hisp.dhis.android.core.relationship.internal.RelationshipStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityTypeAttributeStore
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceTableInfo
 import org.koin.core.annotation.Singleton
 
@@ -43,6 +44,7 @@ internal class JobReportTrackedEntityHandler internal constructor(
     private val trackedEntityAttributeValueStore: TrackedEntityAttributeValueStore,
     private val conflictStore: TrackerImportConflictStore,
     private val trackedEntityStore: TrackedEntityInstanceStore,
+    private val trackedEntityTypeAttributeStore: TrackedEntityTypeAttributeStore,
     private val conflictHelper: TrackerConflictHelper,
     relationshipStore: RelationshipStore,
 ) : JobReportTypeHandler(relationshipStore) {
@@ -76,7 +78,18 @@ internal class JobReportTrackedEntityHandler internal constructor(
     }
 
     suspend fun handleSyncedEntity(uid: String) {
-        trackedEntityAttributeValueStore.setSyncStateByInstance(uid, State.SYNCED)
+        val tei = trackedEntityStore.selectByUid(uid)
+        val teType = tei?.trackedEntityType()
+
+        if (teType != null) {
+            val tetAttributes = trackedEntityTypeAttributeStore.getForTrackedEntityType(teType)
+                .mapNotNull { it.trackedEntityAttribute()?.uid() }
+
+            if (tetAttributes.isNotEmpty()) {
+                trackedEntityAttributeValueStore.setSyncStateByAttributes(uid, tetAttributes, State.SYNCED)
+            }
+        }
+
         trackedEntityAttributeValueStore.removeDeletedAttributeValuesByInstance(uid)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTypeHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTypeHandler.kt
@@ -53,7 +53,7 @@ internal abstract class JobReportTypeHandler(
         handleObject(jo.objectUid(), State.TO_UPDATE)
     }
 
-    protected abstract suspend fun handleObject(uid: String, state: State): HandleAction
+    internal abstract suspend fun handleObject(uid: String, state: State): HandleAction
     protected abstract suspend fun storeConflict(errorReport: JobValidationError)
     protected abstract suspend fun getRelatedRelationships(uid: String): List<Relationship>
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
@@ -43,6 +43,14 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
     fun setSyncStateByInstance(state: String, uid: String)
 
     @Query(
+        """UPDATE TrackedEntityAttributeValue 
+        SET ${TrackedEntityAttributeValueTableInfo.Columns.SYNC_STATE} = :state 
+        WHERE ${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_INSTANCE} = :teiUid
+          AND ${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE} IN (:attributeUids)""",
+    )
+    fun setSyncStateByAttributes(state: String, teiUid: String, attributeUids: List<String>)
+
+    @Query(
         """
         DELETE FROM ${TrackedEntityAttributeValueTableInfo.TABLE_NAME}
         WHERE ${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_INSTANCE} = :trackedEntityInstanceUid

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueDaoAux.kt
@@ -111,9 +111,11 @@ internal interface TrackedEntityAttributeValueDaoAux : ObjectDao<TrackedEntityAt
         DELETE FROM ${TrackedEntityAttributeValueTableInfo.TABLE_NAME}
         WHERE ${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_INSTANCE} = :trackedEntityInstanceUid
           AND ${TrackedEntityAttributeValueTableInfo.Columns.VALUE} IS NULL
+          AND ${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE} IN (:attributeUids)
     """,
     )
-    fun removeDeletedAttributeValuesByInstance(
+    fun removeDeletedAttributeValuesByInstanceAndAttributes(
         trackedEntityInstanceUid: String,
+        attributeUids: List<String>,
     ): Int
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueStoreImpl.kt
@@ -115,9 +115,14 @@ internal class TrackedEntityAttributeValueStoreImpl(
         )
     }
 
-    override suspend fun removeDeletedAttributeValuesByInstance(trackedEntityInstanceUid: String) {
-        val dao = databaseAdapter.getCurrentDatabase().trackedEntityAttributeValueDao()
-        dao.removeDeletedAttributeValuesByInstance(trackedEntityInstanceUid)
+    override suspend fun removeDeletedAttributeValuesByInstanceAndAttributes(
+        trackedEntityInstanceUid: String,
+        attributeUids: List<String>,
+    ) {
+        if (attributeUids.isNotEmpty()) {
+            val dao = databaseAdapter.getCurrentDatabase().trackedEntityAttributeValueDao()
+            dao.removeDeletedAttributeValuesByInstanceAndAttributes(trackedEntityInstanceUid, attributeUids)
+        }
     }
 
     override suspend fun setSyncStateByInstance(trackedEntityInstanceUid: String, syncState: State) {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueStoreImpl.kt
@@ -124,4 +124,13 @@ internal class TrackedEntityAttributeValueStoreImpl(
         val dao = daoProvider() as TrackedEntityAttributeValueDao
         dao.setSyncStateByInstance(syncState.name, trackedEntityInstanceUid)
     }
+
+    override suspend fun setSyncStateByAttributes(
+        trackedEntityInstanceUid: String,
+        attributeUids: List<String>,
+        syncState: State,
+    ) {
+        val dao = daoProvider() as TrackedEntityAttributeValueDao
+        dao.setSyncStateByAttributes(syncState.name, trackedEntityInstanceUid, attributeUids)
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where all tei attributes (both from the tei type and the program) were set as SYNCED when the tei was checked to be posted in the server, which is strictly incorrect since the program related attributes are sent in the enrollment part of the post. This has been solved by splitting the SYNCED setting attributes by enrollment and tei job result fetching.

Related task: [ANDROSDK-2213](https://dhis2.atlassian.net/browse/ANDROSDK-2213)

[ANDROSDK-2213]: https://dhis2.atlassian.net/browse/ANDROSDK-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ