### PR TITLE
fix: [ANDROSDK-2226] fix error description null pointer errors

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/executors/internal/APIErrorMapper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/executors/internal/APIErrorMapper.kt
@@ -86,7 +86,6 @@ internal class APIErrorMapper {
 
     private fun sslException(errorBuilder: D2Error.Builder, sslException: SSLException): D2Error {
         return logAndAppendOriginal(errorBuilder, sslException)
-            .errorDescription(sslException.message)
             .errorCode(D2ErrorCode.SSL_ERROR)
             .errorDescription("API call threw SSLException")
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResizerHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResizerHelper.kt
@@ -115,7 +115,7 @@ object FileResizerHelper {
         return D2Error.builder()
             .errorComponent(D2ErrorComponent.SDK)
             .errorCode(D2ErrorCode.FAIL_RESIZING_IMAGE)
-            .errorDescription(e.message)
+            .errorDescription(e.message ?: "Failed to resize image")
             .build()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/AndroidSecureStore.kt
@@ -235,7 +235,7 @@ class AndroidSecureStore(context: Context) : SecureStore {
         return D2Error.builder()
             .errorComponent(D2ErrorComponent.SDK)
             .errorCode(d2ErrorCode)
-            .errorDescription(ex.message)
+            .errorDescription(ex.message ?: "KeyStore error")
             .originalException(ex)
             .created(Date())
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/maintenance/D2ErrorDB.kt
@@ -30,7 +30,7 @@ internal data class D2ErrorDB(
             url(url)
             errorComponent?.let { errorComponent(D2ErrorComponent.valueOf(it)) }
             errorCode?.let { errorCode(D2ErrorCode.valueOf(it)) }
-            errorDescription(errorDescription)
+            errorDescription(errorDescription ?: "Unknown error")
             httpErrorCode(httpErrorCode)
             created(created.toJavaDate())
         }.build()


### PR DESCRIPTION
This PR adds default error description to avoid null pointer exceptions caused by legacy error data in the database.
Related task [ANDROSDK-2226](https://dhis2.atlassian.net/browse/ANDROSDK-2226)

[ANDROSDK-2226]: https://dhis2.atlassian.net/browse/ANDROSDK-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ