### PR TITLE
chore: [ANDROSDK-2254] Add sort by sort order methods to enrollment and event attribute sections

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -7995,6 +7995,7 @@ public final class org/hisp/dhis/android/core/program/ProgramSectionCollectionRe
 	public final fun byMobileRenderType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun byProgramUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun bySortOrder ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/IntegerFilterConnector;
+	public final fun orderBySortOrder (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/program/ProgramSectionCollectionRepository;
 	public final fun withAttributes ()Lorg/hisp/dhis/android/core/program/ProgramSectionCollectionRepository;
 }
 
@@ -8212,6 +8213,7 @@ public final class org/hisp/dhis/android/core/program/ProgramStageSectionsCollec
 	public final fun byMobileRenderType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun byProgramStageUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun bySortOrder ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/IntegerFilterConnector;
+	public final fun orderBySortOrder (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository;
 	public final fun withDataElements ()Lorg/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository;
 	public final fun withProgramIndicators ()Lorg/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository;
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramSectionCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramSectionCollectionRepositoryMockIntegrationShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.testapp.program
 
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -124,5 +125,21 @@ class ProgramSectionCollectionRepositoryMockIntegrationShould : BaseMockIntegrat
             .blockingGet()
 
         assertThat(programSections.size).isEqualTo(1)
+    }
+
+    @Test
+    fun order_by_sort_order() {
+        val programSections = d2.programModule().programSections()
+            .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
+            .blockingGet()
+
+        assertThat(programSections.size).isEqualTo(2)
+        assertThat(programSections[0].sortOrder()).isLessThan(programSections[1].sortOrder())
+
+        val reversedProgramSections = d2.programModule().programSections()
+            .orderBySortOrder(RepositoryScope.OrderByDirection.DESC)
+            .blockingGet()
+
+        assertThat(reversedProgramSections[0].sortOrder()).isGreaterThan(reversedProgramSections[1].sortOrder())
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramStageSectionCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramStageSectionCollectionRepositoryMockIntegrationShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.testapp.program
 
 import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
@@ -116,5 +117,21 @@ class ProgramStageSectionCollectionRepositoryMockIntegrationShould : BaseMockInt
             .blockingGet()
 
         assertThat(stageSections.size).isEqualTo(1)
+    }
+
+    @Test
+    fun order_by_sort_order() {
+        val programStageSections = d2.programModule().programStageSections()
+            .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
+            .blockingGet()
+
+        assertThat(programStageSections.size).isEqualTo(2)
+        assertThat(programStageSections[0].sortOrder()).isLessThan(programStageSections[1].sortOrder())
+
+        val reversedSections = d2.programModule().programStageSections()
+            .orderBySortOrder(RepositoryScope.OrderByDirection.DESC)
+            .blockingGet()
+
+        assertThat(reversedSections[0].sortOrder()).isGreaterThan(reversedSections[1].sortOrder())
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramSectionCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramSectionCollectionRepository.kt
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.IntegerFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope.OrderByDirection
 import org.hisp.dhis.android.core.program.internal.ProgramSectionAttributeChildrenAppender
 import org.hisp.dhis.android.core.program.internal.ProgramSectionStore
 import org.hisp.dhis.android.persistence.program.ProgramSectionTableInfo
@@ -89,6 +90,10 @@ class ProgramSectionCollectionRepository internal constructor(
 
     fun withAttributes(): ProgramSectionCollectionRepository {
         return cf.withChild(TRACKED_ENTITY_ATTRIBUTES)
+    }
+
+    fun orderBySortOrder(direction: OrderByDirection?): ProgramSectionCollectionRepository {
+        return cf.withOrderBy(ProgramSectionTableInfo.Columns.SORT_ORDER, direction)
     }
 
     internal companion object {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.kt
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.IntegerFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope.OrderByDirection
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionDataElementChildrenAppender
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionProgramIndicatorChildrenAppender
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionStore
@@ -86,6 +87,10 @@ class ProgramStageSectionsCollectionRepository internal constructor(
 
     fun withDataElements(): ProgramStageSectionsCollectionRepository {
         return cf.withChild(DATA_ELEMENTS)
+    }
+
+    fun orderBySortOrder(direction: OrderByDirection?): ProgramStageSectionsCollectionRepository {
+        return cf.withOrderBy(ProgramStageSectionTableInfo.Columns.SORT_ORDER, direction)
     }
 
     internal companion object {


### PR DESCRIPTION
Related task: [ANDROSDK-2254](https://dhis2.atlassian.net/browse/ANDROSDK-2254)

[ANDROSDK-2254]: https://dhis2.atlassian.net/browse/ANDROSDK-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ