### PR TITLE
feat: [ANDROSDK-2191] Add Azure Hybrid map layer support with composite layers

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6756,6 +6756,7 @@ public abstract class org/hisp/dhis/android/core/map/layer/MapLayer : org/hisp/d
 	public abstract fun imageUrl ()Ljava/lang/String;
 	public abstract fun imageryProviders ()Ljava/util/List;
 	public abstract fun layers ()Ljava/lang/String;
+	public abstract fun linkedLayerUid ()Ljava/lang/String;
 	public abstract fun mapLayerPosition ()Lorg/hisp/dhis/android/core/map/layer/MapLayerPosition;
 	public abstract fun mapService ()Lorg/hisp/dhis/android/core/map/layer/MapService;
 	public abstract fun name ()Ljava/lang/String;
@@ -6776,6 +6777,7 @@ public abstract class org/hisp/dhis/android/core/map/layer/MapLayer$Builder {
 	public abstract fun imageUrl (Ljava/lang/String;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
 	public abstract fun imageryProviders (Ljava/util/List;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
 	public abstract fun layers (Ljava/lang/String;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
+	public abstract fun linkedLayerUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
 	public abstract fun mapLayerPosition (Lorg/hisp/dhis/android/core/map/layer/MapLayerPosition;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
 	public abstract fun mapService (Lorg/hisp/dhis/android/core/map/layer/MapService;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
 	public abstract fun name (Ljava/lang/String;)Lorg/hisp/dhis/android/core/map/layer/MapLayer$Builder;
@@ -6792,6 +6794,7 @@ public final class org/hisp/dhis/android/core/map/layer/MapLayerCollectionReposi
 	public final fun byImageFormat ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byImageUrl ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun byLayers ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
+	public final fun byLinkedLayerUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun byMapLayerPosition ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byMapService ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byName ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
@@ -13892,6 +13895,7 @@ public final class org/hisp/dhis/android/persistence/map/MapLayerTableInfo$Colum
 	public static final field IMAGE_FORMAT Ljava/lang/String;
 	public static final field IMAGE_URL Ljava/lang/String;
 	public static final field LAYERS Ljava/lang/String;
+	public static final field LINKED_LAYER_UID Ljava/lang/String;
 	public static final field MAP_LAYER_POSITION Ljava/lang/String;
 	public static final field MAP_SERVICE Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/map/layer/AzureMapLayerCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/map/layer/AzureMapLayerCollectionRepositoryMockIntegrationShould.kt
@@ -47,7 +47,7 @@ class AzureMapLayerCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
     fun filter_all() {
         val mapLayers = d2.mapsModule().mapLayers().blockingGet()
 
-        assertThat(mapLayers.size).isEqualTo(8)
+        assertThat(mapLayers.size).isEqualTo(10)
     }
 
     @Test
@@ -71,7 +71,7 @@ class AzureMapLayerCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
     @Test
     fun filter_by_display_name() {
         val mapLayers = d2.mapsModule().mapLayers()
-            .byName().eq(AzureBasemaps.list.first().name)
+            .byDisplayName().eq(AzureBasemaps.list.first().name)
             .blockingGet()
 
         assertThat(mapLayers.size).isEqualTo(1)
@@ -92,7 +92,7 @@ class AzureMapLayerCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
             .byExternal().isFalse
             .blockingGet()
 
-        assertThat(mapLayers.size).isEqualTo(4)
+        assertThat(mapLayers.size).isEqualTo(6)
     }
 
     @Test
@@ -101,16 +101,71 @@ class AzureMapLayerCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
             .byMapLayerPosition().eq(MapLayerPosition.BASEMAP)
             .blockingGet()
 
-        assertThat(mapLayers.size).isEqualTo(6)
+        assertThat(mapLayers.size).isEqualTo(7)
+    }
+
+    @Test
+    fun filter_by_overlay_position() {
+        val mapLayers = d2.mapsModule().mapLayers()
+            .byMapLayerPosition().eq(MapLayerPosition.OVERLAY)
+            .blockingGet()
+
+        assertThat(mapLayers.size).isEqualTo(3)
+    }
+
+    @Test
+    fun verify_hybrid_layers_are_linked() {
+        val hybridBasemap = AzureBasemaps.list.find { it.id == "azureHybrid" }!!
+        val baseLayerUid = hybridBasemap.id + hybridBasemap.styles.first().idSuffix
+        val overlayLayerUid = hybridBasemap.id + hybridBasemap.styles.last().idSuffix
+
+        // Get the overlay layer and verify it's linked to the base layer
+        val overlayLayer = d2.mapsModule().mapLayers()
+            .byUid().eq(overlayLayerUid)
+            .blockingGet()
+            .first()
+
+        assertThat(overlayLayer.linkedLayerUid()).isEqualTo(baseLayerUid)
+        assertThat(overlayLayer.mapLayerPosition()).isEqualTo(MapLayerPosition.OVERLAY)
+
+        // Get the base layer and verify it has no linkedLayerUid
+        val baseLayer = d2.mapsModule().mapLayers()
+            .byUid().eq(baseLayerUid)
+            .blockingGet()
+            .first()
+
+        assertThat(baseLayer.linkedLayerUid()).isNull()
+        assertThat(baseLayer.mapLayerPosition()).isEqualTo(MapLayerPosition.BASEMAP)
+    }
+
+    @Test
+    fun filter_by_linked_layer_uid() {
+        val hybridBasemap = AzureBasemaps.list.find { it.id == "azureHybrid" }!!
+        val baseLayerUid = hybridBasemap.id + hybridBasemap.styles.first().idSuffix
+
+        val linkedLayers = d2.mapsModule().mapLayers()
+            .byLinkedLayerUid().eq(baseLayerUid)
+            .blockingGet()
+
+        assertThat(linkedLayers.size).isEqualTo(1)
     }
 
     @Test
     fun filter_by_style() {
         val mapLayers = d2.mapsModule().mapLayers()
-            .byStyle().eq(AzureBasemaps.list.first().style)
+            .byStyle().eq(AzureBasemaps.list.first().styles.first().tilesetId)
             .blockingGet()
 
         assertThat(mapLayers.size).isEqualTo(1)
+    }
+
+    @Test
+    fun azure_dark_not_present_due_to_401() {
+        val azureDarkLayers = d2.mapsModule().mapLayers()
+            .byUid().eq("azureDark")
+            .blockingGet()
+
+        assertThat(azureDarkLayers).isEmpty()
     }
 
     @Test
@@ -160,10 +215,16 @@ class AzureMapLayerCollectionRepositoryMockIntegrationShould : BaseMockIntegrati
             setUpClass()
 
             dhis2MockServer.enqueueMockResponse("settings/system_settings.json")
+            // azureLight (1 style - success)
             dhis2MockServer.enqueueMockResponse("map/layer/microsoft/azure_server_response.json")
+            // azureDark (1 style - fails with 401, but not first so continues without Bing fallback)
             dhis2MockServer.enqueueMockResponse(401)
+            // azureAerial (1 style - success)
             dhis2MockServer.enqueueMockResponse("map/layer/microsoft/azure_server_response.json")
-            dhis2MockServer.enqueueMockResponse(401)
+            // azureHybrid (2 styles: imagery + hybrid.road - both success)
+            dhis2MockServer.enqueueMockResponse("map/layer/microsoft/azure_server_response.json")
+            dhis2MockServer.enqueueMockResponse("map/layer/microsoft/azure_server_response.json")
+            // external map layers
             dhis2MockServer.enqueueMockResponse("map/layer/externalmap/external_map_layers.json")
 
             d2.mapsModule().mapLayersDownloader().downloadMetadata().blockingAwait()

--- a/core/src/main/assets/migrations/180.sql
+++ b/core/src/main/assets/migrations/180.sql
@@ -29,3 +29,9 @@ ALTER TABLE DataApproval RENAME TO DataApproval_Old;
 CREATE TABLE DataApproval(workflow TEXT NOT NULL, organisationUnit TEXT NOT NULL, period TEXT NOT NULL, attributeOptionCombo TEXT NOT NULL, state TEXT NOT NULL, PRIMARY KEY(workflow, attributeOptionCombo, period, organisationUnit), FOREIGN KEY(attributeOptionCombo) REFERENCES CategoryOptionCombo(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(period) REFERENCES Period(periodId) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED, FOREIGN KEY(organisationUnit) REFERENCES OrganisationUnit(uid) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED);
 INSERT OR IGNORE INTO DataApproval(workflow, organisationUnit, period, attributeOptionCombo, state) SELECT workflow, organisationUnit, period, attributeOptionCombo, state FROM DataApproval_Old WHERE state IS NOT NULL;
 DROP TABLE IF EXISTS DataApproval_Old;
+
+
+# Add linkedLayerUid for composite map layers (ANDROSDK-2191)
+
+ALTER TABLE MapLayer ADD COLUMN linkedLayerUid TEXT;
+

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayer.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayer.java
@@ -86,6 +86,9 @@ public abstract class MapLayer implements CoreObject, ObjectWithUidInterface {
     @Nullable
     public abstract String layers();
 
+    @Nullable
+    public abstract String linkedLayerUid();
+
     public abstract Builder toBuilder();
 
     public static Builder builder() {
@@ -122,6 +125,8 @@ public abstract class MapLayer implements CoreObject, ObjectWithUidInterface {
         public abstract Builder imageFormat(ImageFormat imageFormat);
 
         public abstract Builder layers(String layers);
+
+        public abstract Builder linkedLayerUid(String linkedLayerUid);
 
         public abstract MapLayer build();
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerCollectionRepository.kt
@@ -101,6 +101,10 @@ class MapLayerCollectionRepository internal constructor(
         return cf.string(MapLayerTableInfo.Columns.LAYERS)
     }
 
+    fun byLinkedLayerUid(): StringFilterConnector<MapLayerCollectionRepository> {
+        return cf.string(MapLayerTableInfo.Columns.LINKED_LAYER_UID)
+    }
+
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<MapLayer> = mapOf(
             MapLayer.IMAGERY_PROVIDERS to MapLayerImagerProviderChildrenAppender::create,

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureBasemap.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureBasemap.kt
@@ -28,8 +28,16 @@
 
 package org.hisp.dhis.android.core.map.layer.internal.microsoft
 
+import org.hisp.dhis.android.core.map.layer.MapLayerPosition
+
 internal data class AzureBasemap(
     val id: String,
     val name: String,
-    val style: String,
+    val styles: List<AzureBasemapStyle>,
+)
+
+internal data class AzureBasemapStyle(
+    val tilesetId: String,
+    val position: MapLayerPosition,
+    val idSuffix: String = "",
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureBasemaps.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureBasemaps.kt
@@ -28,27 +28,38 @@
 
 package org.hisp.dhis.android.core.map.layer.internal.microsoft
 
+import org.hisp.dhis.android.core.map.layer.MapLayerPosition
+
 internal object AzureBasemaps {
     val list: List<AzureBasemap> = listOf(
         AzureBasemap(
             id = "azureLight",
             name = "Azure Road",
-            style = "microsoft.base.road",
+            styles = listOf(
+                AzureBasemapStyle("microsoft.base.road", MapLayerPosition.BASEMAP),
+            ),
         ),
         AzureBasemap(
             id = "azureDark",
             name = "Azure Dark",
-            style = "microsoft.base.darkgrey",
+            styles = listOf(
+                AzureBasemapStyle("microsoft.base.darkgrey", MapLayerPosition.BASEMAP),
+            ),
         ),
         AzureBasemap(
             id = "azureAerial",
             name = "Azure Aerial",
-            style = "microsoft.imagery",
+            styles = listOf(
+                AzureBasemapStyle("microsoft.imagery", MapLayerPosition.BASEMAP),
+            ),
         ),
         AzureBasemap(
             id = "azureHybrid",
             name = "Azure Aerial Labels",
-            style = "microsoft.base.hybrid.road",
+            styles = listOf(
+                AzureBasemapStyle("microsoft.imagery", MapLayerPosition.BASEMAP, "_imagery"),
+                AzureBasemapStyle("microsoft.base.hybrid.road", MapLayerPosition.OVERLAY, "_labels"),
+            ),
         ),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureNetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/AzureNetworkHandler.kt
@@ -31,5 +31,11 @@ package org.hisp.dhis.android.core.map.layer.internal.microsoft
 import org.hisp.dhis.android.core.map.layer.MapLayer
 
 internal fun interface AzureNetworkHandler {
-    suspend fun getBaseMap(url: String, basemap: AzureBasemap, key: String): List<MapLayer>
+    suspend fun getBaseMap(
+        url: String,
+        basemap: AzureBasemap,
+        style: AzureBasemapStyle,
+        key: String,
+        linkedLayerUid: String?,
+    ): List<MapLayer>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/MicrosoftMapsCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/MicrosoftMapsCallFactory.kt
@@ -103,18 +103,36 @@ internal class MicrosoftMapsCallFactory(
     }
 
     private suspend fun downloadAzureBasemap(key: String, basemap: AzureBasemap): List<MapLayer> {
-        return coroutineExecutor.wrap(storeError = false) {
-            azureNetworkHandler.getBaseMap(getAzureUrl(basemap.style, key), basemap, key)
-        }.let { result ->
+        val allLayers = mutableListOf<MapLayer>()
+        var baseLayerUid: String? = null
+
+        basemap.styles.forEachIndexed { index, style ->
+            val isBaseLayer = index == 0
+
+            val result = coroutineExecutor.wrap(storeError = false) {
+                azureNetworkHandler.getBaseMap(
+                    url = getAzureUrl(style.tilesetId, key),
+                    basemap = basemap,
+                    style = style,
+                    key = key,
+                    linkedLayerUid = if (isBaseLayer) null else baseLayerUid,
+                )
+            }
+
             when (result) {
-                is Success -> result.value
+                is Success -> {
+                    allLayers += result.value
+                    if (isBaseLayer) {
+                        baseLayerUid = result.value.firstOrNull()?.uid()
+                    }
+                }
                 is Failure -> if (result.failure.httpErrorCode() == HttpStatusCode.Unauthorized.value) {
                     throw result.failure
-                } else {
-                    emptyList()
                 }
             }
         }
+
+        return allLayers
     }
 
     private suspend fun downloadBingBasemap(key: String, basemap: BingBasemap): List<MapLayer> {
@@ -123,14 +141,14 @@ internal class MicrosoftMapsCallFactory(
         }.getOrNull().orEmpty()
     }
 
-    private fun getAzureUrl(style: String, key: String) =
+    private fun getAzureUrl(tilesetId: String, key: String) =
         if (D2Manager.isTestMode && !D2Manager.isRealIntegration) {
             "${ServerURLWrapper.serverUrl}/api/mockAzureMaps"
         } else {
             "https://atlas.microsoft.com/map/tileset" +
                 "?api-version=2024-04-01" +
                 "&subscription-key=$key" +
-                "&tilesetId=$style"
+                "&tilesetId=$tilesetId"
         }
 
     private fun getBingUrl(style: String, key: String) =

--- a/core/src/main/java/org/hisp/dhis/android/network/azure/AzureNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/azure/AzureNetworkHandlerImpl.kt
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.network.azure
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 import org.hisp.dhis.android.core.map.layer.MapLayer
 import org.hisp.dhis.android.core.map.layer.internal.microsoft.AzureBasemap
+import org.hisp.dhis.android.core.map.layer.internal.microsoft.AzureBasemapStyle
 import org.hisp.dhis.android.core.map.layer.internal.microsoft.AzureNetworkHandler
 import org.koin.core.annotation.Singleton
 
@@ -39,8 +40,14 @@ internal class AzureNetworkHandlerImpl(
     httpServiceClient: HttpServiceClient,
 ) : AzureNetworkHandler {
     private val service = AzureService(httpServiceClient)
-    override suspend fun getBaseMap(url: String, basemap: AzureBasemap, key: String): List<MapLayer> {
+    override suspend fun getBaseMap(
+        url: String,
+        basemap: AzureBasemap,
+        style: AzureBasemapStyle,
+        key: String,
+        linkedLayerUid: String?,
+    ): List<MapLayer> {
         val apiPayload = service.getBaseMap(url)
-        return apiPayload.toDomain(basemap, key)
+        return apiPayload.toDomain(basemap, style, key, linkedLayerUid)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/azure/AzureServerResponseDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/azure/AzureServerResponseDTO.kt
@@ -33,9 +33,9 @@ import org.hisp.dhis.android.core.map.layer.ImageFormat
 import org.hisp.dhis.android.core.map.layer.MapLayer
 import org.hisp.dhis.android.core.map.layer.MapLayerImageryProvider
 import org.hisp.dhis.android.core.map.layer.MapLayerImageryProviderArea
-import org.hisp.dhis.android.core.map.layer.MapLayerPosition
 import org.hisp.dhis.android.core.map.layer.MapService
 import org.hisp.dhis.android.core.map.layer.internal.microsoft.AzureBasemap
+import org.hisp.dhis.android.core.map.layer.internal.microsoft.AzureBasemapStyle
 import java.util.Locale
 
 @Serializable
@@ -50,7 +50,13 @@ internal data class AzureServerResponseDTO(
     val attribution: String? = null,
     val scheme: String? = null,
 ) {
-    fun toDomain(basemap: AzureBasemap, key: String): List<MapLayer> {
+    fun toDomain(
+        basemap: AzureBasemap,
+        style: AzureBasemapStyle,
+        key: String,
+        linkedLayerUid: String?,
+    ): List<MapLayer> {
+        val layerUid = basemap.id + style.idSuffix
         return tiles.map { tileTemplate ->
             val coverageAreas = listOf(
                 MapLayerImageryProviderArea.builder()
@@ -62,7 +68,7 @@ internal data class AzureServerResponseDTO(
             val providers = attribution?.takeIf { it.isNotBlank() }?.let {
                 listOf(
                     MapLayerImageryProvider.builder()
-                        .mapLayer(basemap.id)
+                        .mapLayer(layerUid)
                         .attribution(it)
                         .coverageAreas(coverageAreas)
                         .build(),
@@ -70,17 +76,18 @@ internal data class AzureServerResponseDTO(
             }.orEmpty()
 
             MapLayer.builder()
-                .uid(basemap.id)
+                .uid(layerUid)
                 .name(basemap.name)
                 .displayName(basemap.name)
-                .style(basemap.style)
+                .style(style.tilesetId)
                 .external(false)
-                .mapLayerPosition(MapLayerPosition.BASEMAP)
+                .mapLayerPosition(style.position)
                 .imageUrl("$tileTemplate&subscription-key=$key")
                 .subdomains(emptyList())
                 .imageryProviders(providers)
                 .mapService(scheme?.uppercase(Locale.ROOT)?.let { MapService.valueOf(it) })
                 .imageFormat(ImageFormat.PNG)
+                .linkedLayerUid(linkedLayerUid)
                 .build()
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/map/MapLayerDB.kt
@@ -26,6 +26,7 @@ internal data class MapLayerDB(
     val mapService: String?,
     val imageFormat: String?,
     val layers: String?,
+    val linkedLayerUid: String?,
 ) : EntityDB<MapLayer> {
 
     override fun toDomain(): MapLayer {
@@ -43,6 +44,7 @@ internal data class MapLayerDB(
             mapService?.let { mapService(MapService.valueOf(it)) }
             imageFormat?.let { imageFormat(ImageFormat.valueOf(it)) }
             layers(layers)
+            linkedLayerUid(linkedLayerUid)
         }.build()
     }
 }
@@ -62,5 +64,6 @@ internal fun MapLayer.toDB(): MapLayerDB {
         mapService = mapService()?.name,
         imageFormat = imageFormat()?.name,
         layers = layers(),
+        linkedLayerUid = linkedLayerUid(),
     )
 }


### PR DESCRIPTION
Add support for Azure Hybrid map tiles by combining `microsoft.imagery` (satellite) with `microsoft.base.hybrid.road` (labels overlay)
- Introduce `linkedLayerUid` field to link overlay layers to their base layer
- Refactor `AzureBasemap` to support multiple styles per basemap


**Breaking changes for app consumers**
Apps now must filter basemaps by `linkedLayerUid == null` and render linked overlays on top of their base layer.