### PR TITLE
fix: [ANDROSDK-2236] Use DataInputPeriods to determine editableStatus in DataSetInstanceService

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4659,6 +4659,7 @@ public final class org/hisp/dhis/android/core/dataset/DataSetNonEditableReason :
 	public static final field ORGUNIT_IS_NOT_IN_CAPTURE_SCOPE Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static final field PERIOD_IS_NOT_IN_ATTRIBUTE_OPTION_RANGE Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static final field PERIOD_IS_NOT_IN_ORGUNIT_RANGE Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
+	public static final field PERIOD_NOT_IN_DATA_INPUT_PERIODS Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static fun values ()[Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4647,6 +4647,7 @@ public final class org/hisp/dhis/android/core/dataset/DataSetNonEditableReason :
 	public static final field ORGUNIT_IS_NOT_IN_CAPTURE_SCOPE Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static final field PERIOD_IS_NOT_IN_ATTRIBUTE_OPTION_RANGE Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static final field PERIOD_IS_NOT_IN_ORGUNIT_RANGE Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
+	public static final field PERIOD_NOT_IN_DATA_INPUT_PERIODS Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;
 	public static fun values ()[Lorg/hisp/dhis/android/core/dataset/DataSetNonEditableReason;

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceServiceMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceServiceMockIntegrationShould.kt
@@ -103,4 +103,40 @@ class DataSetInstanceServiceMockIntegrationShould :
         assertThat(dataElementOperands[0].dataElement()?.uid()).isEqualTo("g9eOBujte1U")
         assertThat(dataElementOperands[0].categoryOptionCombo()?.uid()).isEqualTo("Gmbgme7z9BF")
     }
+
+    @Test
+    fun do_not_allow_edit_period_not_in_data_input_periods() {
+        val status = d2.dataSetModule().dataSetInstanceService()
+            .blockingGetEditableStatus(
+                "lyLU2wR22tC",
+                "201908",
+                "DiszpKrYNg8",
+                "bRowv6yZOF2",
+            )
+
+        assertThat(status).isInstanceOf(
+            DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_NOT_IN_DATA_INPUT_PERIODS)::class.java,
+        )
+    }
+
+    @Test
+    fun do_not_fail_with_data_input_periods_reason_when_dataset_has_empty_list() {
+        val currentPeriod = d2.periodModule().periodHelper().blockingGetPeriodForPeriodTypeAndDate(
+            PeriodType.Monthly,
+            Date(),
+            0,
+        )
+        
+        val status = d2.dataSetModule().dataSetInstanceService()
+            .blockingGetEditableStatus(
+                "BfMAe6Itzgt",
+                currentPeriod.periodId()!!,
+                "DiszpKrYNg8",
+                "bRowv6yZOF2",
+            )
+
+        if (status is DataSetEditableStatus.NonEditable) {
+            assertThat(status.reason).isNotEqualTo(DataSetNonEditableReason.PERIOD_NOT_IN_DATA_INPUT_PERIODS)
+        }
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceServiceMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetInstanceServiceMockIntegrationShould.kt
@@ -126,7 +126,7 @@ class DataSetInstanceServiceMockIntegrationShould :
             Date(),
             0,
         )
-        
+
         val status = d2.dataSetModule().dataSetInstanceService()
             .blockingGetEditableStatus(
                 "BfMAe6Itzgt",

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetNonEditableReason.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetNonEditableReason.kt
@@ -37,4 +37,5 @@ enum class DataSetNonEditableReason {
     PERIOD_IS_NOT_IN_ATTRIBUTE_OPTION_RANGE,
     CLOSED,
     EXPIRED,
+    PERIOD_NOT_IN_DATA_INPUT_PERIODS,
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -321,8 +321,7 @@ internal class DataSetInstanceServiceImpl(
                     val openingDate = dataInputPeriod.openingDate()
                     val closingDate = dataInputPeriod.closingDate()
 
-                    openingDate == null && closingDate == null ||
-                        (openingDate?.let { !currentDate.before(it) } ?: true) &&
+                    (openingDate?.let { !currentDate.before(it) } ?: true) &&
                         (closingDate?.let { !currentDate.after(it) } ?: true)
                 }
             } ?: false

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -323,8 +323,7 @@ internal class DataSetInstanceServiceImpl(
                     val openingDate = dataInputPeriod.openingDate()
                     val closingDate = dataInputPeriod.closingDate()
 
-                    openingDate == null && closingDate == null ||
-                        (openingDate?.let { !currentDate.before(it) } ?: true) &&
+                    (openingDate?.let { !currentDate.before(it) } ?: true) &&
                         (closingDate?.let { !currentDate.after(it) } ?: true)
                 }
             } ?: false

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -88,7 +88,7 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): DataSetEditableStatus {
-        val dataSet = dataSetCollectionRepository.uid(dataSetUid).blockingGet()
+        val dataSet = dataSetCollectionRepository.withDataInputPeriods().uid(dataSetUid).blockingGet()
         val period = periodHelper.getPeriodForPeriodId(periodId).blockingGet()
         return when {
             !blockingHasDataWriteAccess(dataSetUid) ->
@@ -114,6 +114,9 @@ internal class DataSetInstanceServiceImpl(
 
             dataSet?.let { blockingIsClosed(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.CLOSED)
+
+            dataSet?.let { !blockingIsInDataInputPeriods(dataSet, period) } ?: false ->
+                DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_NOT_IN_DATA_INPUT_PERIODS)
 
             else -> DataSetEditableStatus.Editable
         }
@@ -306,6 +309,25 @@ internal class DataSetInstanceServiceImpl(
         return listOfNotNull(period.startDate(), period.endDate()).all { date ->
             organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, date)
         }
+    }
+
+    internal fun blockingIsInDataInputPeriods(dataSet: DataSet, period: Period): Boolean {
+        val dataInputPeriods = dataSet.dataInputPeriods()
+
+        return dataInputPeriods.isNullOrEmpty() || dataInputPeriods
+            .filter { it.period().uid() == period.periodId() }
+            .takeIf { it.isNotEmpty() }
+            ?.let { matchingPeriods ->
+                val currentDate = Date()
+                matchingPeriods.any { dataInputPeriod ->
+                    val openingDate = dataInputPeriod.openingDate()
+                    val closingDate = dataInputPeriod.closingDate()
+
+                    openingDate == null && closingDate == null ||
+                        (openingDate?.let { !currentDate.before(it) } ?: true) &&
+                        (closingDate?.let { !currentDate.after(it) } ?: true)
+                }
+            } ?: false
     }
 
     private fun getCategoryOptions(attributeOptionComboUid: String): List<CategoryOption> {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -88,7 +88,7 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): DataSetEditableStatus {
-        val dataSet = dataSetCollectionRepository.uid(dataSetUid).blockingGet()
+        val dataSet = dataSetCollectionRepository.withDataInputPeriods().uid(dataSetUid).blockingGet()
         val period = periodHelper.getPeriodForPeriodId(periodId).blockingGet()
         return when {
             !blockingHasDataWriteAccess(dataSetUid) ->
@@ -114,6 +114,9 @@ internal class DataSetInstanceServiceImpl(
 
             dataSet?.let { blockingIsClosed(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.CLOSED)
+
+            dataSet?.let { !blockingIsInDataInputPeriods(dataSet, period) } ?: false ->
+                DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_NOT_IN_DATA_INPUT_PERIODS)
 
             else -> DataSetEditableStatus.Editable
         }
@@ -304,6 +307,25 @@ internal class DataSetInstanceServiceImpl(
         return listOfNotNull(period.startDate(), period.endDate()).all { date ->
             organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, date)
         }
+    }
+
+    internal fun blockingIsInDataInputPeriods(dataSet: DataSet, period: Period): Boolean {
+        val dataInputPeriods = dataSet.dataInputPeriods()
+
+        return dataInputPeriods.isNullOrEmpty() || dataInputPeriods
+            .filter { it.period().uid() == period.periodId() }
+            .takeIf { it.isNotEmpty() }
+            ?.let { matchingPeriods ->
+                val currentDate = Date()
+                matchingPeriods.any { dataInputPeriod ->
+                    val openingDate = dataInputPeriod.openingDate()
+                    val closingDate = dataInputPeriod.closingDate()
+
+                    openingDate == null && closingDate == null ||
+                        (openingDate?.let { !currentDate.before(it) } ?: true) &&
+                        (closingDate?.let { !currentDate.after(it) } ?: true)
+                }
+            } ?: false
     }
 
     private fun getCategoryOptions(attributeOptionComboUid: String): List<CategoryOption> {


### PR DESCRIPTION
This PR adds an editable status check for the data input period. Also adds a new DataSetNonEditableReason enum item for this, to which the app will need to adapt.

Related task [ANDROSDK-2236](https://dhis2.atlassian.net/browse/ANDROSDK-2236)

[ANDROSDK-2236]: https://dhis2.atlassian.net/browse/ANDROSDK-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ