### PR TITLE
fix: [ANDROSDK-2216] Include programOwners in TEI online search results

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchItemHelper.kt
@@ -68,6 +68,7 @@ object TrackedEntitySearchItemHelper {
             .trackedEntityType(i.type.uid())
             .geometry(i.geometry)
             .trackedEntityAttributeValues(i.attributeValues?.map(::toTrackedEntityAttributeValue))
+            .programOwners(i.programOwners?.map { toProgramOwner(it, i.uid) })
             .syncState(i.syncState)
             .aggregatedSyncState(i.aggregatedSyncState)
             .build()
@@ -91,6 +92,17 @@ object TrackedEntitySearchItemHelper {
                 ownerOrgUnit = owner.ownerOrgUnit(),
             )
         } ?: emptyList()
+    }
+
+    private fun toProgramOwner(
+        p: TrackedEntitySearchItemProgramOwner,
+        trackedEntityInstance: String,
+    ): ProgramOwner {
+        return ProgramOwner.builder()
+            .program(p.program)
+            .ownerOrgUnit(p.ownerOrgUnit)
+            .trackedEntityInstance(trackedEntityInstance)
+            .build()
     }
 
     private fun from(

--- a/core/src/main/java/org/hisp/dhis/android/network/tracker/NewTrackedEntityInstanceFields.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/tracker/NewTrackedEntityInstanceFields.kt
@@ -52,6 +52,11 @@ internal object NewTrackedEntityInstanceFields : BaseFields<NewTrackerImporterTr
 
     val asRelationshipFields = Fields.from(commonFields())
 
+    val asSearchFields = Fields.from(
+        commonFields(),
+        fh.nestedField<ProgramOwner>(PROGRAM_OWNERS),
+    )
+
     val allFields = Fields.from(
         commonFields(),
         fh.nestedField<NewTrackerImporterRelationship>(RELATIONSHIPS).with(NewRelationshipFields.allFields),

--- a/core/src/main/java/org/hisp/dhis/android/network/tracker/TrackerExporterNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/tracker/TrackerExporterNetworkHandlerImpl.kt
@@ -171,7 +171,7 @@ internal class TrackerExporterNetworkHandlerImpl(
         query: TrackedEntityInstanceQueryOnline,
     ): Payload<TrackedEntityInstance> {
         val apiPayload = service.getTrackedEntityInstances(
-            fields = NewTrackedEntityInstanceFields.asRelationshipFields,
+            fields = NewTrackedEntityInstanceFields.asSearchFields,
             trackedEntityInstances = parameterManager.getTrackedEntitiesParameter(query.uids),
             orgUnits = parameterManager.getOrgunitsParameter(getOrgunits(query)),
             orgUnitMode = parameterManager.getOrgunitModeParameter(query.orgUnitMode),


### PR DESCRIPTION
When performing a TEI search with online results (not downloaded locally), the `programOwners` field was empty in `TrackedEntitySearchItem`. This caused a crash in the Android app when trying to get the owner org unit name, since the user may not have access to that org unit.

- Created a new `asSearchFields` field set that includes `commonFields()` + `programOwners`
- Updated `getTrackedEntityQuery()` to use the new field set
- Added the missing `programOwners` mapping in `toTrackedEntityInstance()`