### PR TITLE
fix: [ANDROSDK-2255] fix download file endpoints for server versions after 41

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CreateCategoryComboUtils.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CreateCategoryComboUtils.kt
@@ -36,7 +36,7 @@ object CreateCategoryComboUtils {
     const val TEST_CREATED: String = "2001-02-07T16:04:40.387"
     const val TEST_LAST_UPDATED: String = "2001-02-07T16:04:40.387"
 
-    fun create(uid: String?): CategoryCombo {
+    fun create(uid: String?, isDefault: Boolean = false): CategoryCombo {
         return CategoryCombo.builder()
             .uid(uid)
             .code(TEST_CODE)
@@ -44,6 +44,7 @@ object CreateCategoryComboUtils {
             .displayName(TEST_DISPLAY_NAME)
             .created(TEST_CREATED)
             .lastUpdated(TEST_LAST_UPDATED)
+            .isDefault(isDefault)
             .build()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitCallMockIntegrationShould.kt
@@ -77,7 +77,7 @@ class OrganisationUnitCallMockIntegrationShould : BaseMockIntegrationTestEmptyEn
 
             val categoryComboUid = "category_combo_uid"
             val categoryComboStore = koin.get<CategoryComboStore>()
-            categoryComboStore.insert(CategoryCombo.builder().uid(categoryComboUid).build())
+            categoryComboStore.insert(CategoryCombo.builder().uid(categoryComboUid).isDefault(true).build())
 
             // inserting programs for creating OrgUnitProgramLinks
             val programUid = "lxAQ7Zs9VYR"

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramEndpointCallMockIntegrationShould.kt
@@ -95,7 +95,7 @@ class ProgramEndpointCallMockIntegrationShould : BaseMockIntegrationTestEmptyEnq
             executor.wrapTransactionallyRoom {
                 val categoryComboStore = koin.get<CategoryComboStore>()
                 val categoryComboUid = "m2jTvAj5kkm"
-                val categoryCombo = CreateCategoryComboUtils.create(categoryComboUid)
+                val categoryCombo = CreateCategoryComboUtils.create(categoryComboUid, true)
                 categoryComboStore.insert(categoryCombo)
 
                 // inserting tracked entity

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResizerHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResizerHelper.kt
@@ -146,10 +146,10 @@ object FileResizerHelper {
         object Small : DimensionSize("SMALL", 400000L)
         object Medium : DimensionSize("MEDIUM", 1600000L)
         object NotSupported : DimensionSize("NOT_SUPPORTED", 0L)
-        data class Original(val originalMaxSizeB: Long) : DimensionSize(ORIGIANL_NAME, originalMaxSizeB)
+        data class Original(val originalMaxSizeB: Long) : DimensionSize(ORIGINAL_NAME, originalMaxSizeB)
 
         companion object {
-            const val ORIGIANL_NAME = "ORIGINAL"
+            const val ORIGINAL_NAME = "ORIGINAL"
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
@@ -140,8 +140,18 @@ internal class FileResourceDownloadCall(
                 downloadAndPersistFiles(
                     values = trackerDataValues,
                     maxContentLength = params.maxContentLength,
-                    download = fileResourceNetworkHandlder::getFileFromEventValue,
-                    getUid = { v -> v.value() },
+                    download = { v, dimension ->
+                        when (v.valueType) {
+                            ValueType.IMAGE ->
+                                fileResourceNetworkHandlder.getImageFromEventValue(v.value, dimension)
+
+                            ValueType.FILE_RESOURCE ->
+                                fileResourceNetworkHandlder.getFileFromEventValue(v.value)
+
+                            else -> null
+                        }
+                    },
+                    getUid = { v -> v.value.value() },
                 )
             }
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
@@ -37,7 +37,6 @@ import org.hisp.dhis.android.core.icon.CustomIcon
 import org.hisp.dhis.android.core.icon.internal.CustomIconStore
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
 import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
-import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
@@ -107,8 +107,8 @@ internal class FileResourceDownloadCallHelper(
     suspend fun getMissingTrackerDataValues(
         params: FileResourceDownloadParams,
         existingFileResources: List<String>,
-    ): List<TrackedEntityDataValue> {
-        val dataElementUids = dataElementStore.selectUidsWhere(
+    ): List<MissingTrackerDataValue> {
+        val dataElements = dataElementStore.selectWhere(
             WhereClauseBuilder()
                 .appendInKeyEnumValues(DataElementTableInfo.Columns.VALUE_TYPE, params.valueTypes.map { it.valueType })
                 .appendKeyStringValue(DataElementTableInfo.Columns.DOMAIN_TYPE, "TRACKER")
@@ -116,6 +116,7 @@ internal class FileResourceDownloadCallHelper(
         )
 
         val dataValuesWhereClause = WhereClauseBuilder().apply {
+            val dataElementUids = dataElements.map { it.uid() }
             appendInKeyStringValues(TrackedEntityDataValueTableInfo.Columns.DATA_ELEMENT, dataElementUids)
             appendNotInKeyStringValues(TrackedEntityDataValueTableInfo.Columns.VALUE, existingFileResources)
 
@@ -128,6 +129,10 @@ internal class FileResourceDownloadCallHelper(
         }.build()
 
         return trackedEntityDataValueStore.selectWhere(dataValuesWhereClause)
+            .map { dv ->
+                val type = dataElements.find { it.uid() == dv.dataElement() }!!.valueType()!!
+                MissingTrackerDataValue(dv, type)
+            }
     }
 
     suspend fun getMissingAggregatedDataValues(

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUtil.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceUtil.kt
@@ -167,7 +167,7 @@ internal object FileResourceUtil {
 
             // Filter out sizes requiring upscaling
             val validSizes = sizes.filter {
-                it.name == DimensionSize.ORIGIANL_NAME || it.maxSizeB < orignalContentLength
+                it.name == DimensionSize.ORIGINAL_NAME || it.maxSizeB < orignalContentLength
             }
 
             // Step 3: Remove ORIGINAL if it exceeds MEDIUM max size
@@ -179,8 +179,8 @@ internal object FileResourceUtil {
             limitedSizes.lastOrNull { it.maxSizeB <= maxContentLength }?.name ?: DimensionSize.NotSupported.name
         } else {
             when {
-                orignalContentLength == null || maxContentLength == null -> DimensionSize.ORIGIANL_NAME
-                orignalContentLength <= maxContentLength -> DimensionSize.ORIGIANL_NAME
+                orignalContentLength == null || maxContentLength == null -> DimensionSize.ORIGINAL_NAME
+                orignalContentLength <= maxContentLength -> DimensionSize.ORIGINAL_NAME
                 else -> DimensionSize.NotSupported.name
             }
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/MissingTrackerDataValue.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/MissingTrackerDataValue.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2025, University of Oslo
+ *  Copyright (c) 2004-2023, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,45 +28,10 @@
 
 package org.hisp.dhis.android.core.fileresource.internal
 
-import io.ktor.client.request.forms.MultiPartFormDataContent
-import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
-import org.hisp.dhis.android.core.arch.call.queries.internal.UidsQuery
-import org.hisp.dhis.android.core.datavalue.DataValue
-import org.hisp.dhis.android.core.fileresource.FileResource
-import org.hisp.dhis.android.core.icon.CustomIcon
+import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 
-internal interface FileResourceNetworkHandler {
-
-    suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResource
-
-    suspend fun getFileResource(fileResource: String): FileResource
-
-    suspend fun getFileResources(
-        query: UidsQuery,
-    ): Payload<FileResource>
-
-    suspend fun getImageFromTrackedEntityAttribute(
-        v: MissingTrackerAttributeValue,
-        dimension: String,
-    ): ByteArray
-
-    suspend fun getFileFromTrackedEntityAttribute(
-        v: MissingTrackerAttributeValue,
-    ): ByteArray
-
-    suspend fun getImageFromEventValue(
-        v: TrackedEntityDataValue,
-        dimension: String,
-    ): ByteArray
-
-    suspend fun getFileFromEventValue(
-        v: TrackedEntityDataValue,
-    ): ByteArray
-
-    suspend fun getCustomIcon(
-        v: CustomIcon,
-    ): ByteArray
-
-    suspend fun getFileFromDataValue(v: DataValue, dimension: String): ByteArray
-}
+internal data class MissingTrackerDataValue(
+    val value: TrackedEntityDataValue,
+    val valueType: ValueType,
+)

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -105,28 +105,35 @@ internal class FileResourceNetworkHandlerImpl(
         }
     }
 
-    override suspend fun getFileFromEventValue(
-        v: TrackedEntityDataValue,
-        dimension: String,
-    ): ByteArray {
+    override suspend fun getImageFromEventValue(v: TrackedEntityDataValue, dimension: String): ByteArray {
         return if (dhis2VersionManager.isGreaterThan(DHISVersion.V2_41)) {
-            if (dimension == DimensionSize.ORIGIANL_NAME) {
-                service.getFileFromEventValue(
-                    v.event()!!,
-                    v.dataElement()!!,
-                )
-            } else {
-                service.getImageFromEventValue(
-                    v.event()!!,
-                    v.dataElement()!!,
-                    dimension,
-                )
-            }
+            service.getImageFromEventValue(
+                v.event()!!,
+                v.dataElement()!!,
+                dimension,
+            )
         } else {
             service.getFileFromEventValue41(
                 v.event()!!,
                 v.dataElement()!!,
                 dimension,
+            )
+        }
+    }
+
+    override suspend fun getFileFromEventValue(
+        v: TrackedEntityDataValue,
+    ): ByteArray {
+        return if (dhis2VersionManager.isGreaterThan(DHISVersion.V2_41)) {
+            service.getFileFromEventValue(
+                v.event()!!,
+                v.dataElement()!!,
+            )
+        } else {
+            service.getFileFromEventValue41(
+                v.event()!!,
+                v.dataElement()!!,
+                DimensionSize.ORIGIANL_NAME
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -133,7 +133,7 @@ internal class FileResourceNetworkHandlerImpl(
             service.getFileFromEventValue41(
                 v.event()!!,
                 v.dataElement()!!,
-                DimensionSize.ORIGIANL_NAME
+                DimensionSize.ORIGIANL_NAME,
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -32,12 +32,12 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.call.queries.internal.UidsQuery
+import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper.DimensionSize
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceNetworkHandler
 import org.hisp.dhis.android.core.fileresource.internal.MissingTrackerAttributeValue
 import org.hisp.dhis.android.core.icon.CustomIcon
-import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper.DimensionSize
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
 import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -37,12 +37,16 @@ import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceNetworkHandler
 import org.hisp.dhis.android.core.fileresource.internal.MissingTrackerAttributeValue
 import org.hisp.dhis.android.core.icon.CustomIcon
+import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper.DimensionSize
+import org.hisp.dhis.android.core.systeminfo.DHISVersion
+import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
 import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class FileResourceNetworkHandlerImpl(
     httpServiceClient: HttpServiceClient,
+    private val dhis2VersionManager: DHISVersionManager,
 ) : FileResourceNetworkHandler {
     private val service = FileResourceService(httpServiceClient)
     override suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResource {
@@ -70,31 +74,61 @@ internal class FileResourceNetworkHandlerImpl(
         v: MissingTrackerAttributeValue,
         dimension: String,
     ): ByteArray {
-        return service.getImageFromTrackedEntityAttribute(
-            v.value.trackedEntityInstance()!!,
-            v.value.trackedEntityAttribute()!!,
-            dimension,
-        )
+        return if (dhis2VersionManager.isGreaterThan(DHISVersion.V2_41)) {
+            service.getImageFromTrackedEntityAttribute(
+                v.value.trackedEntityInstance()!!,
+                v.value.trackedEntityAttribute()!!,
+                dimension,
+            )
+        } else {
+            service.getImageFromTrackedEntityAttribute41(
+                v.value.trackedEntityInstance()!!,
+                v.value.trackedEntityAttribute()!!,
+                dimension,
+            )
+        }
     }
 
     override suspend fun getFileFromTrackedEntityAttribute(
         v: MissingTrackerAttributeValue,
     ): ByteArray {
-        return service.getFileFromTrackedEntityAttribute(
-            v.value.trackedEntityInstance()!!,
-            v.value.trackedEntityAttribute()!!,
-        )
+        return if (dhis2VersionManager.isGreaterThan(DHISVersion.V2_41)) {
+            service.getFileFromTrackedEntityAttribute(
+                v.value.trackedEntityInstance()!!,
+                v.value.trackedEntityAttribute()!!,
+            )
+        } else {
+            service.getFileFromTrackedEntityAttribute41(
+                v.value.trackedEntityInstance()!!,
+                v.value.trackedEntityAttribute()!!,
+            )
+        }
     }
 
     override suspend fun getFileFromEventValue(
         v: TrackedEntityDataValue,
         dimension: String,
     ): ByteArray {
-        return service.getFileFromEventValue(
-            v.event()!!,
-            v.dataElement()!!,
-            dimension,
-        )
+        return if (dhis2VersionManager.isGreaterThan(DHISVersion.V2_41)) {
+            if (dimension == DimensionSize.ORIGIANL_NAME) {
+                service.getFileFromEventValue(
+                    v.event()!!,
+                    v.dataElement()!!,
+                )
+            } else {
+                service.getImageFromEventValue(
+                    v.event()!!,
+                    v.dataElement()!!,
+                    dimension,
+                )
+            }
+        } else {
+            service.getFileFromEventValue41(
+                v.event()!!,
+                v.dataElement()!!,
+                dimension,
+            )
+        }
     }
 
     override suspend fun getCustomIcon(

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -133,7 +133,7 @@ internal class FileResourceNetworkHandlerImpl(
             service.getFileFromEventValue41(
                 v.event()!!,
                 v.dataElement()!!,
-                DimensionSize.ORIGIANL_NAME,
+                DimensionSize.ORIGINAL_NAME,
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
@@ -73,7 +73,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         return client.get {
             url("$TRACKED_ENTITY_INSTANCES/$trackedEntityInstanceUid/$trackedEntityAttributeUid/image")
             parameters {
-                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+                dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
     }
@@ -95,7 +95,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         return client.get {
             url("$TRACKER/$TRACKED_ENTIES/$trackedEntityInstanceUid/$ATTRIBUTES/$trackedEntityAttributeUid/image")
             parameters {
-                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+                dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
     }
@@ -119,7 +119,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
             parameters {
                 attribute("eventUid", eventUid)
                 attribute("dataElementUid", dataElementUid)
-                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+                dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
     }
@@ -141,7 +141,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         return client.get {
             url("$TRACKER/$EVENTS/$eventUid/$DATA_VALUES/$dataElementUid/image")
             parameters {
-                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+                dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
     }
@@ -168,7 +168,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
                 attribute("pe", period)
                 attribute("ou", organisationUnit)
                 attribute("co", categoryOptionCombo)
-                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+                dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.network.common.fields.Fields
 import org.hisp.dhis.android.network.common.filters.Filter
 
+@Suppress("TooManyFunctions")
 internal class FileResourceService(private val client: HttpServiceClient) {
 
     suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResourceResponseDTO {
@@ -64,7 +65,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         }
     }
 
-    suspend fun getImageFromTrackedEntityAttribute(
+    suspend fun getImageFromTrackedEntityAttribute41(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUid: String,
         dimension: String,
@@ -77,7 +78,7 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         }
     }
 
-    suspend fun getFileFromTrackedEntityAttribute(
+    suspend fun getFileFromTrackedEntityAttribute41(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUid: String,
     ): ByteArray {
@@ -86,7 +87,29 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         }
     }
 
-    suspend fun getFileFromEventValue(
+    suspend fun getImageFromTrackedEntityAttribute(
+        trackedEntityInstanceUid: String,
+        trackedEntityAttributeUid: String,
+        dimension: String,
+    ): ByteArray {
+        return client.get {
+            url("$TRACKER/$TRACKED_ENTIES/$trackedEntityInstanceUid/$ATTRIBUTES/$trackedEntityAttributeUid/image")
+            parameters {
+                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+            }
+        }
+    }
+
+    suspend fun getFileFromTrackedEntityAttribute(
+        trackedEntityInstanceUid: String,
+        trackedEntityAttributeUid: String,
+    ): ByteArray {
+        return client.get {
+            url("$TRACKER/$TRACKED_ENTIES/$trackedEntityInstanceUid/$ATTRIBUTES/$trackedEntityAttributeUid/file")
+        }
+    }
+
+    suspend fun getFileFromEventValue41(
         eventUid: String,
         dataElementUid: String,
         dimension: String,
@@ -96,6 +119,28 @@ internal class FileResourceService(private val client: HttpServiceClient) {
             parameters {
                 attribute("eventUid", eventUid)
                 attribute("dataElementUid", dataElementUid)
+                dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
+            }
+        }
+    }
+
+    suspend fun getFileFromEventValue(
+        eventUid: String,
+        dataElementUid: String,
+    ): ByteArray {
+        return client.get {
+            url("$TRACKER/$EVENTS/$eventUid/$DATA_VALUES/$dataElementUid/file")
+        }
+    }
+
+    suspend fun getImageFromEventValue(
+        eventUid: String,
+        dataElementUid: String,
+        dimension: String,
+    ): ByteArray {
+        return client.get {
+            url("$TRACKER/$EVENTS/$eventUid/$DATA_VALUES/$dataElementUid/image")
+            parameters {
                 dimension.takeIf { it != DimensionSize.ORIGIANL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
@@ -133,8 +178,11 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         const val FILE_RESOURCE = "fileResource"
         const val TRACKED_ENTITY_INSTANCES = "trackedEntityInstances"
         const val TRACKED_ENTITY_INSTANCE = "trackedEntityInstance"
+        const val TRACKED_ENTIES = "trackedEntities"
+        const val ATTRIBUTES = "attributes"
         const val TRACKED_ENTITY_ATTRIBUTE = "trackedEntityAttribute"
         const val EVENTS = "events"
+        const val TRACKER = "tracker"
         const val DATA_VALUES = "dataValues"
     }
 }


### PR DESCRIPTION
In server version 42, the tracker download file endpoints were updated and the SDK needed to adapt.

Related task: [ANDROSDK-2255](https://dhis2.atlassian.net/browse/ANDROSDK-2255)

[ANDROSDK-2255]: https://dhis2.atlassian.net/browse/ANDROSDK-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ