### PR TITLE
fix: [ANDROSDK-2272] Weekly start day setting name is wrong

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9721,7 +9721,7 @@ public final class org/hisp/dhis/android/core/settings/SystemSetting$SystemSetti
 
 public final class org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl {
 	public final fun analyticsFinancialYearStart ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
-	public final fun analyticsWeekStart ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
+	public final fun analyticsWeeklyStart ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
 	public final fun byKey ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byValue ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun customColor ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
@@ -39,7 +39,6 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
-import kotlin.time.toKotlinInstant
 
 /**
  * Integration test to verify that financial year periods are generated correctly

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/FinancialYearPeriodIntegrationShould.kt
@@ -29,12 +29,17 @@ package org.hisp.dhis.android.core.period.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.arch.helpers.DateUtils.toKtxInstant
 import org.hisp.dhis.android.core.common.RelativePeriod
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
+import kotlin.time.toKotlinInstant
 
 /**
  * Integration test to verify that financial year periods are generated correctly
@@ -124,14 +129,12 @@ class FinancialYearPeriodIntegrationShould : BaseMockIntegrationTestFullDispatch
         assertThat(periods).isNotEmpty()
         val period = periods[0]
 
-        // For FinancialJuly, the period should start in July (month 7)
+        // For FinancialJuly, the period should start in July
         val startDate = period.startDate()
         assertThat(startDate).isNotNull()
 
-        val calendar = java.util.Calendar.getInstance()
-        calendar.time = startDate
-        val startMonth = calendar.get(java.util.Calendar.MONTH) + 1 // Calendar.MONTH is 0-based
+        val localDate = startDate!!.toKtxInstant().toLocalDateTime(TimeZone.currentSystemDefault()).date
 
-        assertThat(startMonth).isEqualTo(7) // July
+        assertThat(localDate.month).isEqualTo(Month.JULY)
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/WeekStartPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/WeekStartPeriodIntegrationShould.kt
@@ -39,7 +39,6 @@ import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
-import kotlin.time.toKotlinInstant
 
 /**
  * Integration test to verify that weekly periods are generated correctly

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/WeekStartPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/WeekStartPeriodIntegrationShould.kt
@@ -29,12 +29,17 @@ package org.hisp.dhis.android.core.period.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.arch.helpers.DateUtils.toKtxInstant
 import org.hisp.dhis.android.core.common.RelativePeriod
 import org.hisp.dhis.android.core.period.PeriodType
 import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
+import kotlin.time.toKotlinInstant
 
 /**
  * Integration test to verify that weekly periods are generated correctly
@@ -138,14 +143,12 @@ class WeekStartPeriodIntegrationShould : BaseMockIntegrationTestFullDispatcher()
         assertThat(periods).isNotEmpty()
         val period = periods[0]
 
-        // For WeeklyFriday, the period should start on Friday (day 6 in Calendar, FRIDAY)
+        // For WeeklyFriday, the period should start on Friday
         val startDate = period.startDate()
         assertThat(startDate).isNotNull()
 
-        val calendar = java.util.Calendar.getInstance()
-        calendar.time = startDate
-        val dayOfWeek = calendar.get(java.util.Calendar.DAY_OF_WEEK)
+        val localDate = startDate!!.toKtxInstant().toLocalDateTime(TimeZone.currentSystemDefault())
 
-        assertThat(dayOfWeek).isEqualTo(java.util.Calendar.FRIDAY)
+        assertThat(localDate.dayOfWeek).isEqualTo(DayOfWeek.FRIDAY)
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/WeekStartPeriodIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/WeekStartPeriodIntegrationShould.kt
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.period.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.common.RelativePeriod
+import org.hisp.dhis.android.core.period.PeriodType
+import org.hisp.dhis.android.core.settings.SystemSettingCollectionRepository
+import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
+import org.junit.Test
+
+/**
+ * Integration test to verify that weekly periods are generated correctly
+ * based on the analyticsWeekStart system setting.
+ */
+class WeekStartPeriodIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+
+    private val systemSettingRepository: SystemSettingCollectionRepository = d2.settingModule().systemSetting()
+    private val relativePeriodHelper: RelativePeriodHelper = koin.get()
+    private val parentPeriodGenerator: ParentPeriodGenerator = koin.get()
+
+    @Test
+    fun use_week_start_from_system_setting() = runTest {
+        // Verify that the system setting is loaded (from system_settings.json in test resources)
+        val setting = systemSettingRepository.analyticsWeeklyStart().blockingGet()
+        assertThat(setting).isNotNull()
+        assertThat(setting?.value()).isEqualTo("WEEKLY_FRIDAY")
+
+        // Verify that the helper returns the correct PeriodType
+        val periodType = relativePeriodHelper.getWeeklyPeriodType()
+        assertThat(periodType).isEqualTo(PeriodType.WeeklyFriday)
+    }
+
+    @Test
+    fun generate_this_week_with_friday_start() = runTest {
+        // The mock data has WEEKLY_FRIDAY configured
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.THIS_WEEK)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(1)
+
+        // Verify the period ID contains "FriW" suffix
+        val periodId = periods[0].periodId()
+        assertThat(periodId).contains("FriW")
+
+        // Verify the period type is WeeklyFriday
+        assertThat(periods[0].periodType()).isEqualTo(PeriodType.WeeklyFriday)
+    }
+
+    @Test
+    fun generate_last_week_with_friday_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_WEEK)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(1)
+
+        // Verify the period ID contains "FriW" suffix
+        val periodId = periods[0].periodId()
+        assertThat(periodId).contains("FriW")
+
+        // Verify the period type is WeeklyFriday
+        assertThat(periods[0].periodType()).isEqualTo(PeriodType.WeeklyFriday)
+    }
+
+    @Test
+    fun generate_last_4_weeks_with_friday_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_4_WEEKS)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(4)
+
+        // Verify all periods have "FriW" suffix
+        periods.forEach { period ->
+            assertThat(period.periodId()).contains("FriW")
+            assertThat(period.periodType()).isEqualTo(PeriodType.WeeklyFriday)
+        }
+    }
+
+    @Test
+    fun generate_last_12_weeks_with_friday_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_12_WEEKS)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(12)
+
+        // Verify all periods have "FriW" suffix
+        periods.forEach { period ->
+            assertThat(period.periodId()).contains("FriW")
+            assertThat(period.periodType()).isEqualTo(PeriodType.WeeklyFriday)
+        }
+    }
+
+    @Test
+    fun generate_last_52_weeks_with_friday_start() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.LAST_52_WEEKS)
+
+        assertThat(periods).isNotEmpty()
+        assertThat(periods.size).isEqualTo(52)
+
+        // Verify all periods have "FriW" suffix
+        periods.forEach { period ->
+            assertThat(period.periodId()).contains("FriW")
+            assertThat(period.periodType()).isEqualTo(PeriodType.WeeklyFriday)
+        }
+    }
+
+    @Test
+    fun verify_weekly_friday_period_starts_on_friday() = runTest {
+        val periods = parentPeriodGenerator.generateRelativePeriods(RelativePeriod.THIS_WEEK)
+
+        assertThat(periods).isNotEmpty()
+        val period = periods[0]
+
+        // For WeeklyFriday, the period should start on Friday (day 6 in Calendar, FRIDAY)
+        val startDate = period.startDate()
+        assertThat(startDate).isNotNull()
+
+        val calendar = java.util.Calendar.getInstance()
+        calendar.time = startDate
+        val dayOfWeek = calendar.get(java.util.Calendar.DAY_OF_WEEK)
+
+        assertThat(dayOfWeek).isEqualTo(java.util.Calendar.FRIDAY)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/ParametersBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/ParametersBuilder.kt
@@ -31,9 +31,14 @@ package org.hisp.dhis.android.core.arch.api
 import org.hisp.dhis.android.network.common.fields.Fields
 import org.hisp.dhis.android.network.common.filters.Filter
 
+@Suppress("TooManyFunctions")
 class ParametersBuilder(var parameters: MutableList<Pair<String, String>>) {
     internal fun <T> fields(fields: Fields<T>) {
         parameters.add("fields" to fields.generateString())
+    }
+
+    internal fun <T> keys(keys: Fields<T>) {
+        parameters.add("key" to keys.generateString())
     }
 
     internal fun <T> filter(filter: Filter<T>?) {

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/RelativePeriodHelper.kt
@@ -59,7 +59,7 @@ internal class RelativePeriodHelperImpl(
     }
 
     override fun getWeeklyPeriodType(): PeriodType {
-        val setting = systemSettingRepository.analyticsWeekStart().blockingGet()
+        val setting = systemSettingRepository.analyticsWeeklyStart().blockingGet()
         return setting?.value()?.let { mapWeekStartSetting(it) } ?: PeriodType.Weekly
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/SystemSettingCollectionRepository.kt
@@ -86,7 +86,7 @@ class SystemSettingCollectionRepository internal constructor(
         return byKey().eq(SystemSettingKey.ANALYTICS_FINANCIAL_YEAR_START).one()
     }
 
-    fun analyticsWeekStart(): ReadOnlyOneObjectRepositoryFinalImpl<SystemSetting> {
+    fun analyticsWeeklyStart(): ReadOnlyOneObjectRepositoryFinalImpl<SystemSetting> {
         return byKey().eq(SystemSettingKey.ANALYTICS_WEEK_START).one()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsDTO.kt
@@ -41,7 +41,7 @@ internal data class SystemSettingsDTO(
     val keyBingMapsApiKey: String?,
     val keyAzureMapsApiKey: String?,
     val analyticsFinancialYearStart: String?,
-    val analyticsWeekStart: String?,
+    val analyticsWeeklyStart: String?,
 ) {
 
     @Suppress("DEPRECATION")
@@ -51,7 +51,7 @@ internal data class SystemSettingsDTO(
         buildSetting(SystemSettingKey.CUSTOM_COLOR, resolveCustomColor()),
         buildSetting(SystemSettingKey.DEFAULT_BASE_MAP, keyDefaultBaseMap),
         buildSetting(SystemSettingKey.ANALYTICS_FINANCIAL_YEAR_START, analyticsFinancialYearStart),
-        buildSetting(SystemSettingKey.ANALYTICS_WEEK_START, analyticsWeekStart),
+        buildSetting(SystemSettingKey.ANALYTICS_WEEK_START, analyticsWeeklyStart),
     )
 
     fun toDomainBingMapsApiKey(): SystemSetting = buildSetting(SystemSettingKey.BING_BASE_MAP, keyBingMapsApiKey)

--- a/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsFields.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsFields.kt
@@ -38,6 +38,7 @@ internal object SystemSettingsFields : BaseFields<SystemSettingsDTO>() {
     private const val KEY_BING_MAPS_API_KEY = "keyBingMapsApiKey"
     private const val KEY_AZURE_MAPS_API_KEY = "keyAzureMapsApiKey"
     private const val ANALYTICS_FINANCIAL_YEAR_START = "analyticsFinancialYearStart"
+    private const val ANALYTICS_WEEK_START = "analyticsWeeklyStart"
 
     val allFields = Fields.from(
         fh.field(KEY_FLAG),
@@ -45,6 +46,7 @@ internal object SystemSettingsFields : BaseFields<SystemSettingsDTO>() {
         fh.field(KEY_CUSTOM_COLOR_MOBILE),
         fh.field(KEY_DEFAULT_BASE_MAP),
         fh.field(ANALYTICS_FINANCIAL_YEAR_START),
+        fh.field(ANALYTICS_WEEK_START),
     )
 
     val bingApiKey = Fields.from(

--- a/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/systemsettings/SystemSettingsService.kt
@@ -36,7 +36,7 @@ internal class SystemSettingsService(private val client: HttpServiceClient) {
         return client.get {
             url("systemSettings")
             parameters {
-                fields(fields)
+                keys(fields)
             }
         }
     }

--- a/core/src/sharedTest/resources/settings/system_settings.json
+++ b/core/src/sharedTest/resources/settings/system_settings.json
@@ -3,5 +3,6 @@
   "keyCustomColorMobile": "#007DEB",
   "keyDefaultBaseMap": "keyDefaultBaseMap",
   "keyBingMapsApiKey": "keyBingMapsApiKey",
-  "analyticsFinancialYearStart": "FINANCIAL_YEAR_JULY"
+  "analyticsFinancialYearStart": "FINANCIAL_YEAR_JULY",
+  "analyticsWeeklyStart": "WEEKLY_FRIDAY"
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SystemSettingsDTOMappingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SystemSettingsDTOMappingShould.kt
@@ -45,7 +45,7 @@ class SystemSettingsDTOMappingShould {
         keyBingMapsApiKey = null,
         keyAzureMapsApiKey = null,
         analyticsFinancialYearStart = null,
-        analyticsWeekStart = null,
+        analyticsWeeklyStart = null,
     )
 
     private fun List<SystemSetting>.customColor(): SystemSetting =

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/SystemSettingSplitterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/SystemSettingSplitterShould.kt
@@ -44,7 +44,7 @@ class SystemSettingSplitterShould {
         keyBingMapsApiKey = null,
         keyAzureMapsApiKey = null,
         analyticsFinancialYearStart = null,
-        analyticsWeekStart = null,
+        analyticsWeeklyStart = null,
     )
 
     @Test


### PR DESCRIPTION
This task fixes an error in the weekly start setting name that prevented its download and use, defaulting to Monday starting weeks in every analysis. Some other related issues have been fixed:
- fields request keyword for settings changed from "fields" to "key", thus returning only the desired ones instead of all of them
- added tests for weekly relative periods
- added weekly start day key to list of requested ones

Related task: [ANDROSDK-2272](https://dhis2.atlassian.net/browse/ANDROSDK-2272)

[ANDROSDK-2272]: https://dhis2.atlassian.net/browse/ANDROSDK-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ