### PR TITLE
fix: [ANDROSDK-2235] Change LegacyDataValueApi opt-in level from WARNING to ERROR

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/LegacyDataValueApi.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/LegacyDataValueApi.kt
@@ -40,7 +40,7 @@ package org.hisp.dhis.android.core.datavalue
 @RequiresOptIn(
     message = "This API does not require explicit dataSet. For DHIS2 v43+, use the version " +
         "with dataSet parameter. Add @OptIn(LegacyDataValueApi::class) if you understand the implications.",
-    level = RequiresOptIn.Level.WARNING,
+    level = RequiresOptIn.Level.ERROR,
 )
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)


### PR DESCRIPTION
This PR updates the LegacyDataValueApi opt-in annotation level from RequiresOptIn.Level.WARNING to RequiresOptIn.Level.ERROR