### PR TITLE
[ANDROSDK-2260] store and manage cookies in a map

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
@@ -40,29 +40,34 @@ internal class CookieAuthenticatorHelper {
         private const val SET_COOKIE_KEY = "set-cookie"
     }
 
-    private var cookieValue: String? = null
+    private val cookieMap = mutableMapOf<String, String>()
 
     fun storeCookieIfSentByServer(res: HttpResponse) {
         val cookies = res.headers.getAll(SET_COOKIE_KEY)
 
-        if (!cookies.isNullOrEmpty() && !(cookies.size == 1 && cookies[0].contains("SESSION_EXPIRE"))) {
-            val cookieRes = cookies.joinToString("; ") { it.substringBefore(";") }
-            cookieValue = cookieRes
+        if (!cookies.isNullOrEmpty()) {
+            cookies.forEach { cookie ->
+                val nameValue = cookie.substringBefore(";")
+                val name = nameValue.substringBefore("=").trim()
+                if (name.isNotEmpty()) {
+                    cookieMap[name] = nameValue
+                }
+            }
         }
     }
 
     fun isCookieDefined(): Boolean {
-        return cookieValue != null
+        return cookieMap.isNotEmpty()
     }
 
     fun removeCookie() {
-        cookieValue = null
+        cookieMap.clear()
     }
 
     fun addCookieHeader(requestBuilder: HttpRequestBuilder) {
         requestBuilder.apply {
             headers.remove(COOKIE_KEY)
-            header(COOKIE_KEY, cookieValue!!)
+            header(COOKIE_KEY, cookieMap.values.joinToString("; "))
         }
     }
 }


### PR DESCRIPTION
This PR fixes a cookie management issue on the SDK. Before, the cookies from the server were being stored as they were received, so if only the refresh cookie was sent, the login one was being discarded. Now, a map with the different cookies is used, and only the received ones are updated.

Related task: [ANDROSDK-2260](https://dhis2.atlassian.net/browse/ANDROSDK-2260)

[ANDROSDK-2260]: https://dhis2.atlassian.net/browse/ANDROSDK-2260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ