### PR TITLE
chore: [ANDROSDK-2257] Fix SonarCloud coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
     name: JaCoCo Coverage Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [instrumented-tests]
+    needs: [unit-tests, instrumented-tests]
     if: always() && needs.instrumented-tests.result == 'success'
     
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,10 @@ sonarqube {
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.projectName", "dhis2-android-sdk")
         property("sonar.java.binaries", "core/build/intermediates/javac/debug/classes")
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            "${rootProject.projectDir}/core/build/coverage-report/jacocoTestReport.xml",
+        )
 
         if (pullRequestId.isNullOrEmpty()) {
             property("sonar.branch.name", branch)

--- a/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
@@ -65,10 +65,14 @@ jacoco {
 }
 
 tasks.register("jacocoReport", JacocoReport::class) {
+    dependsOn("assembleDebug")
     group = "Coverage"
     description = "Generate XML/HTML code coverage reports for coverage.ec"
 
-    sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+    sourceDirectories.setFrom(
+        "${project.projectDir}/src/main/java",
+        "${project.projectDir}/src/main/kotlin"
+    )
 
     val excludes = mutableSetOf(
         // data binding


### PR DESCRIPTION
Fix JaCoCo and SonarQube configuration so coverage reports are correctly generated and found by SonarCloud during CI analysis.

- Fix JaCoCo report generation by adding dependsOn("assembleDebug") so compiled classes exist when the report runs
- Add Kotlin source directories to JaCoCo so coverage can be mapped to source files
- Use absolute path for sonar.coverage.jacoco.xmlReportPaths to prevent per-module relative path resolution (which caused a core/core/build/... double prefix)
- Add unit-tests as dependency of jacoco-report CI job so unit test coverage data is available


[ANDROSDK-2257](https://dhis2.atlassian.net/browse/ANDROSDK-2257)

[ANDROSDK-2257]: https://dhis2.atlassian.net/browse/ANDROSDK-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ