### PR TITLE
chore: [ANDROSDK-2161] add last access timestamp to accounts

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4081,6 +4081,7 @@ public abstract class org/hisp/dhis/android/core/configuration/internal/Database
 	public abstract fun databaseName ()Ljava/lang/String;
 	public abstract fun encrypted ()Z
 	public abstract fun importDB ()Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccountImport;
+	public abstract fun lastAccessDate ()Ljava/lang/String;
 	public abstract fun loginConfig ()Lorg/hisp/dhis/android/core/server/LoginConfig;
 	public abstract fun serverUrl ()Ljava/lang/String;
 	public abstract fun syncState ()Lorg/hisp/dhis/android/core/common/State;
@@ -4095,6 +4096,7 @@ public abstract class org/hisp/dhis/android/core/configuration/internal/Database
 	public abstract fun databaseName (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun encrypted (Z)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun importDB (Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccountImport;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
+	public abstract fun lastAccessDate (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun loginConfig (Lorg/hisp/dhis/android/core/server/LoginConfig;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun serverUrl (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun syncState (Lorg/hisp/dhis/android/core/common/State;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4077,7 +4077,7 @@ public abstract class org/hisp/dhis/android/core/configuration/internal/Configur
 public abstract class org/hisp/dhis/android/core/configuration/internal/DatabaseAccount {
 	public fun <init> ()V
 	public static fun builder ()Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
-	public abstract fun databaseCreationDate ()Ljava/lang/String;
+	public abstract fun databaseCreationDate ()Ljava/util/Date;
 	public abstract fun databaseName ()Ljava/lang/String;
 	public abstract fun encrypted ()Z
 	public abstract fun importDB ()Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccountImport;
@@ -4092,7 +4092,7 @@ public abstract class org/hisp/dhis/android/core/configuration/internal/Database
 public abstract class org/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder {
 	public fun <init> ()V
 	public abstract fun build ()Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount;
-	public abstract fun databaseCreationDate (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
+	public abstract fun databaseCreationDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun databaseName (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun encrypted (Z)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun importDB (Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccountImport;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4081,7 +4081,7 @@ public abstract class org/hisp/dhis/android/core/configuration/internal/Database
 	public abstract fun databaseName ()Ljava/lang/String;
 	public abstract fun encrypted ()Z
 	public abstract fun importDB ()Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccountImport;
-	public abstract fun lastAccessDate ()Ljava/lang/String;
+	public abstract fun lastAccessDate ()Ljava/util/Date;
 	public abstract fun loginConfig ()Lorg/hisp/dhis/android/core/server/LoginConfig;
 	public abstract fun serverUrl ()Ljava/lang/String;
 	public abstract fun syncState ()Lorg/hisp/dhis/android/core/common/State;
@@ -4096,7 +4096,7 @@ public abstract class org/hisp/dhis/android/core/configuration/internal/Database
 	public abstract fun databaseName (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun encrypted (Z)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun importDB (Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccountImport;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
-	public abstract fun lastAccessDate (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
+	public abstract fun lastAccessDate (Ljava/util/Date;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun loginConfig (Lorg/hisp/dhis/android/core/server/LoginConfig;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun serverUrl (Ljava/lang/String;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;
 	public abstract fun syncState (Lorg/hisp/dhis/android/core/common/State;)Lorg/hisp/dhis/android/core/configuration/internal/DatabaseAccount$Builder;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/Migration301IntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/Migration301IntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.configuration.internal
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
 import org.hisp.dhis.android.core.arch.storage.internal.InMemoryUnsecureStore
 import org.hisp.dhis.android.core.configuration.internal.migration.Migration301
@@ -248,7 +249,8 @@ class Migration301IntegrationShould {
             .serverUrl(url)
             .databaseName(dbName)
             .encrypted(encrypted)
-            .databaseCreationDate(creationDate)
+            .databaseCreationDate(DateUtils.SIMPLE_DATE_FORMAT.parse(creationDate))
+            .lastAccessDate(DateUtils.SIMPLE_DATE_FORMAT.parse(creationDate))
             .importDB(importDB)
             .build()
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/PeriodMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/PeriodMockIntegrationShould.kt
@@ -31,7 +31,7 @@ import com.google.common.truth.Truth
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.period.internal.PeriodStore
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 import java.text.ParseException
@@ -42,7 +42,7 @@ class PeriodMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     fun get_period_passing_period_type_and_a_date() {
         val period = d2.periodModule().periodHelper().blockingGetPeriodForPeriodTypeAndDate(
             PeriodType.BiWeekly,
-            "2019-07-08T12:24:25.319".toJavaDate()!!,
+            "2019-07-08T12:24:25.319".toJavaDateNonNull(),
         )
         Truth.assertThat(period.periodId()).isEqualTo("2019BiW14")
     }
@@ -52,7 +52,7 @@ class PeriodMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
     fun create_period_in_database_if_not_exist() = runTest {
         val periodStore: PeriodStore = koin.get()
 
-        val date = "2010-12-24T12:24:25.319".toJavaDate()!!
+        val date = "2010-12-24T12:24:25.319".toJavaDateNonNull()
 
         var periodInDb = periodStore.selectPeriodByTypeAndDate(PeriodType.Monthly, date)
         Truth.assertThat(periodInDb).isNull()

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetCompleteRegistrationCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetCompleteRegistrationCollectionRepositoryMockIntegrationShould.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.testapp.dataset
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.util.toJavaSimpleDate
+import org.hisp.dhis.android.core.util.toJavaSimpleDateNonNull
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 import java.text.ParseException
@@ -86,7 +86,7 @@ class DataSetCompleteRegistrationCollectionRepositoryMockIntegrationShould : Bas
     fun filter_by_date_after() {
         val dataSetCompleteRegistrations = d2.dataSetModule().dataSetCompleteRegistrations()
             .byDate()
-            .after("2010-08-03".toJavaSimpleDate()!!)
+            .after("2010-08-03".toJavaSimpleDateNonNull())
             .blockingGet()
 
         assertThat(dataSetCompleteRegistrations.size).isEqualTo(1)
@@ -97,7 +97,7 @@ class DataSetCompleteRegistrationCollectionRepositoryMockIntegrationShould : Bas
     fun filter_by_date_before() {
         val dataSetCompleteRegistrations = d2.dataSetModule().dataSetCompleteRegistrations()
             .byDate()
-            .before("2010-08-03".toJavaSimpleDate()!!)
+            .before("2010-08-03".toJavaSimpleDateNonNull())
             .blockingGet()
 
         assertThat(dataSetCompleteRegistrations.size).isEqualTo(2)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/EventCollectionRepositoryMockIntegrationShould.kt
@@ -37,6 +37,7 @@ import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 import java.text.ParseException
@@ -198,7 +199,7 @@ class EventCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTestFu
     fun filter_by_due_date() {
         val events = d2.eventModule().events()
             .byDueDate()
-            .afterOrEqual("2017-01-28T12:35:00.000".toJavaDate()!!)
+            .afterOrEqual("2017-01-28T12:35:00.000".toJavaDateNonNull())
             .blockingGet()
 
         assertThat(events.size).isEqualTo(2)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/search/EventQueryCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/event/search/EventQueryCollectionRepositoryMockIntegrationShould.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.testapp.event.search
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.util.toJavaSimpleDate
+import org.hisp.dhis.android.core.util.toJavaSimpleDateNonNull
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -85,8 +85,8 @@ class EventQueryCollectionRepositoryMockIntegrationShould : BaseMockIntegrationT
     @Test
     fun filter_by_date_data_value() {
         val events1 = d2.eventModule().eventQuery()
-            .byDataValue("uFAQYm3UgBL").after("2019-02-01".toJavaSimpleDate()!!)
-            .byDataValue("uFAQYm3UgBL").before("2019-02-10".toJavaSimpleDate()!!)
+            .byDataValue("uFAQYm3UgBL").after("2019-02-01".toJavaSimpleDateNonNull())
+            .byDataValue("uFAQYm3UgBL").before("2019-02-10".toJavaSimpleDateNonNull())
             .blockingGet()
 
         assertThat(events1.size).isEqualTo(1)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/maintenance/ForeignKeyViolationCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/maintenance/ForeignKeyViolationCollectionRepositoryMockIntegrationShould.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.testapp.maintenance
 
 import com.google.common.truth.Truth.assertThat
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -91,7 +91,7 @@ class ForeignKeyViolationCollectionRepositoryMockIntegrationShould : BaseMockInt
     @Test
     fun filter_by_created() {
         val foreignKeyViolations = d2.maintenanceModule().foreignKeyViolations()
-            .byCreated().after("2019-01-15T08:14:06.767".toJavaDate()!!).blockingGet()
+            .byCreated().after("2019-01-15T08:14:06.767".toJavaDateNonNull()).blockingGet()
         assertThat(foreignKeyViolations.size).isEqualTo(4)
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/AccountManagerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/AccountManagerMockIntegrationShould.kt
@@ -237,6 +237,55 @@ class AccountManagerMockIntegrationShould : BaseMockIntegrationTestEmptyEnqueabl
         loginAndDeleteAccount(user2, pass2, server2)
     }
 
+    @Test
+    fun update_last_access_date_when_getting_accounts() {
+        if (d2.userModule().blockingIsLogged()) {
+            d2.userModule().blockingLogOut()
+        }
+
+        dhis2MockServer.enqueueLoginResponses()
+        d2.userModule().blockingLogIn(user1, pass1, dhis2MockServer.baseEndpoint)
+
+        val initialAccount = d2.userModule().accountManager().getCurrentAccount()
+        val initialLastAccessDate = initialAccount?.lastAccessDate()
+        assertThat(initialLastAccessDate).isNotNull()
+
+        Thread.sleep(1000)
+
+        val accounts = d2.userModule().accountManager().getAccounts()
+        val updatedAccount = accounts.find { it.username() == user1 }
+        val updatedLastAccessDate = updatedAccount?.lastAccessDate()
+
+        assertThat(updatedLastAccessDate).isNotNull()
+        assertThat(updatedLastAccessDate).isNotEqualTo(initialLastAccessDate)
+
+        loginAndDeleteAccount(user1, pass1, dhis2MockServer)
+    }
+
+    @Test
+    fun update_last_access_date_when_getting_current_account() {
+        if (d2.userModule().blockingIsLogged()) {
+            d2.userModule().blockingLogOut()
+        }
+
+        dhis2MockServer.enqueueLoginResponses()
+        d2.userModule().blockingLogIn(user1, pass1, dhis2MockServer.baseEndpoint)
+
+        val initialAccount = d2.userModule().accountManager().getCurrentAccount()
+        val initialLastAccessDate = initialAccount?.lastAccessDate()
+        assertThat(initialLastAccessDate).isNotNull()
+
+        Thread.sleep(1000)
+
+        val updatedAccount = d2.userModule().accountManager().getCurrentAccount()
+        val updatedLastAccessDate = updatedAccount?.lastAccessDate()
+
+        assertThat(updatedLastAccessDate).isNotNull()
+        assertThat(updatedLastAccessDate).isNotEqualTo(initialLastAccessDate)
+
+        loginAndDeleteAccount(user1, pass1, dhis2MockServer)
+    }
+
     private fun addDataValue() {
         val period = d2.periodModule().periodHelper().blockingGetPeriodForPeriodTypeAndDate(PeriodType.Yearly, Date())
         val orgunit = d2.organisationUnitModule().organisationUnits().one().blockingGet()!!

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/AccountManagerMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/user/AccountManagerMockIntegrationShould.kt
@@ -286,6 +286,50 @@ class AccountManagerMockIntegrationShould : BaseMockIntegrationTestEmptyEnqueabl
         loginAndDeleteAccount(user1, pass1, dhis2MockServer)
     }
 
+    @Test
+    fun logged_account_has_more_recent_last_access_date_than_other_accounts() {
+        if (d2.userModule().blockingIsLogged()) {
+            d2.userModule().blockingLogOut()
+        }
+
+        // Login with user1 (older account by creation date)
+        dhis2MockServer.enqueueLoginResponses()
+        d2.userModule().blockingLogIn(user1, pass1, dhis2MockServer.baseEndpoint)
+        d2.userModule().blockingLogOut()
+
+        Thread.sleep(300)
+
+        // Login with user2 (newer account by creation date)
+        val server2 = Dhis2MockServer(0)
+        server2.enqueueLoginResponses()
+        d2.userModule().blockingLogIn(user2, pass2, server2.baseEndpoint)
+        d2.userModule().blockingLogOut()
+
+        Thread.sleep(300)
+
+        // Login again with user1 (should have most recent lastAccessDate now)
+        dhis2MockServer.enqueueLoginResponses()
+        d2.userModule().blockingLogIn(user1, pass1, dhis2MockServer.baseEndpoint)
+
+        Thread.sleep(300)
+
+        // Get accounts and verify user1 (logged) has more recent lastAccessDate than user2
+        // despite user1 being older by creation date
+        val accounts = d2.userModule().accountManager().getAccounts()
+        val account1 = accounts.find { it.username() == user1 }
+        val account2 = accounts.find { it.username() == user2 }
+
+        assertThat(account1).isNotNull()
+        assertThat(account2).isNotNull()
+        assertThat(account1?.lastAccessDate()).isNotNull()
+        assertThat(account2?.lastAccessDate()).isNotNull()
+        assertThat(account1?.lastAccessDate()).isGreaterThan(account2?.lastAccessDate())
+
+        d2.userModule().blockingLogOut()
+        loginAndDeleteAccount(user1, pass1, dhis2MockServer)
+        loginAndDeleteAccount(user2, pass2, server2)
+    }
+
     private fun addDataValue() {
         val period = d2.periodModule().periodHelper().blockingGetPeriodForPeriodTypeAndDate(PeriodType.Yearly, Date())
         val orgunit = d2.organisationUnitModule().organisationUnits().one().blockingGet()!!

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseImportExportImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseImportExportImpl.kt
@@ -43,7 +43,7 @@ import org.hisp.dhis.android.core.user.UserModule
 import org.hisp.dhis.android.core.util.CipherUtil
 import org.hisp.dhis.android.core.util.FileUtils
 import org.hisp.dhis.android.core.util.deleteIfExists
-import org.hisp.dhis.android.core.util.simpleDateFormat
+import org.hisp.dhis.android.core.util.simpleDateFormatNonNull
 import org.koin.core.annotation.Singleton
 import java.io.File
 import java.util.Date
@@ -170,7 +170,7 @@ internal class DatabaseImportExportImpl(
 
         val metadata = DatabaseExportMetadata(
             version = AppDatabase.VERSION,
-            date = Date().simpleDateFormat()!!,
+            date = Date().simpleDateFormatNonNull(),
             serverUrl = userConfiguration.serverUrl(),
             username = userConfiguration.username(),
             encrypted = userConfiguration.encrypted(),

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseAccount.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseAccount.java
@@ -50,6 +50,9 @@ public abstract class DatabaseAccount {
     @NonNull
     public abstract String databaseCreationDate();
 
+    @Nullable
+    public abstract String lastAccessDate();
+
     @NonNull
     public abstract boolean encrypted();
 
@@ -80,6 +83,8 @@ public abstract class DatabaseAccount {
         public abstract Builder encrypted(boolean encrypted);
 
         public abstract Builder databaseCreationDate(String databaseCreationDate);
+
+        public abstract Builder lastAccessDate(String lastAccessDate);
 
         public abstract Builder importDB(DatabaseAccountImport importDB);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseAccount.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseAccount.java
@@ -35,6 +35,8 @@ import com.google.auto.value.AutoValue;
 import org.hisp.dhis.android.core.common.State;
 import org.hisp.dhis.android.core.server.LoginConfig;
 
+import java.util.Date;
+
 @AutoValue
 public abstract class DatabaseAccount {
 
@@ -51,7 +53,7 @@ public abstract class DatabaseAccount {
     public abstract String databaseCreationDate();
 
     @Nullable
-    public abstract String lastAccessDate();
+    public abstract Date lastAccessDate();
 
     @NonNull
     public abstract boolean encrypted();
@@ -84,7 +86,7 @@ public abstract class DatabaseAccount {
 
         public abstract Builder databaseCreationDate(String databaseCreationDate);
 
-        public abstract Builder lastAccessDate(String lastAccessDate);
+        public abstract Builder lastAccessDate(Date lastAccessDate);
 
         public abstract Builder importDB(DatabaseAccountImport importDB);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseAccount.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseAccount.java
@@ -50,7 +50,7 @@ public abstract class DatabaseAccount {
     public abstract String databaseName();
 
     @NonNull
-    public abstract String databaseCreationDate();
+    public abstract Date databaseCreationDate();
 
     @Nullable
     public abstract Date lastAccessDate();
@@ -84,7 +84,7 @@ public abstract class DatabaseAccount {
 
         public abstract Builder encrypted(boolean encrypted);
 
-        public abstract Builder databaseCreationDate(String databaseCreationDate);
+        public abstract Builder databaseCreationDate(Date databaseCreationDate);
 
         public abstract Builder lastAccessDate(Date lastAccessDate);
 

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -71,6 +71,7 @@ internal class DatabaseConfigurationHelper(
             .databaseName(dbName)
             .encrypted(encrypt)
             .databaseCreationDate(dateProvider.dateStr)
+            .lastAccessDate(dateProvider.dateStr)
             .loginConfig(loginConfig)
             .importDB(importDb)
             .build()
@@ -89,6 +90,20 @@ internal class DatabaseConfigurationHelper(
         return (configuration?.toBuilder() ?: DatabasesConfiguration.builder())
             .accounts(otherAccounts + account)
             .build()
+    }
+
+    fun updateLastAccessDate(
+        configuration: DatabasesConfiguration?,
+        serverUrl: String,
+        username: String,
+    ): DatabasesConfiguration? {
+        val account = getAccount(configuration, serverUrl, username) ?: return configuration
+
+        val updatedAccount = account.toBuilder()
+            .lastAccessDate(dateProvider.dateStr)
+            .build()
+
+        return addOrUpdateAccount(configuration, updatedAccount)
     }
 
     companion object {

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.android.core.configuration.internal
 
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.storage.internal.ObjectKeyValueStore
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.koin.core.annotation.Singleton
+import java.util.Date
 
 @Singleton
 internal class DatabaseConfigurationHelper(
@@ -72,7 +74,7 @@ internal class DatabaseConfigurationHelper(
             .databaseName(dbName)
             .encrypted(encrypt)
             .databaseCreationDate(dateProvider.dateStr)
-            .lastAccessDate(dateProvider.dateStr)
+            .lastAccessDate(DateUtils.DATE_FORMAT.parse(dateProvider.dateStr))
             .loginConfig(loginConfig)
             .importDB(importDb)
             .build()
@@ -114,7 +116,7 @@ internal class DatabaseConfigurationHelper(
         val account = getAccount(configuration, serverUrl, username) ?: return configuration
 
         val updatedAccount = account.toBuilder()
-            .lastAccessDate(dateProvider.dateStr)
+            .lastAccessDate(Date())
             .build()
 
         return addOrUpdateAccount(configuration, updatedAccount)

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -73,7 +73,7 @@ internal class DatabaseConfigurationHelper(
             .serverUrl(serverUrl)
             .databaseName(dbName)
             .encrypted(encrypt)
-            .databaseCreationDate(dateProvider.dateStr)
+            .databaseCreationDate(DateUtils.DATE_FORMAT.parse(dateProvider.dateStr))
             .lastAccessDate(DateUtils.DATE_FORMAT.parse(dateProvider.dateStr))
             .loginConfig(loginConfig)
             .importDB(importDb)
@@ -105,7 +105,7 @@ internal class DatabaseConfigurationHelper(
         if (updatedConfiguration != null) {
             store.set(updatedConfiguration)
         }
-        return updatedConfiguration
+        return store.get()
     }
 
     private fun updateAccountLastAccessDate(

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.configuration.internal
 
+import org.hisp.dhis.android.core.arch.storage.internal.ObjectKeyValueStore
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.koin.core.annotation.Singleton
 
@@ -93,6 +94,19 @@ internal class DatabaseConfigurationHelper(
     }
 
     fun updateLastAccessDate(
+        store: ObjectKeyValueStore<DatabasesConfiguration>,
+        serverUrl: String,
+        username: String,
+    ): DatabasesConfiguration? {
+        val configuration = store.get()
+        val updatedConfiguration = updateLastAccessDate(configuration, serverUrl, username)
+        if (updatedConfiguration != null) {
+            store.set(updatedConfiguration)
+        }
+        return updatedConfiguration
+    }
+
+    private fun updateLastAccessDate(
         configuration: DatabasesConfiguration?,
         serverUrl: String,
         username: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -99,14 +99,14 @@ internal class DatabaseConfigurationHelper(
         username: String,
     ): DatabasesConfiguration? {
         val configuration = store.get()
-        val updatedConfiguration = updateLastAccessDate(configuration, serverUrl, username)
+        val updatedConfiguration = updateAccountLastAccessDate(configuration, serverUrl, username)
         if (updatedConfiguration != null) {
             store.set(updatedConfiguration)
         }
         return updatedConfiguration
     }
 
-    private fun updateLastAccessDate(
+    private fun updateAccountLastAccessDate(
         configuration: DatabasesConfiguration?,
         serverUrl: String,
         username: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -116,7 +116,7 @@ internal class DatabaseConfigurationHelper(
         val account = getAccount(configuration, serverUrl, username) ?: return configuration
 
         val updatedAccount = account.toBuilder()
-            .lastAccessDate(Date())
+            .lastAccessDate(DateUtils.DATE_FORMAT.parse(dateProvider.dateStr))
             .build()
 
         return addOrUpdateAccount(configuration, updatedAccount)

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -31,7 +31,6 @@ import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.storage.internal.ObjectKeyValueStore
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.koin.core.annotation.Singleton
-import java.util.Date
 
 @Singleton
 internal class DatabaseConfigurationHelper(

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigration.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigration.kt
@@ -33,6 +33,7 @@ import androidx.sqlite.db.SimpleSQLiteQuery
 import org.hisp.dhis.android.BuildConfig
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.InsecureStore
 import org.hisp.dhis.android.core.configuration.internal.migration.DatabaseConfigurationInsecureStoreOld
@@ -129,7 +130,8 @@ internal class DatabaseConfigurationMigration(
                 serverConf.users.map { userConf ->
                     DatabaseAccount.builder().username(userConf.username)
                         .serverUrl(ServerUrlParser.removeTrailingApi(serverConf.serverUrl))
-                        .databaseName(userConf.databaseName).databaseCreationDate(userConf.databaseCreationDate)
+                        .databaseName(userConf.databaseName)
+                        .databaseCreationDate(DateUtils.DATE_FORMAT.parse(userConf.databaseCreationDate))
                         .encrypted(userConf.encrypted).build()
                 }
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationTransformer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationTransformer.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.configuration.internal
 
-import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import java.util.Date
 
 internal object DatabaseConfigurationTransformer {
@@ -39,7 +38,7 @@ internal object DatabaseConfigurationTransformer {
                         .username(username)
                         .serverUrl(serverUrl)
                         .databaseName(databaseName)
-                        .databaseCreationDate(BaseIdentifiableObject.dateToDateStr(Date()))
+                        .databaseCreationDate(Date())
                         .encrypted(false)
                         .build(),
                 ),

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2Manager.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.configuration.internal
 
 import org.hisp.dhis.android.core.arch.api.internal.ServerURLWrapper
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
-import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.koin.core.annotation.Singleton
 import java.util.Date
@@ -59,7 +58,7 @@ internal class MultiUserDatabaseManagerForD2Manager(
             .encrypted(encrypt)
             .username(username)
             .serverUrl(serverUrl)
-            .databaseCreationDate(DateUtils.DATE_FORMAT.format(Date()))
+            .databaseCreationDate(Date())
             .build()
         ServerURLWrapper.setServerUrl(serverUrl)
         databaseManager.createOrOpenDatabase(config)

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -166,19 +166,14 @@ internal class AccountManagerImpl(
 
     private fun updateCurrentAccountLastAccessDate(): DatabasesConfiguration? {
         val credentials = credentialsSecureStore.get()
-        val configuration = databasesConfigurationStore.get()
-
-        if (credentials != null && configuration != null) {
-            val updatedConfiguration = databaseConfigurationHelper.updateLastAccessDate(
-                configuration,
+        return if (credentials != null) {
+            databaseConfigurationHelper.updateLastAccessDate(
+                databasesConfigurationStore,
                 credentials.serverUrl,
                 credentials.username,
-            )
-            if (updatedConfiguration != null) {
-                databasesConfigurationStore.set(updatedConfiguration)
-                return updatedConfiguration
-            }
+            ) ?: databasesConfigurationStore.get()
+        } else {
+            databasesConfigurationStore.get()
         }
-        return configuration
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogOutCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogOutCall.kt
@@ -69,14 +69,6 @@ class LogOutCall internal constructor(
     }
 
     private fun updateLastAccessDate(serverUrl: String, username: String) {
-        val configuration = databaseConfigurationStore.get()
-        val updatedConfiguration = databaseConfigurationHelper.updateLastAccessDate(
-            configuration,
-            serverUrl,
-            username,
-        )
-        if (updatedConfiguration != null) {
-            databaseConfigurationStore.set(updatedConfiguration)
-        }
+        databaseConfigurationHelper.updateLastAccessDate(databaseConfigurationStore, serverUrl, username)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/util/DateExtensions.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/util/DateExtensions.kt
@@ -46,3 +46,19 @@ internal fun String?.toJavaDate(): Date? {
 internal fun Date?.dateFormat(): String? {
     return this?.let { DateUtils.DATE_FORMAT.format(it) }
 }
+
+internal fun String.toJavaSimpleDateNonNull(): Date {
+    return DateUtils.SIMPLE_DATE_FORMAT.parse(this)
+}
+
+internal fun Date.simpleDateFormatNonNull(): String {
+    return DateUtils.SIMPLE_DATE_FORMAT.format(this)
+}
+
+internal fun String.toJavaDateNonNull(): Date {
+    return DateUtils.DATE_FORMAT.parse(this)
+}
+
+internal fun Date.dateFormatNonNull(): String {
+    return DateUtils.DATE_FORMAT.format(this)
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDB.kt
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.server.LoginConfigDB
 import org.hisp.dhis.android.persistence.server.toDB
@@ -70,7 +71,7 @@ internal fun DatabaseAccount.toDB(): DatabaseAccountDB {
         username = username(),
         serverUrl = serverUrl(),
         databaseName = databaseName(),
-        databaseCreationDate = databaseCreationDate().dateFormat()!!,
+        databaseCreationDate = databaseCreationDate().dateFormatNonNull(),
         lastAccessDate = lastAccessDate().dateFormat(),
         encrypted = encrypted(),
         syncState = syncState()?.name,

--- a/core/src/main/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDB.kt
@@ -29,8 +29,10 @@
 package org.hisp.dhis.android.persistence.configuration
 
 import kotlinx.serialization.Serializable
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
+import org.hisp.dhis.android.core.util.dateFormat
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.server.LoginConfigDB
 import org.hisp.dhis.android.persistence.server.toDB
@@ -41,6 +43,7 @@ internal data class DatabaseAccountDB(
     val serverUrl: String,
     val databaseName: String,
     val databaseCreationDate: String,
+    val lastAccessDate: String?,
     val encrypted: Boolean,
     val syncState: String?,
     val importDB: DatabaseAccountImportDB?,
@@ -48,16 +51,17 @@ internal data class DatabaseAccountDB(
 ) : EntityDB<DatabaseAccount> {
 
     override fun toDomain(): DatabaseAccount {
-        return DatabaseAccount.builder()
-            .username(username)
-            .serverUrl(serverUrl)
-            .databaseName(databaseName)
-            .databaseCreationDate(databaseCreationDate)
-            .encrypted(encrypted)
-            .syncState(syncState?.let { State.valueOf(it) })
-            .importDB(importDB?.toDomain())
-            .loginConfig(loginConfig?.toDomain())
-            .build()
+        return DatabaseAccount.builder().apply {
+            username(username)
+            serverUrl(serverUrl)
+            databaseName(databaseName)
+            databaseCreationDate(DateUtils.DATE_FORMAT.parse(databaseCreationDate))
+            lastAccessDate?.let { lastAccessDate(DateUtils.DATE_FORMAT.parse(it)) }
+            encrypted(encrypted)
+            syncState(syncState?.let { State.valueOf(it) })
+            importDB(importDB?.toDomain())
+            loginConfig(loginConfig?.toDomain())
+        }.build()
     }
 }
 
@@ -66,7 +70,8 @@ internal fun DatabaseAccount.toDB(): DatabaseAccountDB {
         username = username(),
         serverUrl = serverUrl(),
         databaseName = databaseName(),
-        databaseCreationDate = databaseCreationDate(),
+        databaseCreationDate = databaseCreationDate().dateFormat()!!,
+        lastAccessDate = lastAccessDate().dateFormat(),
         encrypted = encrypted(),
         syncState = syncState()?.name,
         importDB = importDB()?.toDB(),

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datavalue/DataValueDB.kt
@@ -4,7 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.persistence.category.CategoryOptionComboDB
 import org.hisp.dhis.android.persistence.common.DataObjectDB
 import org.hisp.dhis.android.persistence.common.DeletableObjectDB
@@ -81,8 +81,8 @@ internal data class DataValueDB(
             attributeOptionCombo(attributeOptionCombo)
             value(value)
             storedBy(storedBy)
-            created?.let { created(it.toJavaDate()!!) }
-            lastUpdated?.let { lastUpdated(it.toJavaDate()!!) }
+            created?.let { created(it.toJavaDateNonNull()) }
+            lastUpdated?.let { lastUpdated(it.toJavaDateNonNull()) }
             comment(comment)
             followUp(followUp)
             syncState?.let { syncState(it.toDomain()) }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
@@ -259,6 +259,21 @@ internal class RoomMultiUserDatabaseManager(
         } else {
             error("Expected a RoomDatabaseAdapter, but got ${databaseAdapter::class.java}")
         }
+
+        // Update last access date when opening database
+        updateLastAccessDate(account.serverUrl(), account.username())
+    }
+
+    private fun updateLastAccessDate(serverUrl: String, username: String) {
+        val configuration = databaseConfigurationSecureStore.get()
+        val updatedConfiguration = configurationHelper.updateLastAccessDate(
+            configuration,
+            serverUrl,
+            username,
+        )
+        if (updatedConfiguration != null) {
+            databaseConfigurationSecureStore.set(updatedConfiguration)
+        }
     }
 
     private fun removeExceedingAccounts() {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
@@ -265,15 +265,7 @@ internal class RoomMultiUserDatabaseManager(
     }
 
     private fun updateLastAccessDate(serverUrl: String, username: String) {
-        val configuration = databaseConfigurationSecureStore.get()
-        val updatedConfiguration = configurationHelper.updateLastAccessDate(
-            configuration,
-            serverUrl,
-            username,
-        )
-        if (updatedConfiguration != null) {
-            databaseConfigurationSecureStore.set(updatedConfiguration)
-        }
+        configurationHelper.updateLastAccessDate(databaseConfigurationSecureStore, serverUrl, username)
     }
 
     private fun removeExceedingAccounts() {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/domain/AggregatedDataSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/domain/AggregatedDataSyncDB.kt
@@ -5,7 +5,7 @@ import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.domain.aggregated.data.internal.AggregatedDataSync
 import org.hisp.dhis.android.core.period.PeriodType
-import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.dataset.DataSetDB
@@ -54,6 +54,6 @@ internal fun AggregatedDataSync.toDB(): AggregatedDataSyncDB {
         futurePeriods = futurePeriods(),
         dataElementsHash = dataElementsHash(),
         organisationUnitsHash = organisationUnitsHash(),
-        lastUpdated = lastUpdated().dateFormat()!!,
+        lastUpdated = lastUpdated().dateFormatNonNull(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDB.kt
@@ -6,7 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.event.internal.EventSync
-import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
@@ -58,6 +58,6 @@ internal fun EventSync.toDB(): EventSyncDB {
         organisationUnitIdsHash = organisationUnitIdsHash(),
         downloadLimit = downloadLimit(),
         workingListsHash = workingListsHash(),
-        lastUpdated = lastUpdated().dateFormat()!!,
+        lastUpdated = lastUpdated().dateFormatNonNull(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/fileresource/FileResourceDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/fileresource/FileResourceDB.kt
@@ -5,7 +5,7 @@ import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.FileResourceDomain
 import org.hisp.dhis.android.core.util.dateFormat
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.persistence.common.DataObjectDB
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.SyncStateDB
@@ -29,8 +29,8 @@ internal data class FileResourceDB(
         return FileResource.builder().apply {
             uid(uid)
             name?.let { name(it) }
-            created?.let { created(it.toJavaDate()!!) }
-            lastUpdated?.let { lastUpdated(it.toJavaDate()!!) }
+            created?.let { created(it.toJavaDateNonNull()) }
+            lastUpdated?.let { lastUpdated(it.toJavaDateNonNull()) }
             contentType?.let { contentType(it) }
             contentLength?.let { contentLength(it) }
             path?.let { path(it) }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramTempOwnerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramTempOwnerDB.kt
@@ -3,7 +3,7 @@ package org.hisp.dhis.android.persistence.trackedentity
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramTempOwner
-import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
@@ -44,8 +44,8 @@ internal fun ProgramTempOwner.toDB(): ProgramTempOwnerDB {
     return ProgramTempOwnerDB(
         program = program(),
         trackedEntityInstance = trackedEntityInstance(),
-        created = created().dateFormat()!!,
-        validUntil = validUntil().dateFormat()!!,
+        created = created().dateFormatNonNull(),
+        validUntil = validUntil().dateFormatNonNull(),
         reason = reason(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeReservedValueStoreImpl.kt
@@ -31,7 +31,7 @@ package org.hisp.dhis.android.persistence.trackedentity
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeReservedValue
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeReservedValueStore
-import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.common.stores.ObjectWithoutUidStoreImpl
@@ -51,7 +51,7 @@ internal class TrackedEntityAttributeReservedValueStoreImpl(
 
     override suspend fun deleteExpired(serverDate: Date) {
         val dao = databaseAdapter.getCurrentDatabase().trackedEntityAttributeReservedValueDao()
-        val serverDateStr = serverDate.dateFormat()!!
+        val serverDateStr = serverDate.dateFormatNonNull()
         dao.deleteExpired(serverDateStr)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDB.kt
@@ -6,7 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceSync
-import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
@@ -57,6 +57,6 @@ internal fun TrackedEntityInstanceSync.toDB(): TrackedEntityInstanceSyncDB {
         organisationUnitIdsHash = organisationUnitIdsHash(),
         downloadLimit = downloadLimit(),
         workingListsHash = workingListsHash(),
-        lastUpdated = lastUpdated().dateFormat()!!,
+        lastUpdated = lastUpdated().dateFormatNonNull(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDB.kt
@@ -3,7 +3,7 @@ package org.hisp.dhis.android.persistence.tracker
 import androidx.room.Entity
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterObjectType
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerJobObject
-import org.hisp.dhis.android.core.util.dateFormat
+import org.hisp.dhis.android.core.util.dateFormatNonNull
 import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.StringListDB
@@ -36,7 +36,7 @@ internal fun TrackerJobObject.toDB(): TrackerJobObjectDB {
         trackerType = trackerType().name,
         objectUid = objectUid(),
         jobUid = jobUid(),
-        lastUpdated = lastUpdated().dateFormat()!!,
+        lastUpdated = lastUpdated().dateFormatNonNull(),
         fileResources = fileResources().toDB(),
     )
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
@@ -47,6 +47,7 @@ class DatabasesConfigurationHelperShould {
         .databaseName(dbName11)
         .encrypted(false)
         .databaseCreationDate(DATE)
+        .lastAccessDate(DATE)
         .build()
 
     private val userConfig12 = DatabaseAccount.builder()
@@ -55,6 +56,7 @@ class DatabasesConfigurationHelperShould {
         .databaseName(dbName12)
         .encrypted(false)
         .databaseCreationDate(DATE)
+        .lastAccessDate(DATE)
         .build()
 
     private val userConfig22 = DatabaseAccount.builder()
@@ -63,6 +65,7 @@ class DatabasesConfigurationHelperShould {
         .databaseName(dbName22)
         .encrypted(false)
         .databaseCreationDate(DATE)
+        .lastAccessDate(DATE)
         .build()
 
     private val singleServerSingleUserConfig = DatabasesConfiguration.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.configuration.internal
 
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.configuration.internal.DatabasesConfigurationUtil.buildUserConfiguration
 import org.junit.Test
 
@@ -47,7 +48,7 @@ class DatabasesConfigurationHelperShould {
         .databaseName(dbName11)
         .encrypted(false)
         .databaseCreationDate(DATE)
-        .lastAccessDate(DATE)
+        .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
     private val userConfig12 = DatabaseAccount.builder()
@@ -56,7 +57,7 @@ class DatabasesConfigurationHelperShould {
         .databaseName(dbName12)
         .encrypted(false)
         .databaseCreationDate(DATE)
-        .lastAccessDate(DATE)
+        .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
     private val userConfig22 = DatabaseAccount.builder()
@@ -65,7 +66,7 @@ class DatabasesConfigurationHelperShould {
         .databaseName(dbName22)
         .encrypted(false)
         .databaseCreationDate(DATE)
-        .lastAccessDate(DATE)
+        .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
     private val singleServerSingleUserConfig = DatabasesConfiguration.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
@@ -47,7 +47,7 @@ class DatabasesConfigurationHelperShould {
         .serverUrl(url1)
         .databaseName(dbName11)
         .encrypted(false)
-        .databaseCreationDate(DATE)
+        .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
@@ -56,7 +56,7 @@ class DatabasesConfigurationHelperShould {
         .serverUrl(url1)
         .databaseName(dbName12)
         .encrypted(false)
-        .databaseCreationDate(DATE)
+        .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
@@ -65,7 +65,7 @@ class DatabasesConfigurationHelperShould {
         .serverUrl(url2)
         .databaseName(dbName22)
         .encrypted(false)
-        .databaseCreationDate(DATE)
+        .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
@@ -186,7 +186,7 @@ class DatabasesConfigurationHelperShould {
             .serverUrl("https://dhis2.org")
             .databaseName("test.db")
             .encrypted(true)
-            .databaseCreationDate("2024-01-01")
+            .databaseCreationDate(SHORT_DATE)
             .build()
 
         val configuration = DatabasesConfiguration.builder()
@@ -210,7 +210,7 @@ class DatabasesConfigurationHelperShould {
             .serverUrl("https://dhis2.org")
             .databaseName("test.db")
             .encrypted(true)
-            .databaseCreationDate("2024-01-01")
+            .databaseCreationDate(SHORT_DATE)
             .build()
 
         val configuration = DatabasesConfiguration.builder()
@@ -235,7 +235,7 @@ class DatabasesConfigurationHelperShould {
             .serverUrl("https://dhis2.org")
             .databaseName("test.db")
             .encrypted(true)
-            .databaseCreationDate("2024-01-01")
+            .databaseCreationDate(SHORT_DATE)
             .build()
 
         val configuration = DatabasesConfiguration.builder()
@@ -260,7 +260,7 @@ class DatabasesConfigurationHelperShould {
             .serverUrl("https://DHIS2.org")
             .databaseName("test.db")
             .encrypted(true)
-            .databaseCreationDate("2024-01-01")
+            .databaseCreationDate(SHORT_DATE)
             .build()
 
         val configuration = DatabasesConfiguration.builder()
@@ -318,7 +318,7 @@ class DatabasesConfigurationHelperShould {
             .serverUrl(serverUrl)
             .databaseName(nameGenerator.getDatabaseName(serverUrl, username1, false))
             .encrypted(false)
-            .databaseCreationDate(DATE)
+            .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
             .build()
 
         return DatabasesConfiguration.builder()
@@ -328,6 +328,7 @@ class DatabasesConfigurationHelperShould {
 
     companion object {
         private const val DATE = "2014-06-06T20:44:21.375"
+        private val SHORT_DATE = DateUtils.SIMPLE_DATE_FORMAT.parse("2024-01-01")
         private const val URL_WITH_SLASHES = "https://play.im.dhis2.org/stable-2-42-2"
         private const val URL_WITH_BACKSLASHES = "https://play.im.dhis2.org\\stable-2-42-2"
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.configuration.internal
 
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.persistence.configuration.DatabasesConfigurationDB
 import org.hisp.dhis.android.persistence.configuration.toDB
@@ -49,7 +50,7 @@ class DatabasesConfigurationShould : CoreObjectShould("configuration/databases_c
         assertThat(user1.serverUrl()).isEqualTo("server1")
         assertThat(user1.databaseName()).isEqualTo("dbname1.db")
         assertThat(user1.encrypted()).isTrue()
-        assertThat(user1.databaseCreationDate()).isEqualTo("2014-06-06T20:44:21.375")
+        assertThat(user1.databaseCreationDate()).isEqualTo(DateUtils.DATE_FORMAT.parse("2014-06-06T20:44:21.375"))
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationUtil.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationUtil.kt
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.android.core.configuration.internal
 
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
+
 object DatabasesConfigurationUtil {
     fun buildUserConfiguration(
         username: String,
@@ -39,7 +41,8 @@ object DatabasesConfigurationUtil {
             .serverUrl(serverUrl)
             .databaseName("database$username")
             .encrypted(false)
-            .databaseCreationDate(creationDate)
+            .databaseCreationDate(DateUtils.DATE_FORMAT.parse(creationDate))
+            .lastAccessDate(DateUtils.DATE_FORMAT.parse(creationDate))
             .build()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2ManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2ManagerUnitShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.configuration.internal
 
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.common.BaseCallShould
 import org.junit.Before
@@ -53,7 +54,8 @@ class MultiUserDatabaseManagerForD2ManagerUnitShould : BaseCallShould() {
         .username(username)
         .serverUrl(serverUrl)
         .encrypted(false)
-        .databaseCreationDate(DATE)
+        .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
+        .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
         .build()
 
     private val databasesConfiguration = DatabasesConfiguration.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.configuration.internal
 import android.content.Context
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.db.access.internal.BaseDatabaseExport
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.common.BaseCallShould
 import org.hisp.dhis.android.core.configuration.internal.DatabasesConfigurationUtil.buildUserConfiguration
 import org.hisp.dhis.android.persistence.db.access.RoomDatabaseManager
@@ -175,6 +176,6 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
     }
 
     companion object {
-        private const val DATE = "2014-06-06T20:44:21.375"
+        private val DATE = DateUtils.DATE_FORMAT.parse("2014-06-06T20:44:21.375")
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogOutCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogOutCallShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.UserIdInMemoryStore
+import org.hisp.dhis.android.core.configuration.internal.DatabaseConfigurationHelper
+import org.hisp.dhis.android.core.configuration.internal.DatabaseConfigurationInsecureStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.systeminfo.internal.ServerTimezoneManager
@@ -51,6 +53,8 @@ class LogOutCallShould {
     private val credentials: Credentials = mock()
     private val databaseManager: DatabaseManager = mock()
     private val serverTimezoneManager: ServerTimezoneManager = mock()
+    private val databaseConfigurationHelper: DatabaseConfigurationHelper = mock()
+    private val databaseConfigurationStore: DatabaseConfigurationInsecureStore = mock()
 
     private lateinit var logOutCall: LogOutCall
 
@@ -58,7 +62,14 @@ class LogOutCallShould {
     fun setUp() {
         whenever(credentials.username).thenReturn("user")
         whenever(credentials.password).thenReturn("password")
-        logOutCall = LogOutCall(databaseManager, credentialsSecureStore, userIdStore, serverTimezoneManager)
+        logOutCall = LogOutCall(
+            databaseManager,
+            credentialsSecureStore,
+            userIdStore,
+            serverTimezoneManager,
+            databaseConfigurationHelper,
+            databaseConfigurationStore,
+        )
     }
 
     @Test


### PR DESCRIPTION
This PR adds a new last access timestamp to user accounts. This is stored on the device so no login is required.
The parameter is updated when logging in, logging out and also for the current account when requesting all or just the current one.
Related task: [ANDROSDK-2161](https://dhis2.atlassian.net/browse/ANDROSDK-2161)

[ANDROSDK-2161]: https://dhis2.atlassian.net/browse/ANDROSDK-2161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ