### PR TITLE
feat: [ANDROSDK-2238] Analytics: respect configured start day in relative weekly period

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9948,6 +9948,7 @@ public abstract class org/hisp/dhis/android/core/settings/SystemSetting$Builder 
 
 public final class org/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey : java/lang/Enum {
 	public static final field ANALYTICS_FINANCIAL_YEAR_START Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
+	public static final field ANALYTICS_WEEK_START Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
 	public static final field BING_BASE_MAP Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
 	public static final field DEFAULT_BASE_MAP Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
 	public static final field FLAG Lorg/hisp/dhis/android/core/settings/SystemSetting$SystemSettingKey;
@@ -9958,6 +9959,7 @@ public final class org/hisp/dhis/android/core/settings/SystemSetting$SystemSetti
 
 public final class org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl {
 	public final fun analyticsFinancialYearStart ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
+	public final fun analyticsWeekStart ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
 	public final fun byKey ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byValue ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun defaultBaseMap ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
@@ -121,11 +121,11 @@ class EventLineListIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() 
     private val legendSetStore: LegendSetStore = koin.get()
     private val legendStore: LegendStore = koin.get()
     private val clockProvider = ClockProviderFactory.createFixed()
-    private val financialYearPeriodHelper = RelativePeriodHelperMock()
+    private val relativePeriodHelper = RelativePeriodHelperMock()
     private val dateFilterPeriodHelper =
         DateFilterPeriodHelper(
             clockProvider,
-            ParentPeriodGeneratorImpl.create(clockProvider, financialYearPeriodHelper),
+            ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper),
         )
     private val organisationUnitHelper = AnalyticsOrganisationUnitHelper(
         userOrganisationUnitStore,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/eventlinelist/EventLineListIntegrationShould.kt
@@ -78,8 +78,8 @@ import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStor
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
 import org.hisp.dhis.android.core.period.clock.internal.createFixed
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
 import org.hisp.dhis.android.core.program.ProgramIndicator
 import org.hisp.dhis.android.core.program.internal.ProgramIndicatorStore
 import org.hisp.dhis.android.core.program.internal.ProgramStageStore
@@ -121,7 +121,7 @@ class EventLineListIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() 
     private val legendSetStore: LegendSetStore = koin.get()
     private val legendStore: LegendStore = koin.get()
     private val clockProvider = ClockProviderFactory.createFixed()
-    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+    private val financialYearPeriodHelper = RelativePeriodHelperMock()
     private val dateFilterPeriodHelper =
         DateFilterPeriodHelper(
             clockProvider,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
@@ -43,7 +43,7 @@ import org.junit.Test
 class FinancialYearPeriodIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     private val systemSettingRepository: SystemSettingCollectionRepository = d2.settingModule().systemSetting()
-    private val financialYearPeriodHelper: FinancialYearPeriodHelper = koin.get()
+    private val relativePeriodHelper: RelativePeriodHelper = koin.get()
     private val parentPeriodGenerator: ParentPeriodGenerator = koin.get()
 
     @Test
@@ -54,7 +54,7 @@ class FinancialYearPeriodIntegrationShould : BaseMockIntegrationTestFullDispatch
         assertThat(setting?.value()).isEqualTo("FINANCIAL_YEAR_JULY")
 
         // Verify that the helper returns the correct PeriodType
-        val periodType = financialYearPeriodHelper.getFinancialYearPeriodType()
+        val periodType = relativePeriodHelper.getFinancialYearPeriodType()
         assertThat(periodType).isEqualTo(PeriodType.FinancialJuly)
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
@@ -65,7 +65,7 @@ class PeriodStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrationSho
 
     @Test
     fun select_correct_period_passing_period_type_and_a_date() = runTest {
-        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        val financialYearPeriodHelper = RelativePeriodHelperMock()
         PeriodHandler(
             periodStore,
             create(ClockProviderFactory.createFixed(), financialYearPeriodHelper),

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
@@ -65,10 +65,10 @@ class PeriodStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrationSho
 
     @Test
     fun select_correct_period_passing_period_type_and_a_date() = runTest {
-        val financialYearPeriodHelper = RelativePeriodHelperMock()
+        val relativePeriodHelper = RelativePeriodHelperMock()
         PeriodHandler(
             periodStore,
-            create(ClockProviderFactory.createFixed(), financialYearPeriodHelper),
+            create(ClockProviderFactory.createFixed(), relativePeriodHelper),
         ).generateAndPersist()
         val period = periodStore.selectPeriodByTypeAndDate(
             PeriodType.SixMonthly,

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/SettingsModuleMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/SettingsModuleMockIntegrationShould.kt
@@ -36,7 +36,7 @@ class SettingsModuleMockIntegrationShould : BaseMockIntegrationTestFullDispatche
     @Test
     fun allow_access_to_system_setting() {
         val systemSettings: List<SystemSetting?> = d2.settingModule().systemSetting().blockingGet()
-        Truth.assertThat(systemSettings.size).isEqualTo(4)
+        Truth.assertThat(systemSettings.size).isEqualTo(5)
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
@@ -42,8 +42,8 @@ import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
@@ -53,7 +53,7 @@ class TrackedEntityInstanceLocalQueryHelperMockIntegrationShould : BaseMockInteg
     private val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
 
     private val clockProvider = ClockProviderFactory.clockProvider
-    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+    private val financialYearPeriodHelper = RelativePeriodHelperMock()
     private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
     private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperMockIntegrationShould.kt
@@ -53,8 +53,8 @@ class TrackedEntityInstanceLocalQueryHelperMockIntegrationShould : BaseMockInteg
     private val trackedEntityInstanceStore: TrackedEntityInstanceStore = koin.get()
 
     private val clockProvider = ClockProviderFactory.clockProvider
-    private val financialYearPeriodHelper = RelativePeriodHelperMock()
-    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
+    private val relativePeriodHelper = RelativePeriodHelperMock()
+    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, relativePeriodHelper))
     private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsPeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/AnalyticsPeriodHelper.kt
@@ -34,14 +34,14 @@ import org.hisp.dhis.android.core.parser.internal.expression.ParserUtils
 import org.hisp.dhis.android.core.period.Period
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 
 object AnalyticsPeriodHelper {
-    private val financialYearPeriodHelper: FinancialYearPeriodHelper = koin.get()
+    private val relativePeriodHelper: RelativePeriodHelper = koin.get()
     private val periodGenerator = ParentPeriodGeneratorImpl.create(
         ClockProviderFactory.clockProvider,
-        financialYearPeriodHelper,
+        relativePeriodHelper,
     )
 
     fun shiftPeriod(period: Period, offset: Int): Period {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/BaseDateEvaluator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/evaluator/BaseDateEvaluator.kt
@@ -34,19 +34,19 @@ import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koi
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
 import org.hisp.dhis.android.core.period.internal.PeriodParser
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import java.util.Date
 
 internal abstract class BaseDateEvaluator(
     private val item: DateItem,
 ) : TrackerLineListEvaluator() {
 
-    private val financialYearPeriodHelper: FinancialYearPeriodHelper = koin.get()
+    private val relativePeriodHelper: RelativePeriodHelper = koin.get()
     private val parentPeriodGenerator = ParentPeriodGeneratorImpl.create(
         ClockProviderFactory.clockProvider,
-        financialYearPeriodHelper,
+        relativePeriodHelper,
     )
     private val periodParser = PeriodParser()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/common/RelativePeriod.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/RelativePeriod.kt
@@ -89,7 +89,7 @@ enum class RelativePeriod constructor(
         return if (isFinancialYearRelativePeriod()) {
             relativePeriodHelper.getFinancialYearPeriodType()
         } else if (isWeeklyRelativePeriod()) {
-            relativePeriodHelper.getWeekStart()
+            relativePeriodHelper.getWeeklyPeriodType()
         } else {
             periodType
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/common/RelativePeriod.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/RelativePeriod.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.core.common
 
 import org.hisp.dhis.android.core.period.PeriodType
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 
 @Suppress("MagicNumber")
 enum class RelativePeriod constructor(
@@ -85,9 +85,11 @@ enum class RelativePeriod constructor(
     LAST_52_WEEKS(PeriodType.Weekly, -52, 0),
     ;
 
-    internal fun getPeriodType(financialYearPeriodHelper: FinancialYearPeriodHelper): PeriodType {
+    internal fun getPeriodType(relativePeriodHelper: RelativePeriodHelper): PeriodType {
         return if (isFinancialYearRelativePeriod()) {
-            financialYearPeriodHelper.getFinancialYearPeriodType()
+            relativePeriodHelper.getFinancialYearPeriodType()
+        } else if (isWeeklyRelativePeriod()) {
+            relativePeriodHelper.getWeekStart()
         } else {
             periodType
         }
@@ -97,12 +99,25 @@ enum class RelativePeriod constructor(
         return this in FINANCIAL_YEAR_PERIODS
     }
 
+    internal fun isWeeklyRelativePeriod(): Boolean {
+        return this in WEEKLY_PERIODS
+    }
+
     companion object {
         internal val FINANCIAL_YEAR_PERIODS = setOf(
             THIS_FINANCIAL_YEAR,
             LAST_FINANCIAL_YEAR,
             LAST_5_FINANCIAL_YEARS,
             LAST_10_FINANCIAL_YEARS,
+        )
+
+        internal val WEEKLY_PERIODS = setOf(
+            WEEKS_THIS_YEAR,
+            THIS_WEEK,
+            LAST_WEEK,
+            LAST_4_WEEKS,
+            LAST_12_WEEKS,
+            LAST_52_WEEKS,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/PeriodDIModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/PeriodDIModule.kt
@@ -30,9 +30,9 @@ package org.hisp.dhis.android.core.period
 
 import org.hisp.dhis.android.core.period.clock.internal.ClockProvider
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGenerator
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Singleton
@@ -44,9 +44,9 @@ internal class PeriodDIModule {
     @Singleton
     fun parentPeriodGenerator(
         clockProvider: ClockProvider,
-        financialYearPeriodHelper: FinancialYearPeriodHelper,
+        relativePeriodHelper: RelativePeriodHelper,
     ): ParentPeriodGenerator {
-        return ParentPeriodGeneratorImpl.create(clockProvider, financialYearPeriodHelper)
+        return ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
     }
 
     @Singleton

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/WeeklyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/WeeklyPeriodGenerators.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.period.generator.internal
 
-import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import kotlin.time.Clock
 
 internal class WeeklyPeriodGenerators(clock: Clock) {

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/WeeklyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/WeeklyPeriodGenerators.kt
@@ -30,12 +30,11 @@ package org.hisp.dhis.android.core.period.generator.internal
 import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import kotlin.time.Clock
 
-internal class WeeklyPeriodGenerators(clock: Clock, relativePeriodHelper: RelativePeriodHelper) {
+internal class WeeklyPeriodGenerators(clock: Clock) {
     val weekly = WeeklyPeriodGeneratorFactory.weekly(clock)
     val weeklyWednesday = WeeklyPeriodGeneratorFactory.wednesday(clock)
     val weeklyThursday = WeeklyPeriodGeneratorFactory.thursday(clock)
     val weeklyFriday = WeeklyPeriodGeneratorFactory.friday(clock)
     val weeklySaturday = WeeklyPeriodGeneratorFactory.saturday(clock)
     val weeklySunday = WeeklyPeriodGeneratorFactory.sunday(clock)
-    val relativePeriodHelper: RelativePeriodHelper = relativePeriodHelper
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/WeeklyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/WeeklyPeriodGenerators.kt
@@ -27,13 +27,15 @@
  */
 package org.hisp.dhis.android.core.period.generator.internal
 
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import kotlin.time.Clock
 
-internal class WeeklyPeriodGenerators(clock: Clock) {
+internal class WeeklyPeriodGenerators(clock: Clock, relativePeriodHelper: RelativePeriodHelper) {
     val weekly = WeeklyPeriodGeneratorFactory.weekly(clock)
     val weeklyWednesday = WeeklyPeriodGeneratorFactory.wednesday(clock)
     val weeklyThursday = WeeklyPeriodGeneratorFactory.thursday(clock)
     val weeklySaturday = WeeklyPeriodGeneratorFactory.saturday(clock)
     val weeklyFriday = WeeklyPeriodGeneratorFactory.friday(clock)
     val weeklySunday = WeeklyPeriodGeneratorFactory.sunday(clock)
+    val relativePeriodHelper: RelativePeriodHelper = relativePeriodHelper
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.period.generator.internal
 
-import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import kotlin.time.Clock
 
 internal class YearlyPeriodGenerators(clock: Clock) {

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
@@ -30,7 +30,7 @@ package org.hisp.dhis.android.core.period.generator.internal
 import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import kotlin.time.Clock
 
-internal class YearlyPeriodGenerators(clock: Clock, relativePeriodHelper: RelativePeriodHelper) {
+internal class YearlyPeriodGenerators(clock: Clock) {
     val yearly = YearlyPeriodGeneratorFactory.yearly(clock)
     val financialApril = YearlyPeriodGeneratorFactory.financialApril(clock)
     val financialJuly = YearlyPeriodGeneratorFactory.financialJuly(clock)
@@ -39,5 +39,4 @@ internal class YearlyPeriodGenerators(clock: Clock, relativePeriodHelper: Relati
     val financialFeb = YearlyPeriodGeneratorFactory.financialFeb(clock)
     val financialAug = YearlyPeriodGeneratorFactory.financialAug(clock)
     val financialSep = YearlyPeriodGeneratorFactory.financialSep(clock)
-    val relativePeriodHelper: RelativePeriodHelper = relativePeriodHelper
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/generator/internal/YearlyPeriodGenerators.kt
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.android.core.period.generator.internal
 
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelper
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelper
 import kotlin.time.Clock
 
-internal class YearlyPeriodGenerators(clock: Clock, financialYearPeriodHelper: FinancialYearPeriodHelper) {
+internal class YearlyPeriodGenerators(clock: Clock, relativePeriodHelper: RelativePeriodHelper) {
     val yearly = YearlyPeriodGeneratorFactory.yearly(clock)
     val financialApril = YearlyPeriodGeneratorFactory.financialApril(clock)
     val financialJuly = YearlyPeriodGeneratorFactory.financialJuly(clock)
@@ -39,5 +39,5 @@ internal class YearlyPeriodGenerators(clock: Clock, financialYearPeriodHelper: F
     val financialFeb = YearlyPeriodGeneratorFactory.financialFeb(clock)
     val financialAug = YearlyPeriodGeneratorFactory.financialAug(clock)
     val financialSep = YearlyPeriodGeneratorFactory.financialSep(clock)
-    val financialYearPeriodHelper: FinancialYearPeriodHelper = financialYearPeriodHelper
+    val relativePeriodHelper: RelativePeriodHelper = relativePeriodHelper
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
@@ -47,6 +47,7 @@ internal class ParentPeriodGeneratorImpl(
     private val monthly: PeriodGenerator,
     private val nMonthly: NMonthlyPeriodGenerators,
     private val yearly: YearlyPeriodGenerators,
+    private val relativePeriodHelper: RelativePeriodHelper,
 ) : ParentPeriodGenerator {
 
     override fun generatePeriods(): List<Period> {
@@ -69,7 +70,7 @@ internal class ParentPeriodGeneratorImpl(
     }
 
     override fun generateRelativePeriods(relativePeriod: RelativePeriod): List<Period> {
-        val periodType = relativePeriod.getPeriodType(yearly.relativePeriodHelper)
+        val periodType = relativePeriod.getPeriodType(relativePeriodHelper)
         val periodGenerator = getPeriodGenerator(periodType)
 
         return when {
@@ -124,11 +125,12 @@ internal class ParentPeriodGeneratorImpl(
             val clock = clockProvider.clock
             return ParentPeriodGeneratorImpl(
                 DailyPeriodGenerator(clock),
-                WeeklyPeriodGenerators(clock, relativePeriodHelper),
+                WeeklyPeriodGenerators(clock),
                 BiWeeklyPeriodGenerator(clock),
                 MonthlyPeriodGenerator(clock),
                 NMonthlyPeriodGenerators(clock),
-                YearlyPeriodGenerators(clock, relativePeriodHelper),
+                YearlyPeriodGenerators(clock),
+                relativePeriodHelper,
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/ParentPeriodGeneratorImpl.kt
@@ -69,7 +69,7 @@ internal class ParentPeriodGeneratorImpl(
     }
 
     override fun generateRelativePeriods(relativePeriod: RelativePeriod): List<Period> {
-        val periodType = relativePeriod.getPeriodType(yearly.financialYearPeriodHelper)
+        val periodType = relativePeriod.getPeriodType(yearly.relativePeriodHelper)
         val periodGenerator = getPeriodGenerator(periodType)
 
         return when {
@@ -119,16 +119,16 @@ internal class ParentPeriodGeneratorImpl(
     companion object {
         fun create(
             clockProvider: ClockProvider,
-            financialYearPeriodHelper: FinancialYearPeriodHelper,
+            relativePeriodHelper: RelativePeriodHelper,
         ): ParentPeriodGeneratorImpl {
             val clock = clockProvider.clock
             return ParentPeriodGeneratorImpl(
                 DailyPeriodGenerator(clock),
-                WeeklyPeriodGenerators(clock),
+                WeeklyPeriodGenerators(clock, relativePeriodHelper),
                 BiWeeklyPeriodGenerator(clock),
                 MonthlyPeriodGenerator(clock),
                 NMonthlyPeriodGenerators(clock),
-                YearlyPeriodGenerators(clock, financialYearPeriodHelper),
+                YearlyPeriodGenerators(clock, relativePeriodHelper),
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
@@ -31,14 +31,15 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.koin.core.annotation.Singleton
 
-internal fun interface FinancialYearPeriodHelper {
+internal interface RelativePeriodHelper {
     fun getFinancialYearPeriodType(): PeriodType
+    fun getWeekStart(): PeriodType
 }
 
 @Singleton
-internal class FinancialYearPeriodHelperImpl(
+internal class RelativePeriodHelperImpl(
     private val systemSettingRepository: SystemSettingCollectionRepository,
-) : FinancialYearPeriodHelper {
+) : RelativePeriodHelper {
     override fun getFinancialYearPeriodType(): PeriodType {
         val setting = systemSettingRepository.analyticsFinancialYearStart().blockingGet()
         return setting?.value()?.let { mapFinancialYearSetting(it) } ?: PeriodType.FinancialApril
@@ -54,6 +55,22 @@ internal class FinancialYearPeriodHelperImpl(
             "FINANCIAL_YEAR_OCTOBER" -> PeriodType.FinancialOct
             "FINANCIAL_YEAR_NOVEMBER" -> PeriodType.FinancialNov
             else -> PeriodType.FinancialApril
+        }
+    }
+
+    override fun getWeekStart(): PeriodType {
+        val setting = systemSettingRepository.analyticsWeekStart().blockingGet()
+        return setting?.value()?.let { mapWeekStartSetting(it) } ?: PeriodType.Weekly
+    }
+
+    private fun mapWeekStartSetting(value: String): PeriodType {
+        return when (value) {
+            "SUNDAY" -> PeriodType.WeeklySunday
+            "WEDNESDAY" -> PeriodType.WeeklyWednesday
+            "THURSDAY" -> PeriodType.WeeklyThursday
+            "FRIDAY" -> PeriodType.WeeklyFriday
+            "SATURDAY" -> PeriodType.WeeklySunday
+            else -> PeriodType.Weekly
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
@@ -33,7 +33,7 @@ import org.koin.core.annotation.Singleton
 
 internal interface RelativePeriodHelper {
     fun getFinancialYearPeriodType(): PeriodType
-    fun getWeekStart(): PeriodType
+    fun getWeeklyPeriodType(): PeriodType
 }
 
 @Singleton
@@ -58,7 +58,7 @@ internal class RelativePeriodHelperImpl(
         }
     }
 
-    override fun getWeekStart(): PeriodType {
+    override fun getWeeklyPeriodType(): PeriodType {
         val setting = systemSettingRepository.analyticsWeekStart().blockingGet()
         return setting?.value()?.let { mapWeekStartSetting(it) } ?: PeriodType.Weekly
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
@@ -65,11 +65,11 @@ internal class RelativePeriodHelperImpl(
 
     private fun mapWeekStartSetting(value: String): PeriodType {
         return when (value) {
-            "SUNDAY" -> PeriodType.WeeklySunday
-            "WEDNESDAY" -> PeriodType.WeeklyWednesday
-            "THURSDAY" -> PeriodType.WeeklyThursday
-            "FRIDAY" -> PeriodType.WeeklyFriday
-            "SATURDAY" -> PeriodType.WeeklySunday
+            "WEEKLY_WEDNESDAY" -> PeriodType.WeeklyWednesday
+            "WEEKLY_THURSDAY" -> PeriodType.WeeklyThursday
+            "WEEKLY_FRIDAY" -> PeriodType.WeeklyFriday
+            "WEEKLY_SATURDAY" -> PeriodType.WeeklySunday
+            "WEEKLY_SUNDAY" -> PeriodType.WeeklySunday
             else -> PeriodType.Weekly
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSetting.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSetting.java
@@ -43,6 +43,7 @@ public abstract class SystemSetting implements CoreObject {
         DEFAULT_BASE_MAP,
         BING_BASE_MAP,
         ANALYTICS_FINANCIAL_YEAR_START,
+        ANALYTICS_WEEK_START,
     }
 
     @Nullable

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
@@ -80,6 +80,10 @@ class SystemSettingCollectionRepository internal constructor(
         return byKey().eq(SystemSettingKey.ANALYTICS_FINANCIAL_YEAR_START).one()
     }
 
+    fun analyticsWeekStart(): ReadOnlyOneObjectRepositoryFinalImpl<SystemSetting> {
+        return byKey().eq(SystemSettingKey.ANALYTICS_WEEK_START).one()
+    }
+
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<SystemSetting> = emptyMap()
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsDTO.kt
@@ -38,6 +38,7 @@ internal data class SystemSettingsDTO(
     val keyDefaultBaseMap: String?,
     val keyBingMapsApiKey: String?,
     val analyticsFinancialYearStart: String?,
+    val analyticsWeekStart: String?,
 ) {
 
     fun toDomainSplitted(): List<SystemSetting> {
@@ -57,8 +58,12 @@ internal data class SystemSettingsDTO(
             .key(SystemSetting.SystemSettingKey.ANALYTICS_FINANCIAL_YEAR_START)
             .value(analyticsFinancialYearStart)
             .build()
+        val analyticsWeekStart = SystemSetting.builder()
+            .key(SystemSetting.SystemSettingKey.ANALYTICS_WEEK_START)
+            .value(analyticsWeekStart)
+            .build()
 
-        return listOf(flag, style, keyDefaultBaseMap, analyticsFinancialYearStart)
+        return listOf(flag, style, keyDefaultBaseMap, analyticsFinancialYearStart, analyticsWeekStart)
     }
 
     fun toDomainBingMapsApiKey(): SystemSetting {

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2026, University of Oslo
+ *  Copyright (c) 2004-2024, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,16 @@ package org.hisp.dhis.android.core.period.internal
 
 import org.hisp.dhis.android.core.period.PeriodType
 
-internal class FinancialYearPeriodHelperMock(
+internal class RelativePeriodHelperMock(
     private val periodType: PeriodType = PeriodType.FinancialApril,
-) : FinancialYearPeriodHelper {
+    private val weekStart: PeriodType = PeriodType.Weekly,
+
+) : RelativePeriodHelper {
     override fun getFinancialYearPeriodType(): PeriodType {
         return periodType
+    }
+
+    override fun getWeekStart(): PeriodType {
+        return weekStart
     }
 }

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
@@ -38,7 +38,7 @@ internal class RelativePeriodHelperMock(
         return periodType
     }
 
-    override fun getWeekStart(): PeriodType {
+    override fun getWeeklyPeriodType(): PeriodType {
         return weekStart
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/common/DateFilterPeriodHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/DateFilterPeriodHelperShould.kt
@@ -31,8 +31,8 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.LocalDateTime
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.period.clock.internal.FixedClockProvider
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
 import org.junit.Before
 import org.junit.Test
 
@@ -44,7 +44,7 @@ class DateFilterPeriodHelperShould {
     fun setUp() {
         val fixedDate = LocalDateTime(2019, 12, 10, 10, 30)
         val clockProvider = FixedClockProvider(fixedDate)
-        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        val financialYearPeriodHelper = RelativePeriodHelperMock()
 
         dateFilterPeriodHelper =
             DateFilterPeriodHelper(

--- a/core/src/test/java/org/hisp/dhis/android/core/common/DateFilterPeriodHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/DateFilterPeriodHelperShould.kt
@@ -44,14 +44,14 @@ class DateFilterPeriodHelperShould {
     fun setUp() {
         val fixedDate = LocalDateTime(2019, 12, 10, 10, 30)
         val clockProvider = FixedClockProvider(fixedDate)
-        val financialYearPeriodHelper = RelativePeriodHelperMock()
+        val relativePeriodHelper = RelativePeriodHelperMock()
 
         dateFilterPeriodHelper =
             DateFilterPeriodHelper(
                 clockProvider,
                 ParentPeriodGeneratorImpl.create(
                     clockProvider,
-                    financialYearPeriodHelper,
+                    relativePeriodHelper,
                 ),
             )
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodGeneratorImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodGeneratorImplShould.kt
@@ -40,8 +40,8 @@ class RelativePeriodGeneratorImplShould {
 
     private val fixedDate = LocalDateTime(2019, 12, 10, 0, 0)
     private val clockProvider = FixedClockProvider(fixedDate)
-    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
-    private val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearPeriodHelper)
+    private val relativePeriodHelper = RelativePeriodHelperMock()
+    private val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
     @Test
     @Suppress("ComplexMethod", "LongMethod")

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2024, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,15 @@ package org.hisp.dhis.android.core.period.internal
 
 import org.hisp.dhis.android.core.period.PeriodType
 
-internal class FinancialYearPeriodHelperMock(
+internal class RelativePeriodHelperMock(
     private val periodType: PeriodType = PeriodType.FinancialApril,
-) : FinancialYearPeriodHelper {
+    private val weekStart: PeriodType = PeriodType.Weekly,
+) : RelativePeriodHelper {
     override fun getFinancialYearPeriodType(): PeriodType {
         return periodType
+    }
+
+    override fun getWeekStart(): PeriodType {
+        return weekStart
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperMock.kt
@@ -37,7 +37,7 @@ internal class RelativePeriodHelperMock(
         return periodType
     }
 
-    override fun getWeekStart(): PeriodType {
+    override fun getWeeklyPeriodType(): PeriodType {
         return weekStart
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperShould.kt
@@ -37,15 +37,15 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class FinancialYearPeriodHelperShould {
+class RelativePeriodHelperShould {
 
     private val fixedDate = LocalDateTime(2019, 12, 10, 0, 0)
     private val clockProvider = FixedClockProvider(fixedDate)
 
     @Test
     fun `Should use FinancialApril when setting is FINANCIAL_YEAR_APRIL`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialApril)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialApril)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -55,8 +55,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should use FinancialJuly when setting is FINANCIAL_YEAR_JULY`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialJuly)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialJuly)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -66,8 +66,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should use FinancialOct when setting is FINANCIAL_YEAR_OCTOBER`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialOct)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialOct)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -77,8 +77,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should use FinancialNov when setting is FINANCIAL_YEAR_NOVEMBER`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialNov)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialNov)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -88,8 +88,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should use FinancialFeb when setting is FINANCIAL_YEAR_FEBRUARY`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialFeb)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialFeb)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -99,8 +99,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should use FinancialAug when setting is FINANCIAL_YEAR_AUGUST`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialAug)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialAug)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -110,8 +110,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should use FinancialSep when setting is FINANCIAL_YEAR_SEPTEMBER`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialSep)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialSep)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_FINANCIAL_YEAR)
 
@@ -121,8 +121,8 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should generate correct LAST_FINANCIAL_YEAR with different settings`() {
-        val financialYearHelperOct = FinancialYearPeriodHelperMock(PeriodType.FinancialOct)
-        val periodGeneratorOct = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelperOct)
+        val relativePeriodHelperOct = RelativePeriodHelperMock(PeriodType.FinancialOct)
+        val periodGeneratorOct = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelperOct)
 
         val periodsOct = periodGeneratorOct.generateRelativePeriods(RelativePeriod.LAST_FINANCIAL_YEAR)
 
@@ -132,13 +132,33 @@ class FinancialYearPeriodHelperShould {
 
     @Test
     fun `Should generate correct LAST_5_FINANCIAL_YEARS with different settings`() {
-        val financialYearHelper = FinancialYearPeriodHelperMock(PeriodType.FinancialJuly)
-        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, financialYearHelper)
+        val relativePeriodHelper = RelativePeriodHelperMock(PeriodType.FinancialJuly)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.LAST_5_FINANCIAL_YEARS)
 
         assertThat(periods.size).isEqualTo(5)
         assertThat(periods[0].periodId()).isEqualTo("2014July")
         assertThat(periods[4].periodId()).isEqualTo("2018July")
+    }
+    @Test
+    fun `Should generate correct THIS_WEEK with different settings`() {
+        val relativePeriodHelper = RelativePeriodHelperMock(weekStart=PeriodType.WeeklyFriday)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_WEEK)
+
+        assertThat(periods.size).isEqualTo(1)
+        assertThat(periods[0].periodId()).isEqualTo("2019FriW49")
+    }
+    @Test
+    fun `Should generate correct LAST_12_WEEKS with different settings`() {
+        val relativePeriodHelper = RelativePeriodHelperMock(weekStart=PeriodType.WeeklySaturday)
+        val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
+
+        val periods = periodGenerator.generateRelativePeriods(RelativePeriod.LAST_12_WEEKS)
+
+        assertThat(periods.size).isEqualTo(12)
+        assertThat(periods.last().periodId()).isEqualTo("2019SatW49")
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelperShould.kt
@@ -141,9 +141,10 @@ class RelativePeriodHelperShould {
         assertThat(periods[0].periodId()).isEqualTo("2014July")
         assertThat(periods[4].periodId()).isEqualTo("2018July")
     }
+
     @Test
     fun `Should generate correct THIS_WEEK with different settings`() {
-        val relativePeriodHelper = RelativePeriodHelperMock(weekStart=PeriodType.WeeklyFriday)
+        val relativePeriodHelper = RelativePeriodHelperMock(weekStart = PeriodType.WeeklyFriday)
         val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.THIS_WEEK)
@@ -151,9 +152,10 @@ class RelativePeriodHelperShould {
         assertThat(periods.size).isEqualTo(1)
         assertThat(periods[0].periodId()).isEqualTo("2019FriW49")
     }
+
     @Test
     fun `Should generate correct LAST_12_WEEKS with different settings`() {
-        val relativePeriodHelper = RelativePeriodHelperMock(weekStart=PeriodType.WeeklySaturday)
+        val relativePeriodHelper = RelativePeriodHelperMock(weekStart = PeriodType.WeeklySaturday)
         val periodGenerator = ParentPeriodGeneratorImpl.create(clockProvider, relativePeriodHelper)
 
         val periods = periodGenerator.generateRelativePeriods(RelativePeriod.LAST_12_WEEKS)

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/SystemSettingSplitterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/SystemSettingSplitterShould.kt
@@ -42,6 +42,7 @@ class SystemSettingSplitterShould {
         keyDefaultBaseMap = "aDefaultBaseMap",
         keyBingMapsApiKey = null,
         analyticsFinancialYearStart = null,
+        analyticsWeekStart = null,
     )
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
@@ -34,8 +34,8 @@ import org.hisp.dhis.android.core.common.*
 import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,7 +54,7 @@ class TrackedEntityInstanceLocalQueryHelperShould {
     fun setUp() {
         queryBuilder = TrackedEntityInstanceQueryRepositoryScope.builder()
         val clockProvider = ClockProviderFactory.clockProvider
-        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        val financialYearPeriodHelper = RelativePeriodHelperMock()
         val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
         localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
@@ -54,8 +54,8 @@ class TrackedEntityInstanceLocalQueryHelperShould {
     fun setUp() {
         queryBuilder = TrackedEntityInstanceQueryRepositoryScope.builder()
         val clockProvider = ClockProviderFactory.clockProvider
-        val financialYearPeriodHelper = RelativePeriodHelperMock()
-        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
+        val relativePeriodHelper = RelativePeriodHelperMock()
+        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, relativePeriodHelper))
         localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
@@ -37,8 +37,8 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMod
 import org.hisp.dhis.android.core.common.AssignedUserMode
 import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityEndpointCallFactory
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
@@ -81,7 +81,7 @@ class TrackedEntityInstanceQueryDataSourceShould {
 
     private val initialCallback: ItemKeyedDataSource.LoadInitialCallback<TrackedEntityInstance> = mock()
     private val clockProvider = ClockProviderFactory.clockProvider
-    private val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+    private val financialYearPeriodHelper = RelativePeriodHelperMock()
     private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
     private val onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
     private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataSourceShould.kt
@@ -81,8 +81,8 @@ class TrackedEntityInstanceQueryDataSourceShould {
 
     private val initialCallback: ItemKeyedDataSource.LoadInitialCallback<TrackedEntityInstance> = mock()
     private val clockProvider = ClockProviderFactory.clockProvider
-    private val financialYearPeriodHelper = RelativePeriodHelperMock()
-    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
+    private val relativePeriodHelper = RelativePeriodHelperMock()
+    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, relativePeriodHelper))
     private val onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
     private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
     private val onlineCache: TrackedEntityInstanceOnlineCache =

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
@@ -50,8 +50,8 @@ class TrackedEntityInstanceQueryOnlineHelperShould {
     fun setUp() {
         queryBuilder = TrackedEntityInstanceQueryRepositoryScope.builder()
             .orgUnits(listOf("uid"))
-        val financialYearPeriodHelper = RelativePeriodHelperMock()
-        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
+        val relativePeriodHelper = RelativePeriodHelperMock()
+        val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, relativePeriodHelper))
         onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelperShould.kt
@@ -33,8 +33,8 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositorySco
 import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
 import org.hisp.dhis.android.core.common.FilterOperatorsHelper.listToStr
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory.clockProvider
-import org.hisp.dhis.android.core.period.internal.FinancialYearPeriodHelperMock
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryOnlineHelper.Companion.toAPIFilterFormat
 import org.junit.Before
 import org.junit.Test
@@ -50,7 +50,7 @@ class TrackedEntityInstanceQueryOnlineHelperShould {
     fun setUp() {
         queryBuilder = TrackedEntityInstanceQueryRepositoryScope.builder()
             .orgUnits(listOf("uid"))
-        val financialYearPeriodHelper = FinancialYearPeriodHelperMock()
+        val financialYearPeriodHelper = RelativePeriodHelperMock()
         val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, financialYearPeriodHelper))
         onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
     }


### PR DESCRIPTION
This PR adds the required logic to use weeks starting in different days than Monday (depending on the corresponding System Settings parameter) for analytics.

Related task: [ANDROSDK-2238](https://dhis2.atlassian.net/browse/ANDROSDK-2238)

[ANDROSDK-2238]: https://dhis2.atlassian.net/browse/ANDROSDK-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ