### PR TITLE
fix: [ANDROSDK-2219] Remove non-null assertions from nullable Note fields in toDB()

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/note/NoteDB.kt
@@ -62,12 +62,12 @@ internal data class NoteDB(
 internal fun Note.toDB(): NoteDB {
     return NoteDB(
         uid = uid(),
-        noteType = noteType()?.name!!,
+        noteType = noteType()?.name,
         event = event(),
         enrollment = enrollment(),
-        value = value()!!,
-        storedBy = storedBy()!!,
-        storedDate = storedDate()!!,
+        value = value(),
+        storedBy = storedBy(),
+        storedDate = storedDate(),
         syncState = syncState()?.toDB(),
         deleted = deleted(),
     )


### PR DESCRIPTION
The `Note.toDB()` function was using non-null assertions (`!!`) on fields that are nullable in both the domain model (`@Nullable`) and the database entity (`String?`).

This caused `NullPointerException` during tracker sync when the server returned null values for these fields, particularly reported for the storedBy field.

Fields fixed in `Note.toDB()`:
- noteType
- value
- storedBy
- storedDate

The !! operator is now removed since both domain and DB allow null values, making the assertions unnecessary and potentially dangerous.
