### PR TITLE
fix: [ANDROSDK-2258] Improve JaCoCo code coverage reporting and add generic Store tests

### DIFF
--- a/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
@@ -123,8 +123,8 @@ tasks.register("jacocoReport", JacocoReport::class) {
         "**/*\$Result$*.*",
         // DHIS2 Android SDK fields
         "**/*AutoValue_*.*",
-        // Room-generated DAO inner classes (EntityInsertionAdapter/EntityDeletionOrUpdateAdapter bind methods)
-        "**/*Dao_Impl\$*.*"
+        // Room-generated DAO classes (generated code not meaningful to cover)
+        "**/*Dao_Impl*.*"
     )
 
     val javaClasses = fileTree(layout.buildDirectory.file("intermediates/javac/debug")) {

--- a/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
@@ -71,7 +71,8 @@ tasks.register("jacocoReport", JacocoReport::class) {
 
     sourceDirectories.setFrom(
         "${project.projectDir}/src/main/java",
-        "${project.projectDir}/src/main/kotlin"
+        "${project.projectDir}/src/main/kotlin",
+        layout.buildDirectory.file("generated/ksp/debug/kotlin")
     )
 
     val excludes = mutableSetOf(

--- a/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-conventions.gradle.kts
@@ -121,7 +121,9 @@ tasks.register("jacocoReport", JacocoReport::class) {
         "**/*\$Result.*",
         "**/*\$Result$*.*",
         // DHIS2 Android SDK fields
-        "**/*AutoValue_*.*"
+        "**/*AutoValue_*.*",
+        // Room-generated DAO inner classes (EntityInsertionAdapter/EntityDeletionOrUpdateAdapter bind methods)
+        "**/*Dao_Impl\$*.*"
     )
 
     val javaClasses = fileTree(layout.buildDirectory.file("intermediates/javac/debug")) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -242,23 +242,19 @@ dependencies {
     androidTestImplementation(libs.androidx.paging.testing)
 }
 
-// Pass migrationDir only to the main debug KSP task via CommandLineArgumentProvider.
-// Test KSP variants (debugAndroidTest, debugUnitTest) must NOT generate migrations,
-// otherwise their non-instrumented classes shadow the JaCoCo-instrumented library
-// classes in the test APK, causing 0% coverage for migrations.
 afterEvaluate {
     tasks.named("kspDebugKotlin").configure {
         (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
-            org.gradle.process.CommandLineArgumentProvider {
+            CommandLineArgumentProvider {
                 listOf("migrationDir=$rootDir/core/src/main/assets/migrations")
-            }
+            },
         )
     }
     tasks.named("kspReleaseKotlin").configure {
         (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
-            org.gradle.process.CommandLineArgumentProvider {
+            CommandLineArgumentProvider {
                 listOf("migrationDir=$rootDir/core/src/main/assets/migrations")
-            }
+            },
         )
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -242,8 +242,25 @@ dependencies {
     androidTestImplementation(libs.androidx.paging.testing)
 }
 
-ksp {
-    arg("migrationDir", "$rootDir/core/src/main/assets/migrations")
+// Pass migrationDir only to the main debug KSP task via CommandLineArgumentProvider.
+// Test KSP variants (debugAndroidTest, debugUnitTest) must NOT generate migrations,
+// otherwise their non-instrumented classes shadow the JaCoCo-instrumented library
+// classes in the test APK, causing 0% coverage for migrations.
+afterEvaluate {
+    tasks.named("kspDebugKotlin").configure {
+        (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
+            org.gradle.process.CommandLineArgumentProvider {
+                listOf("migrationDir=$rootDir/core/src/main/assets/migrations")
+            }
+        )
+    }
+    tasks.named("kspReleaseKotlin").configure {
+        (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
+            org.gradle.process.CommandLineArgumentProvider {
+                listOf("migrationDir=$rootDir/core/src/main/assets/migrations")
+            }
+        )
+    }
 }
 
 detekt {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.google.devtools.ksp.gradle.KspTask
 import org.gradle.api.tasks.Sync
 import org.jetbrains.dokka.gradle.DokkaTask
 
@@ -242,20 +243,21 @@ dependencies {
     androidTestImplementation(libs.androidx.paging.testing)
 }
 
-val migrationDirPath = "$rootDir/core/src/main/assets/migrations"
+class MigrationDirProvider(private val path: String) : CommandLineArgumentProvider {
+    override fun asArguments() = listOf("migrationDir=$path")
+}
+
+val migrationDirPath: String = layout.projectDirectory.dir("src/main/assets/migrations")
+    .asFile.absolutePath
 afterEvaluate {
     tasks.named("kspDebugKotlin").configure {
-        (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
-            CommandLineArgumentProvider {
-                listOf("migrationDir=$migrationDirPath")
-            },
+        (this as KspTask).commandLineArgumentProviders.add(
+            MigrationDirProvider(migrationDirPath),
         )
     }
     tasks.named("kspReleaseKotlin").configure {
-        (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
-            CommandLineArgumentProvider {
-                listOf("migrationDir=$migrationDirPath")
-            },
+        (this as KspTask).commandLineArgumentProviders.add(
+            MigrationDirProvider(migrationDirPath),
         )
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -242,18 +242,19 @@ dependencies {
     androidTestImplementation(libs.androidx.paging.testing)
 }
 
+val migrationDirPath = "$rootDir/core/src/main/assets/migrations"
 afterEvaluate {
     tasks.named("kspDebugKotlin").configure {
         (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
             CommandLineArgumentProvider {
-                listOf("migrationDir=$rootDir/core/src/main/assets/migrations")
+                listOf("migrationDir=$migrationDirPath")
             },
         )
     }
     tasks.named("kspReleaseKotlin").configure {
         (this as com.google.devtools.ksp.gradle.KspTask).commandLineArgumentProviders.add(
             CommandLineArgumentProvider {
-                listOf("migrationDir=$rootDir/core/src/main/assets/migrations")
+                listOf("migrationDir=$migrationDirPath")
             },
         )
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseSQLiteConnectionMigrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseSQLiteConnectionMigrationShould.kt
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.db.access.internal
+
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import org.hisp.dhis.android.persistence.db.migrations.RoomGeneratedMigrations.ALL_MIGRATIONS
+import org.junit.Assert
+import org.junit.Test
+
+class DatabaseSQLiteConnectionMigrationShould {
+
+    @Test
+    fun apply_all_migrations_using_SQLiteConnection() {
+        val driver = BundledSQLiteDriver()
+        val connection = driver.open(":memory:")
+
+        connection.use { conn ->
+            if (ALL_MIGRATIONS.isEmpty()) return
+
+            var currentVersion = ALL_MIGRATIONS.first().startVersion
+            conn.execSQL("PRAGMA user_version = $currentVersion;")
+
+            for (migration in ALL_MIGRATIONS) {
+                Assert.assertEquals(
+                    "Migration order mismatch at version $currentVersion",
+                    migration.startVersion,
+                    currentVersion,
+                )
+                migration.migrate(conn)
+                currentVersion = migration.endVersion
+                conn.execSQL("PRAGMA user_version = $currentVersion;")
+            }
+
+            Assert.assertEquals(
+                "Final DB version after all migrations",
+                AppDatabase.VERSION,
+                currentVersion,
+            )
+        }
+    }
+}

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/attribute/internal/AttributeStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/attribute/internal/AttributeStoreIntegrationShould.kt
@@ -52,4 +52,19 @@ class AttributeStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegrati
             .valueType(ValueType.AGE)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): Attribute {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .shortName(null)
+            .displayShortName(null)
+            .description(null)
+            .displayDescription(null)
+            .valueType(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryComboStoreIntegrationShould.kt
@@ -53,4 +53,15 @@ class CategoryComboStoreIntegrationShould : IdentifiableObjectStoreAbstractInteg
             .displayName("UpdatedCategoryCombo")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): CategoryCombo {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .isDefault(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryOptionComboStoreIntegrationShould.kt
@@ -53,4 +53,15 @@ class CategoryOptionComboStoreIntegrationShould : IdentifiableObjectStoreAbstrac
             .displayName("UpdatedCategoryOptionCombo")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): CategoryOptionCombo {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .categoryCombo(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryOptionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryOptionStoreIntegrationShould.kt
@@ -53,4 +53,16 @@ class CategoryOptionStoreIntegrationShould : IdentifiableObjectStoreAbstractInte
             .displayName("UpdatedCategoryOption")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): CategoryOption {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .startDate(null)
+            .endDate(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryStoreIntegrationShould.kt
@@ -53,4 +53,14 @@ class CategoryStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegratio
             .displayName("UpdatedCategory")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): Category {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingStoreIntegrationShould.java
@@ -56,4 +56,16 @@ public class ValueTypeDeviceRenderingStoreIntegrationShould
                 .step(20)
                 .build();
     }
+
+    @Override
+    protected ValueTypeDeviceRendering buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .objectTable(null)
+                .type(null)
+                .min(null)
+                .max(null)
+                .step(null)
+                .decimalPoints(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/constant/internal/ConstantStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/constant/internal/ConstantStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.constant.ConstantStoreImpl;
 import org.hisp.dhis.android.persistence.constant.ConstantTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,18 @@ public class ConstantStoreIntegrationShould
     protected Constant buildObjectToUpdate() {
         return ConstantSamples.getConstant().toBuilder()
                 .value(25.36)
+                .build();
+    }
+
+    @Override
+    protected Constant buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .value(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableDataObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableDataObjectStoreAbstractIntegrationShould.kt
@@ -127,6 +127,14 @@ abstract class IdentifiableDataObjectStoreAbstractIntegrationShould<M> internal 
         assertThat(exists).isFalse()
     }
 
+    @Test
+    fun get_uploadable_sync_states_including_error_returns_objects() = runTest {
+        dataObjectStore.insert(`object`)
+        dataObjectStore.setSyncState(`object`.uid(), State.TO_POST)
+        val uploadable = dataObjectStore.getUploadableSyncStatesIncludingError()
+        assertThat(uploadable).isNotEmpty()
+    }
+
     init {
         objectWithToDeleteState = buildObjectWithToDeleteState()
         objectWithSyncedState = buildObjectWithSyncedState()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableDataObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableDataObjectStoreAbstractIntegrationShould.kt
@@ -30,23 +30,23 @@ package org.hisp.dhis.android.core.data.database
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
-import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
+import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableDataObjectStore
 import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo
 import org.hisp.dhis.android.core.common.CoreObject
 import org.hisp.dhis.android.core.common.DataObject
 import org.hisp.dhis.android.core.common.ObjectWithDeleteInterface
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface
+import org.hisp.dhis.android.core.common.State
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
-import kotlin.Throws
 
 abstract class IdentifiableDataObjectStoreAbstractIntegrationShould<M> internal constructor(
-    store: IdentifiableObjectStore<M>,
+    internal val dataObjectStore: IdentifiableDataObjectStore<M>,
     tableInfo: TableInfo,
     databaseAdapter: DatabaseAdapter,
 ) : IdentifiableObjectStoreAbstractIntegrationShould<M>(
-    store,
+    dataObjectStore,
     tableInfo,
     databaseAdapter,
 ) where M : ObjectWithUidInterface, M : CoreObject, M : DataObject, M : ObjectWithDeleteInterface {
@@ -75,6 +75,56 @@ abstract class IdentifiableDataObjectStoreAbstractIntegrationShould<M> internal 
         store.insert(objectWithSyncedState)
         val obj = store.selectFirst()
         assertThat(obj!!.deleted()).isEqualTo(false)
+    }
+
+    @Test
+    fun set_and_get_sync_state() = runTest {
+        dataObjectStore.insert(`object`)
+        dataObjectStore.setSyncState(`object`.uid(), State.TO_UPDATE)
+        val state = dataObjectStore.getSyncState(`object`.uid())
+        assertThat(state).isEqualTo(State.TO_UPDATE)
+    }
+
+    @Test
+    fun set_sync_state_for_multiple_uids() = runTest {
+        dataObjectStore.insert(`object`)
+        val result = dataObjectStore.setSyncState(listOf(`object`.uid()), State.ERROR)
+        assertThat(result).isEqualTo(1)
+        val state = dataObjectStore.getSyncState(`object`.uid())
+        assertThat(state).isEqualTo(State.ERROR)
+    }
+
+    @Test
+    fun set_sync_state_if_uploading_updates_when_uploading() = runTest {
+        dataObjectStore.insert(`object`)
+        dataObjectStore.setSyncState(`object`.uid(), State.UPLOADING)
+        val result = dataObjectStore.setSyncStateIfUploading(`object`.uid(), State.SYNCED)
+        assertThat(result).isEqualTo(1)
+        val state = dataObjectStore.getSyncState(`object`.uid())
+        assertThat(state).isEqualTo(State.SYNCED)
+    }
+
+    @Test
+    fun set_sync_state_if_uploading_does_nothing_when_not_uploading() = runTest {
+        dataObjectStore.insert(`object`)
+        dataObjectStore.setSyncState(`object`.uid(), State.TO_POST)
+        val result = dataObjectStore.setSyncStateIfUploading(`object`.uid(), State.SYNCED)
+        assertThat(result).isEqualTo(0)
+        val state = dataObjectStore.getSyncState(`object`.uid())
+        assertThat(state).isEqualTo(State.TO_POST)
+    }
+
+    @Test
+    fun exists_returns_true_for_existing_object() = runTest {
+        dataObjectStore.insert(`object`)
+        val exists = dataObjectStore.exists(`object`.uid())
+        assertThat(exists).isTrue()
+    }
+
+    @Test
+    fun exists_returns_false_for_non_existing_object() = runTest {
+        val exists = dataObjectStore.exists("non_existing_uid")
+        assertThat(exists).isFalse()
     }
 
     init {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableDeletableDataObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableDeletableDataObjectStoreAbstractIntegrationShould.kt
@@ -28,87 +28,68 @@
 package org.hisp.dhis.android.core.data.database
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
-import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectStore
+import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableDeletableDataObjectStore
 import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo
+import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.common.CoreObject
-import org.junit.After
+import org.hisp.dhis.android.core.common.DeletableDataObject
+import org.hisp.dhis.android.core.common.ObjectWithUidInterface
+import org.hisp.dhis.android.core.common.State
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
 
-abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal constructor(
-    private val store: ObjectStore<M>,
+abstract class IdentifiableDeletableDataObjectStoreAbstractIntegrationShould<M> internal constructor(
+    private val deletableStore: IdentifiableDeletableDataObjectStore<M>,
     tableInfo: TableInfo,
     databaseAdapter: DatabaseAdapter,
-) {
-    val `object`: M
-    private val tableInfo: TableInfo
-    private val databaseAdapter: DatabaseAdapter
+) : IdentifiableDataObjectStoreAbstractIntegrationShould<M>(
+    deletableStore,
+    tableInfo,
+    databaseAdapter,
+) where M : ObjectWithUidInterface, M : CoreObject, M : DeletableDataObject {
 
-    protected abstract fun buildObject(): M
+    protected abstract fun buildObjectWithUploadingState(): M
 
     @Before
     @Throws(IOException::class)
-    open fun setUp() {
-        runBlocking { store.delete() }
-    }
-
-    @After
-    open fun tearDown() {
-        runBlocking {
-            store.delete()
-            databaseAdapter.close()
-        }
+    override fun setUp() {
+        super.setUp()
     }
 
     @Test
-    fun insert_and_select_first_object() = runTest {
-        store.insert(`object`)
-        val objectFromDb = store.selectFirst()
-        assertEqualsIgnoreId(objectFromDb)
+    fun set_deleted_marks_object_as_deleted() = runTest {
+        deletableStore.insert(`object`)
+        deletableStore.setDeleted(`object`.uid())
+        val obj = deletableStore.selectByUid(`object`.uid())
+        assertThat(obj!!.deleted()).isTrue()
     }
 
     @Test
-    fun insert_object_and_select_first_object() = runTest {
-        store.insert(`object`)
-        val objectFromDb = store.selectFirst()
-        assertEqualsIgnoreId(objectFromDb)
+    fun set_sync_state_or_delete_updates_state_when_not_synced() = runTest {
+        val uploadingObj = buildObjectWithUploadingState()
+        deletableStore.insert(uploadingObj)
+        val action = deletableStore.setSyncStateOrDelete(uploadingObj.uid(), State.ERROR)
+        assertThat(action).isEqualTo(HandleAction.Update)
     }
 
     @Test
-    fun insert_and_select_all_objects() = runTest {
-        store.insert(`object`)
-        val objectsFromDb = store.selectAll()
-        assertEqualsIgnoreId(objectsFromDb.iterator().next())
+    fun set_sync_state_or_delete_deletes_when_synced_and_deleted() = runTest {
+        val uploadingObj = buildObjectWithUploadingState()
+        deletableStore.insert(uploadingObj)
+        deletableStore.setDeleted(uploadingObj.uid())
+        val action = deletableStore.setSyncStateOrDelete(uploadingObj.uid(), State.SYNCED)
+        assertThat(action).isEqualTo(HandleAction.Delete)
+        val obj = deletableStore.selectByUid(uploadingObj.uid())
+        assertThat(obj).isNull()
     }
 
     @Test
-    fun count_returns_zero_for_empty_table() = runTest {
-        val count = store.count()
-        assertThat(count).isEqualTo(0)
-    }
-
-    @Test
-    fun count_returns_one_after_insert() = runTest {
-        store.insert(`object`)
-        val count = store.count()
-        assertThat(count).isEqualTo(1)
-    }
-
-    fun assertEqualsIgnoreId(localObject: M?) {
-        assertEqualsIgnoreId(localObject, `object`)
-    }
-
-    fun assertEqualsIgnoreId(m1: M?, m2: M) {
-        assertThat(m1).isEqualTo(m2)
-    }
-
-    init {
-        `object` = buildObject()
-        this.tableInfo = tableInfo
-        this.databaseAdapter = databaseAdapter
+    fun select_sync_state_where_returns_states() = runTest {
+        deletableStore.insert(`object`)
+        val states = deletableStore.selectSyncStateWhere("uid = '${`object`.uid()}'")
+        assertThat(states).isNotEmpty()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.kt
@@ -143,6 +143,14 @@ abstract class IdentifiableObjectStoreAbstractIntegrationShould<M> internal cons
         // TODO Implement test for store.selectUidsWhere() method
     }
 
+    @Test
+    fun group_and_get_count_by_uid_returns_correct_counts() = runTest {
+        store.insert(`object`)
+        val result = store.groupAndGetCountBy("uid")
+        assertThat(result).isNotEmpty()
+        assertThat(result[`object`.uid()]).isEqualTo(1)
+    }
+
     init {
         objectToUpdate = buildObjectToUpdate()
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.kt
@@ -139,8 +139,17 @@ abstract class IdentifiableObjectStoreAbstractIntegrationShould<M> internal cons
     }
 
     @Test
-    fun select_inserted_object_uids_where() {
-        // TODO Implement test for store.selectUidsWhere() method
+    fun select_inserted_object_uids_where() = runTest {
+        store.insert(`object`)
+        val uids = store.selectUidsWhere("uid = '${`object`.uid()}'")
+        assertThat(uids).containsExactly(`object`.uid())
+    }
+
+    @Test
+    fun select_inserted_object_uids_where_with_order() = runTest {
+        store.insert(`object`)
+        val uids = store.selectUidsWhere("uid = '${`object`.uid()}'", null)
+        assertThat(uids).containsExactly(`object`.uid())
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/IdentifiableObjectStoreAbstractIntegrationShould.kt
@@ -151,6 +151,14 @@ abstract class IdentifiableObjectStoreAbstractIntegrationShould<M> internal cons
         assertThat(result[`object`.uid()]).isEqualTo(1)
     }
 
+    @Test
+    fun delete_by_entity() = runTest {
+        store.insert(`object`)
+        val deleted = store.deleteByEntity(`object`)
+        assertThat(deleted).isTrue()
+        assertThat(store.selectFirst()).isNull()
+    }
+
     init {
         objectToUpdate = buildObjectToUpdate()
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/LinkStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/LinkStoreAbstractIntegrationShould.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.stores.internal.LinkStore
 import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo
+import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.common.CoreObject
 import org.junit.Before
 import org.junit.Test
@@ -79,6 +80,29 @@ abstract class LinkStoreAbstractIntegrationShould<M : CoreObject> internal const
         val links = store.selectLinksForMasterUid(masterUid)
         assertThat(links.size).isEqualTo(1)
         assertEqualsIgnoreId(links.first(), `object`)
+    }
+
+    @Test
+    fun insert_if_not_exists_inserts_new_object() = runTest {
+        val action = store.insertIfNotExists(`object`)
+        assertThat(action).isEqualTo(HandleAction.Insert)
+        assertThat(store.selectFirst()).isNotNull()
+    }
+
+    @Test
+    fun insert_if_not_exists_does_not_duplicate_or_crash() = runTest {
+        store.insert(`object`)
+        val action = store.insertIfNotExists(`object`)
+        assertThat(action).isAnyOf(HandleAction.NoAction, HandleAction.Insert)
+    }
+
+    @Test
+    fun delete_all_links_removes_everything() = runTest {
+        store.insert(`object`)
+        store.insert(objectWithOtherMasterUid)
+        val deleted = store.deleteAllLinks()
+        assertThat(deleted).isEqualTo(2)
+        assertThat(store.count()).isEqualTo(0)
     }
 
     init {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
@@ -31,6 +31,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
+import org.hisp.dhis.android.core.arch.db.sqlorder.internal.SQLOrderType
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectStore
 import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo
 import org.hisp.dhis.android.core.common.CoreObject
@@ -146,6 +147,66 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
         store.updateOrInsert(nullableObject)
         val objectFromDb = store.selectFirst()
         assertThat(objectFromDb).isEqualTo(nullableObject)
+    }
+
+    @Test
+    fun select_where_returns_matching_objects() = runTest {
+        store.insert(`object`)
+        val result = store.selectWhere("1")
+        assertThat(result).hasSize(1)
+        assertEqualsIgnoreId(result[0])
+    }
+
+    @Test
+    fun select_where_with_order_returns_objects() = runTest {
+        store.insert(`object`)
+        val result = store.selectWhere("1", null)
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun select_where_with_limit_returns_limited_objects() = runTest {
+        store.insert(`object`)
+        val result = store.selectWhere("1", null, 1)
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun select_one_where_returns_matching_object() = runTest {
+        store.insert(`object`)
+        val result = store.selectOneWhere("1")
+        assertEqualsIgnoreId(result)
+    }
+
+    @Test
+    fun count_where_returns_matching_count() = runTest {
+        store.insert(`object`)
+        val count = store.countWhere("1")
+        assertThat(count).isEqualTo(1)
+    }
+
+    @Test
+    fun select_string_columns_where_returns_values() = runTest {
+        val columns = tableInfo.columns().whereUpdate()
+        if (columns.isEmpty()) return@runTest
+        store.insert(`object`)
+        val result = store.selectStringColumnsWhereClause(columns.first(), "1")
+        assertThat(result).isNotEmpty()
+    }
+
+    @Test
+    fun select_raw_query_returns_objects() = runTest {
+        store.insert(`object`)
+        val result = store.selectRawQuery("SELECT * FROM ${tableInfo.name()}")
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun select_one_ordered_by_returns_object() = runTest {
+        store.insert(`object`)
+        val firstColumn = tableInfo.columns().all().first()
+        val result = store.selectOneOrderedBy(firstColumn, SQLOrderType.ASC)
+        assertEqualsIgnoreId(result)
     }
 
     fun assertEqualsIgnoreId(localObject: M?) {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
@@ -98,6 +98,30 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
         assertThat(count).isEqualTo(1)
     }
 
+    @Test
+    fun insert_collection_and_select_all() = runTest {
+        store.insert(listOf(`object`))
+        val objectsFromDb = store.selectAll()
+        assertThat(objectsFromDb.size).isEqualTo(1)
+        assertEqualsIgnoreId(objectsFromDb[0])
+    }
+
+    @Test
+    fun update_collection() = runTest {
+        store.insert(`object`)
+        store.update(listOf(`object`))
+        val objectFromDb = store.selectFirst()
+        assertEqualsIgnoreId(objectFromDb)
+    }
+
+    @Test
+    fun update_or_insert_collection() = runTest {
+        val actions = store.updateOrInsert(listOf(`object`))
+        assertThat(actions).hasSize(1)
+        val objectFromDb = store.selectFirst()
+        assertEqualsIgnoreId(objectFromDb)
+    }
+
     fun assertEqualsIgnoreId(localObject: M?) {
         assertEqualsIgnoreId(localObject, `object`)
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
@@ -49,6 +49,7 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
     private val databaseAdapter: DatabaseAdapter
 
     protected abstract fun buildObject(): M
+    protected open fun buildObjectWithNullableFields(): M? = null
 
     @Before
     @Throws(IOException::class)
@@ -120,6 +121,31 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
         assertThat(actions).hasSize(1)
         val objectFromDb = store.selectFirst()
         assertEqualsIgnoreId(objectFromDb)
+    }
+
+    @Test
+    fun insert_and_select_object_with_nullable_fields() = runTest {
+        val nullableObject = buildObjectWithNullableFields() ?: return@runTest
+        store.insert(nullableObject)
+        val objectFromDb = store.selectFirst()
+        assertThat(objectFromDb).isEqualTo(nullableObject)
+    }
+
+    @Test
+    fun update_object_with_nullable_fields() = runTest {
+        val nullableObject = buildObjectWithNullableFields() ?: return@runTest
+        store.insert(nullableObject)
+        store.update(listOf(nullableObject))
+        val objectFromDb = store.selectFirst()
+        assertThat(objectFromDb).isEqualTo(nullableObject)
+    }
+
+    @Test
+    fun upsert_object_with_nullable_fields() = runTest {
+        val nullableObject = buildObjectWithNullableFields() ?: return@runTest
+        store.updateOrInsert(nullableObject)
+        val objectFromDb = store.selectFirst()
+        assertThat(objectFromDb).isEqualTo(nullableObject)
     }
 
     fun assertEqualsIgnoreId(localObject: M?) {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectStoreAbstractIntegrationShould.kt
@@ -36,6 +36,7 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectStore
 import org.hisp.dhis.android.core.arch.db.tableinfos.TableInfo
 import org.hisp.dhis.android.core.common.CoreObject
 import org.junit.After
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
@@ -126,7 +127,9 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
 
     @Test
     fun insert_and_select_object_with_nullable_fields() = runTest {
-        val nullableObject = buildObjectWithNullableFields() ?: return@runTest
+        val nullableObject = buildObjectWithNullableFields()
+        Assume.assumeNotNull(nullableObject)
+        nullableObject!!
         store.insert(nullableObject)
         val objectFromDb = store.selectFirst()
         assertThat(objectFromDb).isEqualTo(nullableObject)
@@ -134,7 +137,9 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
 
     @Test
     fun update_object_with_nullable_fields() = runTest {
-        val nullableObject = buildObjectWithNullableFields() ?: return@runTest
+        val nullableObject = buildObjectWithNullableFields()
+        Assume.assumeNotNull(nullableObject)
+        nullableObject!!
         store.insert(nullableObject)
         store.update(listOf(nullableObject))
         val objectFromDb = store.selectFirst()
@@ -143,7 +148,9 @@ abstract class ObjectStoreAbstractIntegrationShould<M : CoreObject> internal con
 
     @Test
     fun upsert_object_with_nullable_fields() = runTest {
-        val nullableObject = buildObjectWithNullableFields() ?: return@runTest
+        val nullableObject = buildObjectWithNullableFields()
+        Assume.assumeNotNull(nullableObject)
+        nullableObject!!
         store.updateOrInsert(nullableObject)
         val objectFromDb = store.selectFirst()
         assertThat(objectFromDb).isEqualTo(nullableObject)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectWithoutUidStoreAbstractIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/ObjectWithoutUidStoreAbstractIntegrationShould.kt
@@ -87,6 +87,12 @@ abstract class ObjectWithoutUidStoreAbstractIntegrationShould<M : CoreObject> in
     }
 
     @Test
+    fun delete_where_if_exists_does_not_throw_when_object_missing() = runTest {
+        store.deleteWhereIfExists(`object`)
+        assertThat(store.count()).isEqualTo(0)
+    }
+
+    @Test
     fun insert_same_object_simultaneously_and_transactionally() = runTest {
         val s1 = rxSingle { store.updateOrInsertWhere(`object`) }.subscribeOn(Schedulers.io())
         val s2 = rxSingle { store.updateOrInsertWhere(`object`) }.subscribeOn(Schedulers.io())

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataelement/internal/DataElementOperandStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataelement/internal/DataElementOperandStoreIntegrationShould.java
@@ -58,4 +58,12 @@ public class DataElementOperandStoreIntegrationShould
                 .categoryOptionCombo(ObjectWithUid.create("newCombo"))
                 .build();
     }
+
+    @Override
+    protected DataElementOperand buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .dataElement(null)
+                .categoryOptionCombo(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataelement/internal/DataElementStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataelement/internal/DataElementStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.dataelement.DataElementStoreImpl;
 import org.hisp.dhis.android.persistence.dataelement.DataElementTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -54,6 +56,26 @@ public class DataElementStoreIntegrationShould extends IdentifiableObjectStoreAb
     protected DataElement buildObjectToUpdate() {
         return DataElementSamples.getDataElement().toBuilder()
                 .formName("new-form-name")
+                .build();
+    }
+
+    @Override
+    protected DataElement buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .valueType(null)
+                .aggregationType(null)
+                .formName(null)
+                .domainType(null)
+                .optionSet(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.dataset.DataSetStoreImpl;
 import org.hisp.dhis.android.persistence.dataset.DataSetTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -54,6 +56,25 @@ public class DataSetStoreIntegrationShould extends IdentifiableObjectStoreAbstra
     protected DataSet buildObjectToUpdate() {
         return DataSetSamples.getDataSet().toBuilder()
                 .version(66)
+                .build();
+    }
+
+    @Override
+    protected DataSet buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .periodType(null)
+                .version(null)
+                .expiryDays(null)
+                .workflow(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionStoreIntegrationShould.kt
@@ -53,4 +53,16 @@ class SectionStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegration
             .description("new description")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): Section {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .description(null)
+            .sortOrder(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datastore/DataStoreEntryStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datastore/DataStoreEntryStoreIntegrationShould.kt
@@ -51,4 +51,10 @@ class DataStoreEntryStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegr
             .value("value2")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): DataStoreEntry {
+        return buildObject().toBuilder()
+            .value(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datastore/LocalDataStoreStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datastore/LocalDataStoreStoreIntegrationShould.kt
@@ -51,4 +51,10 @@ class LocalDataStoreStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegr
             .value("value2")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): KeyValuePair {
+        return buildObject().toBuilder()
+            .value(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValueConflictStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValueConflictStoreIntegrationShould.kt
@@ -46,4 +46,15 @@ class DataValueConflictStoreIntegrationShould : ObjectStoreAbstractIntegrationSh
     override fun buildObject(): DataValueConflict {
         return DataValueConflictSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): DataValueConflict {
+        return buildObject().toBuilder()
+            .conflict(null)
+            .value(null)
+            .errorCode(null)
+            .status(null)
+            .created(null)
+            .displayDescription(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValueStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/datavalue/internal/DataValueStoreIntegrationShould.kt
@@ -53,4 +53,14 @@ class DataValueStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegration
             .value("updatedValue")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): DataValue {
+        return buildObject().toBuilder()
+            .value(null)
+            .storedBy(null)
+            .comment(null)
+            .followUp(null)
+            .deleted(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreIntegrationShould.java
@@ -83,4 +83,19 @@ public class EnrollmentStoreIntegrationShould extends IdentifiableDeletableDataO
                 .deleted(false)
                 .build();
     }
+
+    @Override
+    protected Enrollment buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .created(null)
+                .lastUpdated(null)
+                .createdAtClient(null)
+                .lastUpdatedAtClient(null)
+                .enrollmentDate(null)
+                .incidentDate(null)
+                .status(null)
+                .deleted(null)
+                .completedDate(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentStoreIntegrationShould.java
@@ -29,7 +29,7 @@
 package org.hisp.dhis.android.core.enrollment.internal;
 
 import org.hisp.dhis.android.core.common.State;
-import org.hisp.dhis.android.core.data.database.IdentifiableDataObjectStoreAbstractIntegrationShould;
+import org.hisp.dhis.android.core.data.database.IdentifiableDeletableDataObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.enrollment.EnrollmentSamples;
 import org.hisp.dhis.android.core.enrollment.Enrollment;
 import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFactory;
@@ -39,7 +39,7 @@ import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo;
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
-public class EnrollmentStoreIntegrationShould extends IdentifiableDataObjectStoreAbstractIntegrationShould<Enrollment> {
+public class EnrollmentStoreIntegrationShould extends IdentifiableDeletableDataObjectStoreAbstractIntegrationShould<Enrollment> {
 
     public EnrollmentStoreIntegrationShould() {
         super(new EnrollmentStoreImpl(TestDatabaseAdapterFactory.get()),
@@ -72,6 +72,15 @@ public class EnrollmentStoreIntegrationShould extends IdentifiableDataObjectStor
         return EnrollmentSamples.get().toBuilder()
                 .syncState(State.SYNCED)
                 .aggregatedSyncState(State.SYNCED)
+                .build();
+    }
+
+    @Override
+    protected Enrollment buildObjectWithUploadingState() {
+        return EnrollmentSamples.get().toBuilder()
+                .syncState(State.UPLOADING)
+                .aggregatedSyncState(State.UPLOADING)
+                .deleted(false)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventDataFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventDataFilterStoreIntegrationShould.kt
@@ -45,4 +45,16 @@ class EventDataFilterStoreIntegrationShould : ObjectStoreAbstractIntegrationShou
     override fun buildObject(): EventDataFilter {
         return EventDataFilterSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): EventDataFilter {
+        return buildObject().toBuilder()
+            .le(null)
+            .ge(null)
+            .gt(null)
+            .lt(null)
+            .eq(null)
+            .like(null)
+            .dateFilter(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventFilterStoreIntegrationShould.kt
@@ -51,4 +51,16 @@ internal class EventFilterStoreIntegrationShould : IdentifiableObjectStoreAbstra
             .description("new_description")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): EventFilter {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .programStage(null)
+            .description(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventStoreIntegrationShould.java
@@ -29,7 +29,7 @@
 package org.hisp.dhis.android.core.event.internal;
 
 import org.hisp.dhis.android.core.common.State;
-import org.hisp.dhis.android.core.data.database.IdentifiableDataObjectStoreAbstractIntegrationShould;
+import org.hisp.dhis.android.core.data.database.IdentifiableDeletableDataObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.EventSamples;
 import org.hisp.dhis.android.core.event.Event;
 import org.hisp.dhis.android.core.event.EventStatus;
@@ -40,7 +40,7 @@ import org.hisp.dhis.android.persistence.event.EventTableInfo;
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
-public class EventStoreIntegrationShould extends IdentifiableDataObjectStoreAbstractIntegrationShould<Event> {
+public class EventStoreIntegrationShould extends IdentifiableDeletableDataObjectStoreAbstractIntegrationShould<Event> {
 
     public EventStoreIntegrationShould() {
         super(new EventStoreImpl(TestDatabaseAdapterFactory.get()),
@@ -73,6 +73,15 @@ public class EventStoreIntegrationShould extends IdentifiableDataObjectStoreAbst
         return EventSamples.get().toBuilder()
                 .syncState(State.SYNCED)
                 .aggregatedSyncState(State.SYNCED)
+                .build();
+    }
+
+    @Override
+    protected Event buildObjectWithUploadingState() {
+        return EventSamples.get().toBuilder()
+                .syncState(State.UPLOADING)
+                .aggregatedSyncState(State.UPLOADING)
+                .deleted(false)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventStoreIntegrationShould.java
@@ -84,4 +84,22 @@ public class EventStoreIntegrationShould extends IdentifiableDeletableDataObject
                 .deleted(false)
                 .build();
     }
+
+    @Override
+    protected Event buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .enrollment(null)
+                .created(null)
+                .lastUpdated(null)
+                .createdAtClient(null)
+                .lastUpdatedAtClient(null)
+                .status(null)
+                .eventDate(null)
+                .completedDate(null)
+                .dueDate(null)
+                .deleted(null)
+                .assignedUser(null)
+                .completedBy(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventSyncStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventSyncStoreIntegrationShould.java
@@ -47,4 +47,12 @@ public class EventSyncStoreIntegrationShould extends ObjectStoreAbstractIntegrat
     protected EventSync buildObject() {
         return EventSyncSamples.get1();
     }
+
+    @Override
+    protected EventSync buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .program(null)
+                .workingListsHash(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemStoreIntegrationShould.kt
@@ -52,4 +52,10 @@ class ExpressionDimensionItemStoreIntegrationShould :
             .expression("#{fbfJHSPpUQD}")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): ExpressionDimensionItem {
+        return buildObject().toBuilder()
+            .expression(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceStoreIntegrationShould.kt
@@ -51,4 +51,10 @@ class FileResourceStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegr
             .name("new_name")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): FileResource {
+        return buildObject().toBuilder()
+            .domain(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictStoreIntegrationShould.java
@@ -50,4 +50,20 @@ public class TrackerImportConflictStoreIntegrationShould
     protected TrackerImportConflict buildObject() {
         return TrackerImportConflictSamples.get();
     }
+
+    @Override
+    protected TrackerImportConflict buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .conflict(null)
+                .value(null)
+                .trackedEntityInstance(null)
+                .enrollment(null)
+                .event(null)
+                .tableReference(null)
+                .errorCode(null)
+                .status(null)
+                .created(null)
+                .displayDescription(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatorStoreIntegrationShould.kt
@@ -50,4 +50,20 @@ class IndicatorStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegrati
             .indicatorType(ObjectWithUid.create("new_indicator_type_uid"))
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): Indicator {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .shortName(null)
+            .displayShortName(null)
+            .description(null)
+            .displayDescription(null)
+            .numerator(null)
+            .denominator(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatoryTypeStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/indicator/internal/IndicatoryTypeStoreIntegrationShould.kt
@@ -53,4 +53,16 @@ class IndicatoryTypeStoreIntegrationShould : IdentifiableObjectStoreAbstractInte
             .factor(2)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): IndicatorType {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .number(null)
+            .factor(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendSetStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.legendset.LegendSetStoreImpl;
 import org.hisp.dhis.android.persistence.legendset.LegendSetTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -54,6 +56,18 @@ public class LegendSetStoreIntegrationShould extends IdentifiableObjectStoreAbst
     protected LegendSet buildObjectToUpdate() {
         return LegendSetSamples.getLegendSet().toBuilder()
                 .symbolizer("new_color")
+                .build();
+    }
+
+    @Override
+    protected LegendSet buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .symbolizer(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/internal/LegendStoreIntegrationShould.java
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.legendset.LegendStoreImpl;
 import org.hisp.dhis.android.persistence.legendset.LegendTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,20 @@ public class LegendStoreIntegrationShould extends IdentifiableObjectStoreAbstrac
     protected Legend buildObjectToUpdate() {
         return LegendSamples.getLegend().toBuilder()
                 .legendSet(ObjectWithUid.create("new_legend_set_uid"))
+                .build();
+    }
+
+    @Override
+    protected Legend buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .startValue(null)
+                .endValue(null)
+                .color(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/D2ErrorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/D2ErrorStoreIntegrationShould.java
@@ -49,4 +49,14 @@ public class D2ErrorStoreIntegrationShould extends ObjectStoreAbstractIntegratio
     protected D2Error buildObject() {
         return D2ErrorSamples.get();
     }
+
+    @Override
+    protected D2Error buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .url(null)
+                .errorComponent(null)
+                .httpErrorCode(null)
+                .created(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyViolationStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/maintenance/internal/ForeignKeyViolationStoreIntegrationShould.java
@@ -50,4 +50,18 @@ public class ForeignKeyViolationStoreIntegrationShould
     protected ForeignKeyViolation buildObject() {
         return ForeignKeyViolationSamples.get();
     }
+
+    @Override
+    protected ForeignKeyViolation buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .fromTable(null)
+                .fromColumn(null)
+                .toTable(null)
+                .toColumn(null)
+                .notFoundValue(null)
+                .fromObjectUid(null)
+                .fromObjectRow(null)
+                .created(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/map/internal/MapLayerStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/map/internal/MapLayerStoreIntegrationShould.kt
@@ -51,4 +51,13 @@ class MapLayerStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegratio
             .name("new_name")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): MapLayer {
+        return buildObject().toBuilder()
+            .code(null)
+            .mapService(null)
+            .imageFormat(null)
+            .layers(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/note/internal/NoteStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/note/internal/NoteStoreIntegrationShould.java
@@ -57,4 +57,17 @@ public class NoteStoreIntegrationShould extends IdentifiableObjectStoreAbstractI
                 .syncState(State.SYNCED)
                 .build();
     }
+
+    @Override
+    protected Note buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .noteType(null)
+                .event(null)
+                .enrollment(null)
+                .value(null)
+                .storedBy(null)
+                .storedDate(null)
+                .deleted(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionGroupStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionGroupStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.option.OptionGroupStoreImpl;
 import org.hisp.dhis.android.persistence.option.OptionGroupTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -54,6 +56,17 @@ public class OptionGroupStoreIntegrationShould extends IdentifiableObjectStoreAb
     protected OptionGroup buildObjectToUpdate() {
         return OptionGroupSamples.getOptionGroup().toBuilder()
                 .name("new_name")
+                .build();
+    }
+
+    @Override
+    protected OptionGroup buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionSetStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionSetStoreIntegrationShould.kt
@@ -54,4 +54,16 @@ class OptionSetStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegrati
             .valueType(ValueType.NUMBER)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): OptionSet {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .version(null)
+            .valueType(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/internal/OptionStoreIntegrationShould.kt
@@ -54,4 +54,15 @@ class OptionStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegrationS
             .optionSet(ObjectWithUid.create("updatedOptionSet"))
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): Option {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .sortOrder(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitGroupStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitGroupStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitGroupStoreImpl;
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitGroupTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,19 @@ public class OrganisationUnitGroupStoreIntegrationShould
     protected OrganisationUnitGroup buildObjectToUpdate() {
         return buildObject().toBuilder()
                 .shortName("new_short_name")
+                .build();
+    }
+
+    @Override
+    protected OrganisationUnitGroup buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitLevelStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitLevelStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitLevelStoreImpl;
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitLevelTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,18 @@ public class OrganisationUnitLevelStoreIntegrationShould
     protected OrganisationUnitLevel buildObjectToUpdate() {
         return buildObject().toBuilder()
                 .level(3)
+                .build();
+    }
+
+    @Override
+    protected OrganisationUnitLevel buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .level(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitStoreImpl;
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -54,6 +56,26 @@ public class OrganisationUnitStoreIntegrationShould extends IdentifiableObjectSt
     protected OrganisationUnit buildObjectToUpdate() {
         return buildObject().toBuilder()
                 .level(67)
+                .build();
+    }
+
+    @Override
+    protected OrganisationUnit buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .path(null)
+                .openingDate((Date) null)
+                .closedDate((Date) null)
+                .level(null)
+                .parent(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodStoreIntegrationShould.kt
@@ -63,6 +63,14 @@ class PeriodStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrationSho
             .build()
     }
 
+    override fun buildObjectWithNullableFields(): Period {
+        return buildObject().toBuilder()
+            .periodType(null)
+            .startDate(null)
+            .endDate(null)
+            .build()
+    }
+
     @Test
     fun select_correct_period_passing_period_type_and_a_date() = runTest {
         val relativePeriodHelper = RelativePeriodHelperMock()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramIndicatorStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramIndicatorTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -53,6 +55,24 @@ public class ProgramIndicatorStoreIntegrationShould extends IdentifiableObjectSt
     protected ProgramIndicator buildObjectToUpdate() {
         return ProgramIndicatorSamples.getProgramIndicator().toBuilder()
                 .decimals(413)
+                .build();
+    }
+
+    @Override
+    protected ProgramIndicator buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .expression(null)
+                .filter(null)
+                .decimals(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleActionStoreIntegrationShould.kt
@@ -52,4 +52,14 @@ internal class ProgramRuleActionStoreIntegrationShould :
             .data("newData")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramRuleAction {
+        return buildObject().toBuilder()
+            .data(null)
+            .content(null)
+            .location(null)
+            .trackedEntityAttribute(null)
+            .programIndicator(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramRuleStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramRuleTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,20 @@ public class ProgramRuleStoreIntegrationShould
     protected ProgramRule buildObjectToUpdate() {
         return ProgramRuleSamples.getProgramRule().toBuilder()
                 .condition("new_condition")
+                .build();
+    }
+
+    @Override
+    protected ProgramRule buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .priority(null)
+                .condition(null)
+                .programStage(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleVariableStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramRuleVariableStoreIntegrationShould.java
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramRuleVariableStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramRuleVariableTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -56,6 +58,20 @@ public class ProgramRuleVariableStoreIntegrationShould
     protected ProgramRuleVariable buildObjectToUpdate() {
         return ProgramRuleVariableSamples.getProgramRuleVariable().toBuilder()
                 .programRuleVariableSourceType(ProgramRuleVariableSourceType.CALCULATED_VALUE)
+                .build();
+    }
+
+    @Override
+    protected ProgramRuleVariable buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .programStage(null)
+                .dataElement(null)
+                .trackedEntityAttribute(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramSectionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramSectionStoreIntegrationShould.kt
@@ -51,4 +51,17 @@ class ProgramSectionStoreIntegrationShould : IdentifiableObjectStoreAbstractInte
             .sortOrder(2)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramSection {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .description(null)
+            .sortOrder(null)
+            .formName(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageDataElementStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageDataElementStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramStageDataElementStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramStageDataElementTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -57,4 +59,17 @@ public class ProgramStageDataElementStoreIntegrationShould extends IdentifiableO
                 .build();
     }
 
+    @Override
+    protected ProgramStageDataElement buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .displayInReports(null)
+                .compulsory(null)
+                .sortOrder(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageSectionStoreIntegrationShould.kt
@@ -51,4 +51,17 @@ class ProgramStageSectionStoreIntegrationShould : IdentifiableObjectStoreAbstrac
             .sortOrder(2)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramStageSection {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .sortOrder(null)
+            .description(null)
+            .displayDescription(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStageStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramStageStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramStageTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -54,6 +56,21 @@ public class ProgramStageStoreIntegrationShould extends IdentifiableObjectStoreA
     protected ProgramStage buildObjectToUpdate() {
         return ProgramStageSamples.getProgramStage().toBuilder()
                 .minDaysFromStart(12)
+                .build();
+    }
+
+    @Override
+    protected ProgramStage buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .description(null)
+                .displayDescription(null)
+                .periodType(null)
+                .sortOrder(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -53,6 +55,25 @@ public class ProgramStoreIntegrationShould extends IdentifiableObjectStoreAbstra
     protected Program buildObjectToUpdate() {
         return ProgramSamples.getProgram().toBuilder()
                 .expiryDays(5)
+                .build();
+    }
+
+    @Override
+    protected Program buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .version(null)
+                .programType(null)
+                .relatedProgram(null)
+                .trackedEntityType(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/program/internal/ProgramTrackedEntityAttributeStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.program.ProgramTrackedEntityAttributeStoreImpl;
 import org.hisp.dhis.android.persistence.program.ProgramTrackedEntityAttributeTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,21 @@ public class ProgramTrackedEntityAttributeStoreIntegrationShould
     protected ProgramTrackedEntityAttribute buildObjectToUpdate() {
         return ProgramTrackedEntityAttributeSamples.getProgramTrackedEntityAttribute().toBuilder()
                 .sortOrder(2)
+                .build();
+    }
+
+    @Override
+    protected ProgramTrackedEntityAttribute buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .mandatory(null)
+                .allowFutureDate(null)
+                .sortOrder(null)
+                .searchable(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListAttributeValueFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListAttributeValueFilterStoreIntegrationShould.kt
@@ -45,4 +45,17 @@ class ProgramStageWorkingListAttributeValueFilterStoreIntegrationShould :
     override fun buildObject(): ProgramStageWorkingListAttributeValueFilter {
         return ProgramStageWorkingListAttributeValueFilterSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramStageWorkingListAttributeValueFilter {
+        return buildObject().toBuilder()
+            .sw(null)
+            .ew(null)
+            .le(null)
+            .ge(null)
+            .gt(null)
+            .lt(null)
+            .like(null)
+            .dateFilter(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListEventDataFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListEventDataFilterStoreIntegrationShould.kt
@@ -45,4 +45,15 @@ class ProgramStageWorkingListEventDataFilterStoreIntegrationShould :
     override fun buildObject(): ProgramStageWorkingListEventDataFilter {
         return ProgramStageWorkingListEventDataFilterSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramStageWorkingListEventDataFilter {
+        return buildObject().toBuilder()
+            .le(null)
+            .ge(null)
+            .gt(null)
+            .lt(null)
+            .like(null)
+            .dateFilter(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListStoreIntegrationShould.kt
@@ -53,4 +53,11 @@ class ProgramStageWorkingListStoreIntegrationShould :
             .programStage(ObjectWithUid.create("other_program_stage"))
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramStageWorkingList {
+        return buildObject().toBuilder()
+            .description(null)
+            .programStageQueryCriteria(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListStoreIntegrationShould.kt
@@ -57,7 +57,6 @@ class ProgramStageWorkingListStoreIntegrationShould :
     override fun buildObjectWithNullableFields(): ProgramStageWorkingList {
         return buildObject().toBuilder()
             .description(null)
-            .programStageQueryCriteria(null)
             .build()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipItemStoreIntegrationShould.kt
@@ -59,6 +59,13 @@ class RelationshipItemStoreIntegrationShould : ObjectWithoutUidStoreAbstractInte
             .build()
     }
 
+    override fun buildObjectWithNullableFields(): RelationshipItem {
+        return buildObject().toBuilder()
+            .trackedEntityInstance(null)
+            .enrollment(null)
+            .build()
+    }
+
     @Test
     fun get_by_entity_uid() = runTest {
         val sample = RelationshipItemSamples.getRelationshipItem()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipStoreIntegrationShould.java
@@ -56,4 +56,14 @@ public class RelationshipStoreIntegrationShould extends IdentifiableObjectStoreA
                 .name("new_name")
                 .build();
     }
+
+    @Override
+    protected Relationship buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .name(null)
+                .created(null)
+                .lastUpdated(null)
+                .deleted(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipTypeStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/relationship/internal/RelationshipTypeStoreIntegrationShould.kt
@@ -53,4 +53,17 @@ class RelationshipTypeStoreIntegrationShould : IdentifiableObjectStoreAbstractIn
             .fromToName("updatedFromToName")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): RelationshipType {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .fromToName(null)
+            .toFromName(null)
+            .bidirectional(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/resource/internal/ResourceStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/resource/internal/ResourceStoreIntegrationShould.kt
@@ -57,6 +57,12 @@ class ResourceStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrationS
             .build()
     }
 
+    override fun buildObjectWithNullableFields(): Resource {
+        return buildObject().toBuilder()
+            .lastSynced(null)
+            .build()
+    }
+
     @Test
     fun return_last_updated() = runTest {
         store.insert(ResourceSamples.getResource())

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsDhisVisualizationStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsDhisVisualizationStoreIntegrationShould.kt
@@ -47,4 +47,15 @@ class AnalyticsDhisVisualizationStoreIntegrationShould :
     override fun buildObject(): AnalyticsDhisVisualization {
         return AnalyticsSettingsSamples.analyticsDhisVisualization
     }
+
+    override fun buildObjectWithNullableFields(): AnalyticsDhisVisualization {
+        return buildObject().toBuilder()
+            .scopeUid(null)
+            .scope(null)
+            .groupUid(null)
+            .groupName(null)
+            .timestamp(null)
+            .name(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiAttributeStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiAttributeStoreIntegrationShould.kt
@@ -45,4 +45,10 @@ class AnalyticsTeiAttributeStoreIntegrationShould : ObjectStoreAbstractIntegrati
     override fun buildObject(): AnalyticsTeiAttribute {
         return AnalyticsSettingsSamples.analyticsTeiAttribute
     }
+
+    override fun buildObjectWithNullableFields(): AnalyticsTeiAttribute {
+        return buildObject().toBuilder()
+            .whoComponent(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiDataElementStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiDataElementStoreIntegrationShould.kt
@@ -45,4 +45,11 @@ class AnalyticsTeiDataElementStoreIntegrationShould : ObjectStoreAbstractIntegra
     override fun buildObject(): AnalyticsTeiDataElement {
         return AnalyticsSettingsSamples.analyticsTeiDataElementSample
     }
+
+    override fun buildObjectWithNullableFields(): AnalyticsTeiDataElement {
+        return buildObject().toBuilder()
+            .whoComponent(null)
+            .programStage(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiIndicatorStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiIndicatorStoreIntegrationShould.kt
@@ -45,4 +45,11 @@ class AnalyticsTeiIndicatorStoreIntegrationShould : ObjectStoreAbstractIntegrati
     override fun buildObject(): AnalyticsTeiIndicator {
         return AnalyticsSettingsSamples.analyticsTeiIndicator
     }
+
+    override fun buildObjectWithNullableFields(): AnalyticsTeiIndicator {
+        return buildObject().toBuilder()
+            .whoComponent(null)
+            .programStage(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiSettingStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiSettingStoreIntegrationShould.kt
@@ -45,4 +45,11 @@ class AnalyticsTeiSettingStoreIntegrationShould : ObjectStoreAbstractIntegration
     override fun buildObject(): AnalyticsTeiSetting {
         return AnalyticsSettingsSamples.analyticsTeiSetting
     }
+
+    override fun buildObjectWithNullableFields(): AnalyticsTeiSetting {
+        return buildObject().toBuilder()
+            .programStage(null)
+            .period(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataStoreIntegrationShould.kt
@@ -46,5 +46,4 @@ class AnalyticsTeiWHONutritionDataStoreIntegrationShould :
     override fun buildObject(): AnalyticsTeiWHONutritionData {
         return AnalyticsSettingsSamples.analyticsTeiWHONutritionData
     }
-
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataStoreIntegrationShould.kt
@@ -46,4 +46,10 @@ class AnalyticsTeiWHONutritionDataStoreIntegrationShould :
     override fun buildObject(): AnalyticsTeiWHONutritionData {
         return AnalyticsSettingsSamples.analyticsTeiWHONutritionData
     }
+
+    override fun buildObjectWithNullableFields(): AnalyticsTeiWHONutritionData {
+        return buildObject().toBuilder()
+            .chartType(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataStoreIntegrationShould.kt
@@ -47,9 +47,4 @@ class AnalyticsTeiWHONutritionDataStoreIntegrationShould :
         return AnalyticsSettingsSamples.analyticsTeiWHONutritionData
     }
 
-    override fun buildObjectWithNullableFields(): AnalyticsTeiWHONutritionData {
-        return buildObject().toBuilder()
-            .chartType(null)
-            .build()
-    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/CustomIntentStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/CustomIntentStoreIntegrationShould.kt
@@ -46,4 +46,13 @@ class CustomIntentStoreIntegrationShould : ObjectStoreAbstractIntegrationShould<
     override fun buildObject(): CustomIntent {
         return CustomIntentSamples.getCustomIntent()
     }
+
+    override fun buildObjectWithNullableFields(): CustomIntent {
+        return buildObject().toBuilder()
+            .name(null)
+            .packageName(null)
+            .request(null)
+            .response(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/DataSetSettingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/DataSetSettingStoreIntegrationShould.java
@@ -50,4 +50,15 @@ public class DataSetSettingStoreIntegrationShould
     protected DataSetSetting buildObject() {
         return DataSetSettingSamples.getDataSetSetting();
     }
+
+    @Override
+    protected DataSetSetting buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .uid(null)
+                .name(null)
+                .lastUpdated(null)
+                .periodDSDownload(null)
+                .periodDSDBTrimming(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/FilterSettingStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/FilterSettingStoreIntegrationShould.kt
@@ -46,4 +46,14 @@ class FilterSettingStoreIntegrationShould : ObjectStoreAbstractIntegrationShould
     override fun buildObject(): FilterSetting {
         return FilterSettingSamples.getFilterSetting()
     }
+
+    override fun buildObjectWithNullableFields(): FilterSetting {
+        return buildObject().toBuilder()
+            .scope(null)
+            .filterType(null)
+            .uid(null)
+            .sort(null)
+            .filter(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/GeneralSettingsStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/GeneralSettingsStoreIntegrationShould.kt
@@ -45,4 +45,18 @@ class GeneralSettingsStoreIntegrationShould : ObjectStoreAbstractIntegrationShou
     override fun buildObject(): GeneralSettings {
         return GeneralSettingsSamples.getGeneralSettings()
     }
+
+    override fun buildObjectWithNullableFields(): GeneralSettings {
+        return buildObject().toBuilder()
+            .lastUpdated(null)
+            .reservedValues(null)
+            .smsGateway(null)
+            .smsResultSender(null)
+            .matomoID(null)
+            .matomoURL(null)
+            .allowScreenCapture(null)
+            .messageOfTheDay(null)
+            .experimentalFeatures(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionStoreIntegrationShould.kt
@@ -45,4 +45,8 @@ class LatestAppVersionStoreIntegrationShould : ObjectStoreAbstractIntegrationSho
     override fun buildObject(): LatestAppVersion {
         return latestAppVersion
     }
+
+    override fun buildObjectWithNullableFields(): LatestAppVersion {
+        return buildObject().toBuilder().downloadURL(null).build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/ProgramConfigurationSettingStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/ProgramConfigurationSettingStoreIntegrationShould.kt
@@ -46,4 +46,17 @@ class ProgramConfigurationSettingStoreIntegrationShould :
     override fun buildObject(): ProgramConfigurationSetting {
         return ProgramConfigurationSettingSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramConfigurationSetting {
+        return buildObject().toBuilder()
+            .uid(null)
+            .completionSpinner(null)
+            .optionalSearch(null)
+            .disableReferrals(null)
+            .disableCollapsibleSections(null)
+            .itemHeader(null)
+            .minimumLocationAccuracy(null)
+            .disableManualLocation(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/ProgramSettingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/ProgramSettingStoreIntegrationShould.java
@@ -50,4 +50,27 @@ public class ProgramSettingStoreIntegrationShould
     protected ProgramSetting buildObject() {
         return ProgramSettingSamples.getProgramSetting();
     }
+
+    @Override
+    protected ProgramSetting buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .uid(null)
+                .name(null)
+                .lastUpdated(null)
+                .teiDownload(null)
+                .teiDBTrimming(null)
+                .eventsDownload(null)
+                .eventsDBTrimming(null)
+                .updateDownload(null)
+                .updateDBTrimming(null)
+                .settingDownload(null)
+                .settingDBTrimming(null)
+                .enrollmentDownload(null)
+                .enrollmentDBTrimming(null)
+                .eventDateDownload(null)
+                .eventDateDBTrimming(null)
+                .enrollmentDateDownload(null)
+                .enrollmentDateDBTrimming(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/SynchronizationSettingsStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/SynchronizationSettingsStoreIntegrationShould.kt
@@ -45,4 +45,13 @@ class SynchronizationSettingsStoreIntegrationShould : ObjectStoreAbstractIntegra
     override fun buildObject(): SynchronizationSettings {
         return SynchronizationSettingsSamples.getSynchronizationSettings()
     }
+
+    override fun buildObjectWithNullableFields(): SynchronizationSettings {
+        return buildObject().toBuilder()
+            .metadataSync(null)
+            .trackerImporterVersion(null)
+            .trackerExporterVersion(null)
+            .fileMaxLengthBytes(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/SystemSettingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/SystemSettingStoreIntegrationShould.java
@@ -56,4 +56,11 @@ public class SystemSettingStoreIntegrationShould extends ObjectWithoutUidStoreAb
                 .value("new_value")
                 .build();
     }
+
+    @Override
+    protected SystemSetting buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .value(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/UserSettingsStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/settings/internal/UserSettingsStoreIntegrationShould.java
@@ -50,4 +50,11 @@ public class UserSettingsStoreIntegrationShould
     protected UserSettings buildObject() {
         return UserSettingsSamples.getUserSettings();
     }
+
+    @Override
+    protected UserSettings buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .keyDbLocale(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSConfigStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSConfigStoreIntegrationShould.kt
@@ -52,4 +52,10 @@ class SMSConfigStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegration
             .value("value2")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): KeyValuePair {
+        return buildObject().toBuilder()
+            .value(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionStoreIntegrationShould.kt
@@ -52,4 +52,5 @@ class SMSOngoingSubmissionStoreIntegrationShould : ObjectWithoutUidStoreAbstract
             .type(SubmissionType.ENROLLMENT)
             .build()
     }
+
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionStoreIntegrationShould.kt
@@ -52,5 +52,4 @@ class SMSOngoingSubmissionStoreIntegrationShould : ObjectWithoutUidStoreAbstract
             .type(SubmissionType.ENROLLMENT)
             .build()
     }
-
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/internal/SystemInfoStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/systeminfo/internal/SystemInfoStoreIntegrationShould.java
@@ -54,4 +54,14 @@ public class SystemInfoStoreIntegrationShould extends ObjectWithoutUidStoreAbstr
     protected SystemInfo buildObjectToUpdate() {
         return SystemInfoSamples.get2();
     }
+
+    @Override
+    protected SystemInfo buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .serverDate(null)
+                .dateFormat(null)
+                .version(null)
+                .systemName(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/AttributeValueFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/AttributeValueFilterStoreIntegrationShould.kt
@@ -45,4 +45,18 @@ class AttributeValueFilterStoreIntegrationShould : ObjectStoreAbstractIntegratio
     override fun buildObject(): AttributeValueFilter {
         return AttributeValueFilterSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): AttributeValueFilter {
+        return buildObject().toBuilder()
+            .sw(null)
+            .ew(null)
+            .le(null)
+            .ge(null)
+            .gt(null)
+            .lt(null)
+            .eq(null)
+            .like(null)
+            .dateFilter(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/ReservedValueSettingStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/ReservedValueSettingStoreIntegrationShould.java
@@ -57,4 +57,11 @@ public class ReservedValueSettingStoreIntegrationShould extends
                 .numberOfValuesToReserve(100)
                 .build();
     }
+
+    @Override
+    protected ReservedValueSetting buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .numberOfValuesToReserve(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeStoreIntegrationShould.java
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.android.core.trackedentity.internal;
 
+import androidx.annotation.NonNull;
+
 import org.hisp.dhis.android.core.data.database.IdentifiableObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityAttributeSamples;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute;
@@ -35,6 +37,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeStoreImpl;
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +59,25 @@ public class TrackedEntityAttributeStoreIntegrationShould
     protected TrackedEntityAttribute buildObjectToUpdate() {
         return TrackedEntityAttributeSamples.get().toBuilder()
                 .description("new_description")
+                .build();
+    }
+
+    @Override
+    protected TrackedEntityAttribute buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .pattern(null)
+                .optionSet(null)
+                .valueType(null)
+                .formName(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityAttributeValueStoreIntegrationShould.java
@@ -57,4 +57,13 @@ public class TrackedEntityAttributeValueStoreIntegrationShould
                 .value("new_value")
                 .build();
     }
+
+    @Override
+    protected TrackedEntityAttributeValue buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .created(null)
+                .lastUpdated(null)
+                .value(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceEventFilterStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceEventFilterStoreIntegrationShould.java
@@ -50,4 +50,14 @@ public class TrackedEntityInstanceEventFilterStoreIntegrationShould
     protected TrackedEntityInstanceEventFilter buildObject() {
         return TrackedEntityInstanceEventFilterSamples.get();
     }
+
+    @Override
+    protected TrackedEntityInstanceEventFilter buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .programStage(null)
+                .eventStatus(null)
+                .eventCreatedPeriod(null)
+                .assignedUserMode(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterStoreIntegrationShould.kt
@@ -52,4 +52,13 @@ class TrackedEntityInstanceFilterStoreIntegrationShould :
             .description("new_description")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): TrackedEntityInstanceFilter {
+        return buildObject().toBuilder()
+            .description(null)
+            .sortOrder(null)
+            .entityQueryCriteria(null)
+            .eventFilters(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterStoreIntegrationShould.kt
@@ -57,7 +57,6 @@ class TrackedEntityInstanceFilterStoreIntegrationShould :
         return buildObject().toBuilder()
             .description(null)
             .sortOrder(null)
-            .entityQueryCriteria(null)
             .eventFilters(null)
             .build()
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreIntegrationShould.java
@@ -29,7 +29,7 @@
 package org.hisp.dhis.android.core.trackedentity.internal;
 
 import org.hisp.dhis.android.core.common.State;
-import org.hisp.dhis.android.core.data.database.IdentifiableDataObjectStoreAbstractIntegrationShould;
+import org.hisp.dhis.android.core.data.database.IdentifiableDeletableDataObjectStoreAbstractIntegrationShould;
 import org.hisp.dhis.android.core.data.trackedentity.TrackedEntityInstanceSamples;
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFactory;
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
 public class TrackedEntityInstanceStoreIntegrationShould extends
-        IdentifiableDataObjectStoreAbstractIntegrationShould<TrackedEntityInstance> {
+        IdentifiableDeletableDataObjectStoreAbstractIntegrationShould<TrackedEntityInstance> {
 
     public TrackedEntityInstanceStoreIntegrationShould() {
         super(new TrackedEntityInstanceStoreImpl(TestDatabaseAdapterFactory.get()),
@@ -73,6 +73,15 @@ public class TrackedEntityInstanceStoreIntegrationShould extends
         return TrackedEntityInstanceSamples.get().toBuilder()
                 .syncState(State.SYNCED)
                 .aggregatedSyncState(State.SYNCED)
+                .build();
+    }
+
+    @Override
+    protected TrackedEntityInstance buildObjectWithUploadingState() {
+        return TrackedEntityInstanceSamples.get().toBuilder()
+                .syncState(State.UPLOADING)
+                .aggregatedSyncState(State.UPLOADING)
+                .deleted(false)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceStoreIntegrationShould.java
@@ -84,4 +84,17 @@ public class TrackedEntityInstanceStoreIntegrationShould extends
                 .deleted(false)
                 .build();
     }
+
+    @Override
+    protected TrackedEntityInstance buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .created(null)
+                .lastUpdated(null)
+                .createdAtClient(null)
+                .lastUpdatedAtClient(null)
+                .organisationUnit(null)
+                .trackedEntityType(null)
+                .deleted(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSyncStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSyncStoreIntegrationShould.java
@@ -47,4 +47,12 @@ public class TrackedEntityInstanceSyncStoreIntegrationShould extends ObjectStore
     protected TrackedEntityInstanceSync buildObject() {
         return TrackedEntityInstanceSyncSamples.get1();
     }
+
+    @Override
+    protected TrackedEntityInstanceSync buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .program(null)
+                .workingListsHash(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeAttributeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeAttributeStoreIntegrationShould.java
@@ -63,4 +63,12 @@ public class TrackedEntityTypeAttributeStoreIntegrationShould
     protected String addMasterUid() {
         return TrackedEntityTypeAttributeSamples.get().trackedEntityType().uid();
     }
+
+    @Override
+    protected TrackedEntityTypeAttribute buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .mandatory(null)
+                .sortOrder(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityTypeStoreIntegrationShould.java
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.utils.integration.mock.TestDatabaseAdapterFact
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner;
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityTypeStoreImpl;
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityTypeTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,21 @@ public class TrackedEntityTypeStoreIntegrationShould
     protected TrackedEntityType buildObjectToUpdate() {
         return TrackedEntityTypeSamples.get().toBuilder()
                 .description("new_description")
+                .build();
+    }
+
+    @Override
+    protected TrackedEntityType buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerStoreIntegrationShould.kt
@@ -50,4 +50,10 @@ class ProgramOwnerStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrat
             .ownerOrgUnit("Other orgunit")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): ProgramOwner {
+        return buildObject().toBuilder()
+            .syncState(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObjectStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObjectStoreIntegrationShould.kt
@@ -51,5 +51,4 @@ class TrackerJobObjectStoreIntegrationShould : ObjectWithoutUidStoreAbstractInte
             .fileResources(listOf("file_resource_uid"))
             .build()
     }
-
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObjectStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObjectStoreIntegrationShould.kt
@@ -51,4 +51,5 @@ class TrackerJobObjectStoreIntegrationShould : ObjectWithoutUidStoreAbstractInte
             .fileResources(listOf("file_resource_uid"))
             .build()
     }
+
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
@@ -51,4 +51,5 @@ class StockUseCaseStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegr
             .stockOnHand("new_stock_on_hand")
             .build()
     }
+
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
@@ -54,9 +54,7 @@ class StockUseCaseStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegr
 
     override fun buildObjectWithNullableFields(): InternalStockUseCase {
         return buildObject().toBuilder()
-            .itemDescription(null)
-            .description(null)
-            .stockOnHand(null)
+            .transactions(null)
             .build()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
@@ -51,5 +51,4 @@ class StockUseCaseStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegr
             .stockOnHand("new_stock_on_hand")
             .build()
     }
-
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/usecase/stock/internal/StockUseCaseStoreIntegrationShould.kt
@@ -51,4 +51,12 @@ class StockUseCaseStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegr
             .stockOnHand("new_stock_on_hand")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): InternalStockUseCase {
+        return buildObject().toBuilder()
+            .itemDescription(null)
+            .description(null)
+            .stockOnHand(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/AuthenticatedUserStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/AuthenticatedUserStoreIntegrationShould.java
@@ -57,4 +57,11 @@ public class AuthenticatedUserStoreIntegrationShould
                 .hash("new_hash")
                 .build();
     }
+
+    @Override
+    protected AuthenticatedUser buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .hash(null)
+                .build();
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserGroupStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserGroupStoreIntegrationShould.kt
@@ -51,4 +51,14 @@ class UserGroupStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegrati
             .name("new_name")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): UserGroup {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserRoleStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserRoleStoreIntegrationShould.kt
@@ -51,4 +51,14 @@ class UserRoleStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegratio
             .name("new_name")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): UserRole {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/internal/UserStoreIntegrationShould.kt
@@ -51,4 +51,21 @@ class UserStoreIntegrationShould : IdentifiableObjectStoreAbstractIntegrationSho
             .name("new_name")
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): User {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .birthday(null)
+            .education(null)
+            .gender(null)
+            .surname(null)
+            .firstName(null)
+            .email(null)
+            .username(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/validation/internal/ValidationRuleStoreIntegrationShould.java
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/validation/internal/ValidationRuleStoreIntegrationShould.java
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.core.validation.ValidationRule;
 import org.hisp.dhis.android.core.validation.ValidationRuleImportance;
 import org.hisp.dhis.android.persistence.validation.ValidationRuleStoreImpl;
 import org.hisp.dhis.android.persistence.validation.ValidationRuleTableInfo;
+import java.util.Date;
+
 import org.junit.runner.RunWith;
 
 @RunWith(D2JunitRunner.class)
@@ -55,6 +57,22 @@ public class ValidationRuleStoreIntegrationShould extends IdentifiableObjectStor
     protected ValidationRule buildObjectToUpdate() {
         return ValidationRuleSamples.get().toBuilder()
                 .importance(ValidationRuleImportance.MEDIUM)
+                .build();
+    }
+
+    @Override
+    protected ValidationRule buildObjectWithNullableFields() {
+        return buildObject().toBuilder()
+                .code(null)
+                .name(null)
+                .displayName(null)
+                .created((Date) null)
+                .lastUpdated((Date) null)
+                .shortName(null)
+                .displayShortName(null)
+                .description(null)
+                .displayDescription(null)
+                .instruction(null)
                 .build();
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/visualization/internal/TrackerVisualizationStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/visualization/internal/TrackerVisualizationStoreIntegrationShould.kt
@@ -53,4 +53,13 @@ class TrackerVisualizationStoreIntegrationShould :
             .type(TrackerVisualizationType.LINE)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): TrackerVisualization {
+        return buildObject().toBuilder()
+            .description(null)
+            .displayDescription(null)
+            .type(null)
+            .outputType(null)
+            .build()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/visualization/internal/VisualizationStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/visualization/internal/VisualizationStoreIntegrationShould.kt
@@ -52,4 +52,21 @@ class VisualizationStoreIntegrationShould : IdentifiableObjectStoreAbstractInteg
             .hideEmptyRowItems(HideEmptyItemStrategy.AFTER_LAST)
             .build()
     }
+
+    override fun buildObjectWithNullableFields(): Visualization {
+        return buildObject().toBuilder()
+            .code(null)
+            .name(null)
+            .displayName(null)
+            .created(null)
+            .lastUpdated(null)
+            .description(null)
+            .displayDescription(null)
+            .title(null)
+            .displayTitle(null)
+            .subtitle(null)
+            .displaySubtitle(null)
+            .type(null)
+            .build()
+    }
 }

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/settings/DataSetConfigurationSettingStoreIntegrationShould.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/settings/DataSetConfigurationSettingStoreIntegrationShould.kt
@@ -46,4 +46,12 @@ class DataSetConfigurationSettingStoreIntegrationShould :
     override fun buildObject(): DataSetConfigurationSetting {
         return DataSetConfigurationSettingSamples.get()
     }
+
+    override fun buildObjectWithNullableFields(): DataSetConfigurationSetting {
+        return buildObject().toBuilder()
+            .uid(null)
+            .minimumLocationAccuracy(null)
+            .disableManualLocation(null)
+            .build()
+    }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeShould.kt
@@ -34,13 +34,11 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.network.attribute.AttributeDTO
 import org.junit.Test
 
-class AttributeShould : CoreObjectShould("attribute/attribute.json") {
-
-    override fun roundTripSerializer() = AttributeDTO.serializer()
+internal class AttributeShould : CoreObjectShould<AttributeDTO>("attribute/attribute.json", AttributeDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val attributeDTO = deserialize(AttributeDTO.serializer())
+        val attributeDTO = deserialize()
         val attribute = attributeDTO.toDomain()
 
         assertThat(attribute.uid()).isEqualTo("r6KOit2qCGw")

--- a/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class AttributeShould : CoreObjectShould("attribute/attribute.json") {
 
+    override fun roundTripSerializer() = AttributeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val attributeDTO = deserialize(AttributeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeValueShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.attribute.AttributeValueDTO
 import org.junit.Test
 
 class AttributeValueShould : CoreObjectShould("attribute/attributeValue.json") {
+    override fun roundTripSerializer() = AttributeValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val attributeValueDTO = deserialize(AttributeValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/attribute/AttributeValueShould.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.attribute.AttributeValueDTO
 import org.junit.Test
 
-class AttributeValueShould : CoreObjectShould("attribute/attributeValue.json") {
-    override fun roundTripSerializer() = AttributeValueDTO.serializer()
+internal class AttributeValueShould : CoreObjectShould<AttributeValueDTO>(
+    "attribute/attributeValue.json",
+    AttributeValueDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val attributeValueDTO = deserialize(AttributeValueDTO.serializer())
+        val attributeValueDTO = deserialize()
         val attributeValue = attributeValueDTO.toDomain()
 
         assertThat(attributeValue.value()).isEqualTo("value_test")

--- a/core/src/test/java/org/hisp/dhis/android/core/authority/AuthorityShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/authority/AuthorityShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.authority.AuthorityDTO
 import org.junit.Test
 
-class AuthorityShould : CoreObjectShould("authority/authorities.json") {
-
-    override fun roundTripSerializer() = ListSerializer(AuthorityDTO.serializer())
+internal class AuthorityShould : CoreObjectShould<List<AuthorityDTO>>(
+    "authority/authorities.json",
+    ListSerializer(AuthorityDTO.serializer()),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val authorityDTOList: List<AuthorityDTO> = deserialize(ListSerializer(AuthorityDTO.serializer()))
+        val authorityDTOList = deserialize()
         val authorities = authorityDTOList.map { it.toDomain() }
 
         assertThat(authorities.size).isEqualTo(2)

--- a/core/src/test/java/org/hisp/dhis/android/core/authority/AuthorityShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/authority/AuthorityShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class AuthorityShould : CoreObjectShould("authority/authorities.json") {
 
+    override fun roundTripSerializer() = ListSerializer(AuthorityDTO.serializer())
+
     @Test
     override fun map_from_json_string() {
         val authorityDTOList: List<AuthorityDTO> = deserialize(ListSerializer(AuthorityDTO.serializer()))

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryComboShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryComboShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class CategoryComboShould : CoreObjectShould("category/category_combo.json") {
 
+    override fun roundTripSerializer() = CategoryComboDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val comboDTO = deserialize(CategoryComboDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryComboShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryComboShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.categorycombo.CategoryComboDTO
 import org.junit.Test
 
-class CategoryComboShould : CoreObjectShould("category/category_combo.json") {
-
-    override fun roundTripSerializer() = CategoryComboDTO.serializer()
+internal class CategoryComboShould : CoreObjectShould<CategoryComboDTO>(
+    "category/category_combo.json",
+    CategoryComboDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val comboDTO = deserialize(CategoryComboDTO.serializer())
+        val comboDTO = deserialize()
         val combo = comboDTO.toDomain()
 
         assertThat(combo.uid()).isEqualTo("m2jTvAj5kkm")

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class CategoryOptionComboShould : CoreObjectShould("category/category_option_combo.json") {
 
+    override fun roundTripSerializer() = CategoryOptionComboDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val categoryOptionComboDTO = deserialize(CategoryOptionComboDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.category.CategoryOptionComboDTO
 import org.junit.Test
 
-class CategoryOptionComboShould : CoreObjectShould("category/category_option_combo.json") {
-
-    override fun roundTripSerializer() = CategoryOptionComboDTO.serializer()
+internal class CategoryOptionComboShould : CoreObjectShould<CategoryOptionComboDTO>(
+    "category/category_option_combo.json",
+    CategoryOptionComboDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val categoryOptionComboDTO = deserialize(CategoryOptionComboDTO.serializer())
+        val categoryOptionComboDTO = deserialize()
         val categoryOptionCombo = categoryOptionComboDTO.toDomain("categoryComboUid")
 
         assertThat(categoryOptionCombo.uid()).isEqualTo("S34ULMcHMca")

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionOrganisationUnitsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionOrganisationUnitsShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.categoryoption.CategoryOptionOrganisationUnitsDTO
 import org.junit.Test
 
-class CategoryOptionOrganisationUnitsShould : CoreObjectShould("category/category_option_orgunits.json") {
-
-    override fun roundTripSerializer() = CategoryOptionOrganisationUnitsDTO.serializer()
+internal class CategoryOptionOrganisationUnitsShould : CoreObjectShould<CategoryOptionOrganisationUnitsDTO>(
+    "category/category_option_orgunits.json",
+    CategoryOptionOrganisationUnitsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val categoryOptionOrganisationUnitsDTO = deserialize(CategoryOptionOrganisationUnitsDTO.serializer())
+        val categoryOptionOrganisationUnitsDTO = deserialize()
         val linksMap = categoryOptionOrganisationUnitsDTO.toDomain()
 
         assertThat(linksMap.size).isEqualTo(3)

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionOrganisationUnitsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionOrganisationUnitsShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class CategoryOptionOrganisationUnitsShould : CoreObjectShould("category/category_option_orgunits.json") {
 
+    override fun roundTripSerializer() = CategoryOptionOrganisationUnitsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val categoryOptionOrganisationUnitsDTO = deserialize(CategoryOptionOrganisationUnitsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.categoryoption.CategoryOptionDTO
 import org.junit.Test
 
-class CategoryOptionShould : CoreObjectShould("category/category_option.json") {
-
-    override fun roundTripSerializer() = CategoryOptionDTO.serializer()
+internal class CategoryOptionShould : CoreObjectShould<CategoryOptionDTO>(
+    "category/category_option.json",
+    CategoryOptionDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val optionDTO = deserialize(CategoryOptionDTO.serializer())
+        val optionDTO = deserialize()
         val option = optionDTO.toDomain()
 
         assertThat(option.uid()).isEqualTo("cQYFfHX9oIT")

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class CategoryOptionShould : CoreObjectShould("category/category_option.json") {
 
+    override fun roundTripSerializer() = CategoryOptionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val optionDTO = deserialize(CategoryOptionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryShould.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.category.CategoryDTO
 import org.junit.Test
 
-class CategoryShould : CoreObjectShould("category/category.json") {
-
-    override fun roundTripSerializer() = CategoryDTO.serializer()
+internal class CategoryShould : CoreObjectShould<CategoryDTO>("category/category.json", CategoryDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val categoryDTO = deserialize(CategoryDTO.serializer())
+        val categoryDTO = deserialize()
         val category = categoryDTO.toDomain()
 
         assertThat(category.uid()).isEqualTo("KfdsGBcoiCa")

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class CategoryShould : CoreObjectShould("category/category.json") {
 
+    override fun roundTripSerializer() = CategoryDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val categoryDTO = deserialize(CategoryDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/common/AccessShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/AccessShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.common.dto.AccessDTO
 import org.junit.Test
 
 class AccessShould : CoreObjectShould("common/access.json") {
+    override fun roundTripSerializer() = AccessDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val accessDTO = deserialize(AccessDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/common/AccessShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/AccessShould.kt
@@ -31,12 +31,11 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.network.common.dto.AccessDTO
 import org.junit.Test
 
-class AccessShould : CoreObjectShould("common/access.json") {
-    override fun roundTripSerializer() = AccessDTO.serializer()
+internal class AccessShould : CoreObjectShould<AccessDTO>("common/access.json", AccessDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val accessDTO = deserialize(AccessDTO.serializer())
+        val accessDTO = deserialize()
         val access = accessDTO.toDomain()
 
         assertThat(access.read()).isTrue()

--- a/core/src/test/java/org/hisp/dhis/android/core/common/CoreObjectShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/CoreObjectShould.kt
@@ -43,7 +43,10 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.io.InputStream
 
-abstract class CoreObjectShould(private val jsonPath: String) {
+abstract class CoreObjectShould<T>(
+    private val jsonPath: String,
+    private val serializer: kotlinx.serialization.KSerializer<T>,
+) {
 
     private val jsonParser = KotlinxJsonParser.instance
 
@@ -81,22 +84,16 @@ abstract class CoreObjectShould(private val jsonPath: String) {
 
     abstract fun map_from_json_string()
 
-    internal open fun roundTripSerializer(): kotlinx.serialization.KSerializer<out Any>? = null
-
     @Test
     open fun round_trip_json_serialization() {
-        val serializer = roundTripSerializer() ?: return
-
-        @Suppress("UNCHECKED_CAST")
-        val typedSerializer = serializer as kotlinx.serialization.KSerializer<Any>
-        val original = deserialize(typedSerializer)
-        val serialized = serialize(original, typedSerializer)
-        val deserialized = deserialize(serialized, typedSerializer)
-        val reserialized = serialize(deserialized, typedSerializer)
+        val original = deserialize()
+        val serialized = serialize(original, serializer)
+        val deserialized = deserialize(serialized, serializer)
+        val reserialized = serialize(deserialized, serializer)
         assertThat(reserialized).isEqualTo(serialized)
     }
 
-    protected fun <T> deserialize(serializer: kotlinx.serialization.KSerializer<T>): T {
+    protected fun deserialize(): T {
         return deserializePath(jsonPath, serializer)
     }
 
@@ -111,10 +108,6 @@ abstract class CoreObjectShould(private val jsonPath: String) {
 
     protected fun <T> serialize(value: T, serializer: kotlinx.serialization.KSerializer<T>): String {
         return jsonParser.encodeToString(serializer, value)
-    }
-
-    protected fun getStringValueFromFile(): String {
-        return getStringValueFromFile(jsonPath)
     }
 
     private fun getStringValueFromFile(path: String): String {

--- a/core/src/test/java/org/hisp/dhis/android/core/common/CoreObjectShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/CoreObjectShould.kt
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.common
 
+import com.google.common.truth.Truth.assertThat
 import kotlinx.datetime.TimeZone
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext
 import org.hisp.dhis.android.core.arch.helpers.DateTimezoneConverter
@@ -35,6 +36,7 @@ import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.category.internal.DefaultCategoryComboManager
 import org.hisp.dhis.android.core.systeminfo.internal.ServerTimezoneManager
 import org.junit.Before
+import org.junit.Test
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
 import org.mockito.kotlin.doReturn
@@ -78,6 +80,21 @@ abstract class CoreObjectShould(private val jsonPath: String) {
     }
 
     abstract fun map_from_json_string()
+
+    internal open fun roundTripSerializer(): kotlinx.serialization.KSerializer<out Any>? = null
+
+    @Test
+    open fun round_trip_json_serialization() {
+        val serializer = roundTripSerializer() ?: return
+
+        @Suppress("UNCHECKED_CAST")
+        val typedSerializer = serializer as kotlinx.serialization.KSerializer<Any>
+        val original = deserialize(typedSerializer)
+        val serialized = serialize(original, typedSerializer)
+        val deserialized = deserialize(serialized, typedSerializer)
+        val reserialized = serialize(deserialized, typedSerializer)
+        assertThat(reserialized).isEqualTo(serialized)
+    }
 
     protected fun <T> deserialize(serializer: kotlinx.serialization.KSerializer<T>): T {
         return deserializePath(jsonPath, serializer)

--- a/core/src/test/java/org/hisp/dhis/android/core/common/DataAccessShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/DataAccessShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.common.dto.DataAccessDTO
 import org.junit.Test
 
 class DataAccessShould : CoreObjectShould("common/data_access.json") {
+    override fun roundTripSerializer() = DataAccessDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataAccessDTO = deserialize(DataAccessDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/common/DataAccessShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/DataAccessShould.kt
@@ -31,12 +31,14 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.network.common.dto.DataAccessDTO
 import org.junit.Test
 
-class DataAccessShould : CoreObjectShould("common/data_access.json") {
-    override fun roundTripSerializer() = DataAccessDTO.serializer()
+internal class DataAccessShould : CoreObjectShould<DataAccessDTO>(
+    "common/data_access.json",
+    DataAccessDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataAccessDTO = deserialize(DataAccessDTO.serializer())
+        val dataAccessDTO = deserialize()
         val dataAccess = dataAccessDTO.toDomain()
 
         assertThat(dataAccess.read()).isTrue()

--- a/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingShould.kt
@@ -31,12 +31,14 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.network.programstage.ValueTypeDeviceRenderingDTO
 import org.junit.Test
 
-class ValueTypeDeviceRenderingShould : CoreObjectShould("common/value_type_device_rendering.json") {
-    override fun roundTripSerializer() = ValueTypeDeviceRenderingDTO.serializer()
+internal class ValueTypeDeviceRenderingShould : CoreObjectShould<ValueTypeDeviceRenderingDTO>(
+    "common/value_type_device_rendering.json",
+    ValueTypeDeviceRenderingDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val valueTypeDeviceRenderingDTO = deserialize(ValueTypeDeviceRenderingDTO.serializer())
+        val valueTypeDeviceRenderingDTO = deserialize()
         val valueTypeDeviceRendering = valueTypeDeviceRenderingDTO.toDomain()
 
         assertThat(valueTypeDeviceRendering.type())

--- a/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeDeviceRenderingShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.programstage.ValueTypeDeviceRenderingDTO
 import org.junit.Test
 
 class ValueTypeDeviceRenderingShould : CoreObjectShould("common/value_type_device_rendering.json") {
+    override fun roundTripSerializer() = ValueTypeDeviceRenderingDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val valueTypeDeviceRenderingDTO = deserialize(ValueTypeDeviceRenderingDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeRenderingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeRenderingShould.kt
@@ -31,12 +31,14 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.network.programstage.ValueTypeRenderingDTO
 import org.junit.Test
 
-class ValueTypeRenderingShould : CoreObjectShould("common/value_type_rendering.json") {
-    override fun roundTripSerializer() = ValueTypeRenderingDTO.serializer()
+internal class ValueTypeRenderingShould : CoreObjectShould<ValueTypeRenderingDTO>(
+    "common/value_type_rendering.json",
+    ValueTypeRenderingDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val valueTypeRenderingDTO = deserialize(ValueTypeRenderingDTO.serializer())
+        val valueTypeRenderingDTO = deserialize()
         val valueTypeRendering = valueTypeRenderingDTO.toDomain()
 
         assertThat(valueTypeRendering.desktop()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeRenderingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/common/ValueTypeRenderingShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.programstage.ValueTypeRenderingDTO
 import org.junit.Test
 
 class ValueTypeRenderingShould : CoreObjectShould("common/value_type_rendering.json") {
+    override fun roundTripSerializer() = ValueTypeRenderingDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val valueTypeRenderingDTO = deserialize(ValueTypeRenderingDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
@@ -34,13 +34,14 @@ import org.hisp.dhis.android.persistence.configuration.DatabasesConfigurationDB
 import org.hisp.dhis.android.persistence.configuration.toDB
 import org.junit.Test
 
-class DatabasesConfigurationShould : CoreObjectShould("configuration/databases_configuration.json") {
-
-    override fun roundTripSerializer() = DatabasesConfigurationDB.serializer()
+internal class DatabasesConfigurationShould : CoreObjectShould<DatabasesConfigurationDB>(
+    "configuration/databases_configuration.json",
+    DatabasesConfigurationDB.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val configurationDao = deserialize(DatabasesConfigurationDB.serializer())
+        val configurationDao = deserialize()
         val configuration = configurationDao.toDomain()
 
         assertThat(configuration.versionCode()).isEqualTo(260)
@@ -57,7 +58,7 @@ class DatabasesConfigurationShould : CoreObjectShould("configuration/databases_c
 
     @Test
     fun equal_when_deserialize_serialize_deserialize() {
-        val configurationDao = deserialize(DatabasesConfigurationDB.serializer())
+        val configurationDao = deserialize()
         val configuration = configurationDao.toDomain()
 
         val serialized = serialize(configuration.toDB(), DatabasesConfigurationDB.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class DatabasesConfigurationShould : CoreObjectShould("configuration/databases_configuration.json") {
 
+    override fun roundTripSerializer() = DatabasesConfigurationDB.serializer()
+
     @Test
     override fun map_from_json_string() {
         val configurationDao = deserialize(DatabasesConfigurationDB.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/migration/DatabasesConfigurationOldShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/migration/DatabasesConfigurationOldShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.persistence.configuration.migration.DatabasesConfigurationOldDB
 import org.junit.Test
 
-class DatabasesConfigurationOldShould : CoreObjectShould("configuration/databases_configuration_old.json") {
-
-    override fun roundTripSerializer() = DatabasesConfigurationOldDB.serializer()
+internal class DatabasesConfigurationOldShould : CoreObjectShould<DatabasesConfigurationOldDB>(
+    "configuration/databases_configuration_old.json",
+    DatabasesConfigurationOldDB.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val configuration = deserialize(DatabasesConfigurationOldDB.serializer())
+        val configuration = deserialize()
 
         assertThat(configuration.loggedServerUrl).isEqualTo("https://dhis2.org")
         assertThat(configuration.servers.size).isEqualTo(1)
@@ -55,7 +56,7 @@ class DatabasesConfigurationOldShould : CoreObjectShould("configuration/database
 
     @Test
     fun equal_when_deserialize_serialize_deserialize() {
-        val configuration = deserialize(DatabasesConfigurationOldDB.serializer())
+        val configuration = deserialize()
 
         val serialized = serialize(configuration, DatabasesConfigurationOldDB.serializer())
         val deserialized = deserialize(serialized, DatabasesConfigurationOldDB.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/migration/DatabasesConfigurationOldShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/migration/DatabasesConfigurationOldShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class DatabasesConfigurationOldShould : CoreObjectShould("configuration/databases_configuration_old.json") {
 
+    override fun roundTripSerializer() = DatabasesConfigurationOldDB.serializer()
+
     @Test
     override fun map_from_json_string() {
         val configuration = deserialize(DatabasesConfigurationOldDB.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/constant/ConstantShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/constant/ConstantShould.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.constant.ConstantDTO
 import org.junit.Test
 
-class ConstantShould : CoreObjectShould("constant/constant.json") {
-
-    override fun roundTripSerializer() = ConstantDTO.serializer()
+internal class ConstantShould : CoreObjectShould<ConstantDTO>("constant/constant.json", ConstantDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val constantDTO = deserialize(ConstantDTO.serializer())
+        val constantDTO = deserialize()
         val constant = constantDTO.toDomain()
 
         assertThat(constant.created())

--- a/core/src/test/java/org/hisp/dhis/android/core/constant/ConstantShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/constant/ConstantShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class ConstantShould : CoreObjectShould("constant/constant.json") {
 
+    override fun roundTripSerializer() = ConstantDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val constantDTO = deserialize(ConstantDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataapproval/DataApprovalShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataapproval/DataApprovalShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.dataapproval.DataApprovalDTO
 import org.junit.Test
 
-class DataApprovalShould : CoreObjectShould("dataapproval/data_approval.json") {
-
-    override fun roundTripSerializer() = DataApprovalDTO.serializer()
+internal class DataApprovalShould : CoreObjectShould<DataApprovalDTO>(
+    "dataapproval/data_approval.json",
+    DataApprovalDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataApprovalDTO = deserialize(DataApprovalDTO.serializer())
+        val dataApprovalDTO = deserialize()
         val dataApproval = dataApprovalDTO.toDomain()!!
 
         assertThat(dataApproval.period()).isEqualTo("2019")

--- a/core/src/test/java/org/hisp/dhis/android/core/dataapproval/DataApprovalShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataapproval/DataApprovalShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class DataApprovalShould : CoreObjectShould("dataapproval/data_approval.json") {
 
+    override fun roundTripSerializer() = DataApprovalDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataApprovalDTO = deserialize(DataApprovalDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementOperandShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementOperandShould.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.dataset.DataElementOperandDTO
 import org.junit.Test
 
-class DataElementOperandShould : CoreObjectShould("dataelement/data_element_operand.json") {
-    override fun roundTripSerializer() = DataElementOperandDTO.serializer()
+internal class DataElementOperandShould : CoreObjectShould<DataElementOperandDTO>(
+    "dataelement/data_element_operand.json",
+    DataElementOperandDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataElementOperandDTO = deserialize(DataElementOperandDTO.serializer())
+        val dataElementOperandDTO = deserialize()
         val dataElementOperand = dataElementOperandDTO.toDomain()
 
         assertThat(dataElementOperand.uid()).isEqualTo("ca8lfO062zg.Gmbgme7z9BF")

--- a/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementOperandShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementOperandShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.dataset.DataElementOperandDTO
 import org.junit.Test
 
 class DataElementOperandShould : CoreObjectShould("dataelement/data_element_operand.json") {
+    override fun roundTripSerializer() = DataElementOperandDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataElementOperandDTO = deserialize(DataElementOperandDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementShould.kt
@@ -34,12 +34,14 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.network.dataelement.DataElementDTO
 import org.junit.Test
 
-class DataElementShould : CoreObjectShould("dataelement/data_element.json") {
-    override fun roundTripSerializer() = DataElementDTO.serializer()
+internal class DataElementShould : CoreObjectShould<DataElementDTO>(
+    "dataelement/data_element.json",
+    DataElementDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataElementDTO = deserialize(DataElementDTO.serializer())
+        val dataElementDTO = deserialize()
         val dataElement = dataElementDTO.toDomain()
 
         // basic properties

--- a/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataelement/DataElementShould.kt
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.network.dataelement.DataElementDTO
 import org.junit.Test
 
 class DataElementShould : CoreObjectShould("dataelement/data_element.json") {
+    override fun roundTripSerializer() = DataElementDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataElementDTO = deserialize(DataElementDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataInputPeriodShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataInputPeriodShould.kt
@@ -34,12 +34,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.dataset.DataInputPeriodDTO
 import org.junit.Test
 
-class DataInputPeriodShould : CoreObjectShould("dataset/data_input_period.json") {
-    override fun roundTripSerializer() = DataInputPeriodDTO.serializer()
+internal class DataInputPeriodShould : CoreObjectShould<DataInputPeriodDTO>(
+    "dataset/data_input_period.json",
+    DataInputPeriodDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataInputPeriodDTO = deserialize(DataInputPeriodDTO.serializer())
+        val dataInputPeriodDTO = deserialize()
         val dataInputPeriod = dataInputPeriodDTO.toDomain(null)
 
         assertThat(getUidOrNull(dataInputPeriod.period())).isEqualTo("201801")

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataInputPeriodShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataInputPeriodShould.kt
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.network.dataset.DataInputPeriodDTO
 import org.junit.Test
 
 class DataInputPeriodShould : CoreObjectShould("dataset/data_input_period.json") {
+    override fun roundTripSerializer() = DataInputPeriodDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataInputPeriodDTO = deserialize(DataInputPeriodDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.util.toJavaSimpleDate
 import org.hisp.dhis.android.network.datasetcompleteregistration.DataSetCompleteRegistrationDTO
 import org.junit.Test
 
-class DataSetCompleteRegistrationShould : CoreObjectShould("dataset/data_set_complete_registration.json") {
-    override fun roundTripSerializer() = DataSetCompleteRegistrationDTO.serializer()
+internal class DataSetCompleteRegistrationShould : CoreObjectShould<DataSetCompleteRegistrationDTO>(
+    "dataset/data_set_complete_registration.json",
+    DataSetCompleteRegistrationDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataSetCompleteRegistrationDTO = deserialize(DataSetCompleteRegistrationDTO.serializer())
+        val dataSetCompleteRegistrationDTO = deserialize()
         val dataSetCompleteRegistration = dataSetCompleteRegistrationDTO.toDomain()
 
         assertThat(dataSetCompleteRegistration.period()).isEqualTo("201703")

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.datasetcompleteregistration.DataSetComplete
 import org.junit.Test
 
 class DataSetCompleteRegistrationShould : CoreObjectShould("dataset/data_set_complete_registration.json") {
+    override fun roundTripSerializer() = DataSetCompleteRegistrationDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataSetCompleteRegistrationDTO = deserialize(DataSetCompleteRegistrationDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationWithCompletedShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationWithCompletedShould.kt
@@ -33,15 +33,14 @@ import org.hisp.dhis.android.core.util.toJavaSimpleDate
 import org.hisp.dhis.android.network.datasetcompleteregistration.DataSetCompleteRegistrationDTO
 import org.junit.Test
 
-class DataSetCompleteRegistrationWithCompletedShould : CoreObjectShould(
+internal class DataSetCompleteRegistrationWithCompletedShould : CoreObjectShould<DataSetCompleteRegistrationDTO>(
     "dataset/data_set_complete_registration_with_completed.json",
+    DataSetCompleteRegistrationDTO.serializer(),
 ) {
-
-    override fun roundTripSerializer() = DataSetCompleteRegistrationDTO.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val dataSetCompleteRegistrationDTO = deserialize(DataSetCompleteRegistrationDTO.serializer())
+        val dataSetCompleteRegistrationDTO = deserialize()
         val dataSetCompleteRegistration = dataSetCompleteRegistrationDTO.toDomain()
 
         assertThat(dataSetCompleteRegistration.period()).isEqualTo("201703")

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationWithCompletedShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationWithCompletedShould.kt
@@ -37,6 +37,8 @@ class DataSetCompleteRegistrationWithCompletedShould : CoreObjectShould(
     "dataset/data_set_complete_registration_with_completed.json",
 ) {
 
+    override fun roundTripSerializer() = DataSetCompleteRegistrationDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataSetCompleteRegistrationDTO = deserialize(DataSetCompleteRegistrationDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetShould.kt
@@ -39,12 +39,11 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.network.dataset.DataSetDTO
 import org.junit.Test
 
-class DataSetShould : CoreObjectShould("dataset/data_set.json") {
-    override fun roundTripSerializer() = DataSetDTO.serializer()
+internal class DataSetShould : CoreObjectShould<DataSetDTO>("dataset/data_set.json", DataSetDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val dataSetDTO = deserialize(DataSetDTO.serializer())
+        val dataSetDTO = deserialize()
         val dataSet = dataSetDTO.toDomain()
 
         assertThat(dataSet.code()).isEqualTo("DS_394131")

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetShould.kt
@@ -40,6 +40,8 @@ import org.hisp.dhis.android.network.dataset.DataSetDTO
 import org.junit.Test
 
 class DataSetShould : CoreObjectShould("dataset/data_set.json") {
+    override fun roundTripSerializer() = DataSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataSetDTO = deserialize(DataSetDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/SectionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/SectionShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.dataset.SectionDTO
 import org.junit.Test
 
 class SectionShould : CoreObjectShould("dataset/section.json") {
+    override fun roundTripSerializer() = SectionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val sectionDTO = deserialize(SectionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/SectionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/SectionShould.kt
@@ -33,12 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.dataset.SectionDTO
 import org.junit.Test
 
-class SectionShould : CoreObjectShould("dataset/section.json") {
-    override fun roundTripSerializer() = SectionDTO.serializer()
+internal class SectionShould : CoreObjectShould<SectionDTO>("dataset/section.json", SectionDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val sectionDTO = deserialize(SectionDTO.serializer())
+        val sectionDTO = deserialize()
         val section = sectionDTO.toDomain()
 
         assertThat(section.uid()).isEqualTo("Y2rk0vzgvAx")

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetEmptyShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetEmptyShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
 class DataValueSetEmptyShould : CoreObjectShould("common/empty_object.json") {
+    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         deserialize(DataValueSetDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetEmptyShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetEmptyShould.kt
@@ -31,11 +31,13 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
-class DataValueSetEmptyShould : CoreObjectShould("common/empty_object.json") {
-    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+internal class DataValueSetEmptyShould : CoreObjectShould<DataValueSetDTO>(
+    "common/empty_object.json",
+    DataValueSetDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        deserialize(DataValueSetDTO.serializer()).toDomain()
+        deserialize().toDomain()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetOnlyCommonFieldsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetOnlyCommonFieldsShould.kt
@@ -31,11 +31,13 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
-class DataValueSetOnlyCommonFieldsShould : CoreObjectShould("datavalue/data_values_only_common_fields.json") {
-    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+internal class DataValueSetOnlyCommonFieldsShould : CoreObjectShould<DataValueSetDTO>(
+    "datavalue/data_values_only_common_fields.json",
+    DataValueSetDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        deserialize(DataValueSetDTO.serializer()).toDomain()
+        deserialize().toDomain()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetOnlyCommonFieldsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetOnlyCommonFieldsShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
 class DataValueSetOnlyCommonFieldsShould : CoreObjectShould("datavalue/data_values_only_common_fields.json") {
+    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         deserialize(DataValueSetDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
 class DataValueSetShould : CoreObjectShould("datavalue/data_values_lyLU2wR22tC.json") {
+    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         deserialize(DataValueSetDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetShould.kt
@@ -31,11 +31,13 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
-class DataValueSetShould : CoreObjectShould("datavalue/data_values_lyLU2wR22tC.json") {
-    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+internal class DataValueSetShould : CoreObjectShould<DataValueSetDTO>(
+    "datavalue/data_values_lyLU2wR22tC.json",
+    DataValueSetDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        deserialize(DataValueSetDTO.serializer()).toDomain()
+        deserialize().toDomain()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetSinglePeriodShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetSinglePeriodShould.kt
@@ -31,11 +31,13 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
-class DataValueSetSinglePeriodShould : CoreObjectShould("datavalue/data_values_single_period.json") {
-    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+internal class DataValueSetSinglePeriodShould : CoreObjectShould<DataValueSetDTO>(
+    "datavalue/data_values_single_period.json",
+    DataValueSetDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        deserialize(DataValueSetDTO.serializer()).toDomain()
+        deserialize().toDomain()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetSinglePeriodShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueSetSinglePeriodShould.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.network.datavalue.DataValueSetDTO
 import org.junit.Test
 
 class DataValueSetSinglePeriodShould : CoreObjectShould("datavalue/data_values_single_period.json") {
+    override fun roundTripSerializer() = DataValueSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         deserialize(DataValueSetDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.datavalue.DataValueDTO
 import org.junit.Test
 
-class DataValueShould : CoreObjectShould("datavalue/data_value.json") {
-    override fun roundTripSerializer() = DataValueDTO.serializer()
+internal class DataValueShould : CoreObjectShould<DataValueDTO>(
+    "datavalue/data_value.json",
+    DataValueDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataValueDTO = deserialize(DataValueDTO.serializer())
+        val dataValueDTO = deserialize()
         val dataValue = dataValueDTO.toDomain("lyLU2wR22tC")
 
         assertThat(dataValue.dataElement()).isEqualTo("s46m5MS0hxu")

--- a/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/datavalue/DataValueShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.datavalue.DataValueDTO
 import org.junit.Test
 
 class DataValueShould : CoreObjectShould("datavalue/data_value.json") {
+    override fun roundTripSerializer() = DataValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataValueDTO = deserialize(DataValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentShould.kt
@@ -35,12 +35,14 @@ import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.network.enrollment.EnrollmentDTO
 import org.junit.Test
 
-class EnrollmentShould : CoreObjectShould("enrollment/enrollment.json") {
-    override fun roundTripSerializer() = EnrollmentDTO.serializer()
+internal class EnrollmentShould : CoreObjectShould<EnrollmentDTO>(
+    "enrollment/enrollment.json",
+    EnrollmentDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val enrollmentDTO = deserialize(EnrollmentDTO.serializer())
+        val enrollmentDTO = deserialize()
         val enrollment = enrollmentDTO.toDomain()
 
         assertThat(enrollment.created()).isEqualTo("2015-03-28T12:27:50.740".toJavaDate())

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentShould.kt
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.network.enrollment.EnrollmentDTO
 import org.junit.Test
 
 class EnrollmentShould : CoreObjectShould("enrollment/enrollment.json") {
+    override fun roundTripSerializer() = EnrollmentDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val enrollmentDTO = deserialize(EnrollmentDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/NewTrackerImporterEnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/NewTrackerImporterEnrollmentShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewEnrollmentDTO
 import org.junit.Test
 
-class NewTrackerImporterEnrollmentShould : CoreObjectShould("enrollment/new_tracker_importer_enrollment.json") {
-
-    override fun roundTripSerializer() = NewEnrollmentDTO.serializer()
+internal class NewTrackerImporterEnrollmentShould : CoreObjectShould<NewEnrollmentDTO>(
+    "enrollment/new_tracker_importer_enrollment.json",
+    NewEnrollmentDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val enrollmentDTO = deserialize(NewEnrollmentDTO.serializer())
+        val enrollmentDTO = deserialize()
         val enrollment = enrollmentDTO.toDomain()
 
         assertThat(enrollment.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2018-01-20T10:44:02.929"))

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/NewTrackerImporterEnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/NewTrackerImporterEnrollmentShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class NewTrackerImporterEnrollmentShould : CoreObjectShould("enrollment/new_tracker_importer_enrollment.json") {
 
+    override fun roundTripSerializer() = NewEnrollmentDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val enrollmentDTO = deserialize(NewEnrollmentDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventFilterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventFilterShould.kt
@@ -37,14 +37,15 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.network.eventfilter.EventFilterDTO
 import org.junit.Test
 
-class EventFilterShould : CoreObjectShould("event/event_filter.json") {
-
-    override fun roundTripSerializer() = EventFilterDTO.serializer()
+internal class EventFilterShould : CoreObjectShould<EventFilterDTO>(
+    "event/event_filter.json",
+    EventFilterDTO.serializer(),
+) {
 
     @Test
     @Suppress("LongMethod")
     override fun map_from_json_string() {
-        val eventFilterDTO = deserialize(EventFilterDTO.serializer())
+        val eventFilterDTO = deserialize()
         val eventFilter = eventFilterDTO.toDomain()
 
         assertThat(eventFilter.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2019-09-27T00:19:06.590"))

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventFilterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventFilterShould.kt
@@ -39,6 +39,8 @@ import org.junit.Test
 
 class EventFilterShould : CoreObjectShould("event/event_filter.json") {
 
+    override fun roundTripSerializer() = EventFilterDTO.serializer()
+
     @Test
     @Suppress("LongMethod")
     override fun map_from_json_string() {

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventShould.kt
@@ -34,12 +34,11 @@ import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.network.event.EventDTO
 import org.junit.Test
 
-class EventShould : CoreObjectShould("event/event.json") {
-    override fun roundTripSerializer() = EventDTO.serializer()
+internal class EventShould : CoreObjectShould<EventDTO>("event/event.json", EventDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val eventDTO = deserialize(EventDTO.serializer())
+        val eventDTO = deserialize()
         val event = eventDTO.toDomain()
 
         assertThat(event.uid()).isEqualTo("hnaWBxMw5j3")

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventShould.kt
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.network.event.EventDTO
 import org.junit.Test
 
 class EventShould : CoreObjectShould("event/event.json") {
+    override fun roundTripSerializer() = EventDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val eventDTO = deserialize(EventDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadGreaterEqualV41Should.kt
@@ -32,15 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewEventPayload
 import org.junit.Test
 
-class NewTrackerImporterEventPayloadGreaterEqualV41Should : CoreObjectShould(
+internal class NewTrackerImporterEventPayloadGreaterEqualV41Should : CoreObjectShould<NewEventPayload>(
     "event/new_tracker_importer_events_greater_equal_v41.json",
+    NewEventPayload.serializer(),
 ) {
-
-    override fun roundTripSerializer() = NewEventPayload.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val eventPayloadDTO = deserialize(NewEventPayload.serializer())
+        val eventPayloadDTO = deserialize()
         val eventPayload = eventPayloadDTO
 
         assertThat(eventPayload.pager().page).isEqualTo(1)

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadGreaterEqualV41Should.kt
@@ -36,6 +36,8 @@ class NewTrackerImporterEventPayloadGreaterEqualV41Should : CoreObjectShould(
     "event/new_tracker_importer_events_greater_equal_v41.json",
 ) {
 
+    override fun roundTripSerializer() = NewEventPayload.serializer()
+
     @Test
     override fun map_from_json_string() {
         val eventPayloadDTO = deserialize(NewEventPayload.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadLowerV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadLowerV41Should.kt
@@ -36,6 +36,8 @@ class NewTrackerImporterEventPayloadLowerV41Should : CoreObjectShould(
     "event/new_tracker_importer_events_lower_v41.json",
 ) {
 
+    override fun roundTripSerializer() = NewEventPayload.serializer()
+
     @Test
     override fun map_from_json_string() {
         val eventPayloadDTO = deserialize(NewEventPayload.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadLowerV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventPayloadLowerV41Should.kt
@@ -32,15 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewEventPayload
 import org.junit.Test
 
-class NewTrackerImporterEventPayloadLowerV41Should : CoreObjectShould(
+internal class NewTrackerImporterEventPayloadLowerV41Should : CoreObjectShould<NewEventPayload>(
     "event/new_tracker_importer_events_lower_v41.json",
+    NewEventPayload.serializer(),
 ) {
-
-    override fun roundTripSerializer() = NewEventPayload.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val eventPayloadDTO = deserialize(NewEventPayload.serializer())
+        val eventPayloadDTO = deserialize()
         val eventPayload = eventPayloadDTO
 
         assertThat(eventPayload.pager().page).isEqualTo(1)

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventShould.kt
@@ -35,13 +35,14 @@ import org.hisp.dhis.android.core.event.EventInternalAccessor.accessTrackedEntit
 import org.hisp.dhis.android.network.tracker.NewEventDTO
 import org.junit.Test
 
-class NewTrackerImporterEventShould : CoreObjectShould("event/new_tracker_importer_event.json") {
-
-    override fun roundTripSerializer() = NewEventDTO.serializer()
+internal class NewTrackerImporterEventShould : CoreObjectShould<NewEventDTO>(
+    "event/new_tracker_importer_event.json",
+    NewEventDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val eventDTO = deserialize(NewEventDTO.serializer())
+        val eventDTO = deserialize()
         val event = eventDTO.toDomain()
 
         assertThat(event.uid()).isEqualTo("EsHa0edW6uY")

--- a/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/NewTrackerImporterEventShould.kt
@@ -37,6 +37,8 @@ import org.junit.Test
 
 class NewTrackerImporterEventShould : CoreObjectShould("event/new_tracker_importer_event.json") {
 
+    override fun roundTripSerializer() = NewEventDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val eventDTO = deserialize(NewEventDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class ExpressionDimensionItemShould : CoreObjectShould("expressiondimensionitem/expression_dimension_item.json") {
 
+    override fun roundTripSerializer() = ExpressionDimensionItemDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val itemDTO = deserialize(ExpressionDimensionItemDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/expressiondimensionitem/ExpressionDimensionItemShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.expressiondimensionitem.ExpressionDimensionItemDTO
 import org.junit.Test
 
-class ExpressionDimensionItemShould : CoreObjectShould("expressiondimensionitem/expression_dimension_item.json") {
-
-    override fun roundTripSerializer() = ExpressionDimensionItemDTO.serializer()
+internal class ExpressionDimensionItemShould : CoreObjectShould<ExpressionDimensionItemDTO>(
+    "expressiondimensionitem/expression_dimension_item.json",
+    ExpressionDimensionItemDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val itemDTO = deserialize(ExpressionDimensionItemDTO.serializer())
+        val itemDTO = deserialize()
         val item = itemDTO.toDomain()
 
         assertThat(item.uid()).isEqualTo("MUcDTQTYanb")

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/FileResourceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/FileResourceShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class FileResourceShould : CoreObjectShould("fileresource/file_resource.json") {
 
+    override fun roundTripSerializer() = FileResourceDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val fileResourceDTO = deserialize(FileResourceDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/FileResourceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/FileResourceShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.fileresource.FileResourceDTO
 import org.junit.Test
 
-class FileResourceShould : CoreObjectShould("fileresource/file_resource.json") {
-
-    override fun roundTripSerializer() = FileResourceDTO.serializer()
+internal class FileResourceShould : CoreObjectShould<FileResourceDTO>(
+    "fileresource/file_resource.json",
+    FileResourceDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val fileResourceDTO = deserialize(FileResourceDTO.serializer())
+        val fileResourceDTO = deserialize()
         val fileResource = fileResourceDTO.toDomain()
 
         assertThat(fileResource.uid()).isEqualTo("SyPJ9weHqBM")

--- a/core/src/test/java/org/hisp/dhis/android/core/icon/CustomIconShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/icon/CustomIconShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class CustomIconShould : CoreObjectShould("icon/custom_icon.json") {
 
+    override fun roundTripSerializer() = CustomIconDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val iconDTO = deserialize(CustomIconDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/icon/CustomIconShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/icon/CustomIconShould.kt
@@ -32,13 +32,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.customicon.CustomIconDTO
 import org.junit.Test
 
-class CustomIconShould : CoreObjectShould("icon/custom_icon.json") {
-
-    override fun roundTripSerializer() = CustomIconDTO.serializer()
+internal class CustomIconShould : CoreObjectShould<CustomIconDTO>("icon/custom_icon.json", CustomIconDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val iconDTO = deserialize(CustomIconDTO.serializer())
+        val iconDTO = deserialize()
         val icon = iconDTO.toDomain()
 
         assertThat(icon.key()).isEqualTo("childIcon")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/DataValueImportSummaryWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/DataValueImportSummaryWebResponseShould.kt
@@ -40,6 +40,8 @@ class DataValueImportSummaryWebResponseShould : CoreObjectShould(
     "imports/data_value_import_summary_web_response.json",
 ) {
 
+    override fun roundTripSerializer() = DataValueImportSummaryWebResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val webResponseDTO = deserialize(DataValueImportSummaryWebResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/DataValueImportSummaryWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/DataValueImportSummaryWebResponseShould.kt
@@ -36,15 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class DataValueImportSummaryWebResponseShould : CoreObjectShould(
+internal class DataValueImportSummaryWebResponseShould : CoreObjectShould<DataValueImportSummaryWebResponseDTO>(
     "imports/data_value_import_summary_web_response.json",
+    DataValueImportSummaryWebResponseDTO.serializer(),
 ) {
-
-    override fun roundTripSerializer() = DataValueImportSummaryWebResponseDTO.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val webResponseDTO = deserialize(DataValueImportSummaryWebResponseDTO.serializer())
+        val webResponseDTO = deserialize()
         val webResponse = webResponseDTO.toDomain()
 
         assertThat(webResponse.response.importStatus()).isEqualTo(ImportStatus.SUCCESS)

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EnrollmentImportEnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EnrollmentImportEnrollmentShould.kt
@@ -36,12 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class EnrollmentImportEnrollmentShould : CoreObjectShould("imports/import_enrollment.json") {
-    override fun roundTripSerializer() = EnrollmentImportSummariesDTO.serializer()
+internal class EnrollmentImportEnrollmentShould : CoreObjectShould<EnrollmentImportSummariesDTO>(
+    "imports/import_enrollment.json",
+    EnrollmentImportSummariesDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val importEnrollmentDTO = deserialize(EnrollmentImportSummariesDTO.serializer())
+        val importEnrollmentDTO = deserialize()
         val importEnrollment = importEnrollmentDTO.toDomain()
 
         assertThat(importEnrollment.imported()).isEqualTo(0)

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EnrollmentImportEnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EnrollmentImportEnrollmentShould.kt
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class EnrollmentImportEnrollmentShould : CoreObjectShould("imports/import_enrollment.json") {
+    override fun roundTripSerializer() = EnrollmentImportSummariesDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val importEnrollmentDTO = deserialize(EnrollmentImportSummariesDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EventImportEventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EventImportEventShould.kt
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class EventImportEventShould : CoreObjectShould("imports/import_event.json") {
+    override fun roundTripSerializer() = EventImportSummariesDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val importEventDTO = deserialize(EventImportSummariesDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EventImportEventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EventImportEventShould.kt
@@ -36,12 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class EventImportEventShould : CoreObjectShould("imports/import_event.json") {
-    override fun roundTripSerializer() = EventImportSummariesDTO.serializer()
+internal class EventImportEventShould : CoreObjectShould<EventImportSummariesDTO>(
+    "imports/import_event.json",
+    EventImportSummariesDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val importEventDTO = deserialize(EventImportSummariesDTO.serializer())
+        val importEventDTO = deserialize()
         val importEvent = importEventDTO.toDomain()
 
         assertThat(importEvent.imported()).isEqualTo(1)

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageBreakGlassSuccessfulShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageBreakGlassSuccessfulShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class HttpMessageBreakGlassSuccessfulShould : CoreObjectShould("trackedentity/glass/break_glass_successful.json") {
 
+    override fun roundTripSerializer() = HttpMessageResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val responseDTO = deserialize(HttpMessageResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageBreakGlassSuccessfulShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageBreakGlassSuccessfulShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.common.dto.HttpMessageResponseDTO
 import org.junit.Test
 
-class HttpMessageBreakGlassSuccessfulShould : CoreObjectShould("trackedentity/glass/break_glass_successful.json") {
-
-    override fun roundTripSerializer() = HttpMessageResponseDTO.serializer()
+internal class HttpMessageBreakGlassSuccessfulShould : CoreObjectShould<HttpMessageResponseDTO>(
+    "trackedentity/glass/break_glass_successful.json",
+    HttpMessageResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val responseDTO = deserialize(HttpMessageResponseDTO.serializer())
+        val responseDTO = deserialize()
         val response = responseDTO.toDomain()
 
         assertThat(response.httpStatus()).isEqualTo("OK")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageClosedProgramShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageClosedProgramShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class HttpMessageClosedProgramShould : CoreObjectShould("trackedentity/glass/closed_program_failure.json") {
 
+    override fun roundTripSerializer() = HttpMessageResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val responseDTO = deserialize(HttpMessageResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageClosedProgramShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageClosedProgramShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.common.dto.HttpMessageResponseDTO
 import org.junit.Test
 
-class HttpMessageClosedProgramShould : CoreObjectShould("trackedentity/glass/closed_program_failure.json") {
-
-    override fun roundTripSerializer() = HttpMessageResponseDTO.serializer()
+internal class HttpMessageClosedProgramShould : CoreObjectShould<HttpMessageResponseDTO>(
+    "trackedentity/glass/closed_program_failure.json",
+    HttpMessageResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val responseDTO = deserialize(HttpMessageResponseDTO.serializer())
+        val responseDTO = deserialize()
         val response = responseDTO.toDomain()
 
         assertThat(response.httpStatus()).isEqualTo("Unauthorized")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageOwnershipDeniedShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageOwnershipDeniedShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class HttpMessageOwnershipDeniedShould : CoreObjectShould("trackedentity/glass/glass_protected_tei_failure.json") {
 
+    override fun roundTripSerializer() = HttpMessageResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val responseDTO = deserialize(HttpMessageResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageOwnershipDeniedShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/HttpMessageOwnershipDeniedShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.common.dto.HttpMessageResponseDTO
 import org.junit.Test
 
-class HttpMessageOwnershipDeniedShould : CoreObjectShould("trackedentity/glass/glass_protected_tei_failure.json") {
-
-    override fun roundTripSerializer() = HttpMessageResponseDTO.serializer()
+internal class HttpMessageOwnershipDeniedShould : CoreObjectShould<HttpMessageResponseDTO>(
+    "trackedentity/glass/glass_protected_tei_failure.json",
+    HttpMessageResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val responseDTO = deserialize(HttpMessageResponseDTO.serializer())
+        val responseDTO = deserialize()
         val response = responseDTO.toDomain()
 
         assertThat(response.httpStatus()).isEqualTo("Unauthorized")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportConflictShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportConflictShould.kt
@@ -35,12 +35,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class ImportConflictShould : CoreObjectShould("imports/import_conflict.json") {
-    override fun roundTripSerializer() = ImportConflictDTO.serializer()
+internal class ImportConflictShould : CoreObjectShould<ImportConflictDTO>(
+    "imports/import_conflict.json",
+    ImportConflictDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val importConflictDTO = deserialize(ImportConflictDTO.serializer())
+        val importConflictDTO = deserialize()
         val importConflict = importConflictDTO.toDomain()
 
         assertThat(importConflict.`object`()).isEqualTo("UOlfIjgN8X6")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportConflictShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportConflictShould.kt
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class ImportConflictShould : CoreObjectShould("imports/import_conflict.json") {
+    override fun roundTripSerializer() = ImportConflictDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val importConflictDTO = deserialize(ImportConflictDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportCountShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportCountShould.kt
@@ -35,12 +35,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class ImportCountShould : CoreObjectShould("imports/import_count.json") {
-    override fun roundTripSerializer() = ImportCountDTO.serializer()
+internal class ImportCountShould : CoreObjectShould<ImportCountDTO>(
+    "imports/import_count.json",
+    ImportCountDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val importCountDTO = deserialize(ImportCountDTO.serializer())
+        val importCountDTO = deserialize()
         val importCount = importCountDTO.toDomain()
 
         assertThat(importCount.imported()).isEqualTo(0)

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportCountShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportCountShould.kt
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class ImportCountShould : CoreObjectShould("imports/import_count.json") {
+    override fun roundTripSerializer() = ImportCountDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val importCountDTO = deserialize(ImportCountDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipDeleteWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipDeleteWebResponseShould.kt
@@ -35,12 +35,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class RelationshipDeleteWebResponseShould : CoreObjectShould("imports/relationship_delete_web_response.json") {
-    override fun roundTripSerializer() = RelationshipDeleteWebResponseDTO.serializer()
+internal class RelationshipDeleteWebResponseShould : CoreObjectShould<RelationshipDeleteWebResponseDTO>(
+    "imports/relationship_delete_web_response.json",
+    RelationshipDeleteWebResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val webResponse = deserialize(RelationshipDeleteWebResponseDTO.serializer()).toDomain()
+        val webResponse = deserialize().toDomain()
 
         assertThat(webResponse.message()).isEqualTo("Import was successful.")
         assertThat(webResponse.response()).isNotNull()

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipDeleteWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipDeleteWebResponseShould.kt
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class RelationshipDeleteWebResponseShould : CoreObjectShould("imports/relationship_delete_web_response.json") {
+    override fun roundTripSerializer() = RelationshipDeleteWebResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val webResponse = deserialize(RelationshipDeleteWebResponseDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipWebResponseShould.kt
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class RelationshipWebResponseShould : CoreObjectShould("imports/relationship_web_response.json") {
+    override fun roundTripSerializer() = RelationshipWebResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val webResponse = deserialize(RelationshipWebResponseDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/RelationshipWebResponseShould.kt
@@ -35,12 +35,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class RelationshipWebResponseShould : CoreObjectShould("imports/relationship_web_response.json") {
-    override fun roundTripSerializer() = RelationshipWebResponseDTO.serializer()
+internal class RelationshipWebResponseShould : CoreObjectShould<RelationshipWebResponseDTO>(
+    "imports/relationship_web_response.json",
+    RelationshipWebResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val webResponse = deserialize(RelationshipWebResponseDTO.serializer()).toDomain()
+        val webResponse = deserialize().toDomain()
 
         assertThat(webResponse.message()).isEqualTo("Import was successful.")
         assertThat(webResponse.response()).isNotNull()

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummariesShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummariesShould.kt
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class TEIImportSummariesShould : CoreObjectShould("imports/import_summaries.json") {
+    override fun roundTripSerializer() = TEIImportSummariesDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val importSummariesDTO = deserialize(TEIImportSummariesDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummariesShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummariesShould.kt
@@ -36,12 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class TEIImportSummariesShould : CoreObjectShould("imports/import_summaries.json") {
-    override fun roundTripSerializer() = TEIImportSummariesDTO.serializer()
+internal class TEIImportSummariesShould : CoreObjectShould<TEIImportSummariesDTO>(
+    "imports/import_summaries.json",
+    TEIImportSummariesDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val importSummariesDTO = deserialize(TEIImportSummariesDTO.serializer())
+        val importSummariesDTO = deserialize()
         val importSummaries = importSummariesDTO.toDomain()
 
         assertThat(importSummaries.responseType()).isEqualTo("ImportSummaries")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithEventConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithEventConflicts.kt
@@ -34,14 +34,15 @@ import org.hisp.dhis.android.core.imports.ImportStatus
 import org.hisp.dhis.android.network.trackedentityinstance.TEIImportSummaryDTO
 import org.junit.Test
 
-class TEIImportSummaryShouldwithEventConflicts : CoreObjectShould("imports/import_summary_with_event_conflicts.json") {
-
-    override fun roundTripSerializer() = TEIImportSummaryDTO.serializer()
+internal class TEIImportSummaryShouldwithEventConflicts : CoreObjectShould<TEIImportSummaryDTO>(
+    "imports/import_summary_with_event_conflicts.json",
+    TEIImportSummaryDTO.serializer(),
+) {
 
     @Test
     @Throws(Exception::class)
     override fun map_from_json_string() {
-        val importSummaryDTO = deserialize(TEIImportSummaryDTO.serializer())
+        val importSummaryDTO = deserialize()
         val importSummary = importSummaryDTO.toDomain()
 
         assertThat(importSummary.responseType()).isEqualTo("ImportSummary")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithEventConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithEventConflicts.kt
@@ -35,6 +35,9 @@ import org.hisp.dhis.android.network.trackedentityinstance.TEIImportSummaryDTO
 import org.junit.Test
 
 class TEIImportSummaryShouldwithEventConflicts : CoreObjectShould("imports/import_summary_with_event_conflicts.json") {
+
+    override fun roundTripSerializer() = TEIImportSummaryDTO.serializer()
+
     @Test
     @Throws(Exception::class)
     override fun map_from_json_string() {

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithTeiConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithTeiConflicts.kt
@@ -36,13 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class TEIImportSummaryShouldwithTeiConflicts : CoreObjectShould("imports/import_summary_with_tei_conflicts.json") {
-
-    override fun roundTripSerializer() = TEIImportSummaryDTO.serializer()
+internal class TEIImportSummaryShouldwithTeiConflicts : CoreObjectShould<TEIImportSummaryDTO>(
+    "imports/import_summary_with_tei_conflicts.json",
+    TEIImportSummaryDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val importSummaryDTO = deserialize(TEIImportSummaryDTO.serializer())
+        val importSummaryDTO = deserialize()
         val importSummary = importSummaryDTO.toDomain()
 
         assertThat(importSummary.status()).isEqualTo(ImportStatus.ERROR)

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithTeiConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithTeiConflicts.kt
@@ -38,6 +38,8 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class TEIImportSummaryShouldwithTeiConflicts : CoreObjectShould("imports/import_summary_with_tei_conflicts.json") {
 
+    override fun roundTripSerializer() = TEIImportSummaryDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val importSummaryDTO = deserialize(TEIImportSummaryDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShould.kt
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class TEIWebResponseShould : CoreObjectShould("imports/web_response.json") {
+    override fun roundTripSerializer() = TEIWebResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val webResponseDto = deserialize(TEIWebResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShould.kt
@@ -35,12 +35,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class TEIWebResponseShould : CoreObjectShould("imports/web_response.json") {
-    override fun roundTripSerializer() = TEIWebResponseDTO.serializer()
+internal class TEIWebResponseShould : CoreObjectShould<TEIWebResponseDTO>(
+    "imports/web_response.json",
+    TEIWebResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val webResponseDto = deserialize(TEIWebResponseDTO.serializer())
+        val webResponseDto = deserialize()
         val webResponse = webResponseDto.toDomain()
 
         assertThat(webResponse.message()).isEqualTo("Import was successful.")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShouldWithImportConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShouldWithImportConflicts.kt
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class TEIWebResponseShouldWithImportConflicts : CoreObjectShould("imports/web_response_with_import_conflicts.json") {
+    override fun roundTripSerializer() = TEIWebResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val webResponseDto = deserialize(TEIWebResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShouldWithImportConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIWebResponseShouldWithImportConflicts.kt
@@ -36,12 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class TEIWebResponseShouldWithImportConflicts : CoreObjectShould("imports/web_response_with_import_conflicts.json") {
-    override fun roundTripSerializer() = TEIWebResponseDTO.serializer()
+internal class TEIWebResponseShouldWithImportConflicts : CoreObjectShould<TEIWebResponseDTO>(
+    "imports/web_response_with_import_conflicts.json",
+    TEIWebResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val webResponseDto = deserialize(TEIWebResponseDTO.serializer())
+        val webResponseDto = deserialize()
         val webResponse = webResponseDto.toDomain()
 
         assertThat(webResponse.message()).isEqualTo("Import was successful.")

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorShould.kt
@@ -36,12 +36,14 @@ import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.network.indicator.IndicatorDTO
 import org.junit.Test
 
-class IndicatorShould : CoreObjectShould("indicators/indicator.json") {
-    override fun roundTripSerializer() = IndicatorDTO.serializer()
+internal class IndicatorShould : CoreObjectShould<IndicatorDTO>(
+    "indicators/indicator.json",
+    IndicatorDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val indicatorDTO = deserialize(IndicatorDTO.serializer())
+        val indicatorDTO = deserialize()
         val indicator = indicatorDTO.toDomain()
 
         assertThat(indicator.code()).isEqualTo("IN_52462")

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorShould.kt
@@ -37,6 +37,8 @@ import org.hisp.dhis.android.network.indicator.IndicatorDTO
 import org.junit.Test
 
 class IndicatorShould : CoreObjectShould("indicators/indicator.json") {
+    override fun roundTripSerializer() = IndicatorDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val indicatorDTO = deserialize(IndicatorDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.indicatortype.IndicatorTypeDTO
 import org.junit.Test
 
 class IndicatorTypeShould : CoreObjectShould("indicators/indicator_type.json") {
+    override fun roundTripSerializer() = IndicatorTypeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val typeDTO = deserialize(IndicatorTypeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/indicator/IndicatorTypeShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.indicatortype.IndicatorTypeDTO
 import org.junit.Test
 
-class IndicatorTypeShould : CoreObjectShould("indicators/indicator_type.json") {
-    override fun roundTripSerializer() = IndicatorTypeDTO.serializer()
+internal class IndicatorTypeShould : CoreObjectShould<IndicatorTypeDTO>(
+    "indicators/indicator_type.json",
+    IndicatorTypeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val typeDTO = deserialize(IndicatorTypeDTO.serializer())
+        val typeDTO = deserialize()
         val type = typeDTO.toDomain()
 
         assertThat(type.code()).isNull()

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.legendset.LegendSetDTO
 import org.junit.Test
 
-class LegendSetShould : CoreObjectShould("legendset/legend_set.json") {
-
-    override fun roundTripSerializer() = LegendSetDTO.serializer()
+internal class LegendSetShould : CoreObjectShould<LegendSetDTO>(
+    "legendset/legend_set.json",
+    LegendSetDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val legendSetDTO = deserialize(LegendSetDTO.serializer())
+        val legendSetDTO = deserialize()
         val legendSet = legendSetDTO.toDomain()
 
         assertThat(legendSet.uid()).isEqualTo("TiOkbpGEud4")

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendSetShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class LegendSetShould : CoreObjectShould("legendset/legend_set.json") {
 
+    override fun roundTripSerializer() = LegendSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val legendSetDTO = deserialize(LegendSetDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class LegendShould : CoreObjectShould("legendset/legend.json") {
 
+    override fun roundTripSerializer() = LegendDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val legendDTO = deserialize(LegendDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/legendset/LegendShould.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.legendset.LegendDTO
 import org.junit.Test
 
-class LegendShould : CoreObjectShould("legendset/legend.json") {
-
-    override fun roundTripSerializer() = LegendDTO.serializer()
+internal class LegendShould : CoreObjectShould<LegendDTO>("legendset/legend.json", LegendDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val legendDTO = deserialize(LegendDTO.serializer())
+        val legendDTO = deserialize()
         val legend = legendDTO.toDomain("legendSetUid")
 
         assertThat(legend.uid()).isEqualTo("ZUUGJnvX40X")

--- a/core/src/test/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/BingServerResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/BingServerResponseShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.bing.BingServerResponseDTO
 import org.junit.Test
 
 class BingServerResponseShould : CoreObjectShould("map/layer/microsoft/bing_server_response.json") {
+    override fun roundTripSerializer() = BingServerResponseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val bingServerResponseDTO = deserialize(BingServerResponseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/BingServerResponseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/map/layer/internal/microsoft/BingServerResponseShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.map.layer.MapLayerPosition
 import org.hisp.dhis.android.network.bing.BingServerResponseDTO
 import org.junit.Test
 
-class BingServerResponseShould : CoreObjectShould("map/layer/microsoft/bing_server_response.json") {
-    override fun roundTripSerializer() = BingServerResponseDTO.serializer()
+internal class BingServerResponseShould : CoreObjectShould<BingServerResponseDTO>(
+    "map/layer/microsoft/bing_server_response.json",
+    BingServerResponseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val bingServerResponseDTO = deserialize(BingServerResponseDTO.serializer())
+        val bingServerResponseDTO = deserialize()
         assertThat(bingServerResponseDTO.resourceSets!!.size).isEqualTo(1)
 
         bingServerResponseDTO.resourceSets.first().let { s ->

--- a/core/src/test/java/org/hisp/dhis/android/core/note/NewTrackerImporterNoteShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/note/NewTrackerImporterNoteShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class NewTrackerImporterNoteShould : CoreObjectShould("note/new_tracker_importer_note.json") {
 
+    override fun roundTripSerializer() = NewNoteDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val noteDTO = deserialize(NewNoteDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/note/NewTrackerImporterNoteShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/note/NewTrackerImporterNoteShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewNoteDTO
 import org.junit.Test
 
-class NewTrackerImporterNoteShould : CoreObjectShould("note/new_tracker_importer_note.json") {
-
-    override fun roundTripSerializer() = NewNoteDTO.serializer()
+internal class NewTrackerImporterNoteShould : CoreObjectShould<NewNoteDTO>(
+    "note/new_tracker_importer_note.json",
+    NewNoteDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val noteDTO = deserialize(NewNoteDTO.serializer())
+        val noteDTO = deserialize()
         val note = noteDTO.toDomain()
 
         assertThat(note.uid()).isEqualTo("zCBxfBfjnQZ")

--- a/core/src/test/java/org/hisp/dhis/android/core/note/NoteShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/note/NoteShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.note.NoteDTO
 import org.junit.Test
 
 class NoteShould : CoreObjectShould("note/note_30.json") {
+    override fun roundTripSerializer() = NoteDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val noteDTO = deserialize(NoteDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/note/NoteShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/note/NoteShould.kt
@@ -32,12 +32,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.note.NoteDTO
 import org.junit.Test
 
-class NoteShould : CoreObjectShould("note/note_30.json") {
-    override fun roundTripSerializer() = NoteDTO.serializer()
+internal class NoteShould : CoreObjectShould<NoteDTO>("note/note_30.json", NoteDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val noteDTO = deserialize(NoteDTO.serializer())
+        val noteDTO = deserialize()
         val note = noteDTO.toDomain()
 
         assertThat(note.uid()).isEqualTo("noteUid")

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionGroupShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class OptionGroupShould : CoreObjectShould("option/option_group.json") {
 
+    override fun roundTripSerializer() = OptionGroupDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val optionGroupDTO = deserialize(OptionGroupDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionGroupShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.optiongroup.OptionGroupDTO
 import org.junit.Test
 
-class OptionGroupShould : CoreObjectShould("option/option_group.json") {
-
-    override fun roundTripSerializer() = OptionGroupDTO.serializer()
+internal class OptionGroupShould : CoreObjectShould<OptionGroupDTO>(
+    "option/option_group.json",
+    OptionGroupDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val optionGroupDTO = deserialize(OptionGroupDTO.serializer())
+        val optionGroupDTO = deserialize()
         val optionGroup = optionGroupDTO.toDomain()
 
         assertThat(optionGroup.uid()).isEqualTo("j3JYGVCIEdz")

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionSetShould.kt
@@ -34,13 +34,11 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.network.optionset.OptionSetDTO
 import org.junit.Test
 
-class OptionSetShould : CoreObjectShould("option/option_set.json") {
-
-    override fun roundTripSerializer() = OptionSetDTO.serializer()
+internal class OptionSetShould : CoreObjectShould<OptionSetDTO>("option/option_set.json", OptionSetDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val optionSetDTO = deserialize(OptionSetDTO.serializer())
+        val optionSetDTO = deserialize()
         val optionSet = optionSetDTO.toDomain()
 
         assertThat(optionSet.uid()).isEqualTo("VQ2lai3OfVG")

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionSetShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionSetShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class OptionSetShould : CoreObjectShould("option/option_set.json") {
 
+    override fun roundTripSerializer() = OptionSetDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val optionSetDTO = deserialize(OptionSetDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionShould.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.option.OptionDTO
 import org.junit.Test
 
-class OptionShould : CoreObjectShould("option/option.json") {
-
-    override fun roundTripSerializer() = OptionDTO.serializer()
+internal class OptionShould : CoreObjectShould<OptionDTO>("option/option.json", OptionDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val optionDTO = deserialize(OptionDTO.serializer())
+        val optionDTO = deserialize()
         val option = optionDTO.toDomain()
 
         assertThat(option.uid()).isEqualTo("Y1ILwhy5VDY")

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class OptionShould : CoreObjectShould("option/option.json") {
 
+    override fun roundTripSerializer() = OptionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val optionDTO = deserialize(OptionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitGroupShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class OrganisationUnitGroupShould : CoreObjectShould("organisationunit/organisation_unit_group.json") {
 
+    override fun roundTripSerializer() = OrganisationUnitGroupDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val organisationUnitGroupDTO = deserialize(OrganisationUnitGroupDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitGroupShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.organisationunit.OrganisationUnitGroupDTO
 import org.junit.Test
 
-class OrganisationUnitGroupShould : CoreObjectShould("organisationunit/organisation_unit_group.json") {
-
-    override fun roundTripSerializer() = OrganisationUnitGroupDTO.serializer()
+internal class OrganisationUnitGroupShould : CoreObjectShould<OrganisationUnitGroupDTO>(
+    "organisationunit/organisation_unit_group.json",
+    OrganisationUnitGroupDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val organisationUnitGroupDTO = deserialize(OrganisationUnitGroupDTO.serializer())
+        val organisationUnitGroupDTO = deserialize()
         val organisationUnitGroup = organisationUnitGroupDTO.toDomain()
 
         assertThat(organisationUnitGroup.uid()).isEqualTo("CXw2yu5fodb")

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitLevelShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitLevelShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.organisationunitlevel.OrganisationUnitLevelDTO
 import org.junit.Test
 
-class OrganisationUnitLevelShould : CoreObjectShould("organisationunit/organisation_unit_level.json") {
-
-    override fun roundTripSerializer() = OrganisationUnitLevelDTO.serializer()
+internal class OrganisationUnitLevelShould : CoreObjectShould<OrganisationUnitLevelDTO>(
+    "organisationunit/organisation_unit_level.json",
+    OrganisationUnitLevelDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val organisationUnitLevelDTO = deserialize(OrganisationUnitLevelDTO.serializer())
+        val organisationUnitLevelDTO = deserialize()
         val organisationUnitLevel = organisationUnitLevelDTO.toDomain()
 
         assertThat(organisationUnitLevel.uid()).isEqualTo("H1KlN4QIauv")

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitLevelShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitLevelShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class OrganisationUnitLevelShould : CoreObjectShould("organisationunit/organisation_unit_level.json") {
 
+    override fun roundTripSerializer() = OrganisationUnitLevelDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val organisationUnitLevelDTO = deserialize(OrganisationUnitLevelDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitShould.kt
@@ -37,13 +37,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class OrganisationUnitShould : CoreObjectShould("organisationunit/organisation_unit.json") {
-
-    override fun roundTripSerializer() = OrganisationUnitDTO.serializer()
+internal class OrganisationUnitShould : CoreObjectShould<OrganisationUnitDTO>(
+    "organisationunit/organisation_unit.json",
+    OrganisationUnitDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val organisationUnitDTO = deserialize(OrganisationUnitDTO.serializer())
+        val organisationUnitDTO = deserialize()
         val organisationUnit = organisationUnitDTO.toDomain()
 
         assertThat(organisationUnit.uid()).isEqualTo("FLjwMPWLrL2")

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitShould.kt
@@ -39,6 +39,8 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class OrganisationUnitShould : CoreObjectShould("organisationunit/organisation_unit.json") {
 
+    override fun roundTripSerializer() = OrganisationUnitDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val organisationUnitDTO = deserialize(OrganisationUnitDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/payload/ProgramPayloadShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/payload/ProgramPayloadShould.kt
@@ -36,12 +36,14 @@ import org.hisp.dhis.android.network.program.ProgramDTO
 import org.hisp.dhis.android.network.program.ProgramPayload
 import org.junit.Test
 
-class ProgramPayloadShould : CoreObjectShould("program/program_payload.json") {
-    override fun roundTripSerializer() = ProgramPayload.serializer()
+internal class ProgramPayloadShould : CoreObjectShould<ProgramPayload>(
+    "program/program_payload.json",
+    ProgramPayload.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val payloadDTO: ProgramPayload = deserialize(ProgramPayload.serializer())
+        val payloadDTO = deserialize()
         val payload = payloadDTO.mapItems(ProgramDTO::toDomain)
 
         val programs: List<Program?> = payload.items()

--- a/core/src/test/java/org/hisp/dhis/android/core/payload/ProgramPayloadShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/payload/ProgramPayloadShould.kt
@@ -37,6 +37,8 @@ import org.hisp.dhis.android.network.program.ProgramPayload
 import org.junit.Test
 
 class ProgramPayloadShould : CoreObjectShould("program/program_payload.json") {
+    override fun roundTripSerializer() = ProgramPayload.serializer()
+
     @Test
     override fun map_from_json_string() {
         val payloadDTO: ProgramPayload = deserialize(ProgramPayload.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramIndicatorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramIndicatorShould.kt
@@ -37,6 +37,8 @@ import org.junit.Test
 
 class ProgramIndicatorShould : CoreObjectShould("program/program_indicator.json") {
 
+    override fun roundTripSerializer() = ProgramIndicatorDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programIndicatorDTO = deserialize(ProgramIndicatorDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramIndicatorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramIndicatorShould.kt
@@ -35,13 +35,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.programindicator.ProgramIndicatorDTO
 import org.junit.Test
 
-class ProgramIndicatorShould : CoreObjectShould("program/program_indicator.json") {
-
-    override fun roundTripSerializer() = ProgramIndicatorDTO.serializer()
+internal class ProgramIndicatorShould : CoreObjectShould<ProgramIndicatorDTO>(
+    "program/program_indicator.json",
+    ProgramIndicatorDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programIndicatorDTO = deserialize(ProgramIndicatorDTO.serializer())
+        val programIndicatorDTO = deserialize()
         val programIndicator = programIndicatorDTO.toDomain()
 
         assertThat(programIndicator.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2015-09-21T23:35:50.945"))

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleActionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleActionShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class ProgramRuleActionShould : CoreObjectShould("program/program_rule_action.json") {
 
+    override fun roundTripSerializer() = ProgramRuleActionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programRuleActionDTO = deserialize(ProgramRuleActionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleActionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleActionShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.programrule.ProgramRuleActionDTO
 import org.junit.Test
 
-class ProgramRuleActionShould : CoreObjectShould("program/program_rule_action.json") {
-
-    override fun roundTripSerializer() = ProgramRuleActionDTO.serializer()
+internal class ProgramRuleActionShould : CoreObjectShould<ProgramRuleActionDTO>(
+    "program/program_rule_action.json",
+    ProgramRuleActionDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programRuleActionDTO = deserialize(ProgramRuleActionDTO.serializer())
+        val programRuleActionDTO = deserialize()
         val programRuleAction = programRuleActionDTO.toDomain("NAgjOfWMXg6")
 
         assertThat(programRuleAction.lastUpdated()).isEqualTo(DateUtils.DATE_FORMAT.parse("2015-09-14T22:22:15.458"))

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.programrule.ProgramRuleDTO
 import org.junit.Test
 
-class ProgramRuleShould : CoreObjectShould("program/program_rule.json") {
-
-    override fun roundTripSerializer() = ProgramRuleDTO.serializer()
+internal class ProgramRuleShould : CoreObjectShould<ProgramRuleDTO>(
+    "program/program_rule.json",
+    ProgramRuleDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programRuleDTO = deserialize(ProgramRuleDTO.serializer())
+        val programRuleDTO = deserialize()
         val programRule = programRuleDTO.toDomain()
 
         assertThat(programRule.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2015-09-14T21:17:40.841"))

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class ProgramRuleShould : CoreObjectShould("program/program_rule.json") {
 
+    override fun roundTripSerializer() = ProgramRuleDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programRuleDTO = deserialize(ProgramRuleDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleVariableShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleVariableShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.program.ProgramRuleVariableDTO
 import org.junit.Test
 
 class ProgramRuleVariableShould : CoreObjectShould("program/program_rule_variable.json") {
+    override fun roundTripSerializer() = ProgramRuleVariableDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programRuleVariableDTO = deserialize(ProgramRuleVariableDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleVariableShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramRuleVariableShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.program.ProgramRuleVariableDTO
 import org.junit.Test
 
-class ProgramRuleVariableShould : CoreObjectShould("program/program_rule_variable.json") {
-    override fun roundTripSerializer() = ProgramRuleVariableDTO.serializer()
+internal class ProgramRuleVariableShould : CoreObjectShould<ProgramRuleVariableDTO>(
+    "program/program_rule_variable.json",
+    ProgramRuleVariableDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programRuleVariableDTO = deserialize(ProgramRuleVariableDTO.serializer())
+        val programRuleVariableDTO = deserialize()
         val programRuleVariable = programRuleVariableDTO.toDomain()
 
         assertThat(programRuleVariable.created()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSection32Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSection32Should.kt
@@ -35,12 +35,14 @@ import org.hisp.dhis.android.core.common.ObjectStyle
 import org.hisp.dhis.android.network.program.ProgramSectionDTO
 import org.junit.Test
 
-class ProgramSection32Should : CoreObjectShould("program/program_section_32_and_previous.json") {
-    override fun roundTripSerializer() = ProgramSectionDTO.serializer()
+internal class ProgramSection32Should : CoreObjectShould<ProgramSectionDTO>(
+    "program/program_section_32_and_previous.json",
+    ProgramSectionDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programSectionDTO = deserialize(ProgramSectionDTO.serializer())
+        val programSectionDTO = deserialize()
         val programSection = programSectionDTO.toDomain()
 
         assertThat(programSection.uid()).isEqualTo("Nc8OxbNuVH3")

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSection32Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSection32Should.kt
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.network.program.ProgramSectionDTO
 import org.junit.Test
 
 class ProgramSection32Should : CoreObjectShould("program/program_section_32_and_previous.json") {
+    override fun roundTripSerializer() = ProgramSectionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programSectionDTO = deserialize(ProgramSectionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSectionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSectionShould.kt
@@ -35,12 +35,14 @@ import org.hisp.dhis.android.core.common.ObjectStyle
 import org.hisp.dhis.android.network.program.ProgramSectionDTO
 import org.junit.Test
 
-class ProgramSectionShould : CoreObjectShould("program/program_section.json") {
-    override fun roundTripSerializer() = ProgramSectionDTO.serializer()
+internal class ProgramSectionShould : CoreObjectShould<ProgramSectionDTO>(
+    "program/program_section.json",
+    ProgramSectionDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programSectionDTO = deserialize(ProgramSectionDTO.serializer())
+        val programSectionDTO = deserialize()
         val programSection = programSectionDTO.toDomain()
 
         assertThat(programSection.uid()).isEqualTo("Nc8OxbNuVH3")

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSectionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramSectionShould.kt
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.network.program.ProgramSectionDTO
 import org.junit.Test
 
 class ProgramSectionShould : CoreObjectShould("program/program_section.json") {
+    override fun roundTripSerializer() = ProgramSectionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programSectionDTO = deserialize(ProgramSectionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramShould.kt
@@ -34,12 +34,11 @@ import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.network.program.ProgramDTO
 import org.junit.Test
 
-class ProgramShould : CoreObjectShould("program/program.json") {
-    override fun roundTripSerializer() = ProgramDTO.serializer()
+internal class ProgramShould : CoreObjectShould<ProgramDTO>("program/program.json", ProgramDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val programDTO = deserialize(ProgramDTO.serializer())
+        val programDTO = deserialize()
         val program = programDTO.toDomain()
 
         assertThat(program.lastUpdated()).isEqualTo(DateUtils.DATE_FORMAT.parse("2015-10-15T11:32:27.242"))

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramShould.kt
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.network.program.ProgramDTO
 import org.junit.Test
 
 class ProgramShould : CoreObjectShould("program/program.json") {
+    override fun roundTripSerializer() = ProgramDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programDTO = deserialize(ProgramDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageDataElementShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageDataElementShould.kt
@@ -37,6 +37,8 @@ import org.hisp.dhis.android.network.programstage.ProgramStageDataElementDTO
 import org.junit.Test
 
 class ProgramStageDataElementShould : CoreObjectShould("program/program_stage_data_element.json") {
+    override fun roundTripSerializer() = ProgramStageDataElementDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programStageDataElementDTO = deserialize(ProgramStageDataElementDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageDataElementShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageDataElementShould.kt
@@ -36,12 +36,14 @@ import org.hisp.dhis.android.core.common.ValueTypeRenderingType
 import org.hisp.dhis.android.network.programstage.ProgramStageDataElementDTO
 import org.junit.Test
 
-class ProgramStageDataElementShould : CoreObjectShould("program/program_stage_data_element.json") {
-    override fun roundTripSerializer() = ProgramStageDataElementDTO.serializer()
+internal class ProgramStageDataElementShould : CoreObjectShould<ProgramStageDataElementDTO>(
+    "program/program_stage_data_element.json",
+    ProgramStageDataElementDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programStageDataElementDTO = deserialize(ProgramStageDataElementDTO.serializer())
+        val programStageDataElementDTO = deserialize()
         val programStageDataElement = programStageDataElementDTO.toDomain()
 
         Truth.assertThat(programStageDataElement.lastUpdated()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageShould.kt
@@ -38,6 +38,8 @@ import org.hisp.dhis.android.network.programstage.ProgramStageDTO
 import org.junit.Test
 
 class ProgramStageShould : CoreObjectShould("program/program_stage.json") {
+    override fun roundTripSerializer() = ProgramStageDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programStageDTO = deserialize(ProgramStageDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramStageShould.kt
@@ -37,12 +37,14 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.network.programstage.ProgramStageDTO
 import org.junit.Test
 
-class ProgramStageShould : CoreObjectShould("program/program_stage.json") {
-    override fun roundTripSerializer() = ProgramStageDTO.serializer()
+internal class ProgramStageShould : CoreObjectShould<ProgramStageDTO>(
+    "program/program_stage.json",
+    ProgramStageDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programStageDTO = deserialize(ProgramStageDTO.serializer())
+        val programStageDTO = deserialize()
         val programStage = programStageDTO.toDomain()
 
         assertThat(programStage.lastUpdated()).isEqualTo(DateUtils.DATE_FORMAT.parse("2013-04-10T12:15:02.041"))

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeShould.kt
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.network.program.ProgramTrackedEntityAttributeDTO
 import org.junit.Test
 
 class ProgramTrackedEntityAttributeShould : CoreObjectShould("program/program_tracked_entity_attribute.json") {
+    override fun roundTripSerializer() = ProgramTrackedEntityAttributeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programTrackedEntityAttributeDTO = deserialize(ProgramTrackedEntityAttributeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/ProgramTrackedEntityAttributeShould.kt
@@ -35,12 +35,14 @@ import org.hisp.dhis.android.core.common.ValueTypeRenderingType
 import org.hisp.dhis.android.network.program.ProgramTrackedEntityAttributeDTO
 import org.junit.Test
 
-class ProgramTrackedEntityAttributeShould : CoreObjectShould("program/program_tracked_entity_attribute.json") {
-    override fun roundTripSerializer() = ProgramTrackedEntityAttributeDTO.serializer()
+internal class ProgramTrackedEntityAttributeShould : CoreObjectShould<ProgramTrackedEntityAttributeDTO>(
+    "program/program_tracked_entity_attribute.json",
+    ProgramTrackedEntityAttributeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programTrackedEntityAttributeDTO = deserialize(ProgramTrackedEntityAttributeDTO.serializer())
+        val programTrackedEntityAttributeDTO = deserialize()
         val programTrackedEntityAttribute = programTrackedEntityAttributeDTO.toDomain()
 
         assertThat(programTrackedEntityAttribute.created()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListShould.kt
@@ -39,6 +39,8 @@ import org.junit.Test
 
 class ProgramStageWorkingListShould : CoreObjectShould("programstageworkinglist/program_stage_working_list.json") {
 
+    override fun roundTripSerializer() = ProgramStageWorkingListDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val workingListDTO = deserialize(ProgramStageWorkingListDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListShould.kt
@@ -37,13 +37,14 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.network.programstageworkinglist.ProgramStageWorkingListDTO
 import org.junit.Test
 
-class ProgramStageWorkingListShould : CoreObjectShould("programstageworkinglist/program_stage_working_list.json") {
-
-    override fun roundTripSerializer() = ProgramStageWorkingListDTO.serializer()
+internal class ProgramStageWorkingListShould : CoreObjectShould<ProgramStageWorkingListDTO>(
+    "programstageworkinglist/program_stage_working_list.json",
+    ProgramStageWorkingListDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val workingListDTO = deserialize(ProgramStageWorkingListDTO.serializer())
+        val workingListDTO = deserialize()
         val workingList = workingListDTO.toDomain()
 
         assertThat(workingList.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2023-01-26T19:16:58.712"))

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/NewTrackerImporterRelationshipShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/NewTrackerImporterRelationshipShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class NewTrackerImporterRelationshipShould : CoreObjectShould("relationship/new_relationship.json") {
 
+    override fun roundTripSerializer() = NewRelationshipDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val relationshipDTO = deserialize(NewRelationshipDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/NewTrackerImporterRelationshipShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/NewTrackerImporterRelationshipShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewRelationshipDTO
 import org.junit.Test
 
-class NewTrackerImporterRelationshipShould : CoreObjectShould("relationship/new_relationship.json") {
-
-    override fun roundTripSerializer() = NewRelationshipDTO.serializer()
+internal class NewTrackerImporterRelationshipShould : CoreObjectShould<NewRelationshipDTO>(
+    "relationship/new_relationship.json",
+    NewRelationshipDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val relationshipDTO = deserialize(NewRelationshipDTO.serializer())
+        val relationshipDTO = deserialize()
         val relationship = relationshipDTO.toDomain()
 
         assertThat(relationship.uid()).isEqualTo("VdjOfugUb9y")

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/Relationship30Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/Relationship30Should.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.relationship.RelationshipDTO
 import org.junit.Test
 
 class Relationship30Should : CoreObjectShould("relationship/relationship_30.json") {
+    override fun roundTripSerializer() = RelationshipDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val relationshipDTO = deserialize(RelationshipDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/Relationship30Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/Relationship30Should.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.relationship.RelationshipDTO
 import org.junit.Test
 
-class Relationship30Should : CoreObjectShould("relationship/relationship_30.json") {
-    override fun roundTripSerializer() = RelationshipDTO.serializer()
+internal class Relationship30Should : CoreObjectShould<RelationshipDTO>(
+    "relationship/relationship_30.json",
+    RelationshipDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val relationshipDTO = deserialize(RelationshipDTO.serializer())
+        val relationshipDTO = deserialize()
         val relationship = relationshipDTO.toDomain()
 
         assertThat(relationship.uid()).isEqualTo("nEenWmSyUEp")

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType30Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType30Should.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.relationshiptype.RelationshipTypeDTO
 import org.junit.Test
 
 class RelationshipType30Should : CoreObjectShould("relationship/relationship_type_30.json") {
+    override fun roundTripSerializer() = RelationshipTypeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val relationshipTypeDTO = deserialize(RelationshipTypeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType30Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType30Should.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.relationshiptype.RelationshipTypeDTO
 import org.junit.Test
 
-class RelationshipType30Should : CoreObjectShould("relationship/relationship_type_30.json") {
-    override fun roundTripSerializer() = RelationshipTypeDTO.serializer()
+internal class RelationshipType30Should : CoreObjectShould<RelationshipTypeDTO>(
+    "relationship/relationship_type_30.json",
+    RelationshipTypeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val relationshipTypeDTO = deserialize(RelationshipTypeDTO.serializer())
+        val relationshipTypeDTO = deserialize()
         val relationshipType = relationshipTypeDTO.toDomain()
 
         assertThat(relationshipType.uid()).isEqualTo("V2kkHafqs8G")

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType32Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType32Should.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.relationshiptype.RelationshipTypeDTO
 import org.junit.Test
 
-class RelationshipType32Should : CoreObjectShould("relationship/relationship_type_32.json") {
-    override fun roundTripSerializer() = RelationshipTypeDTO.serializer()
+internal class RelationshipType32Should : CoreObjectShould<RelationshipTypeDTO>(
+    "relationship/relationship_type_32.json",
+    RelationshipTypeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val relationshipTypeDTO = deserialize(RelationshipTypeDTO.serializer())
+        val relationshipTypeDTO = deserialize()
         val relationshipType = relationshipTypeDTO.toDomain()
 
         assertThat(relationshipType.uid()).isEqualTo("WiH6923nMtb")

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType32Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType32Should.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.relationshiptype.RelationshipTypeDTO
 import org.junit.Test
 
 class RelationshipType32Should : CoreObjectShould("relationship/relationship_type_32.json") {
+    override fun roundTripSerializer() = RelationshipTypeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val relationshipTypeDTO = deserialize(RelationshipTypeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/server/LoginConfigShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/LoginConfigShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.loginconfig.LoginConfigDTO
 import org.junit.Test
 
-class LoginConfigShould : CoreObjectShould("server/login_config.json") {
-
-    override fun roundTripSerializer() = LoginConfigDTO.serializer()
+internal class LoginConfigShould : CoreObjectShould<LoginConfigDTO>(
+    "server/login_config.json",
+    LoginConfigDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val loginConfigDTO = deserialize(LoginConfigDTO.serializer())
+        val loginConfigDTO = deserialize()
         val loginConfig = loginConfigDTO.toDomain()
 
         assertThat(loginConfig.apiVersion).isEqualTo("2.41.3")

--- a/core/src/test/java/org/hisp/dhis/android/core/server/LoginConfigShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/LoginConfigShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class LoginConfigShould : CoreObjectShould("server/login_config.json") {
 
+    override fun roundTripSerializer() = LoginConfigDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val loginConfigDTO = deserialize(LoginConfigDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV1Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV1Should.kt
@@ -33,6 +33,8 @@ import org.junit.Test
 
 class AnalyticsSettingV1Should : CoreObjectShould("settings/analytics_settings.json") {
 
+    override fun roundTripSerializer() = AnalyticsSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val analyticsSettingsDTO = deserialize(AnalyticsSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV1Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV1Should.kt
@@ -31,13 +31,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.AnalyticsSettingsDTO
 import org.junit.Test
 
-class AnalyticsSettingV1Should : CoreObjectShould("settings/analytics_settings.json") {
-
-    override fun roundTripSerializer() = AnalyticsSettingsDTO.serializer()
+internal class AnalyticsSettingV1Should : CoreObjectShould<AnalyticsSettingsDTO>(
+    "settings/analytics_settings.json",
+    AnalyticsSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val analyticsSettingsDTO = deserialize(AnalyticsSettingsDTO.serializer())
+        val analyticsSettingsDTO = deserialize()
         val analyticsSettings = analyticsSettingsDTO.toDomain()
 
         AnalyticsSettingAsserts.assertTeiAnalytics(analyticsSettings.tei())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV2Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV2Should.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class AnalyticsSettingV2Should : CoreObjectShould("settings/analytics_settings_v2.json") {
 
+    override fun roundTripSerializer() = AnalyticsSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val analyticsSettingsDTO = deserialize(AnalyticsSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV2Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV2Should.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.AnalyticsSettingsDTO
 import org.junit.Test
 
-class AnalyticsSettingV2Should : CoreObjectShould("settings/analytics_settings_v2.json") {
-
-    override fun roundTripSerializer() = AnalyticsSettingsDTO.serializer()
+internal class AnalyticsSettingV2Should : CoreObjectShould<AnalyticsSettingsDTO>(
+    "settings/analytics_settings_v2.json",
+    AnalyticsSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val analyticsSettingsDTO = deserialize(AnalyticsSettingsDTO.serializer())
+        val analyticsSettingsDTO = deserialize()
         val analyticsSettings = analyticsSettingsDTO.toDomain()
 
         AnalyticsSettingAsserts.assertTeiAnalytics(analyticsSettings.tei())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV3Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV3Should.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class AnalyticsSettingV3Should : CoreObjectShould("settings/analytics_settings_v3.json") {
 
+    override fun roundTripSerializer() = AnalyticsSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val analyticsSettingsDTO = deserialize(AnalyticsSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV3Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AnalyticsSettingV3Should.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.AnalyticsSettingsDTO
 import org.junit.Test
 
-class AnalyticsSettingV3Should : CoreObjectShould("settings/analytics_settings_v3.json") {
-
-    override fun roundTripSerializer() = AnalyticsSettingsDTO.serializer()
+internal class AnalyticsSettingV3Should : CoreObjectShould<AnalyticsSettingsDTO>(
+    "settings/analytics_settings_v3.json",
+    AnalyticsSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val analyticsSettingsDTO = deserialize(AnalyticsSettingsDTO.serializer())
+        val analyticsSettingsDTO = deserialize()
         val analyticsSettings = analyticsSettingsDTO.toDomain()
 
         AnalyticsSettingAsserts.assertTeiAnalytics(analyticsSettings.tei())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV1Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV1Should.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.AppearanceSettingsDTO
 import org.junit.Test
 
-class AppearanceSettingsV1Should : CoreObjectShould("settings/appearance_settings_v1.json") {
-    override fun roundTripSerializer() = AppearanceSettingsDTO.serializer()
+internal class AppearanceSettingsV1Should : CoreObjectShould<AppearanceSettingsDTO>(
+    "settings/appearance_settings_v1.json",
+    AppearanceSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val appearanceSettingsDTO = deserialize(AppearanceSettingsDTO.serializer())
+        val appearanceSettingsDTO = deserialize()
         val appearanceSettings = appearanceSettingsDTO.toDomain()
 
         val filterSorting = appearanceSettings.filterSorting()

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV1Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV1Should.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.settings.AppearanceSettingsDTO
 import org.junit.Test
 
 class AppearanceSettingsV1Should : CoreObjectShould("settings/appearance_settings_v1.json") {
+    override fun roundTripSerializer() = AppearanceSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val appearanceSettingsDTO = deserialize(AppearanceSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV2Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV2Should.kt
@@ -32,14 +32,15 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.AppearanceSettingsDTO
 import org.junit.Test
 
-class AppearanceSettingsV2Should : CoreObjectShould("settings/appearance_settings_v2.json") {
-
-    override fun roundTripSerializer() = AppearanceSettingsDTO.serializer()
+internal class AppearanceSettingsV2Should : CoreObjectShould<AppearanceSettingsDTO>(
+    "settings/appearance_settings_v2.json",
+    AppearanceSettingsDTO.serializer(),
+) {
 
     @Test
     @Suppress("LongMethod")
     override fun map_from_json_string() {
-        val appearanceSettingsDTO = deserialize(AppearanceSettingsDTO.serializer())
+        val appearanceSettingsDTO = deserialize()
         val appearanceSettings = appearanceSettingsDTO.toDomain()
 
         val filterSorting = appearanceSettings.filterSorting()

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV2Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/AppearanceSettingsV2Should.kt
@@ -33,6 +33,9 @@ import org.hisp.dhis.android.network.settings.AppearanceSettingsDTO
 import org.junit.Test
 
 class AppearanceSettingsV2Should : CoreObjectShould("settings/appearance_settings_v2.json") {
+
+    override fun roundTripSerializer() = AppearanceSettingsDTO.serializer()
+
     @Test
     @Suppress("LongMethod")
     override fun map_from_json_string() {

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.settings.CustomIntentsDTO
 import org.junit.Test
 
 class CustomIntentsShould : CoreObjectShould("settings/custom_intents.json") {
+    override fun roundTripSerializer() = CustomIntentsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val customIntentsDTO = deserialize(CustomIntentsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.CustomIntentsDTO
 import org.junit.Test
 
-class CustomIntentsShould : CoreObjectShould("settings/custom_intents.json") {
-    override fun roundTripSerializer() = CustomIntentsDTO.serializer()
+internal class CustomIntentsShould : CoreObjectShould<CustomIntentsDTO>(
+    "settings/custom_intents.json",
+    CustomIntentsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val customIntentsDTO = deserialize(CustomIntentsDTO.serializer())
+        val customIntentsDTO = deserialize()
         val customIntents = customIntentsDTO.toDomain()
 
         assertThat(customIntents.customIntents()?.size).isEqualTo(2)

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/DataSetSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/DataSetSettingsShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.settings.DataSetSettingsDTO
 import org.junit.Test
 
 class DataSetSettingsShould : CoreObjectShould("settings/dataset_settings.json") {
+    override fun roundTripSerializer() = DataSetSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataSetSettingsDTO = deserialize(DataSetSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/DataSetSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/DataSetSettingsShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.DataSetSettingsDTO
 import org.junit.Test
 
-class DataSetSettingsShould : CoreObjectShould("settings/dataset_settings.json") {
-    override fun roundTripSerializer() = DataSetSettingsDTO.serializer()
+internal class DataSetSettingsShould : CoreObjectShould<DataSetSettingsDTO>(
+    "settings/dataset_settings.json",
+    DataSetSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val dataSetSettingsDTO = deserialize(DataSetSettingsDTO.serializer())
+        val dataSetSettingsDTO = deserialize()
         val dataSetSettings = dataSetSettingsDTO.toDomain()
 
         val global = dataSetSettings.globalSettings()

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV1Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV1Should.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 import java.io.IOException
 
 class GeneralSettingsV1Should : CoreObjectShould("settings/general_settings_v1.json") {
+    override fun roundTripSerializer() = GeneralSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val generalSettingsDTO = deserialize(GeneralSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV1Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV1Should.kt
@@ -34,12 +34,14 @@ import org.hisp.dhis.android.network.settings.GeneralSettingsDTO
 import org.junit.Test
 import java.io.IOException
 
-class GeneralSettingsV1Should : CoreObjectShould("settings/general_settings_v1.json") {
-    override fun roundTripSerializer() = GeneralSettingsDTO.serializer()
+internal class GeneralSettingsV1Should : CoreObjectShould<GeneralSettingsDTO>(
+    "settings/general_settings_v1.json",
+    GeneralSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val generalSettingsDTO = deserialize(GeneralSettingsDTO.serializer())
+        val generalSettingsDTO = deserialize()
         val generalSettings = generalSettingsDTO.toDomain()
 
         Truth.assertThat(generalSettings.dataSync()).isEqualTo(DataSyncPeriod.EVERY_24_HOURS)

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV2Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV2Should.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.settings.GeneralSettingsDTO
 import org.junit.Test
 
 class GeneralSettingsV2Should : CoreObjectShould("settings/general_settings_v2.json") {
+    override fun roundTripSerializer() = GeneralSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val generalSettingsDTO = deserialize(GeneralSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV2Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/GeneralSettingsV2Should.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.GeneralSettingsDTO
 import org.junit.Test
 
-class GeneralSettingsV2Should : CoreObjectShould("settings/general_settings_v2.json") {
-    override fun roundTripSerializer() = GeneralSettingsDTO.serializer()
+internal class GeneralSettingsV2Should : CoreObjectShould<GeneralSettingsDTO>(
+    "settings/general_settings_v2.json",
+    GeneralSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val generalSettingsDTO = deserialize(GeneralSettingsDTO.serializer())
+        val generalSettingsDTO = deserialize()
         val generalSettings = generalSettingsDTO.toDomain()
 
         assertThat(generalSettings.dataSync()).isNull()

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/LatestAppVersionSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/LatestAppVersionSettingsShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.apkdistribution.LatestAppVersionDTO
 import org.junit.Test
 
-class LatestAppVersionSettingsShould : CoreObjectShould("settings/latest_app_version.json") {
-
-    override fun roundTripSerializer() = LatestAppVersionDTO.serializer()
+internal class LatestAppVersionSettingsShould : CoreObjectShould<LatestAppVersionDTO>(
+    "settings/latest_app_version.json",
+    LatestAppVersionDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val latestAppVersioDTO = deserialize(LatestAppVersionDTO.serializer())
+        val latestAppVersioDTO = deserialize()
         val latestAppVersion = latestAppVersioDTO.toDomain()
 
         Truth.assertThat(latestAppVersion.version()).isEqualTo("v2.7.1.1")

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/LatestAppVersionSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/LatestAppVersionSettingsShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class LatestAppVersionSettingsShould : CoreObjectShould("settings/latest_app_version.json") {
 
+    override fun roundTripSerializer() = LatestAppVersionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val latestAppVersioDTO = deserialize(LatestAppVersionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.settings.ProgramSettingsDTO
 import org.junit.Test
 
-class ProgramSettingsShould : CoreObjectShould("settings/program_settings.json") {
-    override fun roundTripSerializer() = ProgramSettingsDTO.serializer()
+internal class ProgramSettingsShould : CoreObjectShould<ProgramSettingsDTO>(
+    "settings/program_settings.json",
+    ProgramSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programSettingsDTO = deserialize(ProgramSettingsDTO.serializer())
+        val programSettingsDTO = deserialize()
         val programSettings = programSettingsDTO.toDomain()
 
         val global = programSettings.globalSettings()

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.settings.ProgramSettingsDTO
 import org.junit.Test
 
 class ProgramSettingsShould : CoreObjectShould("settings/program_settings.json") {
+    override fun roundTripSerializer() = ProgramSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programSettingsDTO = deserialize(ProgramSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SettingsAppInfoShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SettingsAppInfoShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.settings.internal.SettingsAppDataStoreVersion
 import org.hisp.dhis.android.network.settings.SettingsAppInfoDTO
 import org.junit.Test
 
-class SettingsAppInfoShould : CoreObjectShould("settings/app_info.json") {
-    override fun roundTripSerializer() = SettingsAppInfoDTO.serializer()
+internal class SettingsAppInfoShould : CoreObjectShould<SettingsAppInfoDTO>(
+    "settings/app_info.json",
+    SettingsAppInfoDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val appInfoDTO = deserialize(SettingsAppInfoDTO.serializer())
+        val appInfoDTO = deserialize()
         val appInfo = appInfoDTO.toDomain()
 
         assertThat(appInfo.dataStoreVersion()).isEqualTo(SettingsAppDataStoreVersion.V2_0)

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SettingsAppInfoShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SettingsAppInfoShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.settings.SettingsAppInfoDTO
 import org.junit.Test
 
 class SettingsAppInfoShould : CoreObjectShould("settings/app_info.json") {
+    override fun roundTripSerializer() = SettingsAppInfoDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val appInfoDTO = deserialize(SettingsAppInfoDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SynchronizationSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SynchronizationSettingsShould.kt
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.network.settings.SynchronizationSettingsDTO
 import org.junit.Test
 
 class SynchronizationSettingsShould : CoreObjectShould("settings/synchronization_settings.json") {
+    override fun roundTripSerializer() = SynchronizationSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val syncSettingsDTO = deserialize(SynchronizationSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SynchronizationSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SynchronizationSettingsShould.kt
@@ -34,12 +34,14 @@ import org.hisp.dhis.android.core.tracker.TrackerImporterVersion
 import org.hisp.dhis.android.network.settings.SynchronizationSettingsDTO
 import org.junit.Test
 
-class SynchronizationSettingsShould : CoreObjectShould("settings/synchronization_settings.json") {
-    override fun roundTripSerializer() = SynchronizationSettingsDTO.serializer()
+internal class SynchronizationSettingsShould : CoreObjectShould<SynchronizationSettingsDTO>(
+    "settings/synchronization_settings.json",
+    SynchronizationSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val syncSettingsDTO = deserialize(SynchronizationSettingsDTO.serializer())
+        val syncSettingsDTO = deserialize()
         val syncSettings = syncSettingsDTO.toDomain()
 
         assertThat(syncSettings.dataSync()).isEqualTo(DataSyncPeriod.EVERY_24_HOURS)

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SystemSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SystemSettingsShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.systemsettings.SystemSettingsDTO
 import org.junit.Test
 
 class SystemSettingsShould : CoreObjectShould("settings/system_settings.json") {
+    override fun roundTripSerializer() = SystemSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val settingsDTO = deserialize(SystemSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SystemSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SystemSettingsShould.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.systemsettings.SystemSettingsDTO
 import org.junit.Test
 
-class SystemSettingsShould : CoreObjectShould("settings/system_settings.json") {
-    override fun roundTripSerializer() = SystemSettingsDTO.serializer()
+internal class SystemSettingsShould : CoreObjectShould<SystemSettingsDTO>(
+    "settings/system_settings.json",
+    SystemSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val settingsDTO = deserialize(SystemSettingsDTO.serializer())
+        val settingsDTO = deserialize()
         val settingsSplitted = settingsDTO.toDomainSplitted()
         assertThat(settingsSplitted.get(0).key()).isEqualTo(SystemSetting.SystemSettingKey.FLAG)
         assertThat(settingsSplitted.get(0).value()).isEqualTo("sierra_leone")

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/UserSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/UserSettingsShould.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.usersettings.UserSettingsDTO
 import org.junit.Test
 
-class UserSettingsShould : CoreObjectShould("settings/user_settings.json") {
-    override fun roundTripSerializer() = UserSettingsDTO.serializer()
+internal class UserSettingsShould : CoreObjectShould<UserSettingsDTO>(
+    "settings/user_settings.json",
+    UserSettingsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val userSettingsDTO = deserialize(UserSettingsDTO.serializer())
+        val userSettingsDTO = deserialize()
         val userSettings = userSettingsDTO.toDomain()
 
         assertThat(userSettings.keyUiLocale()).isEqualTo("es")

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/UserSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/UserSettingsShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.usersettings.UserSettingsDTO
 import org.junit.Test
 
 class UserSettingsShould : CoreObjectShould("settings/user_settings.json") {
+    override fun roundTripSerializer() = UserSettingsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val userSettingsDTO = deserialize(UserSettingsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/VersionsSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/VersionsSettingsShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.apkdistribution.ApkDistributionVersionDTO
 import org.junit.Test
 
-class VersionsSettingsShould : CoreObjectShould("settings/version.json") {
-
-    override fun roundTripSerializer() = ApkDistributionVersionDTO.serializer()
+internal class VersionsSettingsShould : CoreObjectShould<ApkDistributionVersionDTO>(
+    "settings/version.json",
+    ApkDistributionVersionDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val versionDTO = deserialize(ApkDistributionVersionDTO.serializer())
+        val versionDTO = deserialize()
         val version = versionDTO.toDomain()
 
         assertThat(version.version).isEqualTo("40.1")

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/VersionsSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/VersionsSettingsShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class VersionsSettingsShould : CoreObjectShould("settings/version.json") {
 
+    override fun roundTripSerializer() = ApkDistributionVersionDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val versionDTO = deserialize(ApkDistributionVersionDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/sms/data/webapirepository/internal/MetadataIdsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/sms/data/webapirepository/internal/MetadataIdsShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.metadata.MetadataIdsDTO
 import org.junit.Test
 
-class MetadataIdsShould : CoreObjectShould("sms/metadata_ids.json") {
-
-    override fun roundTripSerializer() = MetadataIdsDTO.serializer()
+internal class MetadataIdsShould : CoreObjectShould<MetadataIdsDTO>(
+    "sms/metadata_ids.json",
+    MetadataIdsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val metadataIdsDTO = deserialize(MetadataIdsDTO.serializer())
+        val metadataIdsDTO = deserialize()
         val metadataIds = metadataIdsDTO.toDomain()
 
         assertThat(metadataIds.system).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/sms/data/webapirepository/internal/MetadataIdsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/sms/data/webapirepository/internal/MetadataIdsShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class MetadataIdsShould : CoreObjectShould("sms/metadata_ids.json") {
 
+    override fun roundTripSerializer() = MetadataIdsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val metadataIdsDTO = deserialize(MetadataIdsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/SystemInfoShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/SystemInfoShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class SystemInfoShould : CoreObjectShould("systeminfo/system_info.json") {
 
+    override fun roundTripSerializer() = SystemInfoDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val systemInfoDTO = deserialize(SystemInfoDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/SystemInfoShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/SystemInfoShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.systeminfo.SystemInfoDTO
 import org.junit.Test
 
-class SystemInfoShould : CoreObjectShould("systeminfo/system_info.json") {
-
-    override fun roundTripSerializer() = SystemInfoDTO.serializer()
+internal class SystemInfoShould : CoreObjectShould<SystemInfoDTO>(
+    "systeminfo/system_info.json",
+    SystemInfoDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val systemInfoDTO = deserialize(SystemInfoDTO.serializer())
+        val systemInfoDTO = deserialize()
         val systemInfo = systemInfoDTO.toDomain()
 
         assertThat(systemInfo.serverDate()).isEqualTo(DateUtils.DATE_FORMAT.parse("2017-11-29T11:27:46.935"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityAttributeValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityAttributeValueShould.kt
@@ -37,6 +37,8 @@ class NewTrackerImporterTrackedEntityAttributeValueShould : CoreObjectShould(
     "trackedentity/new_tracker_importer_tracked_entity_attribute_value.json",
 ) {
 
+    override fun roundTripSerializer() = NewTrackedEntityAttributeValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataValueDTO = deserialize(NewTrackedEntityAttributeValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityAttributeValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityAttributeValueShould.kt
@@ -33,15 +33,15 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewTrackedEntityAttributeValueDTO
 import org.junit.Test
 
-class NewTrackerImporterTrackedEntityAttributeValueShould : CoreObjectShould(
-    "trackedentity/new_tracker_importer_tracked_entity_attribute_value.json",
-) {
-
-    override fun roundTripSerializer() = NewTrackedEntityAttributeValueDTO.serializer()
+internal class NewTrackerImporterTrackedEntityAttributeValueShould :
+    CoreObjectShould<NewTrackedEntityAttributeValueDTO>(
+        "trackedentity/new_tracker_importer_tracked_entity_attribute_value.json",
+        NewTrackedEntityAttributeValueDTO.serializer(),
+    ) {
 
     @Test
     override fun map_from_json_string() {
-        val dataValueDTO = deserialize(NewTrackedEntityAttributeValueDTO.serializer())
+        val dataValueDTO = deserialize()
         val dataValue = dataValueDTO.toDomain("zDhUuAYrxNC")
 
         assertThat(dataValue.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2017-05-26T11:46:22.371"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityDataValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityDataValueShould.kt
@@ -33,15 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewTrackedEntityDataValueDTO
 import org.junit.Test
 
-class NewTrackerImporterTrackedEntityDataValueShould : CoreObjectShould(
+internal class NewTrackerImporterTrackedEntityDataValueShould : CoreObjectShould<NewTrackedEntityDataValueDTO>(
     "trackedentity/new_tracker_importer_tracked_entity_data_value.json",
+    NewTrackedEntityDataValueDTO.serializer(),
 ) {
-
-    override fun roundTripSerializer() = NewTrackedEntityDataValueDTO.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val dataValueDTO = deserialize(NewTrackedEntityDataValueDTO.serializer())
+        val dataValueDTO = deserialize()
         val dataValue = dataValueDTO.toDomain("xE7jOejl9FI")
 
         assertThat(dataValue.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2017-01-20T10:44:03.231"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityDataValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityDataValueShould.kt
@@ -37,6 +37,8 @@ class NewTrackerImporterTrackedEntityDataValueShould : CoreObjectShould(
     "trackedentity/new_tracker_importer_tracked_entity_data_value.json",
 ) {
 
+    override fun roundTripSerializer() = NewTrackedEntityDataValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val dataValueDTO = deserialize(NewTrackedEntityDataValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
@@ -36,6 +36,8 @@ class NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should : CoreObjectSh
     "trackedentity/new_tracker_importer_tracked_entities_greater_equal_v41.json",
 ) {
 
+    override fun roundTripSerializer() = NewTrackedEntityPayload.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityPayloadDTO = deserialize(NewTrackedEntityPayload.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
@@ -32,15 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewTrackedEntityPayload
 import org.junit.Test
 
-class NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should : CoreObjectShould(
+internal class NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should : CoreObjectShould<NewTrackedEntityPayload>(
     "trackedentity/new_tracker_importer_tracked_entities_greater_equal_v41.json",
+    NewTrackedEntityPayload.serializer(),
 ) {
-
-    override fun roundTripSerializer() = NewTrackedEntityPayload.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityPayloadDTO = deserialize(NewTrackedEntityPayload.serializer())
+        val trackedEntityPayloadDTO = deserialize()
         val trackedEntityPayload = trackedEntityPayloadDTO
 
         assertThat(trackedEntityPayload.pager()?.page).isEqualTo(1)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadLowerV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadLowerV41Should.kt
@@ -32,15 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.tracker.NewTrackedEntityPayload
 import org.junit.Test
 
-class NewTrackerImporterTrackedEntityPayloadLowerV41Should : CoreObjectShould(
+internal class NewTrackerImporterTrackedEntityPayloadLowerV41Should : CoreObjectShould<NewTrackedEntityPayload>(
     "trackedentity/new_tracker_importer_tracked_entities_lower_v41.json",
+    NewTrackedEntityPayload.serializer(),
 ) {
-
-    override fun roundTripSerializer() = NewTrackedEntityPayload.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityPayload = deserialize(NewTrackedEntityPayload.serializer())
+        val trackedEntityPayload = deserialize()
 
         assertThat(trackedEntityPayload.pager().page).isEqualTo(1)
         assertThat(trackedEntityPayload.pager().pageSize).isEqualTo(50)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadLowerV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadLowerV41Should.kt
@@ -36,6 +36,8 @@ class NewTrackerImporterTrackedEntityPayloadLowerV41Should : CoreObjectShould(
     "trackedentity/new_tracker_importer_tracked_entities_lower_v41.json",
 ) {
 
+    override fun roundTripSerializer() = NewTrackedEntityPayload.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityPayload = deserialize(NewTrackedEntityPayload.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityShould.kt
@@ -34,15 +34,14 @@ import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.network.tracker.NewTrackedEntityDTO
 import org.junit.Test
 
-class NewTrackerImporterTrackedEntityShould : CoreObjectShould(
+internal class NewTrackerImporterTrackedEntityShould : CoreObjectShould<NewTrackedEntityDTO>(
     "trackedentity/new_tracker_importer_tracked_entity.json",
+    NewTrackedEntityDTO.serializer(),
 ) {
-
-    override fun roundTripSerializer() = NewTrackedEntityDTO.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityDTO = deserialize(NewTrackedEntityDTO.serializer())
+        val trackedEntityDTO = deserialize()
         val trackedEntity = trackedEntityDTO.toDomain()
 
         assertThat(trackedEntity.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2014-06-06T20:44:21.375"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityShould.kt
@@ -38,6 +38,8 @@ class NewTrackerImporterTrackedEntityShould : CoreObjectShould(
     "trackedentity/new_tracker_importer_tracked_entity.json",
 ) {
 
+    override fun roundTripSerializer() = NewTrackedEntityDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityDTO = deserialize(NewTrackedEntityDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueShould.kt
@@ -33,15 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.trackedentityattributereservedvalue.TrackedEntityAttributeReservedValueDTO
 import org.junit.Test
 
-class TrackedEntityAttributeReservedValueShould : CoreObjectShould(
+internal class TrackedEntityAttributeReservedValueShould : CoreObjectShould<TrackedEntityAttributeReservedValueDTO>(
     "trackedentity/tracked_entity_attribute_reserved_value.json",
+    TrackedEntityAttributeReservedValueDTO.serializer(),
 ) {
-
-    override fun roundTripSerializer() = TrackedEntityAttributeReservedValueDTO.serializer()
 
     @Test
     override fun map_from_json_string() {
-        val reservedValueDTO = deserialize(TrackedEntityAttributeReservedValueDTO.serializer())
+        val reservedValueDTO = deserialize()
         val reservedValue = reservedValueDTO.toDomain()
 
         assertThat(reservedValue.ownerObject()).isEqualTo("TRACKEDENTITYATTRIBUTE")

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueShould.kt
@@ -37,6 +37,8 @@ class TrackedEntityAttributeReservedValueShould : CoreObjectShould(
     "trackedentity/tracked_entity_attribute_reserved_value.json",
 ) {
 
+    override fun roundTripSerializer() = TrackedEntityAttributeReservedValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val reservedValueDTO = deserialize(TrackedEntityAttributeReservedValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeShould.kt
@@ -36,12 +36,14 @@ import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.network.trackedentityattribute.TrackedEntityAttributeDTO
 import org.junit.Test
 
-class TrackedEntityAttributeShould : CoreObjectShould("trackedentity/tracked_entity_attribute.json") {
-    override fun roundTripSerializer() = TrackedEntityAttributeDTO.serializer()
+internal class TrackedEntityAttributeShould : CoreObjectShould<TrackedEntityAttributeDTO>(
+    "trackedentity/tracked_entity_attribute.json",
+    TrackedEntityAttributeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityAttributeDTO = deserialize(TrackedEntityAttributeDTO.serializer())
+        val trackedEntityAttributeDTO = deserialize()
         val trackedEntityAttribute = trackedEntityAttributeDTO.toDomain()
 
         assertThat(trackedEntityAttribute.lastUpdated()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeShould.kt
@@ -37,6 +37,8 @@ import org.hisp.dhis.android.network.trackedentityattribute.TrackedEntityAttribu
 import org.junit.Test
 
 class TrackedEntityAttributeShould : CoreObjectShould("trackedentity/tracked_entity_attribute.json") {
+    override fun roundTripSerializer() = TrackedEntityAttributeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityAttributeDTO = deserialize(TrackedEntityAttributeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class TrackedEntityAttributeValueShould : CoreObjectShould("trackedentity/tracked_entity_attribute_value.json") {
 
+    override fun roundTripSerializer() = TrackedEntityAttributeValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityAttributeValueDTO = deserialize(TrackedEntityAttributeValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueShould.kt
@@ -34,13 +34,14 @@ import org.hisp.dhis.android.network.trackedentityinstance.TrackedEntityAttribut
 import org.hisp.dhis.android.network.trackedentityinstance.toDto
 import org.junit.Test
 
-class TrackedEntityAttributeValueShould : CoreObjectShould("trackedentity/tracked_entity_attribute_value.json") {
-
-    override fun roundTripSerializer() = TrackedEntityAttributeValueDTO.serializer()
+internal class TrackedEntityAttributeValueShould : CoreObjectShould<TrackedEntityAttributeValueDTO>(
+    "trackedentity/tracked_entity_attribute_value.json",
+    TrackedEntityAttributeValueDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityAttributeValueDTO = deserialize(TrackedEntityAttributeValueDTO.serializer())
+        val trackedEntityAttributeValueDTO = deserialize()
         val trackedEntityAttributeValue = trackedEntityAttributeValueDTO.toDomain("event")
 
         assertThat(trackedEntityAttributeValue.created()).isEqualTo("2019-12-12T07:35:11.366".toJavaDate())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueShould.kt
@@ -35,13 +35,14 @@ import org.hisp.dhis.android.network.event.TrackedEntityDataValueDTO
 import org.hisp.dhis.android.network.event.toDto
 import org.junit.Test
 
-class TrackedEntityDataValueShould : CoreObjectShould("trackedentity/tracked_entity_data_value.json") {
-
-    override fun roundTripSerializer() = TrackedEntityDataValueDTO.serializer()
+internal class TrackedEntityDataValueShould : CoreObjectShould<TrackedEntityDataValueDTO>(
+    "trackedentity/tracked_entity_data_value.json",
+    TrackedEntityDataValueDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityDataValueDTO = deserialize(TrackedEntityDataValueDTO.serializer())
+        val trackedEntityDataValueDTO = deserialize()
         val trackedEntityDataValue = trackedEntityDataValueDTO.toDomain("event")
 
         assertThat(trackedEntityDataValue.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2014-11-15T14:55:23.779"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueShould.kt
@@ -37,6 +37,8 @@ import org.junit.Test
 
 class TrackedEntityDataValueShould : CoreObjectShould("trackedentity/tracked_entity_data_value.json") {
 
+    override fun roundTripSerializer() = TrackedEntityDataValueDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityDataValueDTO = deserialize(TrackedEntityDataValueDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter37Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter37Should.kt
@@ -30,14 +30,15 @@ package org.hisp.dhis.android.core.trackedentity
 import org.hisp.dhis.android.network.trackedentityinstancefilter.TrackedEntityInstanceFilter37DTO
 import org.junit.Test
 
-class TrackedEntityInstanceFilter37Should :
-    TrackedEntityInstanceFilterCommonShould("trackedentity/tracked_entity_instance_filter_v_37.json") {
-
-    override fun roundTripSerializer() = TrackedEntityInstanceFilter37DTO.serializer()
+internal class TrackedEntityInstanceFilter37Should :
+    TrackedEntityInstanceFilterCommonShould<TrackedEntityInstanceFilter37DTO>(
+        "trackedentity/tracked_entity_instance_filter_v_37.json",
+        TrackedEntityInstanceFilter37DTO.serializer(),
+    ) {
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityInstanceFilter37DTO = deserialize(TrackedEntityInstanceFilter37DTO.serializer())
+        val trackedEntityInstanceFilter37DTO = deserialize()
         val trackedEntityInstanceFilter37 = trackedEntityInstanceFilter37DTO.toDomain()
 
         teiFilterCommonAsserts(trackedEntityInstanceFilter37)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter37Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilter37Should.kt
@@ -33,6 +33,8 @@ import org.junit.Test
 class TrackedEntityInstanceFilter37Should :
     TrackedEntityInstanceFilterCommonShould("trackedentity/tracked_entity_instance_filter_v_37.json") {
 
+    override fun roundTripSerializer() = TrackedEntityInstanceFilter37DTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityInstanceFilter37DTO = deserialize(TrackedEntityInstanceFilter37DTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCommonShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCommonShould.kt
@@ -34,7 +34,10 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.event.EventStatus
 
-abstract class TrackedEntityInstanceFilterCommonShould(jsonPath: String) : CoreObjectShould(jsonPath) {
+abstract class TrackedEntityInstanceFilterCommonShould<T>(
+    jsonPath: String,
+    serializer: kotlinx.serialization.KSerializer<T>,
+) : CoreObjectShould<T>(jsonPath, serializer) {
     protected fun teiFilterCommonAsserts(trackedEntityInstanceFilter: TrackedEntityInstanceFilter) {
         assertThat(trackedEntityInstanceFilter.lastUpdated())
             .isEqualTo(BaseIdentifiableObject.parseDate("2019-09-27T00:19:06.590"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterShould.kt
@@ -44,6 +44,9 @@ import org.mockito.internal.util.collections.Sets
 
 class TrackedEntityInstanceFilterShould :
     TrackedEntityInstanceFilterCommonShould("trackedentity/tracked_entity_instance_filter.json") {
+
+    override fun roundTripSerializer() = TrackedEntityInstanceFilterDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityInstanceFilterDTO = deserialize(TrackedEntityInstanceFilterDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterShould.kt
@@ -42,14 +42,15 @@ import org.hisp.dhis.android.network.trackedentityinstancefilter.TrackedEntityIn
 import org.junit.Test
 import org.mockito.internal.util.collections.Sets
 
-class TrackedEntityInstanceFilterShould :
-    TrackedEntityInstanceFilterCommonShould("trackedentity/tracked_entity_instance_filter.json") {
-
-    override fun roundTripSerializer() = TrackedEntityInstanceFilterDTO.serializer()
+internal class TrackedEntityInstanceFilterShould :
+    TrackedEntityInstanceFilterCommonShould<TrackedEntityInstanceFilterDTO>(
+        "trackedentity/tracked_entity_instance_filter.json",
+        TrackedEntityInstanceFilterDTO.serializer(),
+    ) {
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityInstanceFilterDTO = deserialize(TrackedEntityInstanceFilterDTO.serializer())
+        val trackedEntityInstanceFilterDTO = deserialize()
         val trackedEntityInstanceFilter = trackedEntityInstanceFilterDTO.toDomain()
 
         teiFilterCommonAsserts(trackedEntityInstanceFilter)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceShould.kt
@@ -34,13 +34,14 @@ import org.hisp.dhis.android.core.util.toJavaDate
 import org.hisp.dhis.android.network.trackedentityinstance.TrackedEntityInstanceDTO
 import org.junit.Test
 
-class TrackedEntityInstanceShould : CoreObjectShould("trackedentity/tracked_entity_instance.json") {
-
-    override fun roundTripSerializer() = TrackedEntityInstanceDTO.serializer()
+internal class TrackedEntityInstanceShould : CoreObjectShould<TrackedEntityInstanceDTO>(
+    "trackedentity/tracked_entity_instance.json",
+    TrackedEntityInstanceDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val trackedEntityInstanceDTO = deserialize(TrackedEntityInstanceDTO.serializer())
+        val trackedEntityInstanceDTO = deserialize()
         val trackedEntityInstance = trackedEntityInstanceDTO.toDomain()
 
         assertThat(trackedEntityInstance.lastUpdated()).isEqualTo("2015-10-15T11:32:27.242".toJavaDate())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class TrackedEntityInstanceShould : CoreObjectShould("trackedentity/tracked_entity_instance.json") {
 
+    override fun roundTripSerializer() = TrackedEntityInstanceDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val trackedEntityInstanceDTO = deserialize(TrackedEntityInstanceDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.trackedentitytype.TrackedEntityTypeAttributeDTO
 import org.junit.Test
 
-class TrackedEntityTypeAttributeShould : CoreObjectShould("trackedentity/tracked_entity_type_attribute.json") {
-
-    override fun roundTripSerializer() = TrackedEntityTypeAttributeDTO.serializer()
+internal class TrackedEntityTypeAttributeShould : CoreObjectShould<TrackedEntityTypeAttributeDTO>(
+    "trackedentity/tracked_entity_type_attribute.json",
+    TrackedEntityTypeAttributeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val typeAttributeDTO = deserialize(TrackedEntityTypeAttributeDTO.serializer())
+        val typeAttributeDTO = deserialize()
         val typeAttribute = typeAttributeDTO.toDomain()
 
         assertThat(typeAttribute.displayInList()).isTrue()

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeAttributeShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class TrackedEntityTypeAttributeShould : CoreObjectShould("trackedentity/tracked_entity_type_attribute.json") {
 
+    override fun roundTripSerializer() = TrackedEntityTypeAttributeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val typeAttributeDTO = deserialize(TrackedEntityTypeAttributeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeShould.kt
@@ -35,13 +35,14 @@ import org.hisp.dhis.android.core.common.FeatureType
 import org.hisp.dhis.android.network.trackedentitytype.TrackedEntityTypeDTO
 import org.junit.Test
 
-class TrackedEntityTypeShould : CoreObjectShould("trackedentity/tracked_entity_type.json") {
-
-    override fun roundTripSerializer() = TrackedEntityTypeDTO.serializer()
+internal class TrackedEntityTypeShould : CoreObjectShould<TrackedEntityTypeDTO>(
+    "trackedentity/tracked_entity_type.json",
+    TrackedEntityTypeDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val entityTypeDTO = deserialize(TrackedEntityTypeDTO.serializer())
+        val entityTypeDTO = deserialize()
         val entityType = entityTypeDTO.toDomain()
 
         assertThat(entityType.created()).isEqualTo(DateUtils.DATE_FORMAT.parse("2014-08-20T12:28:56.409"))

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityTypeShould.kt
@@ -37,6 +37,8 @@ import org.junit.Test
 
 class TrackedEntityTypeShould : CoreObjectShould("trackedentity/tracked_entity_type.json") {
 
+    override fun roundTripSerializer() = TrackedEntityTypeDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val entityTypeDTO = deserialize(TrackedEntityTypeDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class ProgramOwnerShould : CoreObjectShould("trackedentity/ownership/program_owner.json") {
 
+    override fun roundTripSerializer() = ProgramOwnerDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val programOwnerDTO = deserialize(ProgramOwnerDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.trackedentityinstance.ProgramOwnerDTO
 import org.junit.Test
 
-class ProgramOwnerShould : CoreObjectShould("trackedentity/ownership/program_owner.json") {
-
-    override fun roundTripSerializer() = ProgramOwnerDTO.serializer()
+internal class ProgramOwnerShould : CoreObjectShould<ProgramOwnerDTO>(
+    "trackedentity/ownership/program_owner.json",
+    ProgramOwnerDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val programOwnerDTO = deserialize(ProgramOwnerDTO.serializer())
+        val programOwnerDTO = deserialize()
         val programOwner = programOwnerDTO.toDomain()
 
         assertThat(programOwner.program()).isEqualTo("lxAQ7Zs9VYR")

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridMapperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridMapperShould.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.network.trackedentityinstance.SearchGridDTO
 import org.junit.Test
 
 class SearchGridMapperShould : CoreObjectShould("trackedentity/search_grid.json") {
+    override fun roundTripSerializer() = SearchGridDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val searchGrid = deserialize(SearchGridDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridMapperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridMapperShould.kt
@@ -33,12 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.trackedentityinstance.SearchGridDTO
 import org.junit.Test
 
-class SearchGridMapperShould : CoreObjectShould("trackedentity/search_grid.json") {
-    override fun roundTripSerializer() = SearchGridDTO.serializer()
+internal class SearchGridMapperShould : CoreObjectShould<SearchGridDTO>(
+    "trackedentity/search_grid.json",
+    SearchGridDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val searchGrid = deserialize(SearchGridDTO.serializer())
+        val searchGrid = deserialize()
         val teis = searchGrid.toDomain()
 
         assertThat(teis.size).isEqualTo(2)

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridShould.kt
@@ -32,12 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.trackedentityinstance.SearchGridDTO
 import org.junit.Test
 
-class SearchGridShould : CoreObjectShould("trackedentity/search_grid.json") {
-    override fun roundTripSerializer() = SearchGridDTO.serializer()
+internal class SearchGridShould : CoreObjectShould<SearchGridDTO>(
+    "trackedentity/search_grid.json",
+    SearchGridDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val searchGrid = deserialize(SearchGridDTO.serializer())
+        val searchGrid = deserialize()
 
         assertThat(searchGrid.headers.size).isEqualTo(9)
 

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/SearchGridShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.network.trackedentityinstance.SearchGridDTO
 import org.junit.Test
 
 class SearchGridShould : CoreObjectShould("trackedentity/search_grid.json") {
+    override fun roundTripSerializer() = SearchGridDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val searchGrid = deserialize(SearchGridDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportErrorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportErrorShould.kt
@@ -35,13 +35,14 @@ import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterObjec
 import org.hisp.dhis.android.network.tracker.JobReportDTO
 import org.junit.Test
 
-class JobReportErrorShould : CoreObjectShould("tracker/importer/jobreport-error.json") {
-
-    override fun roundTripSerializer() = JobReportDTO.serializer()
+internal class JobReportErrorShould : CoreObjectShould<JobReportDTO>(
+    "tracker/importer/jobreport-error.json",
+    JobReportDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val jobReportDTO = deserialize(JobReportDTO.serializer())
+        val jobReportDTO = deserialize()
         val jobReport = jobReportDTO.toDomain()
 
         assertThat(jobReport.status).isEqualTo("ERROR")

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportErrorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportErrorShould.kt
@@ -37,6 +37,8 @@ import org.junit.Test
 
 class JobReportErrorShould : CoreObjectShould("tracker/importer/jobreport-error.json") {
 
+    override fun roundTripSerializer() = JobReportDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val jobReportDTO = deserialize(JobReportDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportSuccessShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportSuccessShould.kt
@@ -38,6 +38,8 @@ import org.junit.Test
 
 class JobReportSuccessShould : CoreObjectShould("tracker/importer/jobreport-success.json") {
 
+    override fun roundTripSerializer() = JobReportDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val jobReportDTO = deserialize(JobReportDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportSuccessShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/JobReportSuccessShould.kt
@@ -36,13 +36,14 @@ import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterObjec
 import org.hisp.dhis.android.network.tracker.JobReportDTO
 import org.junit.Test
 
-class JobReportSuccessShould : CoreObjectShould("tracker/importer/jobreport-success.json") {
-
-    override fun roundTripSerializer() = JobReportDTO.serializer()
+internal class JobReportSuccessShould : CoreObjectShould<JobReportDTO>(
+    "tracker/importer/jobreport-success.json",
+    JobReportDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val jobReportDTO = deserialize(JobReportDTO.serializer())
+        val jobReportDTO = deserialize()
         val jobReport = jobReportDTO.toDomain()
 
         assertThat(jobReport.status).isEqualTo("OK")

--- a/core/src/test/java/org/hisp/dhis/android/core/usecase/stock/InternalStockUseCaseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/usecase/stock/InternalStockUseCaseShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class InternalStockUseCaseShould : CoreObjectShould("usecase.stock/stock_use_case.json") {
 
+    override fun roundTripSerializer() = StockUseCaseDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val stockUseCaseDTO = deserialize(StockUseCaseDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/usecase/stock/InternalStockUseCaseShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/usecase/stock/InternalStockUseCaseShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.usecase.stock.StockUseCaseDTO
 import org.junit.Test
 
-class InternalStockUseCaseShould : CoreObjectShould("usecase.stock/stock_use_case.json") {
-
-    override fun roundTripSerializer() = StockUseCaseDTO.serializer()
+internal class InternalStockUseCaseShould : CoreObjectShould<StockUseCaseDTO>(
+    "usecase.stock/stock_use_case.json",
+    StockUseCaseDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val stockUseCaseDTO = deserialize(StockUseCaseDTO.serializer())
+        val stockUseCaseDTO = deserialize()
         val internalStockUseCase = stockUseCaseDTO.toDomain()
 
         assertThat(internalStockUseCase).isNotNull()

--- a/core/src/test/java/org/hisp/dhis/android/core/user/QrCodeJsonShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/QrCodeJsonShould.kt
@@ -32,13 +32,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.twofactorauth.QrCodeJsonDTO
 import org.junit.Test
 
-class QrCodeJsonShould : CoreObjectShould("user/qr-code.json") {
-
-    override fun roundTripSerializer() = QrCodeJsonDTO.serializer()
+internal class QrCodeJsonShould : CoreObjectShould<QrCodeJsonDTO>("user/qr-code.json", QrCodeJsonDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val qrCodeJsonDTO = deserialize(QrCodeJsonDTO.serializer())
+        val qrCodeJsonDTO = deserialize()
         val secret = qrCodeJsonDTO.toDomain()
 
         assertThat(secret).isEqualTo("HMFQS5AAEFRHQ5D6UNIQCGJUKB3ITNPD")

--- a/core/src/test/java/org/hisp/dhis/android/core/user/QrCodeJsonShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/QrCodeJsonShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class QrCodeJsonShould : CoreObjectShould("user/qr-code.json") {
 
+    override fun roundTripSerializer() = QrCodeJsonDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val qrCodeJsonDTO = deserialize(QrCodeJsonDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/TwoFactorMethodsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/TwoFactorMethodsShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.twofactorauth.TwoFactorMethodsDTO
 import org.junit.Test
 
-class TwoFactorMethodsShould : CoreObjectShould("user/two-factor-methods.json") {
-
-    override fun roundTripSerializer() = TwoFactorMethodsDTO.serializer()
+internal class TwoFactorMethodsShould : CoreObjectShould<TwoFactorMethodsDTO>(
+    "user/two-factor-methods.json",
+    TwoFactorMethodsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val twoFactorMethodsDTO = deserialize(TwoFactorMethodsDTO.serializer())
+        val twoFactorMethodsDTO = deserialize()
         val totp2faEnabled = twoFactorMethodsDTO.toDomain()
 
         assertThat(totp2faEnabled).isEqualTo(true)

--- a/core/src/test/java/org/hisp/dhis/android/core/user/TwoFactorMethodsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/TwoFactorMethodsShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class TwoFactorMethodsShould : CoreObjectShould("user/two-factor-methods.json") {
 
+    override fun roundTripSerializer() = TwoFactorMethodsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val twoFactorMethodsDTO = deserialize(TwoFactorMethodsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/User37Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/User37Should.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.user.UserDTO
 import org.junit.Test
 
-class User37Should : CoreObjectShould("user/user37.json") {
-
-    override fun roundTripSerializer() = UserDTO.serializer()
+internal class User37Should : CoreObjectShould<UserDTO>("user/user37.json", UserDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val userDTO = deserialize(UserDTO.serializer())
+        val userDTO = deserialize()
         val user = userDTO.toDomain()
 
         assertThat(user.name()).isEqualTo("John Barnes")

--- a/core/src/test/java/org/hisp/dhis/android/core/user/User37Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/User37Should.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class User37Should : CoreObjectShould("user/user37.json") {
 
+    override fun roundTripSerializer() = UserDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val userDTO = deserialize(UserDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/User38Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/User38Should.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.user.UserDTO
 import org.junit.Test
 
-class User38Should : CoreObjectShould("user/user38.json") {
-
-    override fun roundTripSerializer() = UserDTO.serializer()
+internal class User38Should : CoreObjectShould<UserDTO>("user/user38.json", UserDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val userDTO = deserialize(UserDTO.serializer())
+        val userDTO = deserialize()
         val user = userDTO.toDomain()
 
         assertThat(user.name()).isEqualTo("John Barnes")

--- a/core/src/test/java/org/hisp/dhis/android/core/user/User38Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/User38Should.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class User38Should : CoreObjectShould("user/user38.json") {
 
+    override fun roundTripSerializer() = UserDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val userDTO = deserialize(UserDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserCredentialShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserCredentialShould.kt
@@ -32,13 +32,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.user.UserCredentialsDTO
 import org.junit.Test
 
-class UserCredentialShould : CoreObjectShould("user/user_credentials.json") {
-
-    override fun roundTripSerializer() = UserCredentialsDTO.serializer()
+internal class UserCredentialShould : CoreObjectShould<UserCredentialsDTO>(
+    "user/user_credentials.json",
+    UserCredentialsDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val userCredentialsDTO = deserialize(UserCredentialsDTO.serializer())
+        val userCredentialsDTO = deserialize()
 
         assertThat(userCredentialsDTO.username).isEqualTo("admin")
 

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserCredentialShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserCredentialShould.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 
 class UserCredentialShould : CoreObjectShould("user/user_credentials.json") {
 
+    override fun roundTripSerializer() = UserCredentialsDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val userCredentialsDTO = deserialize(UserCredentialsDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserGroupShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class UserGroupShould : CoreObjectShould("user/user_group.json") {
 
+    override fun roundTripSerializer() = UserGroupDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val userGroupDTO = deserialize(UserGroupDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserGroupShould.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.user.UserGroupDTO
 import org.junit.Test
 
-class UserGroupShould : CoreObjectShould("user/user_group.json") {
-
-    override fun roundTripSerializer() = UserGroupDTO.serializer()
+internal class UserGroupShould : CoreObjectShould<UserGroupDTO>("user/user_group.json", UserGroupDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val userGroupDTO = deserialize(UserGroupDTO.serializer())
+        val userGroupDTO = deserialize()
         val userGroup = userGroupDTO.toDomain()
 
         assertThat(userGroup.lastUpdated()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserRoleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserRoleShould.kt
@@ -33,13 +33,11 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.user.UserRoleDTO
 import org.junit.Test
 
-class UserRoleShould : CoreObjectShould("user/user_role.json") {
-
-    override fun roundTripSerializer() = UserRoleDTO.serializer()
+internal class UserRoleShould : CoreObjectShould<UserRoleDTO>("user/user_role.json", UserRoleDTO.serializer()) {
 
     @Test
     override fun map_from_json_string() {
-        val userRoleDTO = deserialize(UserRoleDTO.serializer())
+        val userRoleDTO = deserialize()
         val userRole = userRoleDTO.toDomain()
 
         assertThat(userRole.lastUpdated()).isEqualTo(

--- a/core/src/test/java/org/hisp/dhis/android/core/user/UserRoleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/UserRoleShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class UserRoleShould : CoreObjectShould("user/user_role.json") {
 
+    override fun roundTripSerializer() = UserRoleDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val userRoleDTO = deserialize(UserRoleDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleBrokenShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleBrokenShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class ValidationRuleBrokenShould : CoreObjectShould("validation/validation_rule_broken.json") {
 
+    override fun roundTripSerializer() = ValidationRuleDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val validationRule = deserialize(ValidationRuleDTO.serializer()).toDomain()

--- a/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleBrokenShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleBrokenShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.validationrule.ValidationRuleDTO
 import org.junit.Test
 
-class ValidationRuleBrokenShould : CoreObjectShould("validation/validation_rule_broken.json") {
-
-    override fun roundTripSerializer() = ValidationRuleDTO.serializer()
+internal class ValidationRuleBrokenShould : CoreObjectShould<ValidationRuleDTO>(
+    "validation/validation_rule_broken.json",
+    ValidationRuleDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val validationRule = deserialize(ValidationRuleDTO.serializer()).toDomain()
+        val validationRule = deserialize().toDomain()
 
         assertThat(validationRule).isNull()
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class ValidationRuleShould : CoreObjectShould("validation/validation_rule.json") {
 
+    override fun roundTripSerializer() = ValidationRuleDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val validationRuleDTO = deserialize(ValidationRuleDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/validation/ValidationRuleShould.kt
@@ -34,13 +34,14 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.network.validationrule.ValidationRuleDTO
 import org.junit.Test
 
-class ValidationRuleShould : CoreObjectShould("validation/validation_rule.json") {
-
-    override fun roundTripSerializer() = ValidationRuleDTO.serializer()
+internal class ValidationRuleShould : CoreObjectShould<ValidationRuleDTO>(
+    "validation/validation_rule.json",
+    ValidationRuleDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val validationRuleDTO = deserialize(ValidationRuleDTO.serializer())
+        val validationRuleDTO = deserialize()
         val validationRule = validationRuleDTO.toDomain()!!
 
         assertThat(validationRule.code()).isEqualTo("Malaria outbreak")

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/TrackerVisualizationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/TrackerVisualizationShould.kt
@@ -34,13 +34,14 @@ import org.hisp.dhis.android.core.common.SortingDirection
 import org.hisp.dhis.android.network.trackervisualization.TrackerVisualizationDTO
 import org.junit.Test
 
-class TrackerVisualizationShould : CoreObjectShould("visualization/tracker_visualization.json") {
-
-    override fun roundTripSerializer() = TrackerVisualizationDTO.serializer()
+internal class TrackerVisualizationShould : CoreObjectShould<TrackerVisualizationDTO>(
+    "visualization/tracker_visualization.json",
+    TrackerVisualizationDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val visualizationDTO = deserialize(TrackerVisualizationDTO.serializer())
+        val visualizationDTO = deserialize()
         val visualization = visualizationDTO.toDomain()
 
         assertThat(visualization.uid()).isEqualTo("s85urBIkN0z")

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/TrackerVisualizationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/TrackerVisualizationShould.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 
 class TrackerVisualizationShould : CoreObjectShould("visualization/tracker_visualization.json") {
 
+    override fun roundTripSerializer() = TrackerVisualizationDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val visualizationDTO = deserialize(TrackerVisualizationDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/Visualization36DTOShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/Visualization36DTOShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.network.visualization.Visualization36DTO
 import org.hisp.dhis.android.network.visualization.VisualizationDTO
 import org.junit.Test
 
-class Visualization36DTOShould : CoreObjectShould("visualization/visualization_api_36.json") {
-
-    override fun roundTripSerializer() = Visualization36DTO.serializer()
+internal class Visualization36DTOShould : CoreObjectShould<Visualization36DTO>(
+    "visualization/visualization_api_36.json",
+    Visualization36DTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val visualization36 = deserialize(Visualization36DTO.serializer())
+        val visualization36 = deserialize()
 
         assertThat(visualization36.id).isEqualTo("PYBH8ZaAQnC")
         assertThat(visualization36.type).isEqualTo(VisualizationType.PIVOT_TABLE.name)
@@ -50,7 +51,7 @@ class Visualization36DTOShould : CoreObjectShould("visualization/visualization_a
 
     @Test
     fun convert_to_visualization() {
-        val visualization36 = deserialize(Visualization36DTO.serializer())
+        val visualization36 = deserialize()
         val visualization = deserializePath("visualization/visualization.json", VisualizationDTO.serializer())
 
         assertThat(visualization36.toDomain()).isEqualTo(visualization.toDomain())

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/Visualization36DTOShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/Visualization36DTOShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class Visualization36DTOShould : CoreObjectShould("visualization/visualization_api_36.json") {
 
+    override fun roundTripSerializer() = Visualization36DTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val visualization36 = deserialize(Visualization36DTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/VisualizationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/VisualizationShould.kt
@@ -35,6 +35,8 @@ import org.junit.Test
 
 class VisualizationShould : CoreObjectShould("visualization/visualization.json") {
 
+    override fun roundTripSerializer() = VisualizationDTO.serializer()
+
     @Test
     override fun map_from_json_string() {
         val visualizationDTO = deserialize(VisualizationDTO.serializer())

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/VisualizationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/VisualizationShould.kt
@@ -33,13 +33,14 @@ import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.network.visualization.VisualizationDTO
 import org.junit.Test
 
-class VisualizationShould : CoreObjectShould("visualization/visualization.json") {
-
-    override fun roundTripSerializer() = VisualizationDTO.serializer()
+internal class VisualizationShould : CoreObjectShould<VisualizationDTO>(
+    "visualization/visualization.json",
+    VisualizationDTO.serializer(),
+) {
 
     @Test
     override fun map_from_json_string() {
-        val visualizationDTO = deserialize(VisualizationDTO.serializer())
+        val visualizationDTO = deserialize()
         val visualization = visualizationDTO.toDomain()
 
         assertThat(visualization.uid()).isEqualTo("PYBH8ZaAQnC")

--- a/processor/src/main/java/org/hisp/dhis/android/processor/MigrationProcessor.kt
+++ b/processor/src/main/java/org/hisp/dhis/android/processor/MigrationProcessor.kt
@@ -44,11 +44,11 @@ class MigrationProcessor(
 ) : SymbolProcessor {
 
     private val outputPackage = "org.hisp.dhis.android.persistence.db.migrations"
-    private val migrationDir = File(options["migrationDir"]!!).canonicalFile
+    private val migrationDir = options["migrationDir"]?.let { File(it).canonicalFile }
     var invoked = false
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (invoked) {
+        if (invoked || migrationDir == null) {
             return emptyList()
         }
         if (!migrationDir.exists()) {


### PR DESCRIPTION
The plan is to improve JaCoCo code coverage so we have:

- Add generic tests in abstract Store integration base classes
- Fix JaCoCo reporting 0% coverage for migration classes by preventing KSP from generating `RoomGeneratedMigrations` for test variants `debugAndroidTest`/`debugUnitTest`, which were shadowing the JaCoCo-instrumented library classes in the test APK
- Add `DatabaseSQLiteConnectionMigrationShould` test to cover the `migrate(SQLiteConnection)` overload, bringing migration coverage from ~58% to ~100%
- Improve JaCoCo source directories to include Kotlin sources and KSP-generated code
- Exclude Room-generated DAO inner classes (`*Dao_Impl$*`) from JaCoCo report (uncoverable boilerplate)