### PR TITLE
[ANDROSDK-2274] add select_account prompt to appauth intent url

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectRequestHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectRequestHelper.kt
@@ -82,5 +82,6 @@ internal class OpenIDConnectRequestHelper(private val config: OpenIDConnectConfi
         config.redirectUri,
     ).apply {
         setScope("openid email profile")
+        setPrompt("select_account")
     }.build()
 }


### PR DESCRIPTION
This PR adds a parameter to the intent url for OpenId loging in to allow user selection from the already logged in users to the selected provider.

Related task [ANDROSDK-2274](https://dhis2.atlassian.net/browse/ANDROSDK-2274)

[ANDROSDK-2274]: https://dhis2.atlassian.net/browse/ANDROSDK-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ