### PR TITLE
fix: [ANDROSDK-2221] Data set with default cat combo can't be edited

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionComboCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/category/CategoryOptionComboCollectionRepositoryMockIntegrationShould.kt
@@ -157,7 +157,7 @@ class CategoryOptionComboCollectionRepositoryMockIntegrationShould :
             .withOrganisationUnits()
             .uid("apsOixVZlf1")
             .blockingGet()!!
-
-        assertThat(categoryOption.organisationUnits()).isEmpty()
+        // temporary fix for hotfix 1.13.0.1
+        assertThat(categoryOption.organisationUnits()).isNull()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionOrganisationUnitsCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionOrganisationUnitsCall.kt
@@ -71,7 +71,7 @@ internal class CategoryOptionOrganisationUnitsCall(
         val updatedEntries = mutableMapOf<String, List<CategoryOptionRestriction>>()
         for (uid in uids) {
             if (!data.keys.contains(uid)) {
-                if (dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_42)) {
+                if (dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_40)) {
                     updatedEntries[uid] = listOf(CategoryOptionRestriction.NotRestricted())
                 } else {
                     updatedEntries[uid] = listOf(CategoryOptionRestriction.NotAccessibleToUser())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-dhis2AndroidSdkVersion = "1.13.0-SNAPSHOT"
-dhis2AndroidSdkCode = "300"
+dhis2AndroidSdkVersion = "1.13.0.1-SNAPSHOT"
+dhis2AndroidSdkCode = "301"
 
 gradle = "8.9.3"
 kotlin = "2.0.20"


### PR DESCRIPTION
Related task: [ANDROSDK-2221](https://dhis2.atlassian.net/jira/software/c/projects/ANDROSDK/boards/154?selectedIssue=ANDROSDK-2221)

[ANDROSDK-2221]: https://dhis2.atlassian.net/browse/ANDROSDK-2221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ