### PR TITLE
fix: [ANDROSDK-2237] use system settings start month in relative financial year

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3462,6 +3462,7 @@ public final class org/hisp/dhis/android/core/common/RelativeOrganisationUnit : 
 
 public final class org/hisp/dhis/android/core/common/RelativePeriod : java/lang/Enum {
 	public static final field BIMONTHS_THIS_YEAR Lorg/hisp/dhis/android/core/common/RelativePeriod;
+	public static final field Companion Lorg/hisp/dhis/android/core/common/RelativePeriod$Companion;
 	public static final field LAST_10_FINANCIAL_YEARS Lorg/hisp/dhis/android/core/common/RelativePeriod;
 	public static final field LAST_10_YEARS Lorg/hisp/dhis/android/core/common/RelativePeriod;
 	public static final field LAST_12_MONTHS Lorg/hisp/dhis/android/core/common/RelativePeriod;
@@ -3509,6 +3510,9 @@ public final class org/hisp/dhis/android/core/common/RelativePeriod : java/lang/
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/RelativePeriod;
 	public static fun values ()[Lorg/hisp/dhis/android/core/common/RelativePeriod;
+}
+
+public final class org/hisp/dhis/android/core/common/RelativePeriod$Companion {
 }
 
 public final class org/hisp/dhis/android/core/common/SortingDirection : java/lang/Enum {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9928,6 +9928,7 @@ public abstract class org/hisp/dhis/android/core/settings/SystemSetting$Builder 
 }
 
 public final class org/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey : java/lang/Enum {
+	public static final field ANALYTICS_FINANCIAL_YEAR_START Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
 	public static final field BING_BASE_MAP Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
 	public static final field DEFAULT_BASE_MAP Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
 	public static final field FLAG Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
@@ -9937,6 +9938,7 @@ public final class org/hisp/dhis/android/core/settings/SystemSetting$SystemSetti
 }
 
 public final class org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl {
+	public final fun analyticsFinancialYearStart ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
 	public final fun byKey ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byValue ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun defaultBaseMap ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -137,6 +137,12 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 kotlin {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
@@ -59,7 +59,7 @@ class MetadataCallRealIntegrationShould : BaseRealIntegrationTest() {
 
 //    @Test
     fun response_successful_on_sync_meta_data_once() {
-        d2.userModule().logIn(username, password, "https://play.im.dhis2.org/stable-2-42-4").blockingGet()
+        d2.userModule().logIn(username, password, url).blockingGet()
 
         d2.metadataModule().blockingDownload()
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/MetadataCallRealIntegrationShould.kt
@@ -59,7 +59,7 @@ class MetadataCallRealIntegrationShould : BaseRealIntegrationTest() {
 
 //    @Test
     fun response_successful_on_sync_meta_data_once() {
-        d2.userModule().logIn(username, password, url).blockingGet()
+        d2.userModule().logIn(username, password, "https://play.im.dhis2.org/stable-2-42-4").blockingGet()
 
         d2.metadataModule().blockingDownload()
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
@@ -78,6 +78,7 @@ import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStor
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
 import org.hisp.dhis.android.core.period.clock.internal.createFixed
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.internal.ProgramIndicatorStore
@@ -120,8 +121,12 @@ class EventLineListIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() 
     private val legendSetStore: LegendSetStore = koin.get()
     private val legendStore: LegendStore = koin.get()
     private val clockProvider = ClockProviderFactory.createFixed()
+    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
     private val dateFilterPeriodHelper =
-        DateFilterPeriodHelper(clockProvider, ParentPeriodGeneratorImpl.create(clockProvider))
+        DateFilterPeriodHelper(
+            clockProvider,
+            ParentPeriodGeneratorImpl.create(clockProvider, financialYearPeriodHelper),
+        )
     private val organisationUnitHelper = AnalyticsOrganisationUnitHelper(
         userOrganisationUnitStore,
         organisationUnitStore,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2004-2024, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.period.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.common.RelativePeriod
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
+import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
+import org.junit.Test
+
+/**
+ * Integration test to verify that financial year periods are generated correctly
+ * based on the analyticsFinancialYearStart system setting.
+ */
+class FinancialYearPeriodIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+
+    private val systemSettingRepository: SystemSettingCollectionRepository = d2.settingModule().systemSetting()
+    private val financialYearPeriodHelper: FinancialYearPeriodHelper = koin.get()
+    private val parentPeriodGenerator: ParentPeriodGenerator = koin.get()
+
+    @Test
+    fun use_financial_year_from_system_setting() = runTest {
+        // Verify that the system setting is loaded (from system_settings.json in test resources)
+        val setting = systemSettingRepository.analyticsFinancialYearStart().blockingGet()
+        assertThat(setting).isNotNull()
+        assertThat(setting?.value()).isEqualTo("FINANCIAL_YEAR_JULY")
+
+        // Verify that the helper returns the correct PeriodType
+        val periodType = financialYearPeriodHelper.getFinancialYearPeriodType()
+        assertThat(periodType).isEqualTo(PeriodType.FinancialJuly)
+    }
+
+    @Test
+    fun generate_this_financial_year_with_july_start() = runTest {
+        // The mock data has FINANCIAL_YEAR_JULY configured
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(1)
+
+        // Verify the period ID contains "July" suffix
+        val periodId = periods[0].periodId()
+        assertThat(periodId).contains("July")
+
+        // Verify the period type is FinancialJuly
+        assertThat(periods[0].periodType()).isEqualTo(PeriodType.FinancialJuly)
+    }
+
+    @Test
+    fun generate_last_financial_year_with_july_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_FINANCIAL_YEAR)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(1)
+
+        // Verify the period ID contains "July" suffix
+        val periodId = periods[0].periodId()
+        assertThat(periodId).contains("July")
+
+        // Verify the period type is FinancialJuly
+        assertThat(periods[0].periodType()).isEqualTo(PeriodType.FinancialJuly)
+    }
+
+    @Test
+    fun generate_last_5_financial_years_with_july_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_5_FINANCIAL_YEARS)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(5)
+
+        // Verify all periods have "July" suffix
+        periods.forEach { period ->
+            assertThat(period.periodId()).contains("July")
+            assertThat(period.periodType()).isEqualTo(PeriodType.FinancialJuly)
+        }
+    }
+
+    @Test
+    fun generate_last_10_financial_years_with_july_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_10_FINANCIAL_YEARS)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(10)
+
+        // Verify all periods have "July" suffix
+        periods.forEach { period ->
+            assertThat(period.periodId()).contains("July")
+            assertThat(period.periodType()).isEqualTo(PeriodType.FinancialJuly)
+        }
+    }
+
+    @Test
+    fun verify_financial_july_period_starts_in_july() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
+
+        assertThat(periods).isNotEmpty()
+        val period = periods[0]
+
+        // For FinancialJuly, the period should start in July (month 7)
+        val startDate = period.startDate()
+        assertThat(startDate).isNotNull()
+
+        val calendar = java.util.Calendar.getInstance()
+        calendar.time = startDate
+        val startMonth = calendar.get(java.util.Calendar.MONTH) + 1 // Calendar.MONTH is 0-based
+
+        assertThat(startMonth).isEqualTo(7) // July
+    }
+}

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
@@ -65,7 +65,11 @@ class PeriodStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrationSho
 
     @Test
     fun select_correct_period_passing_period_type_and_a_date() = runTest {
-        PeriodHandler(periodStore, create(ClockProviderFactory.createFixed())).generateAndPersist()
+        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        PeriodHandler(
+            periodStore,
+            create(ClockProviderFactory.createFixed(), financialYearPeriodHelper),
+        ).generateAndPersist()
         val period = periodStore.selectPeriodByTypeAndDate(
             PeriodType.SixMonthly,
             DateUtils.DATE_FORMAT.parse("2019-03-02T12:24:25.319"),

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/SettingsModuleMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/SettingsModuleMockIntegrationShould.kt
@@ -36,7 +36,7 @@ class SettingsModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
     @Test
     fun allow_access_to_system_setting() {
         val systemSettings: List<SystemSetting?> = d2.settingModule().systemSetting().blockingGet()
-        Truth.assertThat(systemSettings.size).isEqualTo(3)
+        Truth.assertThat(systemSettings.size).isEqualTo(4)
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
@@ -42,6 +42,7 @@ import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
@@ -52,7 +53,8 @@ class TrackedEntityInstanceLocalQueryHelperMockIntegrationShould : BaseMockInteg
     private val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
 
     private val clockProvider = ClockProviderFactory.clockProvider
-    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider))
+    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
     private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsPeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsPeriodHelper.kt
@@ -28,16 +28,21 @@
 
 package org.hisp.dhis.android.core.analytics.aggregated.internal.evaluator
 
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
 
 object AnalyticsPeriodHelper {
-
-    private val periodGenerator = ParentPeriodGeneratorImpl.create(ClockProviderFactory.clockProvider)
+    private val financialYearPeriodHelper: FinancialYearPeriodHelper = koin.get()
+    private val periodGenerator = ParentPeriodGeneratorImpl.create(
+        ClockProviderFactory.clockProvider,
+        financialYearPeriodHelper,
+    )
 
     fun shiftPeriod(period: Period, offset: Int): Period {
         return periodGenerator.generatePeriod(period.periodType()!!, period.startDate()!!, offset)

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/BaseDateEvaluator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/BaseDateEvaluator.kt
@@ -30,9 +30,11 @@ package org.hisp.dhis.android.core.analytics.trackerlinelist.internal.evaluator
 
 import org.hisp.dhis.android.core.analytics.trackerlinelist.DateFilter
 import org.hisp.dhis.android.core.analytics.trackerlinelist.DateItem
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
 import org.hisp.dhis.android.core.period.internal.PeriodParser
 import java.util.Date
@@ -41,7 +43,11 @@ internal abstract class BaseDateEvaluator(
     private val item: DateItem,
 ) : TrackerLineListEvaluator() {
 
-    private val parentPeriodGenerator = ParentPeriodGeneratorImpl.create(ClockProviderFactory.clockProvider)
+    private val financialYearPeriodHelper: FinancialYearPeriodHelper = koin.get()
+    private val parentPeriodGenerator = ParentPeriodGeneratorImpl.create(
+        ClockProviderFactory.clockProvider,
+        financialYearPeriodHelper,
+    )
     private val periodParser = PeriodParser()
 
     fun getDateWhereClause(): String {

--- a/core/src/main/java/org/hisp/dhis/android/core/common/RelativePeriod.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/RelativePeriod.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.common
 
 import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 
 @Suppress("MagicNumber")
 enum class RelativePeriod constructor(
@@ -82,4 +83,26 @@ enum class RelativePeriod constructor(
     LAST_4_BIWEEKS(PeriodType.BiWeekly, -4, 0),
     LAST_12_WEEKS(PeriodType.Weekly, -12, 0),
     LAST_52_WEEKS(PeriodType.Weekly, -52, 0),
+    ;
+
+    internal fun getPeriodType(financialYearPeriodHelper: FinancialYearPeriodHelper): PeriodType {
+        return if (isFinancialYearRelativePeriod()) {
+            financialYearPeriodHelper.getFinancialYearPeriodType()
+        } else {
+            periodType
+        }
+    }
+
+    internal fun isFinancialYearRelativePeriod(): Boolean {
+        return this in FINANCIAL_YEAR_PERIODS
+    }
+
+    companion object {
+        internal val FINANCIAL_YEAR_PERIODS = setOf(
+            THIS_FINANCIAL_YEAR,
+            LAST_FINANCIAL_YEAR,
+            LAST_5_FINANCIAL_YEARS,
+            LAST_10_FINANCIAL_YEARS,
+        )
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
@@ -27,12 +27,14 @@
  */
 package org.hisp.dhis.android.core.period.generator.internal
 
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 import kotlin.time.Clock
 
-internal class YearlyPeriodGenerators(clock: Clock) {
+internal class YearlyPeriodGenerators(clock: Clock, financialYearPeriodHelper: FinancialYearPeriodHelper) {
     val yearly = YearlyPeriodGeneratorFactory.yearly(clock)
     val financialApril = YearlyPeriodGeneratorFactory.financialApril(clock)
     val financialJuly = YearlyPeriodGeneratorFactory.financialJuly(clock)
     val financialOct = YearlyPeriodGeneratorFactory.financialOct(clock)
     val financialNov = YearlyPeriodGeneratorFactory.financialNov(clock)
+    val financialYearPeriodHelper: FinancialYearPeriodHelper = financialYearPeriodHelper
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelper.kt
@@ -31,7 +31,7 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.koin.core.annotation.Singleton
 
-internal interface FinancialYearPeriodHelper {
+internal fun interface FinancialYearPeriodHelper {
     fun getFinancialYearPeriodType(): PeriodType
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelper.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,32 +25,32 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.android.core.period.internal
 
-package org.hisp.dhis.android.core.period
-
-import org.hisp.dhis.android.core.period.clock.internal.ClockProvider
-import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
-import org.hisp.dhis.android.core.period.internal.ParentPeriodGenerator
-import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
-import org.koin.core.annotation.ComponentScan
-import org.koin.core.annotation.Module
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.koin.core.annotation.Singleton
 
-@Module
-@ComponentScan
-internal class PeriodDIModule {
+internal interface FinancialYearPeriodHelper {
+    fun getFinancialYearPeriodType(): PeriodType
+}
 
-    @Singleton
-    fun parentPeriodGenerator(
-        clockProvider: ClockProvider,
-        financialYearPeriodHelper: FinancialYearPeriodHelper,
-    ): ParentPeriodGenerator {
-        return ParentPeriodGeneratorImpl.create(clockProvider, financialYearPeriodHelper)
+@Singleton
+internal class FinancialYearPeriodHelperImpl(
+    private val systemSettingRepository: SystemSettingCollectionRepository,
+) : FinancialYearPeriodHelper {
+    override fun getFinancialYearPeriodType(): PeriodType {
+        val setting = systemSettingRepository.analyticsFinancialYearStart().blockingGet()
+        return setting?.value()?.let { mapFinancialYearSetting(it) } ?: PeriodType.FinancialApril
     }
 
-    @Singleton
-    fun clockProvider(): ClockProvider {
-        return ClockProviderFactory.clockProvider
+    private fun mapFinancialYearSetting(value: String): PeriodType {
+        return when (value) {
+            "FINANCIAL_YEAR_APRIL" -> PeriodType.FinancialApril
+            "FINANCIAL_YEAR_JULY" -> PeriodType.FinancialJuly
+            "FINANCIAL_YEAR_OCTOBER" -> PeriodType.FinancialOct
+            "FINANCIAL_YEAR_NOVEMBER" -> PeriodType.FinancialNov
+            else -> PeriodType.FinancialApril
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
@@ -47,7 +47,6 @@ internal class ParentPeriodGeneratorImpl(
     private val monthly: PeriodGenerator,
     private val nMonthly: NMonthlyPeriodGenerators,
     private val yearly: YearlyPeriodGenerators,
-    private val financialYearPeriodHelper: FinancialYearPeriodHelper,
 ) : ParentPeriodGenerator {
 
     override fun generatePeriods(): List<Period> {
@@ -70,12 +69,7 @@ internal class ParentPeriodGeneratorImpl(
     }
 
     override fun generateRelativePeriods(relativePeriod: RelativePeriod): List<Period> {
-        val periodType = if (isFinancialYearRelativePeriod(relativePeriod)) {
-            financialYearPeriodHelper.getFinancialYearPeriodType()
-        } else {
-            relativePeriod.periodType
-        }
-
+        val periodType = relativePeriod.getPeriodType(yearly.financialYearPeriodHelper)
         val periodGenerator = getPeriodGenerator(periodType)
 
         return when {
@@ -91,13 +85,6 @@ internal class ParentPeriodGeneratorImpl(
             else ->
                 emptyList()
         }
-    }
-
-    private fun isFinancialYearRelativePeriod(relativePeriod: RelativePeriod): Boolean {
-        return relativePeriod == RelativePeriod.THIS_FINANCIAL_YEAR ||
-            relativePeriod == RelativePeriod.LAST_FINANCIAL_YEAR ||
-            relativePeriod == RelativePeriod.LAST_5_FINANCIAL_YEARS ||
-            relativePeriod == RelativePeriod.LAST_10_FINANCIAL_YEARS
     }
 
     @Suppress("ComplexMethod")
@@ -137,8 +124,7 @@ internal class ParentPeriodGeneratorImpl(
                 BiWeeklyPeriodGenerator(clock),
                 MonthlyPeriodGenerator(clock),
                 NMonthlyPeriodGenerators(clock),
-                YearlyPeriodGenerators(clock),
-                financialYearPeriodHelper,
+                YearlyPeriodGenerators(clock, financialYearPeriodHelper),
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
@@ -47,6 +47,7 @@ internal class ParentPeriodGeneratorImpl(
     private val monthly: PeriodGenerator,
     private val nMonthly: NMonthlyPeriodGenerators,
     private val yearly: YearlyPeriodGenerators,
+    private val financialYearPeriodHelper: FinancialYearPeriodHelper,
 ) : ParentPeriodGenerator {
 
     override fun generatePeriods(): List<Period> {
@@ -69,7 +70,13 @@ internal class ParentPeriodGeneratorImpl(
     }
 
     override fun generateRelativePeriods(relativePeriod: RelativePeriod): List<Period> {
-        val periodGenerator = getPeriodGenerator(relativePeriod.periodType)
+        val periodType = if (isFinancialYearRelativePeriod(relativePeriod)) {
+            financialYearPeriodHelper.getFinancialYearPeriodType()
+        } else {
+            relativePeriod.periodType
+        }
+
+        val periodGenerator = getPeriodGenerator(periodType)
 
         return when {
             relativePeriod.start != null && relativePeriod.end != null ->
@@ -84,6 +91,13 @@ internal class ParentPeriodGeneratorImpl(
             else ->
                 emptyList()
         }
+    }
+
+    private fun isFinancialYearRelativePeriod(relativePeriod: RelativePeriod): Boolean {
+        return relativePeriod == RelativePeriod.THIS_FINANCIAL_YEAR ||
+            relativePeriod == RelativePeriod.LAST_FINANCIAL_YEAR ||
+            relativePeriod == RelativePeriod.LAST_5_FINANCIAL_YEARS ||
+            relativePeriod == RelativePeriod.LAST_10_FINANCIAL_YEARS
     }
 
     @Suppress("ComplexMethod")
@@ -112,7 +126,10 @@ internal class ParentPeriodGeneratorImpl(
     }
 
     companion object {
-        fun create(clockProvider: ClockProvider): ParentPeriodGeneratorImpl {
+        fun create(
+            clockProvider: ClockProvider,
+            financialYearPeriodHelper: FinancialYearPeriodHelper,
+        ): ParentPeriodGeneratorImpl {
             val clock = clockProvider.clock
             return ParentPeriodGeneratorImpl(
                 DailyPeriodGenerator(clock),
@@ -121,6 +138,7 @@ internal class ParentPeriodGeneratorImpl(
                 MonthlyPeriodGenerator(clock),
                 NMonthlyPeriodGenerators(clock),
                 YearlyPeriodGenerators(clock),
+                financialYearPeriodHelper,
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSetting.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSetting.java
@@ -42,6 +42,7 @@ public abstract class SystemSetting implements CoreObject {
         STYLE,
         DEFAULT_BASE_MAP,
         BING_BASE_MAP,
+        ANALYTICS_FINANCIAL_YEAR_START,
     }
 
     @Nullable

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
@@ -76,6 +76,10 @@ class SystemSettingCollectionRepository internal constructor(
         return byKey().eq(SystemSettingKey.DEFAULT_BASE_MAP).one()
     }
 
+    fun analyticsFinancialYearStart(): ReadOnlyOneObjectRepositoryFinalImpl<SystemSetting> {
+        return byKey().eq(SystemSettingKey.ANALYTICS_FINANCIAL_YEAR_START).one()
+    }
+
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<SystemSetting> = emptyMap()
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsDTO.kt
@@ -37,6 +37,7 @@ internal data class SystemSettingsDTO(
     val keyStyle: String?,
     val keyDefaultBaseMap: String?,
     val keyBingMapsApiKey: String?,
+    val analyticsFinancialYearStart: String?,
 ) {
 
     fun toDomainSplitted(): List<SystemSetting> {
@@ -52,8 +53,12 @@ internal data class SystemSettingsDTO(
             .key(SystemSetting.SystemSettingKey.DEFAULT_BASE_MAP)
             .value(keyDefaultBaseMap)
             .build()
+        val analyticsFinancialYearStart = SystemSetting.builder()
+            .key(SystemSetting.SystemSettingKey.ANALYTICS_FINANCIAL_YEAR_START)
+            .value(analyticsFinancialYearStart)
+            .build()
 
-        return listOf(flag, style, keyDefaultBaseMap)
+        return listOf(flag, style, keyDefaultBaseMap, analyticsFinancialYearStart)
     }
 
     fun toDomainBingMapsApiKey(): SystemSetting {

--- a/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsFields.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsFields.kt
@@ -35,11 +35,13 @@ internal object SystemSettingsFields : BaseFields<SystemSettingsDTO>() {
     private const val KEY_STYLE = "keyStyle"
     private const val KEY_DEFAULT_BASE_MAP = "keyDefaultBaseMap"
     private const val KEY_BING_MAPS_API_KEY = "keyBingMapsApiKey"
+    private const val ANALYTICS_FINANCIAL_YEAR_START = "analyticsFinancialYearStart"
 
     val allFields = Fields.from(
         fh.field(KEY_FLAG),
         fh.field(KEY_STYLE),
         fh.field(KEY_DEFAULT_BASE_MAP),
+        fh.field(ANALYTICS_FINANCIAL_YEAR_START),
     )
 
     val bingApiKey = Fields.from(

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelperMock.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelperMock.kt
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2004-2024, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.period.internal
+
+import org.hisp.dhis.android.core.period.PeriodType
+
+internal class FinancialYearPeriodHelperMock(
+    private val periodType: PeriodType = PeriodType.FinancialApril,
+) : FinancialYearPeriodHelper {
+    override fun getFinancialYearPeriodType(): PeriodType {
+        return periodType
+    }
+}

--- a/core/src/sharedTest/resources/settings/system_settings.json
+++ b/core/src/sharedTest/resources/settings/system_settings.json
@@ -2,5 +2,6 @@
   "keyFlag": "sierra_leone",
   "keyStyle": "light_blue/light_blue.css",
   "keyDefaultBaseMap": "keyDefaultBaseMap",
-  "keyBingMapsApiKey": "keyBingMapsApiKey"
+  "keyBingMapsApiKey": "keyBingMapsApiKey",
+  "analyticsFinancialYearStart": "FINANCIAL_YEAR_JULY"
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/common/DateFilterPeriodHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/DateFilterPeriodHelperShould.kt
@@ -31,6 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.LocalDateTime
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.period.clock.internal.FixedClockProvider
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
 import org.junit.Before
 import org.junit.Test
@@ -43,9 +44,16 @@ class DateFilterPeriodHelperShould {
     fun setUp() {
         val fixedDate = LocalDateTime(2019, 12, 10, 10, 30)
         val clockProvider = FixedClockProvider(fixedDate)
+        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
 
         dateFilterPeriodHelper =
-            DateFilterPeriodHelper(clockProvider, ParentPeriodGeneratorImpl.create(clockProvider))
+            DateFilterPeriodHelper(
+                clockProvider,
+                ParentPeriodGeneratorImpl.create(
+                    clockProvider,
+                    financialYearPeriodHelper,
+                ),
+            )
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelperMock.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelperMock.kt
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.period.internal
+
+import org.hisp.dhis.android.core.period.PeriodType
+
+internal class FinancialYearPeriodHelperMock(
+    private val periodType: PeriodType = PeriodType.FinancialApril,
+) : FinancialYearPeriodHelper {
+    override fun getFinancialYearPeriodType(): PeriodType {
+        return periodType
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodHelperShould.kt
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.period.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.datetime.LocalDateTime
+import org.hisp.dhis.android.core.common.RelativePeriod
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.period.clock.internal.FixedClockProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class FinancialYearPeriodHelperShould {
+
+    private val fixedDate = LocalDateTime(2019, 12, 10, 0, 0)
+    private val clockProvider = FixedClockProvider(fixedDate)
+
+    @Test
+    fun `Should use FinancialApril when setting is FINANCIAL_YEAR_APRIL`() {
+        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialApril)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
+
+        assertThat(periods.size).isEqualTo(1)
+        assertThat(periods[0].periodId()).isEqualTo("2019April")
+    }
+
+    @Test
+    fun `Should use FinancialJuly when setting is FINANCIAL_YEAR_JULY`() {
+        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialJuly)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
+
+        assertThat(periods.size).isEqualTo(1)
+        assertThat(periods[0].periodId()).isEqualTo("2019July")
+    }
+
+    @Test
+    fun `Should use FinancialOct when setting is FINANCIAL_YEAR_OCTOBER`() {
+        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialOct)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
+
+        assertThat(periods.size).isEqualTo(1)
+        assertThat(periods[0].periodId()).isEqualTo("2019Oct")
+    }
+
+    @Test
+    fun `Should use FinancialNov when setting is FINANCIAL_YEAR_NOVEMBER`() {
+        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialNov)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
+
+        assertThat(periods.size).isEqualTo(1)
+        assertThat(periods[0].periodId()).isEqualTo("2020Nov")
+    }
+
+    @Test
+    fun `Should generate correct LAST_FINANCIAL_YEAR with different settings`() {
+        val financialYearHelperOct = FinancialYearPeriodHelperMock(PeriodType.FinancialOct)
+        val periodGeneratorOct = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelperOct)
+
+        val periodsOct = periodGeneratorOct.generateRelativePeriods(RelativePeriod.LAST_FINANCIAL_YEAR)
+
+        assertThat(periodsOct.size).isEqualTo(1)
+        assertThat(periodsOct[0].periodId()).isEqualTo("2018Oct")
+    }
+
+    @Test
+    fun `Should generate correct LAST_5_FINANCIAL_YEARS with different settings`() {
+        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialJuly)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.LAST_5_FINANCIAL_YEARS)
+
+        assertThat(periods.size).isEqualTo(5)
+        assertThat(periods[0].periodId()).isEqualTo("2014July")
+        assertThat(periods[4].periodId()).isEqualTo("2018July")
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodGeneratorImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodGeneratorImplShould.kt
@@ -40,7 +40,8 @@ class RelativePeriodGeneratorImplShould {
 
     private val fixedDate = LocalDateTime(2019, 12, 10, 0, 0)
     private val clockProvider = FixedClockProvider(fixedDate)
-    private val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider)
+    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+    private val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearPeriodHelper)
 
     @Test
     @Suppress("ComplexMethod", "LongMethod")

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/SystemSettingSplitterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/SystemSettingSplitterShould.kt
@@ -41,6 +41,7 @@ class SystemSettingSplitterShould {
         keyStyle = "aStyle",
         keyDefaultBaseMap = "aDefaultBaseMap",
         keyBingMapsApiKey = null,
+        analyticsFinancialYearStart = null,
     )
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.common.*
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
 import org.junit.Before
 import org.junit.Test
@@ -53,7 +54,8 @@ class TrackedEntityInstanceLocalQueryHelperShould {
     fun setUp() {
         queryBuilder = TrackedEntityInstanceQueryRepositoryScope.builder()
         val clockProvider = ClockProviderFactory.clockProvider
-        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider))
+        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
         localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
@@ -37,6 +37,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMod
 import org.hisp.dhis.android.core.common.AssignedUserMode
 import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityEndpointCallFactory
@@ -80,7 +81,8 @@ class TrackedEntityInstanceQueryDataSourceShould {
 
     private val initialCallback: ItemKeyedDataSource.LoadInitialCallback<TrackedEntityInstance> = mock()
     private val clockProvider = ClockProviderFactory.clockProvider
-    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider))
+    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
     private val onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
     private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
     private val onlineCache: TrackedEntityInstanceOnlineCache =

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositorySco
 import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
 import org.hisp.dhis.android.core.common.FilterOperatorsHelper.listToStr
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory.clockProvider
+import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryOnlineHelper.Companion.toAPIFilterFormat
 import org.junit.Before
@@ -49,7 +50,8 @@ class TrackedEntityInstanceQueryOnlineHelperShould {
     fun setUp() {
         queryBuilder = TrackedEntityInstanceQueryRepositoryScope.builder()
             .orgUnits(listOf("uid"))
-        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider))
+        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
         onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
     }
 


### PR DESCRIPTION
For analytics, the financial relative periods were not taking into account the correct starting month, which is set on the system settings app. This PR fix downloads the parameter and uses it for resolving the corresponding period.

Related task: [ANDROSDK-2237](https://dhis2.atlassian.net/browse/ANDROSDK-2237)

[ANDROSDK-2237]: https://dhis2.atlassian.net/browse/ANDROSDK-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ