### PR TITLE
fix: [ANDROSDK-2223] replace DataInputPeriodDB primary keys with _id

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -12863,6 +12863,7 @@ public final class org/hisp/dhis/android/persistence/dataset/DataInputPeriodTabl
 	public static final field DATA_SET Ljava/lang/String;
 	public static final field OPENING_DATE Ljava/lang/String;
 	public static final field PERIOD Ljava/lang/String;
+	public static final field _ID Ljava/lang/String;
 	public fun <init> ()V
 	public fun all ()[Ljava/lang/String;
 }

--- a/core/src/main/assets/migrations/178.sql
+++ b/core/src/main/assets/migrations/178.sql
@@ -1,0 +1,18 @@
+# Change DataInputPeriod primary key from composite (dataSet, period, openingDate, closingDate) to auto-incremental _id
+
+ALTER TABLE DataInputPeriod RENAME TO DataInputPeriod_Old;
+
+CREATE TABLE DataInputPeriod(
+    _id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    dataSet TEXT NOT NULL,
+    period TEXT NOT NULL,
+    openingDate TEXT,
+    closingDate TEXT,
+    FOREIGN KEY(dataSet) REFERENCES DataSet(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY(period) REFERENCES Period(periodId) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+);
+
+INSERT INTO DataInputPeriod(_id, dataSet, period, openingDate, closingDate)
+SELECT NULL, dataSet, period, openingDate, closingDate FROM DataInputPeriod_Old;
+
+DROP TABLE DataInputPeriod_Old;

--- a/core/src/main/assets/migrations/178.sql
+++ b/core/src/main/assets/migrations/178.sql
@@ -1,18 +1,6 @@
 # Change DataInputPeriod primary key from composite (dataSet, period, openingDate, closingDate) to auto-incremental _id
 
 ALTER TABLE DataInputPeriod RENAME TO DataInputPeriod_Old;
-
-CREATE TABLE DataInputPeriod(
-    _id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-    dataSet TEXT NOT NULL,
-    period TEXT NOT NULL,
-    openingDate TEXT,
-    closingDate TEXT,
-    FOREIGN KEY(dataSet) REFERENCES DataSet(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    FOREIGN KEY(period) REFERENCES Period(periodId) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
-);
-
-INSERT INTO DataInputPeriod(_id, dataSet, period, openingDate, closingDate)
-SELECT NULL, dataSet, period, openingDate, closingDate FROM DataInputPeriod_Old;
-
-DROP TABLE DataInputPeriod_Old;
+CREATE TABLE DataInputPeriod (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, dataSet TEXT NOT NULL, period TEXT NOT NULL, openingDate TEXT, closingDate TEXT, FOREIGN KEY(dataSet) REFERENCES DataSet(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(period) REFERENCES Period(periodId) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED);
+INSERT INTO DataInputPeriod(_id, dataSet, period, openingDate, closingDate) SELECT NULL, dataSet, period, openingDate, closingDate FROM DataInputPeriod_Old;
+DROP TABLE IF EXISTS DataInputPeriod_Old;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/AppDatabase.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/AppDatabase.kt
@@ -610,6 +610,6 @@ abstract class AppDatabase : RoomDatabase() {
     internal abstract fun visualizationDimensionItemDao(): VisualizationDimensionItemDao
 
     companion object {
-        const val VERSION = 177
+        const val VERSION = 178
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataInputPeriodDB.kt
@@ -1,7 +1,9 @@
 package org.hisp.dhis.android.persistence.dataset
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.dataset.DataInputPeriod
 import org.hisp.dhis.android.core.util.dateFormat
@@ -27,13 +29,15 @@ import org.hisp.dhis.android.persistence.period.PeriodDB
             deferred = true,
         ),
     ],
-    primaryKeys = ["dataSet", "period", "openingDate", "closingDate"],
 )
 internal data class DataInputPeriodDB(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "_id")
+    val id: Int = 0,
     val dataSet: String,
     val period: String,
-    val openingDate: String,
-    val closingDate: String,
+    val openingDate: String?,
+    val closingDate: String?,
 ) : EntityDB<DataInputPeriod> {
 
     override fun toDomain(): DataInputPeriod {
@@ -50,7 +54,7 @@ internal fun DataInputPeriod.toDB(): DataInputPeriodDB {
     return DataInputPeriodDB(
         dataSet = dataSet()!!.uid(),
         period = period().uid(),
-        openingDate = openingDate().dateFormat()!!,
-        closingDate = closingDate().dateFormat()!!,
+        openingDate = openingDate().dateFormat(),
+        closingDate = closingDate().dateFormat(),
     )
 }


### PR DESCRIPTION
openingDate and closingDate from DataInputPeriodDB were being incorrectly used as primary keys.

Related task [ANDROSDK-2223](https://dhis2.atlassian.net/browse/ANDROSDK-2223)

[ANDROSDK-2223]: https://dhis2.atlassian.net/browse/ANDROSDK-2223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ