### PR TITLE
chore: [ANDROSDK-2244] Download orgunit linked to tracker data out of user scope

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventDownloadCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventDownloadCallMockIntegrationShould.kt
@@ -41,7 +41,7 @@ class EventDownloadCallMockIntegrationShould : BaseMockIntegrationTestMetadataDi
 
         testObserver.awaitTerminalEvent()
 
-        testObserver.assertValueCount(4)
+        testObserver.assertValueCount(5)
 
         testObserver.assertValueAt(0) { v: TrackerD2Progress ->
             !v.isComplete &&
@@ -55,7 +55,10 @@ class EventDownloadCallMockIntegrationShould : BaseMockIntegrationTestMetadataDi
             !v.isComplete && v.doneCalls().size == 3 && allProgramsSucceeded(v.programs())
         }
         testObserver.assertValueAt(3) { v ->
-            v.isComplete && v.doneCalls().size == 3 && allProgramsSucceeded(v.programs())
+            !v.isComplete && v.doneCalls().size == 4 && allProgramsSucceeded(v.programs())
+        }
+        testObserver.assertValueAt(4) { v ->
+            v.isComplete && v.doneCalls().size == 4 && allProgramsSucceeded(v.programs())
         }
 
         testObserver.dispose()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
@@ -100,6 +100,9 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
                     koin.get(),
                     koin.get(),
                     koin.get(),
+                    koin.get(),
+                    koin.get(),
+                    koin.get(),
                 ).download(user)
             }
         }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
@@ -101,8 +101,6 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
                     koin.get(),
                     koin.get(),
                     koin.get(),
-                    koin.get(),
-                    koin.get(),
                 ).download(user)
             }
         }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCallMockIntegrationShould.kt
@@ -41,7 +41,7 @@ class TrackedEntityInstanceDownloadCallMockIntegrationShould : BaseMockIntegrati
 
         testObserver.awaitTerminalEvent()
 
-        testObserver.assertValueCount(5)
+        testObserver.assertValueCount(6)
 
         testObserver.assertValueAt(0) { v: TrackerD2Progress ->
             !v.isComplete &&
@@ -58,7 +58,10 @@ class TrackedEntityInstanceDownloadCallMockIntegrationShould : BaseMockIntegrati
             !v.isComplete && v.doneCalls().size == 4 && allProgramsSucceeded(v.programs())
         }
         testObserver.assertValueAt(4) { v ->
-            v.isComplete && v.doneCalls().size == 4 && allProgramsSucceeded(v.programs())
+            !v.isComplete && v.doneCalls().size == 5 && allProgramsSucceeded(v.programs())
+        }
+        testObserver.assertValueAt(5) { v ->
+            v.isComplete && v.doneCalls().size == 5 && allProgramsSucceeded(v.programs())
         }
 
         testObserver.dispose()

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -29,8 +29,8 @@ package org.hisp.dhis.android.core.event.internal
 
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
-import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.search.EventQueryCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -33,11 +33,15 @@ import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandler
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.search.EventQueryCollectionRepository
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
 import org.hisp.dhis.android.core.tracker.exporter.TrackerAPIQuery
 import org.hisp.dhis.android.core.tracker.exporter.TrackerDownloadCall
@@ -50,6 +54,11 @@ internal class EventDownloadCall internal constructor(
     systemInfoModuleDownloader: SystemInfoModuleDownloader,
     relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
+    organisationUnitStore: OrganisationUnitStore,
+    organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
+    trackedEntityInstanceStore: TrackedEntityInstanceStore,
+    enrollmentStore: EnrollmentStore,
+    eventStore: EventStore,
     private val eventQueryBundleFactory: EventQueryBundleFactory,
     private val trackerParentCallFactory: TrackerParentCallFactory,
     private val persistenceCallFactory: EventPersistenceCallFactory,
@@ -60,6 +69,11 @@ internal class EventDownloadCall internal constructor(
     systemInfoModuleDownloader,
     relationshipDownloadAndPersistCallFactory,
     coroutineAPICallExecutor,
+    organisationUnitStore,
+    organisationUnitNetworkHandler,
+    trackedEntityInstanceStore,
+    enrollmentStore,
+    eventStore,
 ) {
 
     override suspend fun getBundles(params: ProgramDataDownloadParams): List<EventQueryBundle> {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -30,10 +30,10 @@ package org.hisp.dhis.android.core.event.internal
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.search.EventQueryCollectionRepository
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
@@ -41,7 +41,6 @@ import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
 import org.hisp.dhis.android.core.tracker.exporter.TrackerAPIQuery
 import org.hisp.dhis.android.core.tracker.exporter.TrackerDownloadCall
@@ -56,9 +55,7 @@ internal class EventDownloadCall internal constructor(
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     organisationUnitStore: OrganisationUnitStore,
     organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
-    trackedEntityInstanceStore: TrackedEntityInstanceStore,
-    enrollmentStore: EnrollmentStore,
-    eventStore: EventStore,
+    databaseAdapter: DatabaseAdapter,
     private val eventQueryBundleFactory: EventQueryBundleFactory,
     private val trackerParentCallFactory: TrackerParentCallFactory,
     private val persistenceCallFactory: EventPersistenceCallFactory,
@@ -71,9 +68,7 @@ internal class EventDownloadCall internal constructor(
     coroutineAPICallExecutor,
     organisationUnitStore,
     organisationUnitNetworkHandler,
-    trackedEntityInstanceStore,
-    enrollmentStore,
-    eventStore,
+    databaseAdapter,
 ) {
 
     override suspend fun getBundles(params: ProgramDataDownloadParams): List<EventQueryBundle> {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -47,6 +47,7 @@ import org.hisp.dhis.android.core.tracker.exporter.TrackerDownloadCall
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.koin.core.annotation.Singleton
 
+@Suppress("LongParameterList")
 @Singleton
 internal class EventDownloadCall internal constructor(
     userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCall.kt
@@ -27,12 +27,11 @@
  */
 package org.hisp.dhis.android.core.organisationunit.internal
 
+import androidx.sqlite.db.SimpleSQLiteQuery
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUids
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitTree
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
@@ -50,9 +49,7 @@ internal class OrganisationUnitCall(
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
     private val organisationUnitStore: OrganisationUnitStore,
     private val collectionCleaner: OrganisationUnitCollectionCleaner,
-    private val trackedEntityInstanceStore: TrackedEntityInstanceStore,
-    private val enrollmentStore: EnrollmentStore,
-    private val eventStore: EventStore,
+    private val databaseAdapter: DatabaseAdapter,
 ) {
 
     companion object {
@@ -151,12 +148,15 @@ internal class OrganisationUnitCall(
     }
 
     private suspend fun getOrgUnitUidsReferencedByTrackerData(): Set<String> {
-        val teiOrgUnits = trackedEntityInstanceStore
-            .selectStringColumnsWhereClause(TrackedEntityInstanceTableInfo.Columns.ORGANISATION_UNIT, "1")
-        val enrollmentOrgUnits = enrollmentStore
-            .selectStringColumnsWhereClause(EnrollmentTableInfo.Columns.ORGANISATION_UNIT, "1")
-        val eventOrgUnits = eventStore
-            .selectStringColumnsWhereClause(EventTableInfo.Columns.ORGANISATION_UNIT, "1")
-        return (teiOrgUnits + enrollmentOrgUnits + eventOrgUnits).toSet()
+        val query = """
+            SELECT DISTINCT ${TrackedEntityInstanceTableInfo.Columns.ORGANISATION_UNIT} 
+            FROM ${TrackedEntityInstanceTableInfo.TABLE_NAME}
+            UNION SELECT DISTINCT ${EnrollmentTableInfo.Columns.ORGANISATION_UNIT} 
+            FROM ${EnrollmentTableInfo.TABLE_NAME}
+            UNION SELECT DISTINCT ${EventTableInfo.Columns.ORGANISATION_UNIT} 
+            FROM ${EventTableInfo.TABLE_NAME}
+        """.trimIndent()
+        val dao = databaseAdapter.getCurrentDatabase().d2Dao()
+        return dao.stringListRawQuery(SimpleSQLiteQuery(query)).toSet()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCall.kt
@@ -28,11 +28,17 @@
 package org.hisp.dhis.android.core.organisationunit.internal
 
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUids
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitTree
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
+import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
+import org.hisp.dhis.android.persistence.event.EventTableInfo
+import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceTableInfo
 import org.hisp.dhis.android.persistence.user.UserOrganisationUnitTableInfo
 import org.koin.core.annotation.Singleton
 import java.util.concurrent.atomic.AtomicInteger
@@ -44,6 +50,9 @@ internal class OrganisationUnitCall(
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
     private val organisationUnitStore: OrganisationUnitStore,
     private val collectionCleaner: OrganisationUnitCollectionCleaner,
+    private val trackedEntityInstanceStore: TrackedEntityInstanceStore,
+    private val enrollmentStore: EnrollmentStore,
+    private val eventStore: EventStore,
 ) {
 
     companion object {
@@ -69,7 +78,8 @@ internal class OrganisationUnitCall(
                 UserOrganisationUnitTableInfo.Columns.ORGANISATION_UNIT,
                 "1",
             )
-        collectionCleaner.deleteNotPresentByUid(assignedOrgunitIds)
+        val trackerDataOrgUnitIds = getOrgUnitUidsReferencedByTrackerData()
+        collectionCleaner.deleteNotPresentByUid(assignedOrgunitIds + trackerDataOrgUnitIds)
     }
 
     private suspend fun downloadSearchOrgUnits(
@@ -138,5 +148,15 @@ internal class OrganisationUnitCall(
         handler.handleMany(orgunits)
 
         return orgunits.size
+    }
+
+    private suspend fun getOrgUnitUidsReferencedByTrackerData(): Set<String> {
+        val teiOrgUnits = trackedEntityInstanceStore
+            .selectStringColumnsWhereClause(TrackedEntityInstanceTableInfo.Columns.ORGANISATION_UNIT, "1")
+        val enrollmentOrgUnits = enrollmentStore
+            .selectStringColumnsWhereClause(EnrollmentTableInfo.Columns.ORGANISATION_UNIT, "1")
+        val eventOrgUnits = eventStore
+            .selectStringColumnsWhereClause(EventTableInfo.Columns.ORGANISATION_UNIT, "1")
+        return (teiOrgUnits + enrollmentOrgUnits + eventOrgUnits).toSet()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitNetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitNetworkHandler.kt
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.core.organisationunit.internal
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 
-internal fun interface OrganisationUnitNetworkHandler {
+internal interface OrganisationUnitNetworkHandler {
     suspend fun getOrganisationUnits(parentUid: String, pageSize: Int, page: Int): Payload<OrganisationUnit>
+    suspend fun getOrganisationUnitsByUid(uids: Set<String>): Payload<OrganisationUnit>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -32,8 +32,12 @@ import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallEx
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
@@ -53,6 +57,11 @@ internal class TrackedEntityInstanceDownloadCall(
     systemInfoModuleDownloader: SystemInfoModuleDownloader,
     relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory,
     private val coroutineCallExecutor: CoroutineAPICallExecutor,
+    organisationUnitStore: OrganisationUnitStore,
+    organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
+    trackedEntityInstanceStore: TrackedEntityInstanceStore,
+    enrollmentStore: EnrollmentStore,
+    eventStore: EventStore,
     private val queryFactory: TrackerQueryBundleFactory,
     private val trackerCallFactory: TrackerParentCallFactory,
     private val persistenceCallFactory: TrackedEntityInstancePersistenceCallFactory,
@@ -64,6 +73,11 @@ internal class TrackedEntityInstanceDownloadCall(
     systemInfoModuleDownloader,
     relationshipDownloadAndPersistCallFactory,
     coroutineCallExecutor,
+    organisationUnitStore,
+    organisationUnitNetworkHandler,
+    trackedEntityInstanceStore,
+    enrollmentStore,
+    eventStore,
 ) {
     override suspend fun getBundles(params: ProgramDataDownloadParams): List<TrackerQueryBundle> {
         return queryFactory.getQueries(params)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -31,9 +31,8 @@ import io.ktor.http.HttpStatusCode
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.helpers.Result
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
@@ -59,9 +58,7 @@ internal class TrackedEntityInstanceDownloadCall(
     private val coroutineCallExecutor: CoroutineAPICallExecutor,
     organisationUnitStore: OrganisationUnitStore,
     organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
-    trackedEntityInstanceStore: TrackedEntityInstanceStore,
-    enrollmentStore: EnrollmentStore,
-    eventStore: EventStore,
+    databaseAdapter: DatabaseAdapter,
     private val queryFactory: TrackerQueryBundleFactory,
     private val trackerCallFactory: TrackerParentCallFactory,
     private val persistenceCallFactory: TrackedEntityInstancePersistenceCallFactory,
@@ -75,9 +72,7 @@ internal class TrackedEntityInstanceDownloadCall(
     coroutineCallExecutor,
     organisationUnitStore,
     organisationUnitNetworkHandler,
-    trackedEntityInstanceStore,
-    enrollmentStore,
-    eventStore,
+    databaseAdapter,
 ) {
     override suspend fun getBundles(params: ProgramDataDownloadParams): List<TrackerQueryBundle> {
         return queryFactory.getQueries(params)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -30,8 +30,8 @@ package org.hisp.dhis.android.core.trackedentity.internal
 import io.ktor.http.HttpStatusCode
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
-import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -37,13 +37,21 @@ import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.call.D2ProgressSyncStatus
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
+import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
+import org.hisp.dhis.android.persistence.event.EventTableInfo
+import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceTableInfo
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -55,6 +63,11 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     private val systemInfoModuleDownloader: SystemInfoModuleDownloader,
     private val relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
+    private val organisationUnitStore: OrganisationUnitStore,
+    private val organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
+    private val trackedEntityInstanceStore: TrackedEntityInstanceStore,
+    private val enrollmentStore: EnrollmentStore,
+    private val eventStore: EventStore,
 ) {
     fun download(params: ProgramDataDownloadParams): Flow<TrackerD2Progress> = channelFlow {
         val progressManager = TrackerD2ProgressManager(null)
@@ -67,6 +80,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
             coroutineAPICallExecutor.wrapTransactionallyRoom(cleanForeignKeyErrors = true) {
                 downloadInternal(params, progressManager, relatives).collect { v -> send(v) }
                 downloadRelationships(progressManager, relatives).collect { v -> send(v) }
+                downloadMissingOrgUnits(progressManager).collect { v -> send(v) }
                 send(progressManager.complete())
             }
         }
@@ -353,6 +367,15 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         emit(progressManager.increaseProgress(TrackedEntityInstance::class.java, false))
     }
 
+    private fun downloadMissingOrgUnits(progressManager: TrackerD2ProgressManager): Flow<TrackerD2Progress> = flow {
+        val missingUids = getMissingOrganisationUnitUids()
+        if (missingUids.isNotEmpty()) {
+            val payload = organisationUnitNetworkHandler.getOrganisationUnitsByUid(missingUids)
+            organisationUnitStore.updateOrInsert(payload.items)
+        }
+        emit(progressManager.increaseProgress(TrackedEntityInstance::class.java, false))
+    }
+
     @Suppress("TooGenericExceptionCaught")
     protected suspend fun getItems(query: TrackerAPIQuery): List<T> {
         return try {
@@ -414,4 +437,18 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         orgunitUid: String?,
         limit: Int,
     ): TrackerAPIQuery?
+
+    private suspend fun getMissingOrganisationUnitUids(): Set<String> {
+        val teiOrgUnits = trackedEntityInstanceStore
+            .selectStringColumnsWhereClause(TrackedEntityInstanceTableInfo.Columns.ORGANISATION_UNIT, "1")
+        val enrollmentOrgUnits = enrollmentStore
+            .selectStringColumnsWhereClause(EnrollmentTableInfo.Columns.ORGANISATION_UNIT, "1")
+        val eventOrgUnits = eventStore
+            .selectStringColumnsWhereClause(EventTableInfo.Columns.ORGANISATION_UNIT, "1")
+
+        val allReferencedOrgUnits = (teiOrgUnits + enrollmentOrgUnits + eventOrgUnits).toSet()
+        val existingOrgUnits = organisationUnitStore.selectUids().toSet()
+
+        return allReferencedOrgUnits - existingOrgUnits
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -35,10 +35,10 @@ import org.hisp.dhis.android.core.arch.api.paging.internal.ApiPagingEngine
 import org.hisp.dhis.android.core.arch.api.paging.internal.Paging
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.call.D2ProgressSyncStatus
+import androidx.sqlite.db.SimpleSQLiteQuery
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
@@ -47,10 +47,10 @@ import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndP
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
 import org.hisp.dhis.android.persistence.event.EventTableInfo
+import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitTableInfo
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceTableInfo
 import kotlin.math.ceil
 import kotlin.math.max
@@ -65,9 +65,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     private val organisationUnitStore: OrganisationUnitStore,
     private val organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
-    private val trackedEntityInstanceStore: TrackedEntityInstanceStore,
-    private val enrollmentStore: EnrollmentStore,
-    private val eventStore: EventStore,
+    private val databaseAdapter: DatabaseAdapter,
 ) {
     fun download(params: ProgramDataDownloadParams): Flow<TrackerD2Progress> = channelFlow {
         val progressManager = TrackerD2ProgressManager(null)
@@ -439,16 +437,17 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     ): TrackerAPIQuery?
 
     private suspend fun getMissingOrganisationUnitUids(): Set<String> {
-        val teiOrgUnits = trackedEntityInstanceStore
-            .selectStringColumnsWhereClause(TrackedEntityInstanceTableInfo.Columns.ORGANISATION_UNIT, "1")
-        val enrollmentOrgUnits = enrollmentStore
-            .selectStringColumnsWhereClause(EnrollmentTableInfo.Columns.ORGANISATION_UNIT, "1")
-        val eventOrgUnits = eventStore
-            .selectStringColumnsWhereClause(EventTableInfo.Columns.ORGANISATION_UNIT, "1")
-
-        val allReferencedOrgUnits = (teiOrgUnits + enrollmentOrgUnits + eventOrgUnits).toSet()
-        val existingOrgUnits = organisationUnitStore.selectUids().toSet()
-
-        return allReferencedOrgUnits - existingOrgUnits
+        val query = """
+            SELECT DISTINCT ${TrackedEntityInstanceTableInfo.Columns.ORGANISATION_UNIT} 
+            FROM ${TrackedEntityInstanceTableInfo.TABLE_NAME}
+            UNION SELECT DISTINCT ${EnrollmentTableInfo.Columns.ORGANISATION_UNIT} 
+            FROM ${EnrollmentTableInfo.TABLE_NAME}
+            UNION SELECT DISTINCT ${EventTableInfo.Columns.ORGANISATION_UNIT} 
+            FROM ${EventTableInfo.TABLE_NAME}
+            EXCEPT SELECT ${OrganisationUnitTableInfo.Columns.UID} 
+            FROM ${OrganisationUnitTableInfo.TABLE_NAME}
+        """.trimIndent()
+        val dao = databaseAdapter.getCurrentDatabase().d2Dao()
+        return dao.stringListRawQuery(SimpleSQLiteQuery(query)).toSet()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.tracker.exporter
 
+import androidx.sqlite.db.SimpleSQLiteQuery
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
@@ -35,7 +36,6 @@ import org.hisp.dhis.android.core.arch.api.paging.internal.ApiPagingEngine
 import org.hisp.dhis.android.core.arch.api.paging.internal.Paging
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.call.D2ProgressSyncStatus
-import androidx.sqlite.db.SimpleSQLiteQuery
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result

--- a/core/src/main/java/org/hisp/dhis/android/network/organisationunit/OrganisationUnitNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/organisationunit/OrganisationUnitNetworkHandlerImpl.kt
@@ -51,4 +51,16 @@ internal class OrganisationUnitNetworkHandlerImpl(
         )
         return apiPayload.mapItems(OrganisationUnitDTO::toDomain)
     }
+
+    override suspend fun getOrganisationUnitsByUid(uids: Set<String>): Payload<OrganisationUnit> {
+        val apiPayload = service.getOrganisationUnits(
+            OrganisationUnitFields.allFields,
+            OrganisationUnitFields.uid.`in`(uids),
+            OrganisationUnitFields.ASC_ORDER,
+            false,
+            uids.size,
+            1,
+        )
+        return apiPayload.mapItems(OrganisationUnitDTO::toDomain)
+    }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.kt
@@ -31,9 +31,9 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
-import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.event.internal.EventStore
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
@@ -115,7 +115,15 @@ class OrganisationUnitCallUnitShould {
         whenever(user.phoneNumber()).doReturn("user_phone_number")
         whenever(user.nationality()).doReturn("user_nationality")
         whenever(userOrganisationUnitLinkStore.queryOrganisationUnitUidsByScope(any())).doReturn(listOf(orgUnitUid))
+        whenever(userOrganisationUnitLinkStore.selectStringColumnsWhereClause(any(), any()))
+            .doReturn(listOf(orgUnitUid))
         whenever(organisationUnitStore.selectByUids(any())).doReturn(listOf(organisationUnit))
+        whenever(trackedEntityInstanceStore.selectStringColumnsWhereClause(any(), any()))
+            .doReturn(emptyList())
+        whenever(enrollmentStore.selectStringColumnsWhereClause(any(), any()))
+            .doReturn(emptyList())
+        whenever(eventStore.selectStringColumnsWhereClause(any(), any()))
+            .doReturn(emptyList())
 
         organisationUnitCall = {
             OrganisationUnitCall(
@@ -169,5 +177,18 @@ class OrganisationUnitCallUnitShould {
         organisationUnitCall.invoke()
 
         verify(organisationUnitHandler, times(2)).handleMany(any())
+    }
+
+    @Test
+    fun include_tracker_data_org_units_in_cleaner_call() = runTest {
+        val trackerOrgUnit = "trackerOrgUnitUid"
+        whenever(trackedEntityInstanceStore.selectStringColumnsWhereClause(any(), any()))
+            .doReturn(listOf(trackerOrgUnit))
+
+        organisationUnitCall.invoke()
+
+        val cleanerCaptor = argumentCaptor<Collection<String>>()
+        verify(collectionCleaner).deleteNotPresentByUid(cleanerCaptor.capture())
+        assertThat(cleanerCaptor.firstValue).contains(trackerOrgUnit)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.kt
@@ -32,6 +32,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.event.internal.EventStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
@@ -61,6 +64,9 @@ class OrganisationUnitCallUnitShould {
     private val organisationUnitHandler: OrganisationUnitHandler = mock()
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
     private val organisationUnitStore: OrganisationUnitStore = mock()
+    private val trackedEntityInstanceStore: TrackedEntityInstanceStore = mock()
+    private val enrollmentStore: EnrollmentStore = mock()
+    private val eventStore: EventStore = mock()
 
     // the call we are testing:
     private lateinit var lastUpdated: Date
@@ -118,6 +124,9 @@ class OrganisationUnitCallUnitShould {
                 userOrganisationUnitLinkStore,
                 organisationUnitStore,
                 collectionCleaner,
+                trackedEntityInstanceStore,
+                enrollmentStore,
+                eventStore,
             ).download(user)
         }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallUnitShould.kt
@@ -27,17 +27,18 @@
  */
 package org.hisp.dhis.android.core.organisationunit.internal
 
+import androidx.sqlite.db.SupportSQLiteQuery
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
-import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
-import org.hisp.dhis.android.core.event.internal.EventStore
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.db.access.internal.AppDatabase
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
-import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.UserInternalAccessor
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
+import org.hisp.dhis.android.persistence.common.daos.D2Dao
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -64,9 +65,9 @@ class OrganisationUnitCallUnitShould {
     private val organisationUnitHandler: OrganisationUnitHandler = mock()
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
     private val organisationUnitStore: OrganisationUnitStore = mock()
-    private val trackedEntityInstanceStore: TrackedEntityInstanceStore = mock()
-    private val enrollmentStore: EnrollmentStore = mock()
-    private val eventStore: EventStore = mock()
+    private val databaseAdapter: DatabaseAdapter = mock()
+    private val appDatabase: AppDatabase = mock()
+    private val d2Dao: D2Dao = mock()
 
     // the call we are testing:
     private lateinit var lastUpdated: Date
@@ -118,11 +119,9 @@ class OrganisationUnitCallUnitShould {
         whenever(userOrganisationUnitLinkStore.selectStringColumnsWhereClause(any(), any()))
             .doReturn(listOf(orgUnitUid))
         whenever(organisationUnitStore.selectByUids(any())).doReturn(listOf(organisationUnit))
-        whenever(trackedEntityInstanceStore.selectStringColumnsWhereClause(any(), any()))
-            .doReturn(emptyList())
-        whenever(enrollmentStore.selectStringColumnsWhereClause(any(), any()))
-            .doReturn(emptyList())
-        whenever(eventStore.selectStringColumnsWhereClause(any(), any()))
+        whenever(databaseAdapter.getCurrentDatabase()).doReturn(appDatabase)
+        whenever(appDatabase.d2Dao()).doReturn(d2Dao)
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>()))
             .doReturn(emptyList())
 
         organisationUnitCall = {
@@ -132,9 +131,7 @@ class OrganisationUnitCallUnitShould {
                 userOrganisationUnitLinkStore,
                 organisationUnitStore,
                 collectionCleaner,
-                trackedEntityInstanceStore,
-                enrollmentStore,
-                eventStore,
+                databaseAdapter,
             ).download(user)
         }
 
@@ -182,7 +179,7 @@ class OrganisationUnitCallUnitShould {
     @Test
     fun include_tracker_data_org_units_in_cleaner_call() = runTest {
         val trackerOrgUnit = "trackerOrgUnitUid"
-        whenever(trackedEntityInstanceStore.selectStringColumnsWhereClause(any(), any()))
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>()))
             .doReturn(listOf(trackerOrgUnit))
 
         organisationUnitCall.invoke()

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -36,18 +36,19 @@ import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallEx
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.internal.AppDatabase
-import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
-import org.hisp.dhis.android.core.arch.helpers.Result
-import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
-import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
-import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
-import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryBundle
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceDownloadCall
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceLastUpdatedManager
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstancePersistenceCallFactory
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryBundleFactory
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryCollectionRepository
+import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterBreakTheGlassHelper
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.hisp.dhis.android.persistence.common.daos.D2Dao
 import org.junit.Before
@@ -74,16 +75,23 @@ class TrackerDownloadCallShould {
     private val databaseAdapter: DatabaseAdapter = mock()
     private val appDatabase: AppDatabase = mock()
     private val d2Dao: D2Dao = mock()
+    private val queryFactory: TrackerQueryBundleFactory = mock()
+    private val trackerCallFactory: TrackerParentCallFactory = mock()
+    private val persistenceCallFactory: TrackedEntityInstancePersistenceCallFactory = mock()
+    private val lastUpdatedManager: TrackedEntityInstanceLastUpdatedManager = mock()
+    private val teiQueryCollectionRepository: TrackedEntityInstanceQueryCollectionRepository = mock()
+    private val breakTheGlassHelper: TrackerImporterBreakTheGlassHelper = mock()
 
-    private lateinit var call: TestTrackerDownloadCall
+    private lateinit var call: TrackedEntityInstanceDownloadCall
 
     @Before
     fun setUp() = runTest {
         whenever(databaseAdapter.getCurrentDatabase()).doReturn(appDatabase)
         whenever(appDatabase.d2Dao()).doReturn(d2Dao)
         whenever(userOrganisationUnitLinkStore.count()).doReturn(1)
+        whenever(queryFactory.getQueries(any())).doReturn(emptyList())
 
-        call = TestTrackerDownloadCall(
+        call = TrackedEntityInstanceDownloadCall(
             userOrganisationUnitLinkStore,
             systemInfoModuleDownloader,
             relationshipDownloadAndPersistCallFactory,
@@ -91,6 +99,12 @@ class TrackerDownloadCallShould {
             organisationUnitStore,
             organisationUnitNetworkHandler,
             databaseAdapter,
+            queryFactory,
+            trackerCallFactory,
+            persistenceCallFactory,
+            lastUpdatedManager,
+            teiQueryCollectionRepository,
+            breakTheGlassHelper,
         )
     }
 
@@ -155,61 +169,4 @@ class TrackerDownloadCallShould {
         assertThat(progressList).isNotEmpty()
         assertThat(progressList.last().isComplete).isTrue()
     }
-}
-
-private class TestTrackerDownloadCall(
-    userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
-    systemInfoModuleDownloader: SystemInfoModuleDownloader,
-    relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory,
-    coroutineAPICallExecutor: CoroutineAPICallExecutorMock,
-    organisationUnitStore: OrganisationUnitStore,
-    organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
-    databaseAdapter: DatabaseAdapter,
-) : TrackerDownloadCall<TrackedEntityInstance, TrackerQueryBundle>(
-    userOrganisationUnitLinkStore,
-    systemInfoModuleDownloader,
-    relationshipDownloadAndPersistCallFactory,
-    coroutineAPICallExecutor,
-    organisationUnitStore,
-    organisationUnitNetworkHandler,
-    databaseAdapter,
-) {
-    override suspend fun getBundles(params: ProgramDataDownloadParams): List<TrackerQueryBundle> = emptyList()
-
-    override suspend fun getPayloadResult(
-        query: TrackerAPIQuery,
-    ): Result<Payload<TrackedEntityInstance>, D2Error> {
-        val emptyPayload: Payload<TrackedEntityInstance> = object : Payload<TrackedEntityInstance> {
-            override val pager: Any? = null
-            override val items: List<TrackedEntityInstance> = emptyList()
-
-            @Deprecated("Use pager attribute instead", replaceWith = ReplaceWith("pager"))
-            override fun pager(): Any? = null
-
-            @Deprecated("Use items attribute instead", replaceWith = ReplaceWith("items"))
-            override fun items(): List<TrackedEntityInstance> = emptyList()
-        }
-        return Result.Success(emptyPayload)
-    }
-
-    override suspend fun persistItems(
-        items: List<TrackedEntityInstance>,
-        params: IdentifiableDataHandlerParams,
-        relatives: RelationshipItemRelatives,
-    ) { }
-
-    override suspend fun updateLastUpdated(bundle: TrackerQueryBundle) { }
-
-    override suspend fun queryByUids(
-        bundle: TrackerQueryBundle,
-        overwrite: Boolean,
-        relatives: RelationshipItemRelatives,
-    ): ItemsWithPagingResult = ItemsWithPagingResult(0, true, null, true)
-
-    override suspend fun getQuery(
-        bundle: TrackerQueryBundle,
-        program: String?,
-        orgunitUid: String?,
-        limit: Int,
-    ): TrackerAPIQuery? = null
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.tracker.exporter
+
+import androidx.sqlite.db.SupportSQLiteQuery
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutorMock
+import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
+import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.db.access.internal.AppDatabase
+import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
+import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
+import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
+import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
+import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryBundle
+import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
+import org.hisp.dhis.android.persistence.common.daos.D2Dao
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(JUnit4::class)
+class TrackerDownloadCallShould {
+
+    private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
+    private val systemInfoModuleDownloader: SystemInfoModuleDownloader = mock()
+    private val relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory = mock()
+    private val coroutineAPICallExecutor = CoroutineAPICallExecutorMock()
+    private val organisationUnitStore: OrganisationUnitStore = mock()
+    private val organisationUnitNetworkHandler: OrganisationUnitNetworkHandler = mock()
+    private val databaseAdapter: DatabaseAdapter = mock()
+    private val appDatabase: AppDatabase = mock()
+    private val d2Dao: D2Dao = mock()
+
+    private lateinit var call: TestTrackerDownloadCall
+
+    @Before
+    fun setUp() = runTest {
+        whenever(databaseAdapter.getCurrentDatabase()).doReturn(appDatabase)
+        whenever(appDatabase.d2Dao()).doReturn(d2Dao)
+        whenever(userOrganisationUnitLinkStore.count()).doReturn(1)
+
+        call = TestTrackerDownloadCall(
+            userOrganisationUnitLinkStore,
+            systemInfoModuleDownloader,
+            relationshipDownloadAndPersistCallFactory,
+            coroutineAPICallExecutor,
+            organisationUnitStore,
+            organisationUnitNetworkHandler,
+            databaseAdapter,
+        )
+    }
+
+    @Test
+    fun download_missing_org_units_when_query_returns_uids() = runTest {
+        val missingOrgUnitUid = "missingOrgUnit1"
+        val orgUnit = OrganisationUnit.builder().uid(missingOrgUnitUid).build()
+        val payload: Payload<OrganisationUnit> = mock()
+
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>()))
+            .doReturn(listOf(missingOrgUnitUid))
+        whenever(organisationUnitNetworkHandler.getOrganisationUnitsByUid(setOf(missingOrgUnitUid)))
+            .doReturn(payload)
+        whenever(payload.items).doReturn(listOf(orgUnit))
+
+        val params = ProgramDataDownloadParams.builder().build()
+        call.download(params).toList()
+
+        verify(organisationUnitNetworkHandler).getOrganisationUnitsByUid(setOf(missingOrgUnitUid))
+        verify(organisationUnitStore).updateOrInsert(listOf(orgUnit))
+    }
+
+    @Test
+    fun not_call_network_when_no_missing_org_units() = runTest {
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>()))
+            .doReturn(emptyList())
+
+        val params = ProgramDataDownloadParams.builder().build()
+        call.download(params).toList()
+
+        verify(organisationUnitNetworkHandler, never()).getOrganisationUnitsByUid(any())
+        verify(organisationUnitStore, never()).updateOrInsert(any<Collection<OrganisationUnit>>())
+    }
+
+    @Test
+    fun download_multiple_missing_org_units() = runTest {
+        val missingUids = listOf("orgUnit1", "orgUnit2", "orgUnit3")
+        val orgUnits = missingUids.map { OrganisationUnit.builder().uid(it).build() }
+        val payload: Payload<OrganisationUnit> = mock()
+
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>()))
+            .doReturn(missingUids)
+        whenever(organisationUnitNetworkHandler.getOrganisationUnitsByUid(missingUids.toSet()))
+            .doReturn(payload)
+        whenever(payload.items).doReturn(orgUnits)
+
+        val params = ProgramDataDownloadParams.builder().build()
+        call.download(params).toList()
+
+        verify(organisationUnitNetworkHandler).getOrganisationUnitsByUid(missingUids.toSet())
+        verify(organisationUnitStore).updateOrInsert(orgUnits)
+    }
+
+    @Test
+    fun emit_progress_after_downloading_missing_org_units() = runTest {
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>()))
+            .doReturn(emptyList())
+
+        val params = ProgramDataDownloadParams.builder().build()
+        val progressList = call.download(params).toList()
+
+        assertThat(progressList).isNotEmpty()
+        assertThat(progressList.last().isComplete).isTrue()
+    }
+}
+
+private class TestTrackerDownloadCall(
+    userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
+    systemInfoModuleDownloader: SystemInfoModuleDownloader,
+    relationshipDownloadAndPersistCallFactory: RelationshipDownloadAndPersistCallFactory,
+    coroutineAPICallExecutor: CoroutineAPICallExecutorMock,
+    organisationUnitStore: OrganisationUnitStore,
+    organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
+    databaseAdapter: DatabaseAdapter,
+) : TrackerDownloadCall<TrackedEntityInstance, TrackerQueryBundle>(
+    userOrganisationUnitLinkStore,
+    systemInfoModuleDownloader,
+    relationshipDownloadAndPersistCallFactory,
+    coroutineAPICallExecutor,
+    organisationUnitStore,
+    organisationUnitNetworkHandler,
+    databaseAdapter,
+) {
+    override suspend fun getBundles(params: ProgramDataDownloadParams): List<TrackerQueryBundle> = emptyList()
+
+    override suspend fun getPayloadResult(
+        query: TrackerAPIQuery,
+    ): Result<Payload<TrackedEntityInstance>, D2Error> {
+        val emptyPayload: Payload<TrackedEntityInstance> = object : Payload<TrackedEntityInstance> {
+            override val pager: Any? = null
+            override val items: List<TrackedEntityInstance> = emptyList()
+
+            @Deprecated("Use pager attribute instead", replaceWith = ReplaceWith("pager"))
+            override fun pager(): Any? = null
+
+            @Deprecated("Use items attribute instead", replaceWith = ReplaceWith("items"))
+            override fun items(): List<TrackedEntityInstance> = emptyList()
+        }
+        return Result.Success(emptyPayload)
+    }
+
+    override suspend fun persistItems(
+        items: List<TrackedEntityInstance>,
+        params: IdentifiableDataHandlerParams,
+        relatives: RelationshipItemRelatives,
+    ) { }
+
+    override suspend fun updateLastUpdated(bundle: TrackerQueryBundle) { }
+
+    override suspend fun queryByUids(
+        bundle: TrackerQueryBundle,
+        overwrite: Boolean,
+        relatives: RelationshipItemRelatives,
+    ): ItemsWithPagingResult = ItemsWithPagingResult(0, true, null, true)
+
+    override suspend fun getQuery(
+        bundle: TrackerQueryBundle,
+        program: String?,
+        orgunitUid: String?,
+        limit: Int,
+    ): TrackerAPIQuery? = null
+}


### PR DESCRIPTION
This PR downloads org units outside the users scope but linked to tracker data. Also, cleaning these secondary org units is prevented when syncing metadata.

Related task: [ANDROSDK-2244](https://dhis2.atlassian.net/browse/ANDROSDK-2244)

[ANDROSDK-2244]: https://dhis2.atlassian.net/browse/ANDROSDK-2244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ