### PR TITLE
fix: [ANDROSDK-2187] Apply let's encrypt certificates to API 24

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/internal/OkHttpClientFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/internal/OkHttpClientFactory.kt
@@ -50,7 +50,7 @@ internal object OkHttpClientFactory {
             client.addInterceptor(interceptor)
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N) {
             val (socketFactory, trustManager) = TrustFactory.getTrustFactoryManager(d2Configuration.context())
             client.sslSocketFactory(socketFactory, trustManager)
         }


### PR DESCRIPTION
According to Let's encrypt documentation, Android 24 and below don't have the ISRG Root certificate installed. This has been verified in an API 24 emulator. Because of that, the validation of Let's encrypt certificate might fail, so it is required to manually install it.

I couldn't make API 24 fail when the certificate was not manually installed, maybe it depends on the device. Anyway, this PR manually installs the certificate for API 24, which makes no harm in case it is already installed.