### PR TITLE
chore: [ANDROSDK-2276] expose suspend functions to API

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -5507,7 +5507,6 @@ public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/d
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByProgram (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun rxDownload ()Lio/reactivex/Observable;
-	public final fun suspendDownload (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/event/EventEditableStatus {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11744,17 +11744,17 @@ public abstract interface class org/hisp/dhis/android/core/user/UserModule {
 	public abstract fun accountManager ()Lorg/hisp/dhis/android/core/user/AccountManager;
 	public abstract fun authenticatedUser ()Lorg/hisp/dhis/android/core/user/AuthenticatedUserObjectRepository;
 	public abstract fun authorities ()Lorg/hisp/dhis/android/core/user/AuthorityCollectionRepository;
-	public abstract fun blockingIsLogged ()Z
-	public abstract fun blockingLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
-	public abstract fun blockingLogOut ()V
-	public abstract fun isLogged ()Lio/reactivex/Single;
-	public abstract fun logIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
-	public abstract fun logOut ()Lio/reactivex/Completable;
+	public fun blockingIsLogged ()Z
+	public fun blockingLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
+	public fun blockingLogOut ()V
+	public fun isLogged ()Lio/reactivex/Single;
+	public fun logIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public fun logOut ()Lio/reactivex/Completable;
 	public abstract fun oauth2Handler ()Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Handler;
 	public abstract fun openIdHandler ()Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectHandler;
-	public abstract fun rxIsLogged ()Lio/reactivex/Single;
-	public abstract fun rxLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
-	public abstract fun rxLogOut ()Lio/reactivex/Completable;
+	public fun rxIsLogged ()Lio/reactivex/Single;
+	public fun rxLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public fun rxLogOut ()Lio/reactivex/Completable;
 	public abstract fun suspendIsLogged (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11763,6 +11763,18 @@ public abstract interface class org/hisp/dhis/android/core/user/UserModule {
 	public abstract fun userCredentials ()Lorg/hisp/dhis/android/core/user/UserCredentialsObjectRepository;
 	public abstract fun userGroups ()Lorg/hisp/dhis/android/core/user/UserGroupCollectionRepository;
 	public abstract fun userRoles ()Lorg/hisp/dhis/android/core/user/UserRoleCollectionRepository;
+}
+
+public final class org/hisp/dhis/android/core/user/UserModule$DefaultImpls {
+	public static fun blockingIsLogged (Lorg/hisp/dhis/android/core/user/UserModule;)Z
+	public static fun blockingLogIn (Lorg/hisp/dhis/android/core/user/UserModule;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
+	public static fun blockingLogOut (Lorg/hisp/dhis/android/core/user/UserModule;)V
+	public static fun isLogged (Lorg/hisp/dhis/android/core/user/UserModule;)Lio/reactivex/Single;
+	public static fun logIn (Lorg/hisp/dhis/android/core/user/UserModule;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public static fun logOut (Lorg/hisp/dhis/android/core/user/UserModule;)Lio/reactivex/Completable;
+	public static fun rxIsLogged (Lorg/hisp/dhis/android/core/user/UserModule;)Lio/reactivex/Single;
+	public static fun rxLogIn (Lorg/hisp/dhis/android/core/user/UserModule;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public static fun rxLogOut (Lorg/hisp/dhis/android/core/user/UserModule;)Lio/reactivex/Completable;
 }
 
 public final class org/hisp/dhis/android/core/user/UserObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -80,6 +80,7 @@ public abstract class org/hisp/dhis/android/core/D2Configuration$Builder {
 
 public final class org/hisp/dhis/android/core/D2Manager {
 	public static final field INSTANCE Lorg/hisp/dhis/android/core/D2Manager;
+	public static final fun RxInstantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;)Lio/reactivex/Single;
 	public static final fun blockingInstantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;)Lorg/hisp/dhis/android/core/D2;
 	public static final fun clear ()V
 	public static final fun getD2 ()Lorg/hisp/dhis/android/core/D2;
@@ -90,6 +91,7 @@ public final class org/hisp/dhis/android/core/D2Manager {
 	public static final fun setTestingDatabase (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun setTestingInsecureStore (Lorg/hisp/dhis/android/core/arch/storage/internal/InsecureStore;)V
 	public static final fun setTestingSecureStore (Lorg/hisp/dhis/android/core/arch/storage/internal/SecureStore;)V
+	public final fun suspendInstantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/analytics/AnalyticsException : java/lang/Throwable {
@@ -225,6 +227,7 @@ public abstract interface class org/hisp/dhis/android/core/analytics/AnalyticsMo
 public abstract interface class org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository {
 	public abstract fun blockingEvaluate ()Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withAggregationType (Lorg/hisp/dhis/android/core/common/AggregationType;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository;
 	public abstract fun withDimension (Lorg/hisp/dhis/android/core/analytics/aggregated/DimensionItem;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository;
 	public abstract fun withFilter (Lorg/hisp/dhis/android/core/analytics/aggregated/DimensionItem;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository;
@@ -234,6 +237,7 @@ public abstract interface class org/hisp/dhis/android/core/analytics/aggregated/
 public abstract interface class org/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository {
 	public abstract fun blockingEvaluate ()Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withOrganisationUnits (Ljava/util/List;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository;
 	public abstract fun withPeriods (Ljava/util/List;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository;
 	public abstract fun withVisualization (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository;
@@ -751,6 +755,7 @@ public abstract interface class org/hisp/dhis/android/core/analytics/linelist/Ev
 	public abstract fun byProgramStage ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public abstract fun byTrackedEntityInstance ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withDataElement (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/linelist/EventLineListRepository;
 	public abstract fun withLegendStrategy (Lorg/hisp/dhis/android/core/analytics/AnalyticsLegendStrategy;)Lorg/hisp/dhis/android/core/analytics/linelist/EventLineListRepository;
 	public abstract fun withProgramIndicator (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/linelist/EventLineListRepository;
@@ -1372,6 +1377,7 @@ public final class org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerL
 public abstract interface class org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository {
 	public abstract fun blockingEvaluate ()Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withColumn (Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListItem;)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository;
 	public abstract fun withEnrollmentOutput (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository;
 	public abstract fun withEventOutput (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository;
@@ -2988,7 +2994,11 @@ public final class org/hisp/dhis/android/core/category/CategoryOptionComboServic
 	public final fun blockingHasWriteAccess (Ljava/util/List;)Z
 	public final fun blockingIsAssignedToOrgUnit (Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun hasAccess (Ljava/lang/String;Ljava/util/Date;)Lio/reactivex/Single;
+	public final fun hasWriteAccess (Ljava/util/List;)Z
 	public final fun isInOptionRange (Ljava/util/List;Ljava/util/Date;)Z
+	public final fun suspendHasAccess (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendHasAccess$default (Lorg/hisp/dhis/android/core/category/CategoryOptionComboService;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun suspendIsAssignedToOrgUnit (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/category/CategoryOptionOrganisationUnitLink : org/hisp/dhis/android/core/common/CoreObject {
@@ -4614,6 +4624,10 @@ public abstract interface class org/hisp/dhis/android/core/dataset/DataSetInstan
 	public abstract fun getMissingMandatoryDataElementOperands (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun getMissingMandatoryFieldsCombination (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun hasDataWriteAccess (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun suspendGetEditableStatus (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendGetMissingMandatoryDataElementOperands (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendGetMissingMandatoryFieldsCombination (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendHasDataWriteAccess (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/dataset/DataSetInstanceSummary : org/hisp/dhis/android/core/common/CoreObject {
@@ -4864,6 +4878,7 @@ public final class org/hisp/dhis/android/core/datastore/DataStoreDownloader : or
 	public final fun blockingDownload ()V
 	public final fun byNamespace ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract class org/hisp/dhis/android/core/datastore/DataStoreEntry : org/hisp/dhis/android/core/common/BaseDeletableDataObject {
@@ -5104,6 +5119,7 @@ public final class org/hisp/dhis/android/core/domain/aggregated/data/AggregatedD
 public abstract interface class org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader {
 	public abstract fun blockingDownload ()V
 	public abstract fun download ()Lio/reactivex/Observable;
+	public abstract fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataCallBundle {
@@ -5313,6 +5329,9 @@ public abstract interface class org/hisp/dhis/android/core/enrollment/Enrollment
 	public abstract fun blockingIsOpen (Ljava/lang/String;)Z
 	public abstract fun getEnrollmentAccess (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun isOpen (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun suspendGetAllowEventCreation (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendGetEnrollmentAccess (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendIsOpen (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/enrollment/EnrollmentStatus : java/lang/Enum {
@@ -5472,6 +5491,7 @@ public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/d
 	public final fun limit (I)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByProgram (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
+	public final fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract class org/hisp/dhis/android/core/event/EventEditableStatus {
@@ -5596,6 +5616,12 @@ public abstract interface class org/hisp/dhis/android/core/event/EventService {
 	public abstract fun hasDataWriteAccess (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun isEditable (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun isInOrgunitRange (Lorg/hisp/dhis/android/core/event/Event;)Lio/reactivex/Single;
+	public abstract fun suspendCanAddEventToEnrollment (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendGetEditableStatus (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendHasCategoryComboAccess (Lorg/hisp/dhis/android/core/event/Event;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendHasDataWriteAccess (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendIsEditable (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendIsInOrgunitRange (Lorg/hisp/dhis/android/core/event/Event;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/event/EventStatus : java/lang/Enum {
@@ -5945,6 +5971,7 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceDownloade
 	public final fun byTrackedEntityUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byValueType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class org/hisp/dhis/android/core/fileresource/FileResourceElementType : java/lang/Enum {
@@ -6095,6 +6122,7 @@ public final class org/hisp/dhis/android/core/imports/TrackerImportConflictColle
 public final class org/hisp/dhis/android/core/imports/TrackerJobManager {
 	public final fun blockingResumePendingJobs ()V
 	public final fun resumePendingJobs ()Lio/reactivex/Observable;
+	public final fun suspendResumePendingJobs ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class org/hisp/dhis/android/core/imports/internal/HttpMessageResponse : org/hisp/dhis/android/core/imports/internal/WebResponse {
@@ -6567,6 +6595,7 @@ public final class org/hisp/dhis/android/core/map/layer/MapLayerCollectionReposi
 
 public final class org/hisp/dhis/android/core/map/layer/MapLayerDownloader : org/hisp/dhis/android/core/arch/modules/internal/UntypedModuleDownloader {
 	public fun downloadMetadata ()Lio/reactivex/Completable;
+	public final fun suspendDownloadMetadata (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/map/layer/MapLayerImageryProvider : org/hisp/dhis/android/core/common/CoreObject {
@@ -7045,6 +7074,8 @@ public final class org/hisp/dhis/android/core/organisationunit/OrganisationUnitS
 	public final fun blockingIsInCaptureScope (Ljava/lang/String;)Z
 	public final fun isDateInOrgunitRange (Ljava/lang/String;Ljava/util/Date;)Lio/reactivex/Single;
 	public final fun isInCaptureScope (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun suspendIsDateInOrgunitRange (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendIsInCaptureScope (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/organisationunit/OrganisationUnitTree {
@@ -7255,10 +7286,10 @@ public final class org/hisp/dhis/android/core/period/internal/PeriodHelper {
 	public static synthetic fun blockingGetPeriodForPeriodTypeAndDate$default (Lorg/hisp/dhis/android/core/period/internal/PeriodHelper;Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;IILjava/lang/Object;)Lorg/hisp/dhis/android/core/period/Period;
 	public final fun blockingGetPeriodsForDataSet (Ljava/lang/String;)Ljava/util/List;
 	public final fun getPeriod (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;)Lorg/hisp/dhis/android/core/period/Period;
-	public final fun getPeriodForPeriodId (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun getPeriodForPeriodTypeAndDate (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;)Lio/reactivex/Single;
 	public final fun getPeriodForPeriodTypeAndDate (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;I)Lio/reactivex/Single;
 	public final fun getPeriodsForDataSet (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun suspendGetPeriodForPeriodId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/period/internal/PeriodHelper$Companion {
@@ -8628,6 +8659,7 @@ public final class org/hisp/dhis/android/core/server/LoginPageLayout : java/lang
 public abstract interface class org/hisp/dhis/android/core/server/ServerModule {
 	public abstract fun blockingCheckServerUrl (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun checkServerUrl (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun suspendCheckServerUrl (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/settings/AnalyticsDhisVisualization : org/hisp/dhis/android/core/common/CoreObject, org/hisp/dhis/android/core/common/ObjectWithUidInterface {
@@ -8717,6 +8749,8 @@ public final class org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizatio
 	public final fun blockingGetByProgram (Ljava/lang/String;)Ljava/util/List;
 	public final fun getByDataSet (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun getByProgram (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun suspendGetByDataSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendGetByProgram (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/settings/AnalyticsSettingObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
@@ -9149,6 +9183,7 @@ public final class org/hisp/dhis/android/core/settings/CustomIntentResponseExtra
 public abstract interface class org/hisp/dhis/android/core/settings/CustomIntentService {
 	public abstract fun blockingEvaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;)Ljava/util/Map;
 	public abstract fun evaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;)Lio/reactivex/Single;
+	public abstract fun suspendEvaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/settings/CustomIntentTrigger {
@@ -9364,6 +9399,8 @@ public final class org/hisp/dhis/android/core/settings/GeneralSettingObjectRepos
 	public final fun blockingHasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;)Z
 	public final fun hasExperimentalFeature (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun hasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;)Lio/reactivex/Single;
+	public final fun suspendHasExperimentalFeature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendHasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/settings/GeneralSettings : org/hisp/dhis/android/core/common/CoreObject {
@@ -10198,6 +10235,7 @@ public abstract interface class org/hisp/dhis/android/core/systeminfo/DHISVersio
 public abstract interface class org/hisp/dhis/android/core/systeminfo/Ping {
 	public abstract fun blockingGet ()Ljava/lang/String;
 	public abstract fun get ()Lio/reactivex/Single;
+	public abstract fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/systeminfo/SMSVersion : java/lang/Enum {
@@ -10251,6 +10289,7 @@ public final class org/hisp/dhis/android/core/systeminfo/SystemInfoObjectReposit
 public final class org/hisp/dhis/android/core/systeminfo/internal/PingImpl : org/hisp/dhis/android/core/systeminfo/Ping {
 	public fun blockingGet ()Ljava/lang/String;
 	public fun get ()Lio/reactivex/Single;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/systeminfo/internal/SystemInfoCall : org/hisp/dhis/android/core/arch/call/internal/DownloadProvider {
@@ -10480,6 +10519,11 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityAttribu
 	public final fun downloadReservedValues (Ljava/lang/String;Ljava/lang/Integer;)Lio/reactivex/Observable;
 	public final fun getReservedValueSummaries ()Lio/reactivex/Single;
 	public final fun getValue (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun suspendCount (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendDownloadAllReservedValues (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public final fun suspendDownloadReservedValues (Ljava/lang/String;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public final fun suspendGetReservedValueSummaries (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendGetValue (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager$Companion {
@@ -11660,6 +11704,9 @@ public abstract interface class org/hisp/dhis/android/core/user/UserModule {
 	public abstract fun logOut ()Lio/reactivex/Completable;
 	public abstract fun oauth2Handler ()Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Handler;
 	public abstract fun openIdHandler ()Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectHandler;
+	public abstract fun suspendIsLogged (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun twoFactorAuthManager ()Lorg/hisp/dhis/android/core/user/TwoFactorAuthManager;
 	public abstract fun user ()Lorg/hisp/dhis/android/core/user/UserObjectRepository;
 	public abstract fun userCredentials ()Lorg/hisp/dhis/android/core/user/UserCredentialsObjectRepository;
@@ -11706,10 +11753,6 @@ public abstract class org/hisp/dhis/android/core/user/UserRole$Builder : org/his
 public final class org/hisp/dhis/android/core/user/UserRoleCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyIdentifiableCollectionRepositoryImpl {
 }
 
-public final class org/hisp/dhis/android/core/user/internal/LogOutCall {
-	public final fun logOut ()Lio/reactivex/Completable;
-}
-
 public final class org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkHelper {
 	public static fun isRoot (Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnit$Scope;Lorg/hisp/dhis/android/core/user/User;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnit;)Z
 	public static fun userIsAssigned (Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnit$Scope;Lorg/hisp/dhis/android/core/user/User;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnit;)Z
@@ -11748,6 +11791,7 @@ public abstract interface class org/hisp/dhis/android/core/user/oauth2/OAuth2Han
 	public abstract fun isLoggedIn ()Z
 	public abstract fun logOutObservable ()Lio/reactivex/Observable;
 	public abstract fun resetRegistration ()V
+	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/user/oauth2/OAuth2State {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -80,13 +80,13 @@ public abstract class org/hisp/dhis/android/core/D2Configuration$Builder {
 
 public final class org/hisp/dhis/android/core/D2Manager {
 	public static final field INSTANCE Lorg/hisp/dhis/android/core/D2Manager;
-	public static final fun RxInstantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;)Lio/reactivex/Single;
 	public static final fun blockingInstantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;)Lorg/hisp/dhis/android/core/D2;
 	public static final fun clear ()V
 	public static final fun getD2 ()Lorg/hisp/dhis/android/core/D2;
 	public static final fun instantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;)Lio/reactivex/Single;
 	public static final fun isD2Instantiated ()Z
 	public static final fun removeCredentials ()V
+	public static final fun rxInstantiateD2 (Lorg/hisp/dhis/android/core/D2Configuration;)Lio/reactivex/Single;
 	public static final fun setCredentials (Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun setTestingDatabase (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun setTestingInsecureStore (Lorg/hisp/dhis/android/core/arch/storage/internal/InsecureStore;)V
@@ -227,6 +227,7 @@ public abstract interface class org/hisp/dhis/android/core/analytics/AnalyticsMo
 public abstract interface class org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository {
 	public abstract fun blockingEvaluate ()Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun rxEvaluate ()Lio/reactivex/Single;
 	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withAggregationType (Lorg/hisp/dhis/android/core/common/AggregationType;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository;
 	public abstract fun withDimension (Lorg/hisp/dhis/android/core/analytics/aggregated/DimensionItem;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository;
@@ -237,6 +238,7 @@ public abstract interface class org/hisp/dhis/android/core/analytics/aggregated/
 public abstract interface class org/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository {
 	public abstract fun blockingEvaluate ()Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun rxEvaluate ()Lio/reactivex/Single;
 	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withOrganisationUnits (Ljava/util/List;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository;
 	public abstract fun withPeriods (Ljava/util/List;)Lorg/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository;
@@ -755,6 +757,7 @@ public abstract interface class org/hisp/dhis/android/core/analytics/linelist/Ev
 	public abstract fun byProgramStage ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public abstract fun byTrackedEntityInstance ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun rxEvaluate ()Lio/reactivex/Single;
 	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withDataElement (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/linelist/EventLineListRepository;
 	public abstract fun withLegendStrategy (Lorg/hisp/dhis/android/core/analytics/AnalyticsLegendStrategy;)Lorg/hisp/dhis/android/core/analytics/linelist/EventLineListRepository;
@@ -1377,6 +1380,7 @@ public final class org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerL
 public abstract interface class org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository {
 	public abstract fun blockingEvaluate ()Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun evaluate ()Lio/reactivex/Single;
+	public abstract fun rxEvaluate ()Lio/reactivex/Single;
 	public abstract fun suspendEvaluate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun withColumn (Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListItem;)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository;
 	public abstract fun withEnrollmentOutput (Ljava/lang/String;)Lorg/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository;
@@ -2996,6 +3000,7 @@ public final class org/hisp/dhis/android/core/category/CategoryOptionComboServic
 	public final fun hasAccess (Ljava/lang/String;Ljava/util/Date;)Lio/reactivex/Single;
 	public final fun hasWriteAccess (Ljava/util/List;)Z
 	public final fun isInOptionRange (Ljava/util/List;Ljava/util/Date;)Z
+	public final fun rxHasAccess (Ljava/lang/String;Ljava/util/Date;)Lio/reactivex/Single;
 	public final fun suspendHasAccess (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun suspendHasAccess$default (Lorg/hisp/dhis/android/core/category/CategoryOptionComboService;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun suspendIsAssignedToOrgUnit (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -4624,6 +4629,10 @@ public abstract interface class org/hisp/dhis/android/core/dataset/DataSetInstan
 	public abstract fun getMissingMandatoryDataElementOperands (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun getMissingMandatoryFieldsCombination (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun hasDataWriteAccess (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxGetEditableStatus (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxGetMissingMandatoryDataElementOperands (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxGetMissingMandatoryFieldsCombination (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxHasDataWriteAccess (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun suspendGetEditableStatus (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendGetMissingMandatoryDataElementOperands (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendGetMissingMandatoryFieldsCombination (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -4878,7 +4887,8 @@ public final class org/hisp/dhis/android/core/datastore/DataStoreDownloader : or
 	public final fun blockingDownload ()V
 	public final fun byNamespace ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
-	public final fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
+	public final fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
+	public final fun rxDownload ()Lio/reactivex/Observable;
 }
 
 public abstract class org/hisp/dhis/android/core/datastore/DataStoreEntry : org/hisp/dhis/android/core/common/BaseDeletableDataObject {
@@ -5119,7 +5129,8 @@ public final class org/hisp/dhis/android/core/domain/aggregated/data/AggregatedD
 public abstract interface class org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader {
 	public abstract fun blockingDownload ()V
 	public abstract fun download ()Lio/reactivex/Observable;
-	public abstract fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun rxDownload ()Lio/reactivex/Observable;
 }
 
 public final class org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataCallBundle {
@@ -5329,6 +5340,9 @@ public abstract interface class org/hisp/dhis/android/core/enrollment/Enrollment
 	public abstract fun blockingIsOpen (Ljava/lang/String;)Z
 	public abstract fun getEnrollmentAccess (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun isOpen (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxAllowEventCreation (Ljava/lang/String;Ljava/util/List;)Lio/reactivex/Single;
+	public abstract fun rxGetEnrollmentAccess (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxIsOpen (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun suspendGetAllowEventCreation (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendGetEnrollmentAccess (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendIsOpen (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -5487,11 +5501,13 @@ public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/d
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getEventFilterCollectionRepository ()Lorg/hisp/dhis/android/core/event/EventFilterCollectionRepository;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun limitByProgram (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
-	public final fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
+	public final fun rxDownload ()Lio/reactivex/Observable;
+	public final fun suspendDownload (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/event/EventEditableStatus {
@@ -5616,6 +5632,12 @@ public abstract interface class org/hisp/dhis/android/core/event/EventService {
 	public abstract fun hasDataWriteAccess (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun isEditable (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun isInOrgunitRange (Lorg/hisp/dhis/android/core/event/Event;)Lio/reactivex/Single;
+	public abstract fun rxCanAddEventToEnrollment (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxGetEditableStatus (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxHasCategoryComboAccess (Lorg/hisp/dhis/android/core/event/Event;)Lio/reactivex/Single;
+	public abstract fun rxHasDataWriteAccess (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxIsEditable (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxIsInOrgunitRange (Lorg/hisp/dhis/android/core/event/Event;)Lio/reactivex/Single;
 	public abstract fun suspendCanAddEventToEnrollment (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendGetEditableStatus (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendHasCategoryComboAccess (Lorg/hisp/dhis/android/core/event/Event;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -5971,7 +5993,8 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceDownloade
 	public final fun byTrackedEntityUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byValueType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
-	public final fun suspendDownload ()Lkotlinx/coroutines/flow/Flow;
+	public final fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
+	public final fun rxDownload ()Lio/reactivex/Observable;
 }
 
 public final class org/hisp/dhis/android/core/fileresource/FileResourceElementType : java/lang/Enum {
@@ -6121,8 +6144,9 @@ public final class org/hisp/dhis/android/core/imports/TrackerImportConflictColle
 
 public final class org/hisp/dhis/android/core/imports/TrackerJobManager {
 	public final fun blockingResumePendingJobs ()V
+	public final fun flowResumePendingJobs ()Lkotlinx/coroutines/flow/Flow;
 	public final fun resumePendingJobs ()Lio/reactivex/Observable;
-	public final fun suspendResumePendingJobs ()Lkotlinx/coroutines/flow/Flow;
+	public final fun rxResumePendingJobs ()Lio/reactivex/Observable;
 }
 
 public final class org/hisp/dhis/android/core/imports/internal/HttpMessageResponse : org/hisp/dhis/android/core/imports/internal/WebResponse {
@@ -6595,6 +6619,7 @@ public final class org/hisp/dhis/android/core/map/layer/MapLayerCollectionReposi
 
 public final class org/hisp/dhis/android/core/map/layer/MapLayerDownloader : org/hisp/dhis/android/core/arch/modules/internal/UntypedModuleDownloader {
 	public fun downloadMetadata ()Lio/reactivex/Completable;
+	public final fun rxDownloadMetadata ()Lio/reactivex/Completable;
 	public final fun suspendDownloadMetadata (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -7074,6 +7099,8 @@ public final class org/hisp/dhis/android/core/organisationunit/OrganisationUnitS
 	public final fun blockingIsInCaptureScope (Ljava/lang/String;)Z
 	public final fun isDateInOrgunitRange (Ljava/lang/String;Ljava/util/Date;)Lio/reactivex/Single;
 	public final fun isInCaptureScope (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxIsDateInOrgunitRange (Ljava/lang/String;Ljava/util/Date;)Lio/reactivex/Single;
+	public final fun rxIsInCaptureScope (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun suspendIsDateInOrgunitRange (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendIsInCaptureScope (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -7289,6 +7316,9 @@ public final class org/hisp/dhis/android/core/period/internal/PeriodHelper {
 	public final fun getPeriodForPeriodTypeAndDate (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;)Lio/reactivex/Single;
 	public final fun getPeriodForPeriodTypeAndDate (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;I)Lio/reactivex/Single;
 	public final fun getPeriodsForDataSet (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxGetPeriodForPeriodTypeAndDate (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;)Lio/reactivex/Single;
+	public final fun rxGetPeriodForPeriodTypeAndDate (Lorg/hisp/dhis/android/core/period/PeriodType;Ljava/util/Date;I)Lio/reactivex/Single;
+	public final fun rxGetPeriodsForDataSet (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun suspendGetPeriodForPeriodId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -8659,6 +8689,7 @@ public final class org/hisp/dhis/android/core/server/LoginPageLayout : java/lang
 public abstract interface class org/hisp/dhis/android/core/server/ServerModule {
 	public abstract fun blockingCheckServerUrl (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun checkServerUrl (Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxCheckServerUrl (Ljava/lang/String;)Lio/reactivex/Single;
 	public abstract fun suspendCheckServerUrl (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -8749,6 +8780,8 @@ public final class org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizatio
 	public final fun blockingGetByProgram (Ljava/lang/String;)Ljava/util/List;
 	public final fun getByDataSet (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun getByProgram (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxGetByDataSet (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxGetByProgram (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun suspendGetByDataSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendGetByProgram (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -9183,6 +9216,7 @@ public final class org/hisp/dhis/android/core/settings/CustomIntentResponseExtra
 public abstract interface class org/hisp/dhis/android/core/settings/CustomIntentService {
 	public abstract fun blockingEvaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;)Ljava/util/Map;
 	public abstract fun evaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;)Lio/reactivex/Single;
+	public abstract fun rxEvaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;)Lio/reactivex/Single;
 	public abstract fun suspendEvaluateRequestParams (Lorg/hisp/dhis/android/core/settings/CustomIntent;Lorg/hisp/dhis/android/core/settings/CustomIntentContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -9399,6 +9433,8 @@ public final class org/hisp/dhis/android/core/settings/GeneralSettingObjectRepos
 	public final fun blockingHasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;)Z
 	public final fun hasExperimentalFeature (Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun hasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;)Lio/reactivex/Single;
+	public final fun rxHasExperimentalFeature (Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxHasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;)Lio/reactivex/Single;
 	public final fun suspendHasExperimentalFeature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendHasExperimentalFeature (Lorg/hisp/dhis/android/core/settings/ExperimentalFeature;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -10235,6 +10271,7 @@ public abstract interface class org/hisp/dhis/android/core/systeminfo/DHISVersio
 public abstract interface class org/hisp/dhis/android/core/systeminfo/Ping {
 	public abstract fun blockingGet ()Ljava/lang/String;
 	public abstract fun get ()Lio/reactivex/Single;
+	public abstract fun rxGet ()Lio/reactivex/Single;
 	public abstract fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -10289,6 +10326,7 @@ public final class org/hisp/dhis/android/core/systeminfo/SystemInfoObjectReposit
 public final class org/hisp/dhis/android/core/systeminfo/internal/PingImpl : org/hisp/dhis/android/core/systeminfo/Ping {
 	public fun blockingGet ()Ljava/lang/String;
 	public fun get ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
 	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -10517,11 +10555,16 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityAttribu
 	public final fun count (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun downloadAllReservedValues (Ljava/lang/Integer;)Lio/reactivex/Observable;
 	public final fun downloadReservedValues (Ljava/lang/String;Ljava/lang/Integer;)Lio/reactivex/Observable;
+	public final fun flowDownloadAllReservedValues (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
+	public final fun flowDownloadReservedValues (Ljava/lang/String;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getReservedValueSummaries ()Lio/reactivex/Single;
 	public final fun getValue (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxCount (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public final fun rxDownloadAllReservedValues (Ljava/lang/Integer;)Lio/reactivex/Observable;
+	public final fun rxDownloadReservedValues (Ljava/lang/String;Ljava/lang/Integer;)Lio/reactivex/Observable;
+	public final fun rxGetReservedValueSummaries ()Lio/reactivex/Single;
+	public final fun rxGetValue (Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 	public final fun suspendCount (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun suspendDownloadAllReservedValues (Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
-	public final fun suspendDownloadReservedValues (Ljava/lang/String;Ljava/lang/Integer;)Lkotlinx/coroutines/flow/Flow;
 	public final fun suspendGetReservedValueSummaries (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendGetValue (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -11704,6 +11747,9 @@ public abstract interface class org/hisp/dhis/android/core/user/UserModule {
 	public abstract fun logOut ()Lio/reactivex/Completable;
 	public abstract fun oauth2Handler ()Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Handler;
 	public abstract fun openIdHandler ()Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectHandler;
+	public abstract fun rxIsLogged ()Lio/reactivex/Single;
+	public abstract fun rxLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun rxLogOut ()Lio/reactivex/Completable;
 	public abstract fun suspendIsLogged (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendLogIn (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -11791,6 +11837,7 @@ public abstract interface class org/hisp/dhis/android/core/user/oauth2/OAuth2Han
 	public abstract fun isLoggedIn ()Z
 	public abstract fun logOutObservable ()Lio/reactivex/Observable;
 	public abstract fun resetRegistration ()V
+	public abstract fun rxLogOutObservable ()Lio/reactivex/Observable;
 	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10912,12 +10912,14 @@ public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEnti
 	public final fun byTrackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getProgramStageWorkingListObjectRepository ()Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListCollectionRepository;
 	public final fun getTrackedEntityInstanceFilterCollectionRepository ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCollectionRepository;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun limitByOrgunit (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun limitByProgram (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun overwrite (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
+	public final fun rxDownload ()Lio/reactivex/Observable;
 }
 
 public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterCall : org/hisp/dhis/android/core/arch/call/factories/internal/UidsCallCoroutines {
@@ -10975,6 +10977,10 @@ public abstract interface class org/hisp/dhis/android/core/trackedentity/ownersh
 	public abstract fun blockingBreakGlass (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun blockingTransfer (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun breakGlass (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Completable;
+	public abstract fun rxBreakGlass (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Completable;
+	public abstract fun rxTransfer (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Completable;
+	public abstract fun suspendBreakGlass (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendTransfer (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun transfer (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Completable;
 }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodHelperIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/period/internal/PeriodHelperIntegrationShould.kt
@@ -28,7 +28,6 @@
 package org.hisp.dhis.android.core.period.internal
 
 import com.google.common.truth.Truth.assertThat
-import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
@@ -46,13 +45,11 @@ class PeriodHelperIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
     fun should_not_crash_when_creating_same_period() = runTest {
         val date = Date()
 
-        val s1 = Single.fromCallable {
-            d2.periodModule().periodHelper().getPeriodForPeriodTypeAndDate(PeriodType.Daily, date)
-        }.subscribeOn(Schedulers.io())
+        val s1 = d2.periodModule().periodHelper().getPeriodForPeriodTypeAndDate(PeriodType.Daily, date)
+            .subscribeOn(Schedulers.io())
 
-        val s2 = Single.fromCallable {
-            d2.periodModule().periodHelper().getPeriodForPeriodTypeAndDate(PeriodType.Daily, date)
-        }.subscribeOn(Schedulers.io())
+        val s2 = d2.periodModule().periodHelper().getPeriodForPeriodTypeAndDate(PeriodType.Daily, date)
+            .subscribeOn(Schedulers.io())
 
         s1.mergeWith(s2).blockingSubscribe()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
@@ -102,7 +102,7 @@ object D2Manager {
      * @return the D2 instance wrapped in a RxJava Single
      */
     @JvmStatic
-    fun RxInstantiateD2(d2Config: D2Configuration): Single<D2> {
+    fun rxInstantiateD2(d2Config: D2Configuration): Single<D2> {
         return rxSingle {
             suspendInstantiateD2(d2Config)
         }
@@ -111,7 +111,7 @@ object D2Manager {
     /**
      * Instantiates D2 with the provided configuration. This is a blocking method. If you are using RxJava,
      * use [D2Manager.instantiateD2] instead.
- * @param d2Config the configuration
+     * @param d2Config the configuration
      * @return the D2 instance
      */
     @JvmStatic

--- a/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.D2ConfigurationValidator.validateAndSetDefaultValues
 import org.hisp.dhis.android.core.NotClosedObjectsDetector.enableNotClosedObjectsDetection
@@ -87,65 +88,91 @@ object D2Manager {
      * @return the D2 instance wrapped in a RxJava Single
      */
     @JvmStatic
+    @Deprecated(message = "Use RxInstantiateD2 instead", ReplaceWith("RxInstantiateD2(d2Config)"))
     fun instantiateD2(d2Config: D2Configuration): Single<D2> {
         return rxSingle {
-            val startTime = System.currentTimeMillis()
-            val context = d2Config.context()
+            suspendInstantiateD2(d2Config)
+        }
+    }
 
-            val secureStore = testingSecureStore ?: AndroidSecureStore(context)
-            val insecureStore = testingInsecureStore ?: AndroidInsecureStore(context)
-
-            val d2Configuration = validateAndSetDefaultValues(d2Config)
-            d2DIComponent = D2DIComponentFactory.create(d2Configuration, secureStore, insecureStore)
-
-            if (isTestMode) {
-                enableNotClosedObjectsDetection()
-            } else {
-                /* SSLContextInitializer, necessary to ensure everything works in Android 4.4 crashes
-                 when running the StrictMode above. That's why it's in the else clause */
-                SSLContextInitializer.initializeSSLContext()
-            }
-
-            val multiUserDatabaseManager = d2DIComponent.multiUserDatabaseManagerForD2Manager
-            multiUserDatabaseManager.applyMigration()
-
-            val credentials = d2DIComponent.credentialsSecureStore.get()
-
-            if (wantToImportDBForExternalTesting()) {
-                multiUserDatabaseManager.loadDbForTesting(
-                    testingServerUrl!!,
-                    testingDatabaseName!!,
-                    false,
-                    testingUsername!!,
-                )
-            } else {
-                multiUserDatabaseManager.loadIfLogged(credentials)
-            }
-
-            d2 = D2(d2DIComponent)
-
-            if (credentials != null) {
-                d2!!.userModule().user().blockingGet()?.uid()?.let { uid ->
-                    d2DIComponent.userIdInMemoryStore.set(uid)
-                }
-            }
-
-            val setUpTime = System.currentTimeMillis() - startTime
-            Log.i(D2Manager::class.java.name, "D2 instantiation took " + setUpTime + "ms")
-
-            d2!!
+    /**
+     * Instantiates D2 with the provided configuration. If you are not using RxJava,
+     * use [D2Manager.blockingInstantiateD2] or [D2Manager.suspendInstantiateD2] instead.
+     * @param d2Config the configuration
+     * @return the D2 instance wrapped in a RxJava Single
+     */
+    @JvmStatic
+    fun RxInstantiateD2(d2Config: D2Configuration): Single<D2> {
+        return rxSingle {
+            suspendInstantiateD2(d2Config)
         }
     }
 
     /**
      * Instantiates D2 with the provided configuration. This is a blocking method. If you are using RxJava,
      * use [D2Manager.instantiateD2] instead.
-     * @param d2Config the configuration
+ * @param d2Config the configuration
      * @return the D2 instance
      */
     @JvmStatic
     fun blockingInstantiateD2(d2Config: D2Configuration): D2? {
-        return instantiateD2(d2Config).blockingGet()
+        return runBlocking {
+            suspendInstantiateD2(d2Config)
+        }
+    }
+
+    /**
+     * Instantiates D2 with the provided configuration. This is a suspend function.
+     * @param d2Config the configuration
+     * @return the D2 instance
+     */
+
+    suspend fun suspendInstantiateD2(d2Config: D2Configuration): D2 {
+        val startTime = System.currentTimeMillis()
+        val context = d2Config.context()
+
+        val secureStore = testingSecureStore ?: AndroidSecureStore(context)
+        val insecureStore = testingInsecureStore ?: AndroidInsecureStore(context)
+
+        val d2Configuration = validateAndSetDefaultValues(d2Config)
+        d2DIComponent = D2DIComponentFactory.create(d2Configuration, secureStore, insecureStore)
+
+        if (isTestMode) {
+            enableNotClosedObjectsDetection()
+        } else {
+            /* SSLContextInitializer, necessary to ensure everything works in Android 4.4 crashes
+                 when running the StrictMode above. That's why it's in the else clause */
+            SSLContextInitializer.initializeSSLContext()
+        }
+
+        val multiUserDatabaseManager = d2DIComponent.multiUserDatabaseManagerForD2Manager
+        multiUserDatabaseManager.applyMigration()
+
+        val credentials = d2DIComponent.credentialsSecureStore.get()
+
+        if (wantToImportDBForExternalTesting()) {
+            multiUserDatabaseManager.loadDbForTesting(
+                testingServerUrl!!,
+                testingDatabaseName!!,
+                false,
+                testingUsername!!,
+            )
+        } else {
+            multiUserDatabaseManager.loadIfLogged(credentials)
+        }
+
+        d2 = D2(d2DIComponent)
+
+        if (credentials != null) {
+            d2!!.userModule().user().blockingGet()?.uid()?.let { uid ->
+                d2DIComponent.userIdInMemoryStore.set(uid)
+            }
+        }
+
+        val setUpTime = System.currentTimeMillis() - startTime
+        Log.i(D2Manager::class.java.name, "D2 instantiation took " + setUpTime + "ms")
+
+        return d2!!
     }
 
     @JvmStatic

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository.kt
@@ -44,7 +44,10 @@ interface AnalyticsRepository {
 
     fun withAggregationType(aggregationType: AggregationType): AnalyticsRepository
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     fun evaluate(): Single<Result<DimensionalResponse, AnalyticsException>>
+
+    fun rxEvaluate(): Single<Result<DimensionalResponse, AnalyticsException>>
 
     fun blockingEvaluate(): Result<DimensionalResponse, AnalyticsException>
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsRepository.kt
@@ -47,4 +47,6 @@ interface AnalyticsRepository {
     fun evaluate(): Single<Result<DimensionalResponse, AnalyticsException>>
 
     fun blockingEvaluate(): Result<DimensionalResponse, AnalyticsException>
+
+    suspend fun suspendEvaluate(): Result<DimensionalResponse, AnalyticsException>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository.kt
@@ -43,4 +43,6 @@ interface AnalyticsVisualizationsRepository {
     fun evaluate(): Single<Result<GridAnalyticsResponse, AnalyticsException>>
 
     fun blockingEvaluate(): Result<GridAnalyticsResponse, AnalyticsException>
+
+    suspend fun suspendEvaluate(): Result<GridAnalyticsResponse, AnalyticsException>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/AnalyticsVisualizationsRepository.kt
@@ -40,7 +40,10 @@ interface AnalyticsVisualizationsRepository {
 
     fun withOrganisationUnits(orgUnits: List<DimensionItem.OrganisationUnitItem>): AnalyticsVisualizationsRepository
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     fun evaluate(): Single<Result<GridAnalyticsResponse, AnalyticsException>>
+
+    fun rxEvaluate(): Single<Result<GridAnalyticsResponse, AnalyticsException>>
 
     fun blockingEvaluate(): Result<GridAnalyticsResponse, AnalyticsException>
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsRepositoryImpl.kt
@@ -62,7 +62,12 @@ internal class AnalyticsRepositoryImpl(
         return updateParams { params -> params.copy(aggregationType = aggregationType) }
     }
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     override fun evaluate(): Single<Result<DimensionalResponse, AnalyticsException>> {
+        return rxSingle { analyticsService.evaluate(params) }
+    }
+
+    override fun rxEvaluate(): Single<Result<DimensionalResponse, AnalyticsException>> {
         return rxSingle { analyticsService.evaluate(params) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsRepositoryImpl.kt
@@ -70,6 +70,10 @@ internal class AnalyticsRepositoryImpl(
         return runBlocking { analyticsService.evaluate(params) }
     }
 
+    override suspend fun suspendEvaluate(): Result<DimensionalResponse, AnalyticsException> {
+        return analyticsService.evaluate(params)
+    }
+
     private fun updateParams(
         func: (params: AnalyticsRepositoryParams) -> AnalyticsRepositoryParams,
     ): AnalyticsRepositoryImpl {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsVisualizationsRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsVisualizationsRepositoryImpl.kt
@@ -58,7 +58,12 @@ internal class AnalyticsVisualizationsRepositoryImpl(
         return updateParams { params -> params.copy(organisationUnits = orgUnits) }
     }
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     override fun evaluate(): Single<Result<GridAnalyticsResponse, AnalyticsException>> {
+        return rxSingle { service.evaluate(params) }
+    }
+
+    override fun rxEvaluate(): Single<Result<GridAnalyticsResponse, AnalyticsException>> {
         return rxSingle { service.evaluate(params) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsVisualizationsRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsVisualizationsRepositoryImpl.kt
@@ -66,6 +66,10 @@ internal class AnalyticsVisualizationsRepositoryImpl(
         return runBlocking { service.evaluate(params) }
     }
 
+    override suspend fun suspendEvaluate(): Result<GridAnalyticsResponse, AnalyticsException> {
+        return service.evaluate(params)
+    }
+
     private fun updateParams(
         func: (params: AnalyticsVisualizationsRepositoryParams) -> AnalyticsVisualizationsRepositoryParams,
     ): AnalyticsVisualizationsRepositoryImpl {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepository.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.EqFilterCon
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.OrganisationUnitFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.PeriodsFilterConnector
 
+@Suppress("TooManyFunctions")
 interface EventLineListRepository : BaseRepository {
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepository.kt
@@ -78,7 +78,10 @@ interface EventLineListRepository : BaseRepository {
      *
      * It is mandatory to specify a programStage using the method [byProgramStage]. Other parameters are optional.
      */
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     fun evaluate(): Single<List<LineListResponse>>
+
+    fun rxEvaluate(): Single<List<LineListResponse>>
 
     /**
      * Blocking version of [evaluate].

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepository.kt
@@ -86,4 +86,6 @@ interface EventLineListRepository : BaseRepository {
      * @see evaluate
      */
     fun blockingEvaluate(): List<LineListResponse>
+
+    suspend fun suspendEvaluate(): List<LineListResponse>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepositoryImpl.kt
@@ -95,7 +95,12 @@ internal class EventLineListRepositoryImpl(
         )
     }
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     override fun evaluate(): Single<List<LineListResponse>> {
+        return rxSingle { eventLineListService.evaluate(eventLineListParams) }
+    }
+
+    override fun rxEvaluate(): Single<List<LineListResponse>> {
         return rxSingle { eventLineListService.evaluate(eventLineListParams) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepositoryImpl.kt
@@ -102,4 +102,8 @@ internal class EventLineListRepositoryImpl(
     override fun blockingEvaluate(): List<LineListResponse> {
         return runBlocking { eventLineListService.evaluate(eventLineListParams) }
     }
+
+    override suspend fun suspendEvaluate(): List<LineListResponse> {
+        return eventLineListService.evaluate(eventLineListParams)
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListRepositoryImpl.kt
@@ -38,6 +38,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilte
 import org.koin.core.annotation.Singleton
 
 @Singleton
+@Suppress("TooManyFunctions")
 internal class EventLineListRepositoryImpl(
     private val eventLineListService: EventLineListService,
     private val eventLineListParams: EventLineListParams,

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository.kt
@@ -54,4 +54,6 @@ interface TrackerLineListRepository {
     fun evaluate(): Single<Result<TrackerLineListResponse, AnalyticsException>>
 
     fun blockingEvaluate(): Result<TrackerLineListResponse, AnalyticsException>
+
+    suspend fun suspendEvaluate(): Result<TrackerLineListResponse, AnalyticsException>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository.kt
@@ -33,6 +33,7 @@ import org.hisp.dhis.android.core.analytics.AnalyticsException
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.repositories.paging.PageConfig
 
+@Suppress("TooManyFunctions")
 interface TrackerLineListRepository {
 
     fun withEventOutput(programStageId: String): TrackerLineListRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepository.kt
@@ -52,7 +52,10 @@ interface TrackerLineListRepository {
 
     fun withSorting(sorting: TrackerLineListSortingItem): TrackerLineListRepository
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     fun evaluate(): Single<Result<TrackerLineListResponse, AnalyticsException>>
+
+    fun rxEvaluate(): Single<Result<TrackerLineListResponse, AnalyticsException>>
 
     fun blockingEvaluate(): Result<TrackerLineListResponse, AnalyticsException>
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerLineListRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerLineListRepositoryImpl.kt
@@ -102,6 +102,10 @@ internal class TrackerLineListRepositoryImpl(
         return runBlocking { service.evaluate(params) }
     }
 
+    override suspend fun suspendEvaluate(): Result<TrackerLineListResponse, AnalyticsException> {
+        return service.evaluate(params)
+    }
+
     private fun updateParams(
         func: (params: TrackerLineListParams) -> TrackerLineListParams,
     ): TrackerLineListRepositoryImpl {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerLineListRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerLineListRepositoryImpl.kt
@@ -94,7 +94,12 @@ internal class TrackerLineListRepositoryImpl(
         return updateParams { params.copy(sorting = listOf(sorting)) }
     }
 
+    @Deprecated(message = "Use rxEvaluate instead", ReplaceWith("rxEvaluate()"))
     override fun evaluate(): Single<Result<TrackerLineListResponse, AnalyticsException>> {
+        return rxSingle { service.evaluate(params) }
+    }
+
+    override fun rxEvaluate(): Single<Result<TrackerLineListResponse, AnalyticsException>> {
         return rxSingle { service.evaluate(params) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/internal/FlowExtensions.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/internal/FlowExtensions.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.runBlocking
 
+@Suppress("TooGenericExceptionThrown")
 internal fun <T> Flow<T>.collectAndWrapException() {
     return runBlocking { this@collectAndWrapException.catch { t -> throw RuntimeException(t) }.collect {} }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/call/internal/FlowExtensions.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/call/internal/FlowExtensions.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,36 +26,12 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.domain.aggregated.data.internal
+package org.hisp.dhis.android.core.arch.call.internal
 
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.asObservable
-import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
-import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedD2Progress
-import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedDataDownloader
-import org.koin.core.annotation.Singleton
 
-@Singleton
-internal class AggregatedDataDownloaderImpl(
-    private val dataCall: AggregatedDataCall,
-) : AggregatedDataDownloader {
-
-    override fun flowDownload(): Flow<AggregatedD2Progress> {
-        return dataCall.download()
-    }
-
-    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
-    override fun download(): Observable<AggregatedD2Progress> {
-        return flowDownload().asObservable()
-    }
-
-    override fun rxDownload(): Observable<AggregatedD2Progress> {
-        return flowDownload().asObservable()
-    }
-
-    override fun blockingDownload() {
-        flowDownload().collectAndWrapException()
-    }
+internal fun <T> Flow<T>.collectAndWrapException() {
+    return runBlocking { this@collectAndWrapException.catch { t -> throw RuntimeException(t) }.collect {} }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboService.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.category
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.koin.core.annotation.Singleton
 import java.util.Date
 
@@ -37,16 +39,30 @@ class CategoryOptionComboService(
 ) {
 
     fun blockingHasAccess(categoryOptionComboUid: String, date: Date?, orgUnitUid: String? = null): Boolean {
+        return runBlocking { suspendHasAccess(categoryOptionComboUid, date, orgUnitUid) }
+    }
+
+    fun hasAccess(categoryOptionComboUid: String, date: Date?): Single<Boolean> {
+        return rxSingle { suspendHasAccess(categoryOptionComboUid, date) }
+    }
+
+    suspend fun suspendHasAccess(categoryOptionComboUid: String, date: Date?, orgUnitUid: String? = null): Boolean {
         val categoryOptions = categoryOptionRepository
             .byCategoryOptionComboUid(categoryOptionComboUid)
-            .blockingGet()
+            .getInternal()
 
-        return blockingIsAssignedToOrgUnit(categoryOptionComboUid, orgUnitUid) &&
-            blockingHasWriteAccess(categoryOptions) &&
+        return suspendIsAssignedToOrgUnit(categoryOptionComboUid, orgUnitUid) &&
+            hasWriteAccess(categoryOptions) &&
             isInOptionRange(categoryOptions, date)
     }
 
     fun blockingHasWriteAccess(
+        categoryOptions: List<CategoryOption>,
+    ): Boolean {
+        return hasWriteAccess(categoryOptions)
+    }
+
+    fun hasWriteAccess(
         categoryOptions: List<CategoryOption>,
     ): Boolean {
         return categoryOptions.none { it.access().data().write() == false }
@@ -56,11 +72,18 @@ class CategoryOptionComboService(
         categoryOptionComboUid: String,
         orgUnitUid: String?,
     ): Boolean {
+        return runBlocking { suspendIsAssignedToOrgUnit(categoryOptionComboUid, orgUnitUid) }
+    }
+
+    suspend fun suspendIsAssignedToOrgUnit(
+        categoryOptionComboUid: String,
+        orgUnitUid: String?,
+    ): Boolean {
         return orgUnitUid?.let {
             val categoryOptions = categoryOptionRepository
                 .byCategoryOptionComboUid(categoryOptionComboUid)
                 .withOrganisationUnits()
-                .blockingGet()
+                .getInternal()
 
             categoryOptions.all { categoryOption ->
                 categoryOption.organisationUnits()?.any {
@@ -68,10 +91,6 @@ class CategoryOptionComboService(
                 } ?: true
             }
         } ?: true
-    }
-
-    fun hasAccess(categoryOptionComboUid: String, date: Date?): Single<Boolean> {
-        return Single.fromCallable { blockingHasAccess(categoryOptionComboUid, date) }
     }
 
     fun isInOptionRange(options: List<CategoryOption>, date: Date?): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboService.kt
@@ -42,7 +42,12 @@ class CategoryOptionComboService(
         return runBlocking { suspendHasAccess(categoryOptionComboUid, date, orgUnitUid) }
     }
 
+    @Deprecated(message = "Use rxHasAccess instead", ReplaceWith("rxHasAccess(categoryOptionComboUid, date)"))
     fun hasAccess(categoryOptionComboUid: String, date: Date?): Single<Boolean> {
+        return rxSingle { suspendHasAccess(categoryOptionComboUid, date) }
+    }
+
+    fun rxHasAccess(categoryOptionComboUid: String, date: Date?): Single<Boolean> {
         return rxSingle { suspendHasAccess(categoryOptionComboUid, date) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.core.dataset
 import io.reactivex.Single
 import org.hisp.dhis.android.core.dataelement.DataElementOperand
 
+@Suppress("TooManyFunctions")
 interface DataSetInstanceService {
 
     fun getEditableStatus(

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
@@ -34,7 +34,12 @@ import org.hisp.dhis.android.core.dataelement.DataElementOperand
 @Suppress("TooManyFunctions")
 interface DataSetInstanceService {
 
-    @Deprecated(message = "Use rxGetEditableStatus instead", ReplaceWith("rxGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
+    @Deprecated(
+        message = "Use rxGetEditableStatus instead",
+        ReplaceWith(
+            "rxGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)",
+        ),
+    )
     fun getEditableStatus(
         dataSetUid: String,
         periodId: String,
@@ -63,7 +68,10 @@ interface DataSetInstanceService {
         attributeOptionComboUid: String,
     ): DataSetEditableStatus
 
-    @Deprecated(message = "Use rxHasDataWriteAccess instead", ReplaceWith("rxHasDataWriteAccess(dataSetUid)"))
+    @Deprecated(
+        message = "Use rxHasDataWriteAccess instead",
+        ReplaceWith("rxHasDataWriteAccess(dataSetUid)"),
+    )
     fun hasDataWriteAccess(dataSetUid: String): Single<Boolean>
 
     fun rxHasDataWriteAccess(dataSetUid: String): Single<Boolean>
@@ -72,7 +80,13 @@ interface DataSetInstanceService {
 
     suspend fun suspendHasDataWriteAccess(dataSetUid: String): Boolean
 
-    @Deprecated(message = "Use rxGetMissingMandatoryDataElementOperands instead", ReplaceWith("rxGetMissingMandatoryDataElementOperands(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
+    @Deprecated(
+        message = "Use rxGetMissingMandatoryDataElementOperands instead",
+        ReplaceWith(
+            "rxGetMissingMandatoryDataElementOperands(dataSetUid, periodId, " +
+                "organisationUnitUid, attributeOptionComboUid)",
+        ),
+    )
     fun getMissingMandatoryDataElementOperands(
         dataSetUid: String,
         periodId: String,
@@ -101,7 +115,13 @@ interface DataSetInstanceService {
         attributeOptionComboUid: String,
     ): List<DataElementOperand>
 
-    @Deprecated(message = "Use rxGetMissingMandatoryFieldsCombination instead", ReplaceWith("rxGetMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
+    @Deprecated(
+        message = "Use rxGetMissingMandatoryFieldsCombination instead",
+        ReplaceWith(
+            "rxGetMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, " +
+                "attributeOptionComboUid)",
+        ),
+    )
     fun getMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
@@ -47,9 +47,18 @@ interface DataSetInstanceService {
         attributeOptionComboUid: String,
     ): DataSetEditableStatus
 
+    suspend fun suspendGetEditableStatus(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): DataSetEditableStatus
+
     fun hasDataWriteAccess(dataSetUid: String): Single<Boolean>
 
     fun blockingHasDataWriteAccess(dataSetUid: String): Boolean
+
+    suspend fun suspendHasDataWriteAccess(dataSetUid: String): Boolean
 
     fun getMissingMandatoryDataElementOperands(
         dataSetUid: String,
@@ -65,6 +74,13 @@ interface DataSetInstanceService {
         attributeOptionComboUid: String,
     ): List<DataElementOperand>
 
+    suspend fun suspendGetMissingMandatoryDataElementOperands(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): List<DataElementOperand>
+
     fun getMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,
@@ -73,6 +89,13 @@ interface DataSetInstanceService {
     ): Single<List<DataElementOperand>>
 
     fun blockingGetMissingMandatoryFieldsCombination(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): List<DataElementOperand>
+
+    suspend fun suspendGetMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetInstanceService.kt
@@ -34,7 +34,15 @@ import org.hisp.dhis.android.core.dataelement.DataElementOperand
 @Suppress("TooManyFunctions")
 interface DataSetInstanceService {
 
+    @Deprecated(message = "Use rxGetEditableStatus instead", ReplaceWith("rxGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
     fun getEditableStatus(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<DataSetEditableStatus>
+
+    fun rxGetEditableStatus(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
@@ -55,13 +63,24 @@ interface DataSetInstanceService {
         attributeOptionComboUid: String,
     ): DataSetEditableStatus
 
+    @Deprecated(message = "Use rxHasDataWriteAccess instead", ReplaceWith("rxHasDataWriteAccess(dataSetUid)"))
     fun hasDataWriteAccess(dataSetUid: String): Single<Boolean>
+
+    fun rxHasDataWriteAccess(dataSetUid: String): Single<Boolean>
 
     fun blockingHasDataWriteAccess(dataSetUid: String): Boolean
 
     suspend fun suspendHasDataWriteAccess(dataSetUid: String): Boolean
 
+    @Deprecated(message = "Use rxGetMissingMandatoryDataElementOperands instead", ReplaceWith("rxGetMissingMandatoryDataElementOperands(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
     fun getMissingMandatoryDataElementOperands(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<List<DataElementOperand>>
+
+    fun rxGetMissingMandatoryDataElementOperands(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
@@ -82,7 +101,15 @@ interface DataSetInstanceService {
         attributeOptionComboUid: String,
     ): List<DataElementOperand>
 
+    @Deprecated(message = "Use rxGetMissingMandatoryFieldsCombination instead", ReplaceWith("rxGetMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
     fun getMissingMandatoryFieldsCombination(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<List<DataElementOperand>>
+
+    fun rxGetMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -151,7 +151,10 @@ internal class DataSetInstanceServiceImpl(
     ): Single<List<DataElementOperand>> {
         return rxSingle {
             suspendGetMissingMandatoryDataElementOperands(
-                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+                dataSetUid,
+                periodId,
+                organisationUnitUid,
+                attributeOptionComboUid,
             )
         }
     }
@@ -164,7 +167,10 @@ internal class DataSetInstanceServiceImpl(
     ): List<DataElementOperand> {
         return runBlocking {
             suspendGetMissingMandatoryDataElementOperands(
-                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+                dataSetUid,
+                periodId,
+                organisationUnitUid,
+                attributeOptionComboUid,
             )
         }
     }
@@ -212,7 +218,10 @@ internal class DataSetInstanceServiceImpl(
     ): Single<List<DataElementOperand>> {
         return rxSingle {
             suspendGetMissingMandatoryFieldsCombination(
-                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+                dataSetUid,
+                periodId,
+                organisationUnitUid,
+                attributeOptionComboUid,
             )
         }
     }
@@ -225,7 +234,10 @@ internal class DataSetInstanceServiceImpl(
     ): List<DataElementOperand> {
         return runBlocking {
             suspendGetMissingMandatoryFieldsCombination(
-                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+                dataSetUid,
+                periodId,
+                organisationUnitUid,
+                attributeOptionComboUid,
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -67,7 +67,13 @@ internal class DataSetInstanceServiceImpl(
     private val periodGenerator: ParentPeriodGenerator,
 ) : DataSetInstanceService {
 
-    @Deprecated(message = "Use rxGetEditableStatus instead", ReplaceWith("rxGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
+    @Deprecated(
+        message = "Use rxGetEditableStatus instead",
+        ReplaceWith(
+            "rxGetEditableStatus(dataSetUid, periodId, organisationUnitUid, " +
+                "attributeOptionComboUid)",
+        ),
+    )
     override fun getEditableStatus(
         dataSetUid: String,
         periodId: String,
@@ -160,7 +166,13 @@ internal class DataSetInstanceServiceImpl(
         return dataSet.access().write() ?: false
     }
 
-    @Deprecated(message = "Use rxGetMissingMandatoryDataElementOperands instead", ReplaceWith("rxGetMissingMandatoryDataElementOperands(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
+    @Deprecated(
+        message = "Use rxGetMissingMandatoryDataElementOperands instead",
+        ReplaceWith(
+            "rxGetMissingMandatoryDataElementOperands(dataSetUid, periodId, organisationUnitUid, " +
+                "attributeOptionComboUid)",
+        ),
+    )
     override fun getMissingMandatoryDataElementOperands(
         dataSetUid: String,
         periodId: String,
@@ -244,7 +256,13 @@ internal class DataSetInstanceServiceImpl(
         } ?: false
     }
 
-    @Deprecated(message = "Use rxGetMissingMandatoryFieldsCombination instead", ReplaceWith("rxGetMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
+    @Deprecated(
+        message = "Use rxGetMissingMandatoryFieldsCombination instead",
+        ReplaceWith(
+            "rxGetMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, " +
+                "attributeOptionComboUid)",
+        ),
+    )
     override fun getMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -67,7 +67,19 @@ internal class DataSetInstanceServiceImpl(
     private val periodGenerator: ParentPeriodGenerator,
 ) : DataSetInstanceService {
 
+    @Deprecated(message = "Use rxGetEditableStatus instead", ReplaceWith("rxGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
     override fun getEditableStatus(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<DataSetEditableStatus> {
+        return rxSingle {
+            suspendGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)
+        }
+    }
+
+    override fun rxGetEditableStatus(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
@@ -130,7 +142,12 @@ internal class DataSetInstanceServiceImpl(
         }
     }
 
+    @Deprecated(message = "Use rxHasDataWriteAccess instead", ReplaceWith("rxHasDataWriteAccess(dataSetUid)"))
     override fun hasDataWriteAccess(dataSetUid: String): Single<Boolean> {
+        return rxSingle { suspendHasDataWriteAccess(dataSetUid) }
+    }
+
+    override fun rxHasDataWriteAccess(dataSetUid: String): Single<Boolean> {
         return rxSingle { suspendHasDataWriteAccess(dataSetUid) }
     }
 
@@ -143,7 +160,24 @@ internal class DataSetInstanceServiceImpl(
         return dataSet.access().write() ?: false
     }
 
+    @Deprecated(message = "Use rxGetMissingMandatoryDataElementOperands instead", ReplaceWith("rxGetMissingMandatoryDataElementOperands(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
     override fun getMissingMandatoryDataElementOperands(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<List<DataElementOperand>> {
+        return rxSingle {
+            suspendGetMissingMandatoryDataElementOperands(
+                dataSetUid,
+                periodId,
+                organisationUnitUid,
+                attributeOptionComboUid,
+            )
+        }
+    }
+
+    override fun rxGetMissingMandatoryDataElementOperands(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
@@ -210,7 +244,24 @@ internal class DataSetInstanceServiceImpl(
         } ?: false
     }
 
+    @Deprecated(message = "Use rxGetMissingMandatoryFieldsCombination instead", ReplaceWith("rxGetMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)"))
     override fun getMissingMandatoryFieldsCombination(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<List<DataElementOperand>> {
+        return rxSingle {
+            suspendGetMissingMandatoryFieldsCombination(
+                dataSetUid,
+                periodId,
+                organisationUnitUid,
+                attributeOptionComboUid,
+            )
+        }
+    }
+
+    override fun rxGetMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
@@ -252,9 +303,9 @@ internal class DataSetInstanceServiceImpl(
         val stringListCache = ExpirableCache<String, List<String>>(TimeUnit.SECONDS.toMillis(120))
 
         val dataSet = dataSetCollectionRepository.withDataSetElements()
-            .uid(dataSetUid).getInternal() ?: return emptyList()
-
-        if (dataSet.fieldCombinationRequired() != true) return emptyList()
+            .uid(dataSetUid).getInternal()
+            ?.takeIf { it.fieldCombinationRequired() == true }
+            ?: return emptyList()
 
         return dataSet.dataSetElements().orEmpty().flatMap { dataSetElement ->
             val categoryComboUid = dataSetElement.categoryCombo()?.uid()

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -29,6 +29,8 @@
 package org.hisp.dhis.android.core.dataset.internal
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.cache.internal.ExpirableCache
 import org.hisp.dhis.android.core.category.CategoryOption
 import org.hisp.dhis.android.core.category.CategoryOptionCollectionRepository
@@ -71,51 +73,57 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): Single<DataSetEditableStatus> {
-        return Single.fromCallable {
-            blockingGetEditableStatus(
-                dataSetUid = dataSetUid,
-                periodId = periodId,
-                organisationUnitUid = organisationUnitUid,
-                attributeOptionComboUid = attributeOptionComboUid,
-            )
+        return rxSingle {
+            suspendGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)
         }
     }
 
-    @Suppress("ComplexMethod")
     override fun blockingGetEditableStatus(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): DataSetEditableStatus {
-        val dataSet = dataSetCollectionRepository.withDataInputPeriods().uid(dataSetUid).blockingGet()
-        val period = periodHelper.getPeriodForPeriodId(periodId).blockingGet()
+        return runBlocking {
+            suspendGetEditableStatus(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    override suspend fun suspendGetEditableStatus(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): DataSetEditableStatus {
+        val dataSet = dataSetCollectionRepository.withDataInputPeriods().uid(dataSetUid).getInternal()
+        val period = periodHelper.suspendGetPeriodForPeriodId(periodId)
         return when {
-            !blockingHasDataWriteAccess(dataSetUid) ->
+            !suspendHasDataWriteAccess(dataSetUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.NO_DATASET_DATA_WRITE_ACCESS)
 
-            !blockingIsCategoryOptionHasDataWriteAccess(attributeOptionComboUid) ->
+            !suspendIsCategoryOptionHasDataWriteAccess(attributeOptionComboUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.NO_ATTRIBUTE_OPTION_COMBO_ACCESS)
 
-            !blockingIsPeriodInCategoryOptionRange(period, attributeOptionComboUid) ->
+            !suspendIsPeriodInCategoryOptionRange(period, attributeOptionComboUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_IS_NOT_IN_ATTRIBUTE_OPTION_RANGE)
 
-            !blockingIsOrgUnitInCaptureScope(organisationUnitUid) ->
+            !suspendIsOrgUnitInCaptureScope(organisationUnitUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.ORGUNIT_IS_NOT_IN_CAPTURE_SCOPE)
 
-            !blockingIsAttributeOptionComboAssignToOrgUnit(attributeOptionComboUid, organisationUnitUid) ->
+            !suspendIsAttributeOptionComboAssignToOrgUnit(attributeOptionComboUid, organisationUnitUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.ATTRIBUTE_OPTION_COMBO_NO_ASSIGN_TO_ORGUNIT)
 
-            !blockingIsPeriodInOrgUnitRange(period, organisationUnitUid) ->
+            !suspendIsPeriodInOrgUnitRange(period, organisationUnitUid) ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_IS_NOT_IN_ORGUNIT_RANGE)
 
-            dataSet?.let { blockingIsExpired(dataSet, period) } ?: false ->
+            dataSet?.let { isExpired(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.EXPIRED)
 
-            dataSet?.let { blockingIsClosed(dataSet, period) } ?: false ->
+            dataSet?.let { isClosed(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.CLOSED)
 
-            dataSet?.let { !blockingIsInDataInputPeriods(dataSet, period) } ?: false ->
+            dataSet?.let { !isInDataInputPeriods(dataSet, period) } ?: false ->
                 DataSetEditableStatus.NonEditable(DataSetNonEditableReason.PERIOD_NOT_IN_DATA_INPUT_PERIODS)
 
             else -> DataSetEditableStatus.Editable
@@ -123,11 +131,15 @@ internal class DataSetInstanceServiceImpl(
     }
 
     override fun hasDataWriteAccess(dataSetUid: String): Single<Boolean> {
-        return Single.just(blockingHasDataWriteAccess(dataSetUid))
+        return rxSingle { suspendHasDataWriteAccess(dataSetUid) }
     }
 
     override fun blockingHasDataWriteAccess(dataSetUid: String): Boolean {
-        val dataSet = dataSetCollectionRepository.uid(dataSetUid).blockingGet() ?: return false
+        return runBlocking { suspendHasDataWriteAccess(dataSetUid) }
+    }
+
+    override suspend fun suspendHasDataWriteAccess(dataSetUid: String): Boolean {
+        val dataSet = dataSetCollectionRepository.uid(dataSetUid).getInternal() ?: return false
         return dataSet.access().write() ?: false
     }
 
@@ -137,10 +149,10 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): Single<List<DataElementOperand>> {
-        return dataSetCollectionRepository.withCompulsoryDataElementOperands().uid(dataSetUid).get().map {
-            it.compulsoryDataElementOperands()?.filter { dataElementOperand ->
-                !hasDataValue(dataSetUid, dataElementOperand, periodId, organisationUnitUid, attributeOptionComboUid)
-            } ?: emptyList()
+        return rxSingle {
+            suspendGetMissingMandatoryDataElementOperands(
+                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+            )
         }
     }
 
@@ -150,15 +162,28 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): List<DataElementOperand> {
-        return getMissingMandatoryDataElementOperands(
-            dataSetUid,
-            periodId,
-            organisationUnitUid,
-            attributeOptionComboUid,
-        ).blockingGet()
+        return runBlocking {
+            suspendGetMissingMandatoryDataElementOperands(
+                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+            )
+        }
     }
 
-    private fun hasDataValue(
+    override suspend fun suspendGetMissingMandatoryDataElementOperands(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): List<DataElementOperand> {
+        val dataSet = dataSetCollectionRepository.withCompulsoryDataElementOperands()
+            .uid(dataSetUid).getInternal()
+
+        return dataSet?.compulsoryDataElementOperands()?.filter { dataElementOperand ->
+            !hasDataValue(dataSetUid, dataElementOperand, periodId, organisationUnitUid, attributeOptionComboUid)
+        } ?: emptyList()
+    }
+
+    private suspend fun hasDataValue(
         dataSetUid: String,
         dataElementOperand: DataElementOperand,
         periodId: String,
@@ -174,73 +199,21 @@ internal class DataSetInstanceServiceImpl(
                     categoryOptionCombo.uid(),
                     attributeOptionComboUid,
                     dataSetUid,
-                ).blockingExists()
+                ).existsInternal()
             }
         } ?: false
     }
 
-    @Suppress("MagicNumber")
     override fun getMissingMandatoryFieldsCombination(
         dataSetUid: String,
         periodId: String,
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): Single<List<DataElementOperand>> {
-        val stringListCache = ExpirableCache<String, List<String>>(TimeUnit.SECONDS.toMillis(120))
-
-        return dataSetCollectionRepository.withDataSetElements().uid(dataSetUid).get().map { dataSet ->
-            if (dataSet.fieldCombinationRequired() != true) return@map emptyList()
-
-            dataSet.dataSetElements().orEmpty().flatMap { dataSetElement ->
-                val categoryComboUid = dataSetElement.categoryCombo()?.uid()
-                    ?: dataElementCollectionRepository
-                        .uid(dataSetElement.dataElement().uid())
-                        .blockingGet()
-                        ?.categoryCombo()
-                        ?.uid()
-
-                categoryComboUid?.let { catComboUid ->
-                    val categoryOptionCombos = getCachedCategoryComboUid(catComboUid, stringListCache) { uid ->
-                        categoryOptionComboCollectionRepository.byCategoryComboUid().eq(uid).blockingGetUids()
-                    }
-
-                    val dataValues = dataValueCollectionRepository
-                        .byPeriod().eq(periodId)
-                        .byOrganisationUnitUid().eq(organisationUnitUid)
-                        .byAttributeOptionComboUid().eq(attributeOptionComboUid)
-                        .byDeleted().isFalse
-                        .byDataElementUid().eq(dataSetElement.dataElement().uid())
-                        .byCategoryOptionComboUid()
-                        .`in`(categoryOptionCombos)
-                        .blockingGet()
-
-                    dataValues.takeIf { it.isNotEmpty() && it.size != categoryOptionCombos.size }
-                        ?.map { dataValue ->
-                            DataElementOperand.builder().apply {
-                                uid(
-                                    listOfNotNull(dataValue.dataElement(), dataValue.categoryOptionCombo())
-                                        .joinToString("."),
-                                )
-                                dataValue.dataElement()?.let { dataElement(ObjectWithUid.create(it)) }
-                                dataValue.categoryOptionCombo()
-                                    ?.let { categoryOptionCombo(ObjectWithUid.create(it)) }
-                            }.build()
-                        } ?: emptyList()
-                } ?: emptyList()
-            }
-        }
-    }
-
-    private fun getCachedCategoryComboUid(
-        uid: String?,
-        categoryComboUidCache: ExpirableCache<String, List<String>>,
-        getFromRepository: (String) -> List<String>,
-    ): List<String> {
-        return if (uid != null) {
-            categoryComboUidCache[uid] ?: getFromRepository(uid)
-                .also { categoryComboUidCache[uid] = it }
-        } else {
-            emptyList()
+        return rxSingle {
+            suspendGetMissingMandatoryFieldsCombination(
+                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+            )
         }
     }
 
@@ -250,39 +223,108 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): List<DataElementOperand> {
-        return getMissingMandatoryFieldsCombination(dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid)
-            .blockingGet()
+        return runBlocking {
+            suspendGetMissingMandatoryFieldsCombination(
+                dataSetUid, periodId, organisationUnitUid, attributeOptionComboUid,
+            )
+        }
     }
 
-    internal fun blockingIsCategoryOptionHasDataWriteAccess(categoryOptionComboUid: String): Boolean {
-        val categoryOptions = getCategoryOptions(categoryOptionComboUid)
-        return categoryOptionComboService.blockingHasWriteAccess(categoryOptions)
+    @Suppress("MagicNumber")
+    override suspend fun suspendGetMissingMandatoryFieldsCombination(
+        dataSetUid: String,
+        periodId: String,
+        organisationUnitUid: String,
+        attributeOptionComboUid: String,
+    ): List<DataElementOperand> {
+        val stringListCache = ExpirableCache<String, List<String>>(TimeUnit.SECONDS.toMillis(120))
+
+        val dataSet = dataSetCollectionRepository.withDataSetElements()
+            .uid(dataSetUid).getInternal() ?: return emptyList()
+
+        if (dataSet.fieldCombinationRequired() != true) return emptyList()
+
+        return dataSet.dataSetElements().orEmpty().flatMap { dataSetElement ->
+            val categoryComboUid = dataSetElement.categoryCombo()?.uid()
+                ?: dataElementCollectionRepository
+                    .uid(dataSetElement.dataElement().uid())
+                    .getInternal()
+                    ?.categoryCombo()
+                    ?.uid()
+
+            categoryComboUid?.let { catComboUid ->
+                val categoryOptionCombos = getCachedCategoryComboUid(catComboUid, stringListCache) { uid ->
+                    categoryOptionComboCollectionRepository.byCategoryComboUid().eq(uid).getUidsInternal()
+                }
+
+                val dataValues = dataValueCollectionRepository
+                    .byPeriod().eq(periodId)
+                    .byOrganisationUnitUid().eq(organisationUnitUid)
+                    .byAttributeOptionComboUid().eq(attributeOptionComboUid)
+                    .byDeleted().isFalse
+                    .byDataElementUid().eq(dataSetElement.dataElement().uid())
+                    .byCategoryOptionComboUid()
+                    .`in`(categoryOptionCombos)
+                    .getInternal()
+
+                dataValues.takeIf { it.isNotEmpty() && it.size != categoryOptionCombos.size }
+                    ?.map { dataValue ->
+                        DataElementOperand.builder().apply {
+                            uid(
+                                listOfNotNull(dataValue.dataElement(), dataValue.categoryOptionCombo())
+                                    .joinToString("."),
+                            )
+                            dataValue.dataElement()?.let { dataElement(ObjectWithUid.create(it)) }
+                            dataValue.categoryOptionCombo()
+                                ?.let { categoryOptionCombo(ObjectWithUid.create(it)) }
+                        }.build()
+                    } ?: emptyList()
+            } ?: emptyList()
+        }
     }
 
-    internal fun blockingIsPeriodInCategoryOptionRange(period: Period, categoryOptionComboUid: String): Boolean {
-        val categoryOptions = getCategoryOptions(categoryOptionComboUid)
+    private suspend fun getCachedCategoryComboUid(
+        uid: String?,
+        categoryComboUidCache: ExpirableCache<String, List<String>>,
+        getFromRepository: suspend (String) -> List<String>,
+    ): List<String> {
+        return if (uid != null) {
+            categoryComboUidCache[uid] ?: getFromRepository(uid)
+                .also { categoryComboUidCache[uid] = it }
+        } else {
+            emptyList()
+        }
+    }
+
+    internal suspend fun suspendIsCategoryOptionHasDataWriteAccess(categoryOptionComboUid: String): Boolean {
+        val categoryOptions = suspendGetCategoryOptions(categoryOptionComboUid)
+        return categoryOptionComboService.hasWriteAccess(categoryOptions)
+    }
+
+    internal suspend fun suspendIsPeriodInCategoryOptionRange(period: Period, categoryOptionComboUid: String): Boolean {
+        val categoryOptions = suspendGetCategoryOptions(categoryOptionComboUid)
         val dates = listOf(period.startDate(), period.endDate())
         return dates.all { date ->
             categoryOptionComboService.isInOptionRange(categoryOptions, date)
         }
     }
 
-    internal fun blockingIsOrgUnitInCaptureScope(orgUnitUid: String): Boolean {
-        return organisationUnitService.blockingIsInCaptureScope(orgUnitUid)
+    internal suspend fun suspendIsOrgUnitInCaptureScope(orgUnitUid: String): Boolean {
+        return organisationUnitService.suspendIsInCaptureScope(orgUnitUid)
     }
 
-    internal fun blockingIsAttributeOptionComboAssignToOrgUnit(
+    internal suspend fun suspendIsAttributeOptionComboAssignToOrgUnit(
         categoryOptionComboUid: String,
         orgUnitUid: String,
     ): Boolean {
-        return categoryOptionComboService.blockingIsAssignedToOrgUnit(
+        return categoryOptionComboService.suspendIsAssignedToOrgUnit(
             categoryOptionComboUid = categoryOptionComboUid,
             orgUnitUid = orgUnitUid,
         )
     }
 
     @Suppress("MagicNumber")
-    internal fun blockingIsExpired(dataSet: DataSet, period: Period): Boolean {
+    internal fun isExpired(dataSet: DataSet, period: Period): Boolean {
         val expiryDays = dataSet.expiryDays()
         return if (expiryDays == null || expiryDays <= 0.0) {
             false
@@ -295,7 +337,7 @@ internal class DataSetInstanceServiceImpl(
         }
     }
 
-    internal fun blockingIsClosed(dataSet: DataSet, period: Period): Boolean {
+    internal fun isClosed(dataSet: DataSet, period: Period): Boolean {
         val periodType = dataSet.periodType() ?: return false
         val openFuturePeriods = dataSet.openFuturePeriods() ?: 0
         val latestFuturePeriod = periodGenerator.generatePeriod(
@@ -306,13 +348,13 @@ internal class DataSetInstanceServiceImpl(
         return period.endDate()?.after(latestFuturePeriod?.endDate()) ?: false
     }
 
-    internal fun blockingIsPeriodInOrgUnitRange(period: Period, orgUnitUid: String): Boolean {
+    internal suspend fun suspendIsPeriodInOrgUnitRange(period: Period, orgUnitUid: String): Boolean {
         return listOfNotNull(period.startDate(), period.endDate()).all { date ->
-            organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, date)
+            organisationUnitService.suspendIsDateInOrgunitRange(orgUnitUid, date)
         }
     }
 
-    internal fun blockingIsInDataInputPeriods(dataSet: DataSet, period: Period): Boolean {
+    internal fun isInDataInputPeriods(dataSet: DataSet, period: Period): Boolean {
         val dataInputPeriods = dataSet.dataInputPeriods()
 
         return dataInputPeriods.isNullOrEmpty() || dataInputPeriods
@@ -330,9 +372,9 @@ internal class DataSetInstanceServiceImpl(
             } ?: false
     }
 
-    private fun getCategoryOptions(attributeOptionComboUid: String): List<CategoryOption> {
+    private suspend fun suspendGetCategoryOptions(attributeOptionComboUid: String): List<CategoryOption> {
         return categoryOptionRepository
             .byCategoryOptionComboUid(attributeOptionComboUid)
-            .blockingGet()
+            .getInternal()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
@@ -29,6 +29,9 @@
 package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -50,12 +53,16 @@ class DataStoreDownloader internal constructor(
     /**
      * Download and persist the content in the dataStore according to the filters specified.
      */
-    fun download(): Observable<D2Progress> {
+    fun suspendDownload(): Flow<D2Progress> {
         return call.download(params)
     }
 
+    fun download(): Observable<D2Progress> {
+        return suspendDownload().asObservable()
+    }
+
     fun blockingDownload() {
-        download().blockingSubscribe()
+        runBlocking { suspendDownload().collect {} }
     }
 
     fun byNamespace(): ListFilterConnector<DataStoreDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
@@ -66,7 +67,7 @@ class DataStoreDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        rxDownload().blockingSubscribe()
+        runBlocking { flowDownload().collect {} }
     }
 
     fun byNamespace(): ListFilterConnector<DataStoreDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
@@ -53,16 +53,21 @@ class DataStoreDownloader internal constructor(
     /**
      * Download and persist the content in the dataStore according to the filters specified.
      */
-    fun suspendDownload(): Flow<D2Progress> {
+    fun flowDownload(): Flow<D2Progress> {
         return call.download(params)
     }
 
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<D2Progress> {
-        return suspendDownload().asObservable()
+        return flowDownload().asObservable()
+    }
+
+    fun rxDownload(): Observable<D2Progress> {
+        return flowDownload().asObservable()
     }
 
     fun blockingDownload() {
-        runBlocking { suspendDownload().collect {} }
+        rxDownload().blockingSubscribe()
     }
 
     fun byNamespace(): ListFilterConnector<DataStoreDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
@@ -67,7 +68,7 @@ class DataStoreDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        runBlocking { flowDownload().collect {} }
+        flowDownload().collectAndWrapException()
     }
 
     fun byNamespace(): ListFilterConnector<DataStoreDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreDownloader.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/internal/DataStoreDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/internal/DataStoreDownloadCall.kt
@@ -28,8 +28,8 @@
 
 package org.hisp.dhis.android.core.datastore.internal
 
-import io.reactivex.Observable
-import kotlinx.coroutines.rx2.rxObservable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
@@ -48,7 +48,7 @@ internal class DataStoreDownloadCall(
     private val versionManager: DHISVersionManagerImpl,
 ) {
 
-    fun download(params: DataStoreDownloadParams): Observable<D2Progress> = rxObservable {
+    fun download(params: DataStoreDownloadParams): Flow<D2Progress> = channelFlow {
         coroutineAPICallExecutor.wrapTransactionallyRoom(cleanForeignKeyErrors = true) {
             val namespaces = networkHandler.getNamespaces()
                 .map { filterNamespaces(params, it) }

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader.kt
@@ -29,8 +29,11 @@
 package org.hisp.dhis.android.core.domain.aggregated.data
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 
 interface AggregatedDataDownloader {
+
+    fun suspendDownload(): Flow<AggregatedD2Progress>
 
     fun download(): Observable<AggregatedD2Progress>
 

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface AggregatedDataDownloader {
 
-    fun suspendDownload(): Flow<AggregatedD2Progress>
+    fun flowDownload(): Flow<AggregatedD2Progress>
 
     @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<AggregatedD2Progress>

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/AggregatedDataDownloader.kt
@@ -35,7 +35,10 @@ interface AggregatedDataDownloader {
 
     fun suspendDownload(): Flow<AggregatedD2Progress>
 
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<AggregatedD2Progress>
+
+    fun rxDownload(): Observable<AggregatedD2Progress>
 
     fun blockingDownload()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
@@ -45,7 +45,12 @@ internal class AggregatedDataDownloaderImpl(
         return dataCall.download()
     }
 
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     override fun download(): Observable<AggregatedD2Progress> {
+        return suspendDownload().asObservable()
+    }
+
+    override fun rxDownload(): Observable<AggregatedD2Progress> {
         return suspendDownload().asObservable()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.domain.aggregated.data.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedD2Progress

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.domain.aggregated.data.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedD2Progress
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedDataDownloader

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
@@ -29,6 +29,8 @@
 package org.hisp.dhis.android.core.domain.aggregated.data.internal
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedD2Progress
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedDataDownloader
@@ -39,11 +41,15 @@ internal class AggregatedDataDownloaderImpl(
     private val dataCall: AggregatedDataCall,
 ) : AggregatedDataDownloader {
 
+    override fun suspendDownload(): Flow<AggregatedD2Progress> {
+        return dataCall.download()
+    }
+
     override fun download(): Observable<AggregatedD2Progress> {
-        return dataCall.download().asObservable()
+        return suspendDownload().asObservable()
     }
 
     override fun blockingDownload() {
-        download().blockingSubscribe()
+        runBlocking { suspendDownload().collect {} }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
@@ -41,20 +41,20 @@ internal class AggregatedDataDownloaderImpl(
     private val dataCall: AggregatedDataCall,
 ) : AggregatedDataDownloader {
 
-    override fun suspendDownload(): Flow<AggregatedD2Progress> {
+    override fun flowDownload(): Flow<AggregatedD2Progress> {
         return dataCall.download()
     }
 
     @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     override fun download(): Observable<AggregatedD2Progress> {
-        return suspendDownload().asObservable()
+        return flowDownload().asObservable()
     }
 
     override fun rxDownload(): Observable<AggregatedD2Progress> {
-        return suspendDownload().asObservable()
+        return flowDownload().asObservable()
     }
 
     override fun blockingDownload() {
-        runBlocking { suspendDownload().collect {} }
+        rxDownload().blockingSubscribe()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataDownloaderImpl.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.domain.aggregated.data.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedD2Progress
 import org.hisp.dhis.android.core.domain.aggregated.data.AggregatedDataDownloader
@@ -54,6 +55,6 @@ internal class AggregatedDataDownloaderImpl(
     }
 
     override fun blockingDownload() {
-        rxDownload().blockingSubscribe()
+        runBlocking { flowDownload().collect {} }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentService.kt
@@ -41,7 +41,10 @@ interface EnrollmentService {
     /**
      * Checks if the enrollment status is ACTIVE.
      */
+    @Deprecated(message = "Use rxIsOpen instead", ReplaceWith("rxIsOpen(enrollmentUid)"))
     fun isOpen(enrollmentUid: String): Single<Boolean>
+
+    fun rxIsOpen(enrollmentUid: String): Single<Boolean>
 
     suspend fun suspendIsOpen(enrollmentUid: String): Boolean
 
@@ -58,13 +61,19 @@ interface EnrollmentService {
      * It checks the data access level to the program, the program access level (OPEN, PROTECTED,...)
      * and the enrollment orgunit scope (SEARCH or CAPTURE).
      */
+    @Deprecated(message = "Use rxGetEnrollmentAccess instead", ReplaceWith("rxGetEnrollmentAccess(trackedEntityInstanceUid, programUid)"))
     fun getEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess>
+
+    fun rxGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess>
 
     suspend fun suspendGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): EnrollmentAccess
 
     fun blockingGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean
 
+    @Deprecated(message = "Use rxAllowEventCreation instead", ReplaceWith("rxAllowEventCreation(enrollmentUid, stagesToHide)"))
     fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean>
+
+    fun rxAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean>
 
     suspend fun suspendGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentService.kt
@@ -43,6 +43,8 @@ interface EnrollmentService {
      */
     fun isOpen(enrollmentUid: String): Single<Boolean>
 
+    suspend fun suspendIsOpen(enrollmentUid: String): Boolean
+
     /**
      * Blocking version of [getEnrollmentAccess].
      *
@@ -58,7 +60,11 @@ interface EnrollmentService {
      */
     fun getEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess>
 
+    suspend fun suspendGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): EnrollmentAccess
+
     fun blockingGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean
 
     fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean>
+
+    suspend fun suspendGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/EnrollmentService.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.enrollment
 
 import io.reactivex.Single
 
+@Suppress("TooManyFunctions")
 interface EnrollmentService {
 
     /**
@@ -61,7 +62,10 @@ interface EnrollmentService {
      * It checks the data access level to the program, the program access level (OPEN, PROTECTED,...)
      * and the enrollment orgunit scope (SEARCH or CAPTURE).
      */
-    @Deprecated(message = "Use rxGetEnrollmentAccess instead", ReplaceWith("rxGetEnrollmentAccess(trackedEntityInstanceUid, programUid)"))
+    @Deprecated(
+        message = "Use rxGetEnrollmentAccess instead",
+        ReplaceWith("rxGetEnrollmentAccess(trackedEntityInstanceUid, programUid)"),
+    )
     fun getEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess>
 
     fun rxGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess>
@@ -70,7 +74,10 @@ interface EnrollmentService {
 
     fun blockingGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean
 
-    @Deprecated(message = "Use rxAllowEventCreation instead", ReplaceWith("rxAllowEventCreation(enrollmentUid, stagesToHide)"))
+    @Deprecated(
+        message = "Use rxAllowEventCreation instead",
+        ReplaceWith("rxAllowEventCreation(enrollmentUid, stagesToHide)"),
+    )
     fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean>
 
     fun rxAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean>

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -52,6 +52,7 @@ import org.hisp.dhis.android.persistence.trackedentity.ProgramTempOwnerTableInfo
 import org.koin.core.annotation.Singleton
 import java.util.Date
 
+@Suppress("TooManyFunctions")
 @Singleton
 internal class EnrollmentServiceImpl(
     private val enrollmentRepository: EnrollmentCollectionRepository,
@@ -64,7 +65,7 @@ internal class EnrollmentServiceImpl(
     private val programOwnerStore: ProgramOwnerStore,
 ) : EnrollmentService {
 
-    override fun blockingIsOpen(enrollmentUid: String): Boolean  {
+    override fun blockingIsOpen(enrollmentUid: String): Boolean {
         return runBlocking { suspendIsOpen(enrollmentUid) }
     }
 
@@ -158,7 +159,7 @@ internal class EnrollmentServiceImpl(
     }
 
     override fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean> {
-        return  rxSingle { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
+        return rxSingle { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
     }
 
     override suspend fun suspendGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -69,7 +69,12 @@ internal class EnrollmentServiceImpl(
         return runBlocking { suspendIsOpen(enrollmentUid) }
     }
 
+    @Deprecated(message = "Use rxIsOpen instead", ReplaceWith("rxIsOpen(enrollmentUid)"))
     override fun isOpen(enrollmentUid: String): Single<Boolean> {
+        return rxSingle { suspendIsOpen(enrollmentUid) }
+    }
+
+    override fun rxIsOpen(enrollmentUid: String): Single<Boolean> {
         return rxSingle { suspendIsOpen(enrollmentUid) }
     }
 
@@ -83,7 +88,12 @@ internal class EnrollmentServiceImpl(
         return runBlocking { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
     }
 
+    @Deprecated(message = "Use rxGetEnrollmentAccess instead", ReplaceWith("rxGetEnrollmentAccess(trackedEntityInstanceUid, programUid)"))
     override fun getEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess> {
+        return rxSingle { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
+    }
+
+    override fun rxGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess> {
         return rxSingle { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
     }
 
@@ -158,7 +168,12 @@ internal class EnrollmentServiceImpl(
         return runBlocking { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
     }
 
+    @Deprecated(message = "Use rxAllowEventCreation instead", ReplaceWith("rxAllowEventCreation(enrollmentUid, stagesToHide)"))
     override fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean> {
+        return rxSingle { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
+    }
+
+    override fun rxAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean> {
         return rxSingle { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -88,7 +88,10 @@ internal class EnrollmentServiceImpl(
         return runBlocking { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
     }
 
-    @Deprecated(message = "Use rxGetEnrollmentAccess instead", ReplaceWith("rxGetEnrollmentAccess(trackedEntityInstanceUid, programUid)"))
+    @Deprecated(
+        message = "Use rxGetEnrollmentAccess instead",
+        ReplaceWith("rxGetEnrollmentAccess(trackedEntityInstanceUid, programUid)"),
+    )
     override fun getEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess> {
         return rxSingle { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
     }
@@ -168,7 +171,10 @@ internal class EnrollmentServiceImpl(
         return runBlocking { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
     }
 
-    @Deprecated(message = "Use rxAllowEventCreation instead", ReplaceWith("rxAllowEventCreation(enrollmentUid, stagesToHide)"))
+    @Deprecated(
+        message = "Use rxAllowEventCreation instead",
+        ReplaceWith("rxAllowEventCreation(enrollmentUid, stagesToHide)"),
+    )
     override fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean> {
         return rxSingle { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -64,25 +64,29 @@ internal class EnrollmentServiceImpl(
     private val programOwnerStore: ProgramOwnerStore,
 ) : EnrollmentService {
 
-    override fun blockingIsOpen(enrollmentUid: String): Boolean {
-        val enrollment = enrollmentRepository.uid(enrollmentUid).blockingGet() ?: return true
+    override fun blockingIsOpen(enrollmentUid: String): Boolean  {
+        return runBlocking { suspendIsOpen(enrollmentUid) }
+    }
+
+    override fun isOpen(enrollmentUid: String): Single<Boolean> {
+        return rxSingle { suspendIsOpen(enrollmentUid) }
+    }
+
+    override suspend fun suspendIsOpen(enrollmentUid: String): Boolean {
+        val enrollment = enrollmentRepository.uid(enrollmentUid).getInternal() ?: return true
 
         return enrollment.status()?.equals(EnrollmentStatus.ACTIVE) ?: false
     }
 
-    override fun isOpen(enrollmentUid: String): Single<Boolean> {
-        return Single.fromCallable { blockingIsOpen(enrollmentUid) }
+    override fun blockingGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): EnrollmentAccess {
+        return runBlocking { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
     }
 
     override fun getEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): Single<EnrollmentAccess> {
-        return rxSingle { getEnrollmentAccessInternal(trackedEntityInstanceUid, programUid) }
+        return rxSingle { suspendGetEnrollmentAccess(trackedEntityInstanceUid, programUid) }
     }
 
-    override fun blockingGetEnrollmentAccess(trackedEntityInstanceUid: String, programUid: String): EnrollmentAccess {
-        return runBlocking { getEnrollmentAccessInternal(trackedEntityInstanceUid, programUid) }
-    }
-
-    private suspend fun getEnrollmentAccessInternal(
+    override suspend fun suspendGetEnrollmentAccess(
         trackedEntityInstanceUid: String,
         programUid: String,
     ): EnrollmentAccess {
@@ -120,13 +124,13 @@ internal class EnrollmentServiceImpl(
         }
     }
 
-    private fun isTeiInCaptureScope(trackedEntityInstanceUid: String): Boolean {
-        val tei = trackedEntityInstanceRepository.uid(trackedEntityInstanceUid).blockingGet()
+    private suspend fun isTeiInCaptureScope(trackedEntityInstanceUid: String): Boolean {
+        val tei = trackedEntityInstanceRepository.uid(trackedEntityInstanceUid).getInternal()
 
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .uid(tei?.organisationUnit())
-            .blockingExists()
+            .existsInternal()
     }
 
     private suspend fun hasProgramOwnership(trackedEntityInstanceUid: String, programUid: String): Boolean {
@@ -150,30 +154,29 @@ internal class EnrollmentServiceImpl(
     }
 
     override fun blockingGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean {
-        val programStages = eventCollectionRepository.byEnrollmentUid().eq(enrollmentUid)
-            .byDeleted().isFalse.get()
-            .toFlowable().flatMapIterable { events: List<Event>? -> events }
-            .map { event: Event -> event.programStage() }
-            .toList()
-            .flatMap { currentProgramStagesUids: List<String?> ->
-                val repository = programStagesCollectionRepository.byProgramUid().eq(
-                    enrollmentRepository.uid(enrollmentUid).blockingGet()?.program(),
-                ).byAccessDataWrite().isTrue
-
-                repository.get().toFlowable()
-                    .flatMapIterable { stages: List<ProgramStage>? -> stages }
-                    .filter { programStage: ProgramStage ->
-                        !currentProgramStagesUids.contains(programStage.uid()) ||
-                            programStage.repeatable()!!
-                    }
-                    .toList()
-            }.blockingGet()
-
-        return programStages.find { !stagesToHide.contains(it.uid()) } != null
+        return runBlocking { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
     }
 
     override fun allowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Single<Boolean> {
-        return Single.fromCallable { blockingGetAllowEventCreation(enrollmentUid, stagesToHide) }
+        return  rxSingle { suspendGetAllowEventCreation(enrollmentUid, stagesToHide) }
+    }
+
+    override suspend fun suspendGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean {
+        val currentProgramStagesUids = eventCollectionRepository.byEnrollmentUid().eq(enrollmentUid)
+            .byDeleted().isFalse.getInternal()
+            .map { event: Event -> event.programStage() }
+
+        val enrollment = enrollmentRepository.uid(enrollmentUid).getInternal()
+        val programStages = programStagesCollectionRepository.byProgramUid().eq(
+            enrollment?.program(),
+        ).byAccessDataWrite().isTrue
+            .getInternal()
+            .filter { programStage: ProgramStage ->
+                !currentProgramStagesUids.contains(programStage.uid()) ||
+                    programStage.repeatable()!!
+            }
+
+        return programStages.find { !stagesToHide.contains(it.uid()) } != null
     }
 
     private suspend fun hasTempOwnership(tei: String, program: String): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -64,10 +65,6 @@ class EventDownloader internal constructor(
         return call.download(params)
     }
 
-    suspend fun suspendDownload() {
-        flowDownload().collect {}
-    }
-
     @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<TrackerD2Progress> {
         return flowDownload().asObservable()
@@ -78,7 +75,7 @@ class EventDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        rxDownload().blockingSubscribe()
+        runBlocking { flowDownload().collect {} }
     }
 
     fun byUid(): ListFilterConnector<EventDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -64,7 +64,12 @@ class EventDownloader internal constructor(
         return call.download(params)
     }
 
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<TrackerD2Progress> {
+        return suspendDownload().asObservable()
+    }
+
+    fun rxDownload(): Observable<TrackerD2Progress> {
         return suspendDownload().asObservable()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -31,6 +31,7 @@ import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
@@ -75,7 +76,7 @@ class EventDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        runBlocking { flowDownload().collect {} }
+        flowDownload().collectAndWrapException()
     }
 
     fun byUid(): ListFilterConnector<EventDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -58,12 +60,16 @@ class EventDownloader internal constructor(
      *
      * @return -
      */
+    fun suspendDownload(): Flow<TrackerD2Progress> {
+        return call.download(params)
+    }
+
     fun download(): Observable<TrackerD2Progress> {
-        return call.download(params).asObservable()
+        return suspendDownload().asObservable()
     }
 
     fun blockingDownload() {
-        download().blockingSubscribe()
+        runBlocking { suspendDownload().collect {} }
     }
 
     fun byUid(): ListFilterConnector<EventDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -40,6 +39,7 @@ import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
 
 @Singleton
+@Suppress("TooManyFunctions")
 class EventDownloader internal constructor(
     private val call: EventDownloadCall,
     private val params: ProgramDataDownloadParams,

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -60,21 +60,25 @@ class EventDownloader internal constructor(
      *
      * @return -
      */
-    fun suspendDownload(): Flow<TrackerD2Progress> {
+    fun flowDownload(): Flow<TrackerD2Progress> {
         return call.download(params)
+    }
+
+    suspend fun suspendDownload() {
+        flowDownload().collect {}
     }
 
     @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<TrackerD2Progress> {
-        return suspendDownload().asObservable()
+        return flowDownload().asObservable()
     }
 
     fun rxDownload(): Observable<TrackerD2Progress> {
-        return suspendDownload().asObservable()
+        return flowDownload().asObservable()
     }
 
     fun blockingDownload() {
-        runBlocking { suspendDownload().collect {} }
+        rxDownload().blockingSubscribe()
     }
 
     fun byUid(): ListFilterConnector<EventDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventService.kt
@@ -47,6 +47,8 @@ interface EventService {
      */
     fun hasDataWriteAccess(eventUid: String): Single<Boolean>
 
+    suspend fun suspendHasDataWriteAccess(eventUid: String): Boolean
+
     /**
      * Blocking version of [isInOrgunitRange].
      *
@@ -58,6 +60,8 @@ interface EventService {
      * Check if the event has the event date within the opening period of the assigned organisation unit.
      */
     fun isInOrgunitRange(event: Event): Single<Boolean>
+
+    suspend fun suspendIsInOrgunitRange(event: Event): Boolean
 
     /**
      * Blocking version of [hasCategoryComboAccess].
@@ -72,6 +76,8 @@ interface EventService {
      */
     fun hasCategoryComboAccess(event: Event): Single<Boolean>
 
+    suspend fun suspendHasCategoryComboAccess(event: Event): Boolean
+
     /**
      * Blocking version of [isEditable].
      *
@@ -84,6 +90,8 @@ interface EventService {
      * the method [getEditableStatus] for a richer description of the status.
      */
     fun isEditable(eventUid: String): Single<Boolean>
+
+    suspend fun suspendIsEditable(eventUid: String): Boolean
 
     /**
      * Blocking version of [getEditableStatus].
@@ -98,6 +106,8 @@ interface EventService {
      */
     fun getEditableStatus(eventUid: String): Single<EventEditableStatus>
 
+    suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus
+
     /**
      * Blocking version of [canAddEventToEnrollment].
      *
@@ -111,4 +121,6 @@ interface EventService {
      * It takes into account the enrollment status and if the program stage is repeatable or not.
      */
     fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean>
+
+    suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventService.kt
@@ -135,7 +135,10 @@ interface EventService {
      *
      * It takes into account the enrollment status and if the program stage is repeatable or not.
      */
-    @Deprecated(message = "Use rxCanAddEventToEnrollment instead", ReplaceWith("rxCanAddEventToEnrollment(enrollmentUid, programStageUid)"))
+    @Deprecated(
+        message = "Use rxCanAddEventToEnrollment instead",
+        ReplaceWith("rxCanAddEventToEnrollment(enrollmentUid, programStageUid)"),
+    )
     fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean>
 
     fun rxCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean>

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventService.kt
@@ -45,7 +45,10 @@ interface EventService {
      * It returns true if the user has data write access to both the program and the program stage.
      * If the event does not exist, returns null
      */
+    @Deprecated(message = "Use rxHasDataWriteAccess instead", ReplaceWith("rxHasDataWriteAccess(eventUid)"))
     fun hasDataWriteAccess(eventUid: String): Single<Boolean>
+
+    fun rxHasDataWriteAccess(eventUid: String): Single<Boolean>
 
     suspend fun suspendHasDataWriteAccess(eventUid: String): Boolean
 
@@ -59,7 +62,10 @@ interface EventService {
     /**
      * Check if the event has the event date within the opening period of the assigned organisation unit.
      */
+    @Deprecated(message = "Use rxIsInOrgunitRange instead", ReplaceWith("rxIsInOrgunitRange(event)"))
     fun isInOrgunitRange(event: Event): Single<Boolean>
+
+    fun rxIsInOrgunitRange(event: Event): Single<Boolean>
 
     suspend fun suspendIsInOrgunitRange(event: Event): Boolean
 
@@ -74,7 +80,10 @@ interface EventService {
      * Check if user has access to the categoryCombo linked to the event and also if the categoryCombo is active
      * in the event date.
      */
+    @Deprecated(message = "Use rxHasCategoryComboAccess instead", ReplaceWith("rxHasCategoryComboAccess(event)"))
     fun hasCategoryComboAccess(event: Event): Single<Boolean>
+
+    fun rxHasCategoryComboAccess(event: Event): Single<Boolean>
 
     suspend fun suspendHasCategoryComboAccess(event: Event): Boolean
 
@@ -89,7 +98,10 @@ interface EventService {
      * Check if the event can be edited or not. If you want to know the reason why the event is not editable, check
      * the method [getEditableStatus] for a richer description of the status.
      */
+    @Deprecated(message = "Use rxIsEditable instead", ReplaceWith("rxIsEditable(eventUid)"))
     fun isEditable(eventUid: String): Single<Boolean>
+
+    fun rxIsEditable(eventUid: String): Single<Boolean>
 
     suspend fun suspendIsEditable(eventUid: String): Boolean
 
@@ -104,7 +116,10 @@ interface EventService {
      * Returns the editable status of an event. In case the event is not editable, the result also includes the
      * reason why it is not editable.
      */
+    @Deprecated(message = "Use rxGetEditableStatus instead", ReplaceWith("rxGetEditableStatus(eventUid)"))
     fun getEditableStatus(eventUid: String): Single<EventEditableStatus>
+
+    fun rxGetEditableStatus(eventUid: String): Single<EventEditableStatus>
 
     suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus
 
@@ -120,7 +135,10 @@ interface EventService {
      *
      * It takes into account the enrollment status and if the program stage is repeatable or not.
      */
+    @Deprecated(message = "Use rxCanAddEventToEnrollment instead", ReplaceWith("rxCanAddEventToEnrollment(enrollmentUid, programStageUid)"))
     fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean>
+
+    fun rxCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean>
 
     suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -73,46 +73,60 @@ internal class EventServiceImpl(
     }
 
     override fun blockingIsInOrgunitRange(event: Event): Boolean {
-        return event.eventDate()?.let { eventDate ->
-            event.organisationUnit()?.let { orgunitUid ->
-                organisationUnitService.blockingIsDateInOrgunitRange(orgunitUid, eventDate)
-            }
-        } ?: true
+        return runBlocking { suspendIsInOrgunitRange(event) }
     }
 
     override fun isInOrgunitRange(event: Event): Single<Boolean> {
         return Single.just(blockingIsInOrgunitRange(event))
     }
 
-    override suspend fun suspendIsInOrgunitRange(event: Event): Boolean = blockingIsInOrgunitRange(event)
+    override suspend fun suspendIsInOrgunitRange(event: Event): Boolean {
+        return event.eventDate()?.let { eventDate ->
+            event.organisationUnit()?.let { orgunitUid ->
+                organisationUnitService.suspendIsDateInOrgunitRange(orgunitUid, eventDate)
+            }
+        } ?: true
+    }
 
     override fun blockingHasCategoryComboAccess(event: Event): Boolean {
-        return event.attributeOptionCombo()?.let {
-            categoryOptionComboService.blockingHasAccess(it, event.eventDate())
-        } ?: true
+        return runBlocking { suspendHasCategoryComboAccess(event) }
     }
 
     override fun hasCategoryComboAccess(event: Event): Single<Boolean> {
         return Single.just(blockingHasCategoryComboAccess(event))
     }
 
-    override suspend fun suspendHasCategoryComboAccess(event: Event): Boolean = blockingHasCategoryComboAccess(event)
+    override suspend fun suspendHasCategoryComboAccess(event: Event): Boolean {
+        return event.attributeOptionCombo()?.let {
+            categoryOptionComboService.suspendHasAccess(it, event.eventDate())
+        } ?: true
+    }
 
     override fun blockingIsEditable(eventUid: String): Boolean {
-        return blockingGetEditableStatus(eventUid) is EventEditableStatus.Editable
+        return runBlocking { suspendIsEditable(eventUid) }
     }
 
     override fun isEditable(eventUid: String): Single<Boolean> {
         return Single.just(blockingIsEditable(eventUid))
     }
 
-    override suspend fun suspendIsEditable(eventUid: String): Boolean = blockingIsEditable(eventUid)
+    override suspend fun suspendIsEditable(eventUid: String): Boolean {
+        return suspendGetEditableStatus(eventUid) is EventEditableStatus.Editable
+    }
 
     @Suppress("ComplexMethod")
     override fun blockingGetEditableStatus(eventUid: String): EventEditableStatus {
-        val event = eventRepository.uid(eventUid).blockingGet()!!
-        val program = programRepository.uid(event.program()).blockingGet()
-        val programStage = programStageRepository.uid(event.programStage()).blockingGet()
+        return runBlocking { suspendGetEditableStatus(eventUid) }
+    }
+
+    override fun getEditableStatus(eventUid: String): Single<EventEditableStatus> {
+        return Single.just(blockingGetEditableStatus(eventUid))
+    }
+
+    override suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus {
+        val event = eventRepository.uid(eventUid).getInternal()!!
+        val program = programRepository.uid(event.program()).getInternal()
+        val programStage = programStageRepository.uid(event.programStage()).getInternal()
 
         return when {
             event.status() == EventStatus.COMPLETED && programStage?.blockEntryForm() == true ->
@@ -126,16 +140,16 @@ internal class EventServiceImpl(
             ) ->
                 EventEditableStatus.NonEditable(EventNonEditableReason.EXPIRED)
 
-            !blockingHasDataWriteAccess(eventUid) ->
+            !suspendHasDataWriteAccess(eventUid) ->
                 EventEditableStatus.NonEditable(EventNonEditableReason.NO_DATA_WRITE_ACCESS)
 
-            !blockingIsInOrgunitRange(event) ->
+            !suspendIsInOrgunitRange(event) ->
                 EventEditableStatus.NonEditable(EventNonEditableReason.EVENT_DATE_IS_NOT_IN_ORGUNIT_RANGE)
 
-            !blockingHasCategoryComboAccess(event) ->
+            !suspendHasCategoryComboAccess(event) ->
                 EventEditableStatus.NonEditable(EventNonEditableReason.NO_CATEGORY_COMBO_ACCESS)
 
-            event.enrollment()?.let { !enrollmentService.blockingIsOpen(it) } ?: false ->
+            event.enrollment()?.let { !enrollmentService.suspendIsOpen(it) } ?: false ->
                 EventEditableStatus.NonEditable(EventNonEditableReason.ENROLLMENT_IS_NOT_OPEN)
 
             !isOwnedByUser(event, program?.accessLevel()) ->
@@ -146,15 +160,17 @@ internal class EventServiceImpl(
         }
     }
 
-    override fun getEditableStatus(eventUid: String): Single<EventEditableStatus> {
-        return Single.just(blockingGetEditableStatus(eventUid))
+    override fun blockingCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean {
+        return runBlocking { suspendCanAddEventToEnrollment(enrollmentUid, programStageUid) }
     }
 
-    override suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus = blockingGetEditableStatus(eventUid)
+    override fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean> {
+        return Single.just(blockingCanAddEventToEnrollment(enrollmentUid, programStageUid))
+    }
 
-    override fun blockingCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean {
-        val enrollment = enrollmentRepository.uid(enrollmentUid).blockingGet()
-        val programStage = programStageRepository.uid(programStageUid).blockingGet()
+    override suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean {
+        val enrollment = enrollmentRepository.uid(enrollmentUid).getInternal()
+        val programStage = programStageRepository.uid(programStageUid).getInternal()
 
         if (enrollment == null || programStage == null) {
             return false
@@ -172,18 +188,11 @@ internal class EventServiceImpl(
         return isActiveEnrollment && acceptMoreEvents
     }
 
-    override fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean> {
-        return Single.just(blockingCanAddEventToEnrollment(enrollmentUid, programStageUid))
-    }
-
-    override suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean =
-        blockingCanAddEventToEnrollment(enrollmentUid, programStageUid)
-
     @Suppress("ReturnCount")
-    private fun isOwnedByUser(event: Event, accessLevel: AccessLevel?): Boolean {
-        val ownerOrgUnit = runBlocking { getOwnerOrgUnit(event) } ?: return false
+    private suspend fun isOwnedByUser(event: Event, accessLevel: AccessLevel?): Boolean {
+        val ownerOrgUnit = getOwnerOrgUnit(event) ?: return false
 
-        if (organisationUnitService.blockingIsInCaptureScope(ownerOrgUnit)) return true
+        if (organisationUnitService.suspendIsInCaptureScope(ownerOrgUnit)) return true
 
         val allowsSearchScope = (accessLevel ?: AccessLevel.OPEN) in listOf(AccessLevel.OPEN, AccessLevel.AUDITED)
         return allowsSearchScope && organisationUnitService.blockingIsInSearchScope(ownerOrgUnit)
@@ -207,11 +216,11 @@ internal class EventServiceImpl(
             ?: event.organisationUnit()
     }
 
-    private fun getEventCount(enrollmentUid: String, programStageUid: String): Int {
+    private suspend fun getEventCount(enrollmentUid: String, programStageUid: String): Int {
         return eventRepository
             .byEnrollmentUid().eq(enrollmentUid)
             .byProgramStageUid().eq(programStageUid)
             .byDeleted().isFalse
-            .blockingCount()
+            .countInternal()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -59,13 +59,17 @@ internal class EventServiceImpl(
 ) : EventService {
 
     override fun blockingHasDataWriteAccess(eventUid: String): Boolean {
-        val event = eventRepository.uid(eventUid).blockingGet() ?: return false
-
-        return programStageRepository.uid(event.programStage()).blockingGet()?.access()?.data()?.write() ?: false
+        return runBlocking { suspendHasDataWriteAccess(eventUid) }
     }
 
     override fun hasDataWriteAccess(eventUid: String): Single<Boolean> {
         return Single.just(blockingHasDataWriteAccess(eventUid))
+    }
+
+    override suspend fun suspendHasDataWriteAccess(eventUid: String): Boolean {
+        val event = eventRepository.uid(eventUid).getInternal() ?: return false
+
+        return programStageRepository.uid(event.programStage()).getInternal()?.access()?.data()?.write() ?: false
     }
 
     override fun blockingIsInOrgunitRange(event: Event): Boolean {
@@ -80,6 +84,8 @@ internal class EventServiceImpl(
         return Single.just(blockingIsInOrgunitRange(event))
     }
 
+    override suspend fun suspendIsInOrgunitRange(event: Event): Boolean = blockingIsInOrgunitRange(event)
+
     override fun blockingHasCategoryComboAccess(event: Event): Boolean {
         return event.attributeOptionCombo()?.let {
             categoryOptionComboService.blockingHasAccess(it, event.eventDate())
@@ -90,6 +96,8 @@ internal class EventServiceImpl(
         return Single.just(blockingHasCategoryComboAccess(event))
     }
 
+    override suspend fun suspendHasCategoryComboAccess(event: Event): Boolean = blockingHasCategoryComboAccess(event)
+
     override fun blockingIsEditable(eventUid: String): Boolean {
         return blockingGetEditableStatus(eventUid) is EventEditableStatus.Editable
     }
@@ -97,6 +105,8 @@ internal class EventServiceImpl(
     override fun isEditable(eventUid: String): Single<Boolean> {
         return Single.just(blockingIsEditable(eventUid))
     }
+
+    override suspend fun suspendIsEditable(eventUid: String): Boolean = blockingIsEditable(eventUid)
 
     @Suppress("ComplexMethod")
     override fun blockingGetEditableStatus(eventUid: String): EventEditableStatus {
@@ -140,6 +150,8 @@ internal class EventServiceImpl(
         return Single.just(blockingGetEditableStatus(eventUid))
     }
 
+    override suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus = blockingGetEditableStatus(eventUid)
+
     override fun blockingCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean {
         val enrollment = enrollmentRepository.uid(enrollmentUid).blockingGet()
         val programStage = programStageRepository.uid(programStageUid).blockingGet()
@@ -163,6 +175,9 @@ internal class EventServiceImpl(
     override fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean> {
         return Single.just(blockingCanAddEventToEnrollment(enrollmentUid, programStageUid))
     }
+
+    override suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean =
+        blockingCanAddEventToEnrollment(enrollmentUid, programStageUid)
 
     @Suppress("ReturnCount")
     private fun isOwnedByUser(event: Event, accessLevel: AccessLevel?): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -190,7 +190,10 @@ internal class EventServiceImpl(
         return runBlocking { suspendCanAddEventToEnrollment(enrollmentUid, programStageUid) }
     }
 
-    @Deprecated(message = "Use rxCanAddEventToEnrollment instead", ReplaceWith("rxCanAddEventToEnrollment(enrollmentUid, programStageUid)"))
+    @Deprecated(
+        message = "Use rxCanAddEventToEnrollment instead",
+        ReplaceWith("rxCanAddEventToEnrollment(enrollmentUid, programStageUid)"),
+    )
     override fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean> {
         return rxSingle { suspendCanAddEventToEnrollment(enrollmentUid, programStageUid) }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -201,7 +201,7 @@ internal class EventServiceImpl(
     private suspend fun getOwnerOrgUnit(event: Event): String? {
         val program = event.program()
         val tei = event.enrollment()
-            ?.let { enrollmentRepository.uid(it).blockingGet() }
+            ?.let { enrollmentRepository.uid(it).getInternal() }
             ?.trackedEntityInstance()
 
         if (program == null || tei == null) return event.organisationUnit()

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -195,7 +195,7 @@ internal class EventServiceImpl(
         if (organisationUnitService.suspendIsInCaptureScope(ownerOrgUnit)) return true
 
         val allowsSearchScope = (accessLevel ?: AccessLevel.OPEN) in listOf(AccessLevel.OPEN, AccessLevel.AUDITED)
-        return allowsSearchScope && organisationUnitService.blockingIsInSearchScope(ownerOrgUnit)
+        return allowsSearchScope && organisationUnitService.isInSearchScope(ownerOrgUnit)
     }
 
     private suspend fun getOwnerOrgUnit(event: Event): String? {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.event.internal
 
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.category.CategoryOptionComboService
 import org.hisp.dhis.android.core.enrollment.EnrollmentCollectionRepository
 import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
@@ -62,8 +63,13 @@ internal class EventServiceImpl(
         return runBlocking { suspendHasDataWriteAccess(eventUid) }
     }
 
+    @Deprecated(message = "Use rxHasDataWriteAccess instead", ReplaceWith("rxHasDataWriteAccess(eventUid)"))
     override fun hasDataWriteAccess(eventUid: String): Single<Boolean> {
-        return Single.just(blockingHasDataWriteAccess(eventUid))
+        return rxSingle { suspendHasDataWriteAccess(eventUid) }
+    }
+
+    override fun rxHasDataWriteAccess(eventUid: String): Single<Boolean> {
+        return rxSingle { suspendHasDataWriteAccess(eventUid) }
     }
 
     override suspend fun suspendHasDataWriteAccess(eventUid: String): Boolean {
@@ -76,8 +82,13 @@ internal class EventServiceImpl(
         return runBlocking { suspendIsInOrgunitRange(event) }
     }
 
+    @Deprecated(message = "Use rxIsInOrgunitRange instead", ReplaceWith("rxIsInOrgunitRange(event)"))
     override fun isInOrgunitRange(event: Event): Single<Boolean> {
-        return Single.just(blockingIsInOrgunitRange(event))
+        return rxSingle { suspendIsInOrgunitRange(event) }
+    }
+
+    override fun rxIsInOrgunitRange(event: Event): Single<Boolean> {
+        return rxSingle { suspendIsInOrgunitRange(event) }
     }
 
     override suspend fun suspendIsInOrgunitRange(event: Event): Boolean {
@@ -92,8 +103,13 @@ internal class EventServiceImpl(
         return runBlocking { suspendHasCategoryComboAccess(event) }
     }
 
+    @Deprecated(message = "Use rxHasCategoryComboAccess instead", ReplaceWith("rxHasCategoryComboAccess(event)"))
     override fun hasCategoryComboAccess(event: Event): Single<Boolean> {
-        return Single.just(blockingHasCategoryComboAccess(event))
+        return rxSingle { suspendHasCategoryComboAccess(event) }
+    }
+
+    override fun rxHasCategoryComboAccess(event: Event): Single<Boolean> {
+        return rxSingle { suspendHasCategoryComboAccess(event) }
     }
 
     override suspend fun suspendHasCategoryComboAccess(event: Event): Boolean {
@@ -106,8 +122,13 @@ internal class EventServiceImpl(
         return runBlocking { suspendIsEditable(eventUid) }
     }
 
+    @Deprecated(message = "Use rxIsEditable instead", ReplaceWith("rxIsEditable(eventUid)"))
     override fun isEditable(eventUid: String): Single<Boolean> {
-        return Single.just(blockingIsEditable(eventUid))
+        return rxSingle { suspendIsEditable(eventUid) }
+    }
+
+    override fun rxIsEditable(eventUid: String): Single<Boolean> {
+        return rxSingle { suspendIsEditable(eventUid) }
     }
 
     override suspend fun suspendIsEditable(eventUid: String): Boolean {
@@ -119,8 +140,13 @@ internal class EventServiceImpl(
         return runBlocking { suspendGetEditableStatus(eventUid) }
     }
 
+    @Deprecated(message = "Use rxGetEditableStatus instead", ReplaceWith("rxGetEditableStatus(eventUid)"))
     override fun getEditableStatus(eventUid: String): Single<EventEditableStatus> {
-        return Single.just(blockingGetEditableStatus(eventUid))
+        return rxSingle { suspendGetEditableStatus(eventUid) }
+    }
+
+    override fun rxGetEditableStatus(eventUid: String): Single<EventEditableStatus> {
+        return rxSingle { suspendGetEditableStatus(eventUid) }
     }
 
     override suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus {
@@ -164,8 +190,13 @@ internal class EventServiceImpl(
         return runBlocking { suspendCanAddEventToEnrollment(enrollmentUid, programStageUid) }
     }
 
+    @Deprecated(message = "Use rxCanAddEventToEnrollment instead", ReplaceWith("rxCanAddEventToEnrollment(enrollmentUid, programStageUid)"))
     override fun canAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean> {
-        return Single.just(blockingCanAddEventToEnrollment(enrollmentUid, programStageUid))
+        return rxSingle { suspendCanAddEventToEnrollment(enrollmentUid, programStageUid) }
+    }
+
+    override fun rxCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Single<Boolean> {
+        return rxSingle { suspendCanAddEventToEnrollment(enrollmentUid, programStageUid) }
     }
 
     override suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.fileresource
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.fileresource
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
@@ -71,7 +72,7 @@ class FileResourceDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        rxDownload().blockingSubscribe()
+        runBlocking { flowDownload().collect {} }
     }
 
     fun byTrackedEntityUid(): ListFilterConnector<FileResourceDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.fileresource
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -58,16 +58,21 @@ class FileResourceDownloader internal constructor(
      *
      * @return -
      */
-    fun suspendDownload(): Flow<D2Progress> {
+    fun flowDownload(): Flow<D2Progress> {
         return call.download(params)
     }
 
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<D2Progress> {
-        return suspendDownload().asObservable()
+        return flowDownload().asObservable()
+    }
+
+    fun rxDownload(): Observable<D2Progress> {
+        return flowDownload().asObservable()
     }
 
     fun blockingDownload() {
-        runBlocking { suspendDownload().collect {} }
+        rxDownload().blockingSubscribe()
     }
 
     fun byTrackedEntityUid(): ListFilterConnector<FileResourceDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EqFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -72,7 +73,7 @@ class FileResourceDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        runBlocking { flowDownload().collect {} }
+        flowDownload().collectAndWrapException()
     }
 
     fun byTrackedEntityUid(): ListFilterConnector<FileResourceDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.fileresource
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
@@ -56,12 +58,16 @@ class FileResourceDownloader internal constructor(
      *
      * @return -
      */
+    fun suspendDownload(): Flow<D2Progress> {
+        return call.download(params)
+    }
+
     fun download(): Observable<D2Progress> {
-        return call.download(params).asObservable()
+        return suspendDownload().asObservable()
     }
 
     fun blockingDownload() {
-        download().blockingSubscribe()
+        runBlocking { suspendDownload().collect {} }
     }
 
     fun byTrackedEntityUid(): ListFilterConnector<FileResourceDownloader, String> {

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.imports
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.tracker.importer.internal.JobQueryCall
@@ -53,6 +54,6 @@ class TrackerJobManager internal constructor(
     }
 
     fun blockingResumePendingJobs() {
-        rxResumePendingJobs().blockingSubscribe()
+        runBlocking { flowResumePendingJobs().collect {} }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
@@ -29,6 +29,8 @@
 package org.hisp.dhis.android.core.imports
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.tracker.importer.internal.JobQueryCall
@@ -38,11 +40,15 @@ import org.koin.core.annotation.Singleton
 class TrackerJobManager internal constructor(
     private val jobQueryCall: JobQueryCall,
 ) {
+    fun suspendResumePendingJobs(): Flow<D2Progress> {
+        return jobQueryCall.queryPendingJobs()
+    }
+
     fun resumePendingJobs(): Observable<D2Progress> {
-        return jobQueryCall.queryPendingJobs().asObservable()
+        return suspendResumePendingJobs().asObservable()
     }
 
     fun blockingResumePendingJobs() {
-        resumePendingJobs().blockingSubscribe()
+        runBlocking { suspendResumePendingJobs().collect {} }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
@@ -40,15 +40,20 @@ import org.koin.core.annotation.Singleton
 class TrackerJobManager internal constructor(
     private val jobQueryCall: JobQueryCall,
 ) {
-    fun suspendResumePendingJobs(): Flow<D2Progress> {
+    fun flowResumePendingJobs(): Flow<D2Progress> {
         return jobQueryCall.queryPendingJobs()
     }
 
+    @Deprecated(message = "Use rxResumePendingJobs instead", ReplaceWith("rxResumePendingJobs()"))
     fun resumePendingJobs(): Observable<D2Progress> {
-        return suspendResumePendingJobs().asObservable()
+        return flowResumePendingJobs().asObservable()
+    }
+
+    fun rxResumePendingJobs(): Observable<D2Progress> {
+        return flowResumePendingJobs().asObservable()
     }
 
     fun blockingResumePendingJobs() {
-        runBlocking { suspendResumePendingJobs().collect {} }
+        rxResumePendingJobs().blockingSubscribe()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.imports
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.tracker.importer.internal.JobQueryCall

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerDownloader.kt
@@ -38,7 +38,11 @@ class MapLayerDownloader internal constructor(
     private val mapLayerCallFactory: MapLayerCallFactory,
 ) : UntypedModuleDownloader {
 
+    suspend fun suspendDownloadMetadata() {
+        mapLayerCallFactory.downloadMetadata()
+    }
+
     override fun downloadMetadata(): Completable {
-        return rxCompletable { mapLayerCallFactory.downloadMetadata() }
+        return rxCompletable { suspendDownloadMetadata() }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/map/layer/MapLayerDownloader.kt
@@ -42,7 +42,12 @@ class MapLayerDownloader internal constructor(
         mapLayerCallFactory.downloadMetadata()
     }
 
+    @Deprecated(message = "Use rxDownloadMetadata instead", ReplaceWith("rxDownloadMetadata()"))
     override fun downloadMetadata(): Completable {
+        return rxCompletable { suspendDownloadMetadata() }
+    }
+
+    fun rxDownloadMetadata(): Completable {
         return rxCompletable { suspendDownloadMetadata() }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -42,7 +42,12 @@ class OrganisationUnitService(
         return runBlocking { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
     }
 
+    @Deprecated(message = "Use rxIsDateInOrgunitRange instead", ReplaceWith("rxIsDateInOrgunitRange(organisationUnitUid, date)"))
     fun isDateInOrgunitRange(organisationUnitUid: String, date: Date): Single<Boolean> {
+        return rxSingle { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
+    }
+
+    fun rxIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Single<Boolean> {
         return rxSingle { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
     }
 
@@ -57,7 +62,12 @@ class OrganisationUnitService(
         suspendIsInCaptureScope(organisationUnitUid)
     }
 
+    @Deprecated(message = "Use rxIsInCaptureScope instead", ReplaceWith("rxIsInCaptureScope(organisationUnitUid)"))
     fun isInCaptureScope(organisationUnitUid: String): Single<Boolean> {
+        return rxSingle { suspendIsInCaptureScope(organisationUnitUid) }
+    }
+
+    fun rxIsInCaptureScope(organisationUnitUid: String): Single<Boolean> {
         return rxSingle { suspendIsInCaptureScope(organisationUnitUid) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -38,8 +38,8 @@ class OrganisationUnitService(
     private val organisationUnitRepository: OrganisationUnitCollectionRepository,
 ) {
 
-    fun blockingIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean = runBlocking {
-        suspendIsDateInOrgunitRange(organisationUnitUid, date)
+    fun blockingIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean  {
+        return runBlocking { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
     }
 
     fun isDateInOrgunitRange(organisationUnitUid: String, date: Date): Single<Boolean> {

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -42,7 +42,10 @@ class OrganisationUnitService(
         return runBlocking { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
     }
 
-    @Deprecated(message = "Use rxIsDateInOrgunitRange instead", ReplaceWith("rxIsDateInOrgunitRange(organisationUnitUid, date)"))
+    @Deprecated(
+        message = "Use rxIsDateInOrgunitRange instead",
+        ReplaceWith("rxIsDateInOrgunitRange(organisationUnitUid, date)"),
+    )
     fun isDateInOrgunitRange(organisationUnitUid: String, date: Date): Single<Boolean> {
         return rxSingle { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -38,7 +38,7 @@ class OrganisationUnitService(
     private val organisationUnitRepository: OrganisationUnitCollectionRepository,
 ) {
 
-    fun blockingIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean  {
+    fun blockingIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean {
         return runBlocking { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -68,10 +68,10 @@ class OrganisationUnitService(
             .getInternal().isNotEmpty()
     }
 
-    internal fun blockingIsInSearchScope(organisationUnitUid: String): Boolean {
+    internal suspend fun isInSearchScope(organisationUnitUid: String): Boolean {
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_TEI_SEARCH)
             .byUid().eq(organisationUnitUid)
-            .blockingGet().isNotEmpty()
+            .getInternal().isNotEmpty()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.organisationunit
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.koin.core.annotation.Singleton
 import java.util.*
 
@@ -36,26 +38,34 @@ class OrganisationUnitService(
     private val organisationUnitRepository: OrganisationUnitCollectionRepository,
 ) {
 
-    fun blockingIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean {
-        val organisationUnit = organisationUnitRepository.uid(organisationUnitUid).blockingGet() ?: return true
+    fun blockingIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean = runBlocking {
+        suspendIsDateInOrgunitRange(organisationUnitUid, date)
+    }
+
+    fun isDateInOrgunitRange(organisationUnitUid: String, date: Date): Single<Boolean> {
+        return rxSingle { suspendIsDateInOrgunitRange(organisationUnitUid, date) }
+    }
+
+    suspend fun suspendIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean {
+        val organisationUnit = organisationUnitRepository.uid(organisationUnitUid).getInternal() ?: return true
 
         return organisationUnit.openingDate()?.before(date) ?: true &&
             organisationUnit.closedDate()?.after(date) ?: true
     }
 
-    fun isDateInOrgunitRange(organisationUnitUid: String, date: Date): Single<Boolean> {
-        return Single.just(blockingIsDateInOrgunitRange(organisationUnitUid, date))
-    }
-
-    fun blockingIsInCaptureScope(organisationUnitUid: String): Boolean {
-        return organisationUnitRepository
-            .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
-            .byUid().eq(organisationUnitUid)
-            .blockingGet().isNotEmpty()
+    fun blockingIsInCaptureScope(organisationUnitUid: String): Boolean = runBlocking {
+        suspendIsInCaptureScope(organisationUnitUid)
     }
 
     fun isInCaptureScope(organisationUnitUid: String): Single<Boolean> {
-        return Single.just(blockingIsInCaptureScope(organisationUnitUid))
+        return rxSingle { suspendIsInCaptureScope(organisationUnitUid) }
+    }
+
+    suspend fun suspendIsInCaptureScope(organisationUnitUid: String): Boolean {
+        return organisationUnitRepository
+            .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
+            .byUid().eq(organisationUnitUid)
+            .getInternal().isNotEmpty()
     }
 
     internal fun blockingIsInSearchScope(organisationUnitUid: String): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodHelper.kt
@@ -38,6 +38,7 @@ import java.util.Date
 import kotlin.math.ceil
 
 @Singleton
+@Suppress("TooManyFunctions")
 class PeriodHelper internal constructor(
     private val periodStore: PeriodStore,
     private val periodForDataSetManager: PeriodForDataSetManager,
@@ -68,7 +69,10 @@ class PeriodHelper internal constructor(
      * @param date       Date contained in the period
      * @return `Single` with the generated period.
      */
-    @Deprecated(message = "Use rxGetPeriodForPeriodTypeAndDate instead", ReplaceWith("rxGetPeriodForPeriodTypeAndDate(periodType, date)"))
+    @Deprecated(
+        message = "Use rxGetPeriodForPeriodTypeAndDate instead",
+        ReplaceWith("rxGetPeriodForPeriodTypeAndDate(periodType, date)"),
+    )
     fun getPeriodForPeriodTypeAndDate(periodType: PeriodType, date: Date): Single<Period> {
         return rxSingle { getPeriodForPeriodTypeAndDateInternal(periodType, date) }
     }
@@ -86,7 +90,10 @@ class PeriodHelper internal constructor(
      * @param periodOffset Number of periods backwards or forwards relative to 'date'
      * @return `Single` with the generated period.
      */
-    @Deprecated(message = "Use rxGetPeriodForPeriodTypeAndDate instead", ReplaceWith("rxGetPeriodForPeriodTypeAndDate(periodType, date, periodOffset)"))
+    @Deprecated(
+        message = "Use rxGetPeriodForPeriodTypeAndDate instead",
+        ReplaceWith("rxGetPeriodForPeriodTypeAndDate(periodType, date, periodOffset)"),
+    )
     fun getPeriodForPeriodTypeAndDate(periodType: PeriodType, date: Date, periodOffset: Int): Single<Period> {
         return rxSingle { getPeriodForPeriodTypeAndDateInternal(periodType, date, periodOffset) }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodHelper.kt
@@ -120,23 +120,15 @@ class PeriodHelper internal constructor(
      */
     @Throws(IllegalArgumentException::class)
     fun blockingGetPeriodForPeriodId(periodId: String): Period {
+        return runBlocking { suspendGetPeriodForPeriodId(periodId) }
+    }
+
+    @Throws(IllegalArgumentException::class)
+    suspend fun suspendGetPeriodForPeriodId(periodId: String): Period {
         val periodType = periodTypeFromPeriodId(periodId)
         val date = Date(periodParser.parse(periodId, periodType).toEpochMilliseconds())
 
-        return blockingGetPeriodForPeriodTypeAndDate(periodType, date)
-    }
-
-    /**
-     * Get a period object specifying a periodId.
-     * If the periodId does not exist in the database, it is inserted.
-     *
-     * @param periodId Period id.
-     * @return `Single` with the generated period.
-     * @throws IllegalArgumentException if the periodId does not match any period
-     */
-    @Throws(IllegalArgumentException::class)
-    fun getPeriodForPeriodId(periodId: String): Single<Period> {
-        return Single.just(blockingGetPeriodForPeriodId(periodId))
+        return getPeriodForPeriodTypeAndDateInternal(periodType, date)
     }
 
     fun getPeriodsForDataSet(dataSetUid: String): Single<List<Period>> {

--- a/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/period/internal/PeriodHelper.kt
@@ -68,8 +68,13 @@ class PeriodHelper internal constructor(
      * @param date       Date contained in the period
      * @return `Single` with the generated period.
      */
+    @Deprecated(message = "Use rxGetPeriodForPeriodTypeAndDate instead", ReplaceWith("rxGetPeriodForPeriodTypeAndDate(periodType, date)"))
     fun getPeriodForPeriodTypeAndDate(periodType: PeriodType, date: Date): Single<Period> {
-        return Single.just(blockingGetPeriodForPeriodTypeAndDate(periodType, date))
+        return rxSingle { getPeriodForPeriodTypeAndDateInternal(periodType, date) }
+    }
+
+    fun rxGetPeriodForPeriodTypeAndDate(periodType: PeriodType, date: Date): Single<Period> {
+        return rxSingle { getPeriodForPeriodTypeAndDateInternal(periodType, date) }
     }
 
     /**
@@ -81,7 +86,12 @@ class PeriodHelper internal constructor(
      * @param periodOffset Number of periods backwards or forwards relative to 'date'
      * @return `Single` with the generated period.
      */
+    @Deprecated(message = "Use rxGetPeriodForPeriodTypeAndDate instead", ReplaceWith("rxGetPeriodForPeriodTypeAndDate(periodType, date, periodOffset)"))
     fun getPeriodForPeriodTypeAndDate(periodType: PeriodType, date: Date, periodOffset: Int): Single<Period> {
+        return rxSingle { getPeriodForPeriodTypeAndDateInternal(periodType, date, periodOffset) }
+    }
+
+    fun rxGetPeriodForPeriodTypeAndDate(periodType: PeriodType, date: Date, periodOffset: Int): Single<Period> {
         return rxSingle { getPeriodForPeriodTypeAndDateInternal(periodType, date, periodOffset) }
     }
 
@@ -131,7 +141,12 @@ class PeriodHelper internal constructor(
         return getPeriodForPeriodTypeAndDateInternal(periodType, date)
     }
 
+    @Deprecated(message = "Use rxGetPeriodsForDataSet instead", ReplaceWith("rxGetPeriodsForDataSet(dataSetUid)"))
     fun getPeriodsForDataSet(dataSetUid: String): Single<List<Period>> {
+        return periodForDataSetManager.getPeriodsForDataSet(dataSetUid)
+    }
+
+    fun rxGetPeriodsForDataSet(dataSetUid: String): Single<List<Period>> {
         return periodForDataSetManager.getPeriodsForDataSet(dataSetUid)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/server/ServerModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/ServerModule.kt
@@ -34,4 +34,5 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 interface ServerModule {
     fun checkServerUrl(serverUrl: String): Single<Result<LoginConfig, D2Error>>
     fun blockingCheckServerUrl(serverUrl: String): Result<LoginConfig, D2Error>
+    suspend fun suspendCheckServerUrl(serverUrl: String): Result<LoginConfig, D2Error>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/server/ServerModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/ServerModule.kt
@@ -32,7 +32,9 @@ import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
 
 interface ServerModule {
+    @Deprecated(message = "Use rxCheckServerUrl instead", ReplaceWith("rxCheckServerUrl(serverUrl)"))
     fun checkServerUrl(serverUrl: String): Single<Result<LoginConfig, D2Error>>
+    fun rxCheckServerUrl(serverUrl: String): Single<Result<LoginConfig, D2Error>>
     fun blockingCheckServerUrl(serverUrl: String): Result<LoginConfig, D2Error>
     suspend fun suspendCheckServerUrl(serverUrl: String): Result<LoginConfig, D2Error>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/ServerModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/ServerModuleImpl.kt
@@ -47,4 +47,8 @@ internal class ServerModuleImpl(
     override fun blockingCheckServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
         return runBlocking { loginConfigCall.checkServerUrl(serverUrl) }
     }
+
+    override suspend fun suspendCheckServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
+        return loginConfigCall.checkServerUrl(serverUrl)
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/ServerModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/ServerModuleImpl.kt
@@ -40,7 +40,12 @@ import org.koin.core.annotation.Singleton
 internal class ServerModuleImpl(
     private val loginConfigCall: LoginConfigCall,
 ) : ServerModule {
+    @Deprecated(message = "Use rxCheckServerUrl instead", ReplaceWith("rxCheckServerUrl(serverUrl)"))
     override fun checkServerUrl(serverUrl: String): Single<Result<LoginConfig, D2Error>> {
+        return rxSingle { loginConfigCall.checkServerUrl(serverUrl) }
+    }
+
+    override fun rxCheckServerUrl(serverUrl: String): Single<Result<LoginConfig, D2Error>> {
         return rxSingle { loginConfigCall.checkServerUrl(serverUrl) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository.kt
@@ -43,26 +43,26 @@ class AnalyticsDhisVisualizationsSettingObjectRepository internal constructor(
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<AnalyticsDhisVisualizationsSetting>(analyticsSettingCall),
     ReadOnlyWithDownloadObjectRepository<AnalyticsDhisVisualizationsSetting> {
     fun getByProgram(program: String?): Single<List<AnalyticsDhisVisualizationsGroup>> {
-        return rxSingle { getByProgramInternal(program)!! }
+        return rxSingle { suspendGetByProgram(program)!! }
     }
 
     fun blockingGetByProgram(program: String?): List<AnalyticsDhisVisualizationsGroup>? {
-        return runBlocking { getByProgramInternal(program) }
+        return runBlocking { suspendGetByProgram(program) }
     }
 
-    private suspend fun getByProgramInternal(program: String?): List<AnalyticsDhisVisualizationsGroup>? {
+    suspend fun suspendGetByProgram(program: String?): List<AnalyticsDhisVisualizationsGroup>? {
         return generateGroups(analyticsDhisVisualizationStore.selectAll()).program()[program]
     }
 
     fun getByDataSet(dataSet: String?): Single<List<AnalyticsDhisVisualizationsGroup>> {
-        return rxSingle { byDataSetInternal(dataSet)!! }
+        return rxSingle { suspendGetByDataSet(dataSet)!! }
     }
 
     fun blockingByDataSet(dataSet: String?): List<AnalyticsDhisVisualizationsGroup>? {
-        return runBlocking { byDataSetInternal(dataSet) }
+        return runBlocking { suspendGetByDataSet(dataSet) }
     }
 
-    private suspend fun byDataSetInternal(dataSet: String?): List<AnalyticsDhisVisualizationsGroup>? {
+    suspend fun suspendGetByDataSet(dataSet: String?): List<AnalyticsDhisVisualizationsGroup>? {
         return generateGroups(analyticsDhisVisualizationStore.selectAll()).dataSet()[dataSet]
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsDhisVisualizationsSettingObjectRepository.kt
@@ -42,7 +42,12 @@ class AnalyticsDhisVisualizationsSettingObjectRepository internal constructor(
     analyticsSettingCall: AnalyticsSettingCall,
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<AnalyticsDhisVisualizationsSetting>(analyticsSettingCall),
     ReadOnlyWithDownloadObjectRepository<AnalyticsDhisVisualizationsSetting> {
+    @Deprecated(message = "Use rxGetByProgram instead", ReplaceWith("rxGetByProgram(program)"))
     fun getByProgram(program: String?): Single<List<AnalyticsDhisVisualizationsGroup>> {
+        return rxSingle { suspendGetByProgram(program)!! }
+    }
+
+    fun rxGetByProgram(program: String?): Single<List<AnalyticsDhisVisualizationsGroup>> {
         return rxSingle { suspendGetByProgram(program)!! }
     }
 
@@ -54,7 +59,12 @@ class AnalyticsDhisVisualizationsSettingObjectRepository internal constructor(
         return generateGroups(analyticsDhisVisualizationStore.selectAll()).program()[program]
     }
 
+    @Deprecated(message = "Use rxGetByDataSet instead", ReplaceWith("rxGetByDataSet(dataSet)"))
     fun getByDataSet(dataSet: String?): Single<List<AnalyticsDhisVisualizationsGroup>> {
+        return rxSingle { suspendGetByDataSet(dataSet)!! }
+    }
+
+    fun rxGetByDataSet(dataSet: String?): Single<List<AnalyticsDhisVisualizationsGroup>> {
         return rxSingle { suspendGetByDataSet(dataSet)!! }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
@@ -31,7 +31,9 @@ package org.hisp.dhis.android.core.settings
 import io.reactivex.Single
 
 interface CustomIntentService {
+    @Deprecated(message = "Use rxEvaluateRequestParams instead", ReplaceWith("rxEvaluateRequestParams(customIntent, context)"))
     fun evaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Single<Map<String, Any?>>
+    fun rxEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Single<Map<String, Any?>>
     fun blockingEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Map<String, Any?>
     suspend fun suspendEvaluateRequestParams(
         customIntent: CustomIntent,

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
@@ -33,5 +33,8 @@ import io.reactivex.Single
 interface CustomIntentService {
     fun evaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Single<Map<String, Any?>>
     fun blockingEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Map<String, Any?>
-    suspend fun suspendEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Map<String, Any?>
+    suspend fun suspendEvaluateRequestParams(
+        customIntent: CustomIntent,
+        context: CustomIntentContext,
+    ): Map<String, Any?>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
@@ -33,4 +33,5 @@ import io.reactivex.Single
 interface CustomIntentService {
     fun evaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Single<Map<String, Any?>>
     fun blockingEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Map<String, Any?>
+    suspend fun suspendEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Map<String, Any?>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/CustomIntentService.kt
@@ -31,7 +31,10 @@ package org.hisp.dhis.android.core.settings
 import io.reactivex.Single
 
 interface CustomIntentService {
-    @Deprecated(message = "Use rxEvaluateRequestParams instead", ReplaceWith("rxEvaluateRequestParams(customIntent, context)"))
+    @Deprecated(
+        message = "Use rxEvaluateRequestParams instead",
+        ReplaceWith("rxEvaluateRequestParams(customIntent, context)"),
+    )
     fun evaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Single<Map<String, Any?>>
     fun rxEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Single<Map<String, Any?>>
     fun blockingEvaluateRequestParams(customIntent: CustomIntent, context: CustomIntentContext): Map<String, Any?>

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
@@ -71,7 +71,7 @@ class GeneralSettingObjectRepository internal constructor(
     }
 
     fun blockingHasExperimentalFeature(featureName: String): Boolean {
-        return runBlocking {suspendHasExperimentalFeature(featureName)}
+        return runBlocking { suspendHasExperimentalFeature(featureName) }
     }
 
     fun hasExperimentalFeature(featureName: String): Single<Boolean> {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
@@ -74,7 +74,12 @@ class GeneralSettingObjectRepository internal constructor(
         return runBlocking { suspendHasExperimentalFeature(featureName) }
     }
 
+    @Deprecated(message = "Use rxHasExperimentalFeature instead", ReplaceWith("rxHasExperimentalFeature(featureName)"))
     fun hasExperimentalFeature(featureName: String): Single<Boolean> {
+        return rxSingle { suspendHasExperimentalFeature(featureName) }
+    }
+
+    fun rxHasExperimentalFeature(featureName: String): Single<Boolean> {
         return rxSingle { suspendHasExperimentalFeature(featureName) }
     }
 
@@ -85,7 +90,12 @@ class GeneralSettingObjectRepository internal constructor(
         return runBlocking { suspendHasExperimentalFeature(feature) }
     }
 
+    @Deprecated(message = "Use rxHasExperimentalFeature instead", ReplaceWith("rxHasExperimentalFeature(feature)"))
     fun hasExperimentalFeature(feature: ExperimentalFeature): Single<Boolean> {
+        return rxSingle { suspendHasExperimentalFeature(feature) }
+    }
+
+    fun rxHasExperimentalFeature(feature: ExperimentalFeature): Single<Boolean> {
         return rxSingle { suspendHasExperimentalFeature(feature) }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/GeneralSettingObjectRepository.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.settings
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyAnyObjectWithDownloadRepositoryImpl
 import org.hisp.dhis.android.core.settings.internal.GeneralSettingCall
@@ -69,18 +71,25 @@ class GeneralSettingObjectRepository internal constructor(
     }
 
     fun blockingHasExperimentalFeature(featureName: String): Boolean {
-        return blockingGet()?.experimentalFeatures()?.contains(featureName) ?: false
+        return runBlocking {suspendHasExperimentalFeature(featureName)}
     }
 
     fun hasExperimentalFeature(featureName: String): Single<Boolean> {
-        return Single.fromCallable { blockingHasExperimentalFeature(featureName) }
+        return rxSingle { suspendHasExperimentalFeature(featureName) }
     }
 
+    suspend fun suspendHasExperimentalFeature(featureName: String): Boolean =
+        getInternal()?.experimentalFeatures()?.contains(featureName) ?: false
+
     fun blockingHasExperimentalFeature(feature: ExperimentalFeature): Boolean {
-        return blockingGet()?.experimentalFeatures()?.contains(feature.jsonName) ?: false
+        return runBlocking { suspendHasExperimentalFeature(feature) }
     }
 
     fun hasExperimentalFeature(feature: ExperimentalFeature): Single<Boolean> {
-        return Single.fromCallable { blockingHasExperimentalFeature(feature) }
+        return rxSingle { suspendHasExperimentalFeature(feature) }
+    }
+
+    suspend fun suspendHasExperimentalFeature(feature: ExperimentalFeature): Boolean {
+        return getInternal()?.experimentalFeatures()?.contains(feature.jsonName) ?: false
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentServiceImpl.kt
@@ -47,7 +47,10 @@ internal class CustomIntentServiceImpl(
     private val userStore: UserStore,
     private val orgunitStore: OrganisationUnitStore,
 ) : CustomIntentService {
-    @Deprecated(message = "Use rxEvaluateRequestParams instead", ReplaceWith("rxEvaluateRequestParams(customIntent, context)"))
+    @Deprecated(
+        message = "Use rxEvaluateRequestParams instead",
+        ReplaceWith("rxEvaluateRequestParams(customIntent, context)"),
+    )
     override fun evaluateRequestParams(
         customIntent: CustomIntent,
         context: CustomIntentContext,

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentServiceImpl.kt
@@ -51,17 +51,17 @@ internal class CustomIntentServiceImpl(
         customIntent: CustomIntent,
         context: CustomIntentContext,
     ): Single<Map<String, Any?>> {
-        return rxSingle { evaluateRequestParamsInternal(customIntent, context) }
+        return rxSingle { suspendEvaluateRequestParams(customIntent, context) }
     }
 
     override fun blockingEvaluateRequestParams(
         customIntent: CustomIntent,
         context: CustomIntentContext,
     ): Map<String, Any?> {
-        return runBlocking { evaluateRequestParamsInternal(customIntent, context) }
+        return runBlocking { suspendEvaluateRequestParams(customIntent, context) }
     }
 
-    private suspend fun evaluateRequestParamsInternal(
+    override suspend fun suspendEvaluateRequestParams(
         customIntent: CustomIntent,
         context: CustomIntentContext,
     ): Map<String, Any?> {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/CustomIntentServiceImpl.kt
@@ -47,7 +47,15 @@ internal class CustomIntentServiceImpl(
     private val userStore: UserStore,
     private val orgunitStore: OrganisationUnitStore,
 ) : CustomIntentService {
+    @Deprecated(message = "Use rxEvaluateRequestParams instead", ReplaceWith("rxEvaluateRequestParams(customIntent, context)"))
     override fun evaluateRequestParams(
+        customIntent: CustomIntent,
+        context: CustomIntentContext,
+    ): Single<Map<String, Any?>> {
+        return rxSingle { suspendEvaluateRequestParams(customIntent, context) }
+    }
+
+    override fun rxEvaluateRequestParams(
         customIntent: CustomIntent,
         context: CustomIntentContext,
     ): Single<Map<String, Any?>> {

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
@@ -36,4 +36,6 @@ interface Ping {
 
     @Throws(D2Error::class)
     fun blockingGet(): String
+
+    suspend fun suspendGet(): String
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
@@ -32,7 +32,10 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 
 interface Ping {
 
+    @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
     fun get(): Single<String>
+
+    fun rxGet(): Single<String>
 
     @Throws(D2Error::class)
     fun blockingGet(): String

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.systeminfo.internal
 
 import io.ktor.http.isSuccess
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
@@ -43,7 +44,7 @@ class PingImpl internal constructor(
 ) : Ping {
 
     override fun get(): Single<String> {
-        return rxSingle { checkPing() }
+        return rxSingle { suspendGet() }
     }
 
     @Throws(D2Error::class)
@@ -52,7 +53,7 @@ class PingImpl internal constructor(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun checkPing(): String {
+    override suspend fun suspendGet(): String {
         try {
             val response = pingNetworkHandler.getPing()
             return if (response.status.isSuccess()) {

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -42,7 +42,12 @@ class PingImpl internal constructor(
     private val pingNetworkHandler: PingNetworkHandler,
 ) : Ping {
 
+    @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
     override fun get(): Single<String> {
+        return rxSingle { suspendGet() }
+    }
+
+    override fun rxGet(): Single<String> {
         return rxSingle { suspendGet() }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.systeminfo.internal
 
 import io.ktor.http.isSuccess
 import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -90,7 +90,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      */
     fun blockingGetValue(attributeUid: String, organisationUnitUid: String): String {
         return runBlocking {
-            getValueCoroutines(attributeUid, organisationUnitUid)
+            suspendGetValue(attributeUid, organisationUnitUid)
         }
     }
 
@@ -104,10 +104,10 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      */
 
     fun getValue(attributeUid: String, organisationUnitUid: String): Single<String> {
-        return rxSingle { getValueCoroutines(attributeUid, organisationUnitUid) }
+        return rxSingle { suspendGetValue(attributeUid, organisationUnitUid) }
     }
 
-    private suspend fun getValueCoroutines(attributeUid: String, organisationUnitUid: String): String {
+    suspend fun suspendGetValue(attributeUid: String, organisationUnitUid: String): String {
         downloadValuesIfBelowThreshold(attributeUid, getOrganisationUnit(organisationUnitUid), null, false)
 
         val pattern = trackedEntityAttributeStore.selectByUid(attributeUid)!!.pattern()
@@ -211,6 +211,9 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         return runBlocking { countInternal(attributeUid, organisationUnitUid) }
     }
 
+    suspend fun suspendCount(attributeUid: String, organisationUnitUid: String?): Int =
+        countInternal(attributeUid, organisationUnitUid)
+
     internal suspend fun countInternal(attributeUid: String, organisationUnitUid: String?): Int {
         return store.count(attributeUid, organisationUnitUid, null)
     }
@@ -231,6 +234,9 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
     fun blockingGetReservedValueSummaries(): List<ReservedValueSummary> {
         return runBlocking { getReservedValueSummariesInternal() }
     }
+
+    suspend fun suspendGetReservedValueSummaries(): List<ReservedValueSummary> =
+        getReservedValueSummariesInternal()
 
     private suspend fun getReservedValueSummariesInternal(): List<ReservedValueSummary> {
         val whereClause =

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -127,7 +127,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ) {
-        runBlocking { downloadReservedValuesFlow(attributeUid, numberOfValuesToFillUp).collect() }
+        runBlocking { suspendDownloadReservedValues(attributeUid, numberOfValuesToFillUp).collect() }
     }
 
     /**
@@ -145,18 +145,18 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @return An Observable that notifies about the progress.
      */
 
+    fun suspendDownloadReservedValues(
+        attributeUid: String,
+        numberOfValuesToFillUp: Int?,
+    ): Flow<D2Progress> = flow {
+        emitAll(downloadValuesForOrgUnits(attributeUid, numberOfValuesToFillUp))
+    }
+
     fun downloadReservedValues(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ): Observable<D2Progress> {
-        return downloadReservedValuesFlow(attributeUid, numberOfValuesToFillUp).asObservable()
-    }
-
-    private fun downloadReservedValuesFlow(
-        attributeUid: String,
-        numberOfValuesToFillUp: Int?,
-    ) = flow {
-        emitAll(downloadValuesForOrgUnits(attributeUid, numberOfValuesToFillUp))
+        return suspendDownloadReservedValues(attributeUid, numberOfValuesToFillUp).asObservable()
     }
 
     /**
@@ -165,7 +165,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      */
     fun blockingDownloadAllReservedValues(numberOfValuesToFillUp: Int?) {
         runBlocking {
-            downloadAllReservedValuesFlow(numberOfValuesToFillUp).collect()
+            suspendDownloadAllReservedValues(numberOfValuesToFillUp).collect()
         }
     }
 
@@ -177,17 +177,15 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @return An Observable that notifies about the progress.
      */
 
-    fun downloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
-        return downloadAllReservedValuesFlow(numberOfValuesToFillUp).asObservable()
-    }
-
-    private fun downloadAllReservedValuesFlow(
-        numberOfValuesToFillUp: Int?,
-    ) = flow {
+    fun suspendDownloadAllReservedValues(numberOfValuesToFillUp: Int?): Flow<D2Progress> = flow {
         val flows = generatedAttributes().map { attribute ->
             downloadValuesForOrgUnits(attribute.uid(), numberOfValuesToFillUp)
         }
         emitAll(flows.merge())
+    }
+
+    fun downloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
+        return suspendDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -32,7 +32,6 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.merge
@@ -157,7 +156,10 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         emitAll(downloadValuesForOrgUnits(attributeUid, numberOfValuesToFillUp))
     }
 
-    @Deprecated(message = "Use rxDownloadReservedValues instead", ReplaceWith("rxDownloadReservedValues(attributeUid, numberOfValuesToFillUp)"))
+    @Deprecated(
+        message = "Use rxDownloadReservedValues instead",
+        ReplaceWith("rxDownloadReservedValues(attributeUid, numberOfValuesToFillUp)"),
+    )
     fun downloadReservedValues(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
@@ -195,7 +197,10 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         emitAll(flows.merge())
     }
 
-    @Deprecated(message = "Use rxDownloadAllReservedValues instead", ReplaceWith("rxDownloadAllReservedValues(numberOfValuesToFillUp)"))
+    @Deprecated(
+        message = "Use rxDownloadAllReservedValues instead",
+        ReplaceWith("rxDownloadAllReservedValues(numberOfValuesToFillUp)"),
+    )
     fun downloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
         return flowDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -103,7 +103,12 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @return Single with value of tracked entity attribute
      */
 
+    @Deprecated(message = "Use rxGetValue instead", ReplaceWith("rxGetValue(attributeUid, organisationUnitUid)"))
     fun getValue(attributeUid: String, organisationUnitUid: String): Single<String> {
+        return rxSingle { suspendGetValue(attributeUid, organisationUnitUid) }
+    }
+
+    fun rxGetValue(attributeUid: String, organisationUnitUid: String): Single<String> {
         return rxSingle { suspendGetValue(attributeUid, organisationUnitUid) }
     }
 
@@ -152,7 +157,15 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         emitAll(downloadValuesForOrgUnits(attributeUid, numberOfValuesToFillUp))
     }
 
+    @Deprecated(message = "Use rxDownloadReservedValues instead", ReplaceWith("rxDownloadReservedValues(attributeUid, numberOfValuesToFillUp)"))
     fun downloadReservedValues(
+        attributeUid: String,
+        numberOfValuesToFillUp: Int?,
+    ): Observable<D2Progress> {
+        return suspendDownloadReservedValues(attributeUid, numberOfValuesToFillUp).asObservable()
+    }
+
+    fun rxDownloadReservedValues(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ): Observable<D2Progress> {
@@ -184,7 +197,12 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         emitAll(flows.merge())
     }
 
+    @Deprecated(message = "Use rxDownloadAllReservedValues instead", ReplaceWith("rxDownloadAllReservedValues(numberOfValuesToFillUp)"))
     fun downloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
+        return suspendDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
+    }
+
+    fun rxDownloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
         return suspendDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
     }
 
@@ -196,7 +214,11 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @param organisationUnitUid An optional organisation unit uid
      * @return Single with the reserved value count by attribute or by attribute and organisation unit.
      */
+    @Deprecated(message = "Use rxCount instead", ReplaceWith("rxCount(attributeUid, organisationUnitUid)"))
     fun count(attributeUid: String, organisationUnitUid: String?): Single<Int> =
+        rxSingle { countInternal(attributeUid, organisationUnitUid) }
+
+    fun rxCount(attributeUid: String, organisationUnitUid: String?): Single<Int> =
         rxSingle { countInternal(attributeUid, organisationUnitUid) }
 
     /**
@@ -221,7 +243,12 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      *
      * @return Single with a list of the reserved value summaries
      */
+    @Deprecated(message = "Use rxGetReservedValueSummaries instead", ReplaceWith("rxGetReservedValueSummaries()"))
     fun getReservedValueSummaries(): Single<List<ReservedValueSummary>> {
+        return rxSingle { getReservedValueSummariesInternal() }
+    }
+
+    fun rxGetReservedValueSummaries(): Single<List<ReservedValueSummary>> {
         return rxSingle { getReservedValueSummariesInternal() }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -131,7 +131,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ) {
-        rxDownloadReservedValues(attributeUid, numberOfValuesToFillUp).blockingSubscribe()
+        runBlocking { flowDownloadReservedValues(attributeUid, numberOfValuesToFillUp).collect {} }
     }
 
     /**
@@ -179,7 +179,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @see .downloadAllReservedValues
      */
     fun blockingDownloadAllReservedValues(numberOfValuesToFillUp: Int?) {
-        rxDownloadAllReservedValues(numberOfValuesToFillUp).blockingSubscribe()
+        runBlocking { flowDownloadAllReservedValues(numberOfValuesToFillUp).collect {} }
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -132,7 +132,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ) {
-        runBlocking { suspendDownloadReservedValues(attributeUid, numberOfValuesToFillUp).collect() }
+        rxDownloadReservedValues(attributeUid, numberOfValuesToFillUp).blockingSubscribe()
     }
 
     /**
@@ -150,7 +150,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @return An Observable that notifies about the progress.
      */
 
-    fun suspendDownloadReservedValues(
+    fun flowDownloadReservedValues(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ): Flow<D2Progress> = flow {
@@ -162,14 +162,14 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ): Observable<D2Progress> {
-        return suspendDownloadReservedValues(attributeUid, numberOfValuesToFillUp).asObservable()
+        return flowDownloadReservedValues(attributeUid, numberOfValuesToFillUp).asObservable()
     }
 
     fun rxDownloadReservedValues(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ): Observable<D2Progress> {
-        return suspendDownloadReservedValues(attributeUid, numberOfValuesToFillUp).asObservable()
+        return flowDownloadReservedValues(attributeUid, numberOfValuesToFillUp).asObservable()
     }
 
     /**
@@ -177,9 +177,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @see .downloadAllReservedValues
      */
     fun blockingDownloadAllReservedValues(numberOfValuesToFillUp: Int?) {
-        runBlocking {
-            suspendDownloadAllReservedValues(numberOfValuesToFillUp).collect()
-        }
+        rxDownloadAllReservedValues(numberOfValuesToFillUp).blockingSubscribe()
     }
 
     /**
@@ -190,7 +188,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @return An Observable that notifies about the progress.
      */
 
-    fun suspendDownloadAllReservedValues(numberOfValuesToFillUp: Int?): Flow<D2Progress> = flow {
+    fun flowDownloadAllReservedValues(numberOfValuesToFillUp: Int?): Flow<D2Progress> = flow {
         val flows = generatedAttributes().map { attribute ->
             downloadValuesForOrgUnits(attribute.uid(), numberOfValuesToFillUp)
         }
@@ -199,11 +197,11 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
 
     @Deprecated(message = "Use rxDownloadAllReservedValues instead", ReplaceWith("rxDownloadAllReservedValues(numberOfValuesToFillUp)"))
     fun downloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
-        return suspendDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
+        return flowDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
     }
 
     fun rxDownloadAllReservedValues(numberOfValuesToFillUp: Int?): Observable<D2Progress> {
-        return suspendDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
+        return flowDownloadAllReservedValues(numberOfValuesToFillUp).asObservable()
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -28,12 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import io.reactivex.Observable
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.onErrorReturn
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
@@ -47,7 +42,6 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilterCollectionRepository
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
-import kotlin.coroutines.CoroutineContext
 
 @Singleton
 @Suppress("TooManyFunctions")

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -68,14 +69,23 @@ class TrackedEntityInstanceDownloader internal constructor(
      * It makes use of paging with a best effort strategy: in case a page fails to be downloaded or persisted, it is
      * skipped and the rest of pages are persisted.
      *
-     * @return An Observable that notifies about the progress.
+     * @return -
      */
+    fun flowDownload(): Flow<TrackerD2Progress> {
+        return call.download(params)
+    }
+
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
     fun download(): Observable<TrackerD2Progress> {
-        return call.download(params).asObservable()
+        return flowDownload().asObservable()
+    }
+
+    fun rxDownload(): Observable<TrackerD2Progress> {
+        return flowDownload().asObservable()
     }
 
     fun blockingDownload() {
-        download().blockingSubscribe()
+        rxDownload().blockingSubscribe()
     }
 
     fun byUid(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -28,9 +28,14 @@
 package org.hisp.dhis.android.core.trackedentity.internal
 
 import io.reactivex.Observable
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onErrorReturn
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ScopedFilterConnectorFactory
@@ -42,6 +47,7 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilterCollectionRepository
 import org.hisp.dhis.android.core.tracker.exporter.TrackerD2Progress
 import org.koin.core.annotation.Singleton
+import kotlin.coroutines.CoroutineContext
 
 @Singleton
 @Suppress("TooManyFunctions")
@@ -86,7 +92,7 @@ class TrackedEntityInstanceDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        runBlocking { flowDownload().collect {} }
+        flowDownload().collectAndWrapException()
     }
 
     fun byUid(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.trackedentity.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.ListFilterConnector
@@ -85,7 +86,7 @@ class TrackedEntityInstanceDownloader internal constructor(
     }
 
     fun blockingDownload() {
-        rxDownload().blockingSubscribe()
+        runBlocking { flowDownload().collect {} }
     }
 
     fun byUid(): ListFilterConnector<TrackedEntityInstanceDownloader, String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManager.kt
@@ -31,9 +31,21 @@ package org.hisp.dhis.android.core.trackedentity.ownership
 import io.reactivex.Completable
 
 interface OwnershipManager {
+    @Deprecated(
+        message = "Use rxBreakGlass instead",
+        ReplaceWith("rxBreakGlass(trackedEntityInstance, program, reason)"),
+    )
     fun breakGlass(trackedEntityInstance: String, program: String, reason: String): Completable
+    fun rxBreakGlass(trackedEntityInstance: String, program: String, reason: String): Completable
     fun blockingBreakGlass(trackedEntityInstance: String, program: String, reason: String)
+    suspend fun suspendBreakGlass(trackedEntityInstance: String, program: String, reason: String)
 
+    @Deprecated(
+        message = "Use rxTransfer instead",
+        ReplaceWith("rxTransfer(trackedEntityInstance, program, ownerOrgUnit)"),
+    )
     fun transfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String): Completable
+    fun rxTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String): Completable
     fun blockingTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String)
+    suspend fun suspendTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManagerImpl.kt
@@ -53,6 +53,7 @@ import java.util.Date
 import kotlin.time.Instant
 
 @Singleton
+@Suppress("TooManyFunctions")
 internal class OwnershipManagerImpl(
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     private val ownershipNetworkHandler: OwnershipNetworkHandler,
@@ -62,12 +63,24 @@ internal class OwnershipManagerImpl(
     private val clockProvider: ClockProvider,
 ) : OwnershipManager {
 
+    @Deprecated(
+        message = "Use rxBreakGlass instead",
+        ReplaceWith("rxBreakGlass(trackedEntityInstance, program, reason)"),
+    )
     override fun breakGlass(trackedEntityInstance: String, program: String, reason: String): Completable {
-        return rxCompletable { breakGlassInternal(trackedEntityInstance, program, reason) }
+        return rxCompletable { suspendBreakGlass(trackedEntityInstance, program, reason) }
+    }
+
+    override fun rxBreakGlass(trackedEntityInstance: String, program: String, reason: String): Completable {
+        return rxCompletable { suspendBreakGlass(trackedEntityInstance, program, reason) }
     }
 
     override fun blockingBreakGlass(trackedEntityInstance: String, program: String, reason: String) {
-        runBlocking { breakGlassInternal(trackedEntityInstance, program, reason) }
+        runBlocking { suspendBreakGlass(trackedEntityInstance, program, reason) }
+    }
+
+    override suspend fun suspendBreakGlass(trackedEntityInstance: String, program: String, reason: String) {
+        breakGlassInternal(trackedEntityInstance, program, reason)
     }
 
     private suspend fun breakGlassInternal(trackedEntityInstance: String, program: String, reason: String) {
@@ -104,12 +117,24 @@ internal class OwnershipManagerImpl(
             )
     }
 
+    @Deprecated(
+        message = "Use rxTransfer instead",
+        ReplaceWith("rxTransfer(trackedEntityInstance, program, ownerOrgUnit)"),
+    )
     override fun transfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String): Completable {
-        return rxCompletable { transferInternal(trackedEntityInstance, program, ownerOrgUnit) }
+        return rxCompletable { suspendTransfer(trackedEntityInstance, program, ownerOrgUnit) }
+    }
+
+    override fun rxTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String): Completable {
+        return rxCompletable { suspendTransfer(trackedEntityInstance, program, ownerOrgUnit) }
     }
 
     override fun blockingTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String) {
-        runBlocking { transferInternal(trackedEntityInstance, program, ownerOrgUnit) }
+        runBlocking { suspendTransfer(trackedEntityInstance, program, ownerOrgUnit) }
+    }
+
+    override suspend fun suspendTransfer(trackedEntityInstance: String, program: String, ownerOrgUnit: String) {
+        transferInternal(trackedEntityInstance, program, ownerOrgUnit)
     }
 
     private suspend fun transferInternal(trackedEntityInstance: String, program: String, ownerOrgUnit: String) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
@@ -40,13 +40,19 @@ interface UserModule {
     fun authorities(): AuthorityCollectionRepository
     fun user(): UserObjectRepository
     fun accountManager(): AccountManager
+    @Deprecated(message = "Use rxLogIn instead", ReplaceWith("rxLogIn(username, password, serverUrl)"))
     fun logIn(username: String, password: String, serverUrl: String): Single<User>
+    fun rxLogIn(username: String, password: String, serverUrl: String): Single<User>
     fun blockingLogIn(username: String, password: String, serverUrl: String): User
     suspend fun suspendLogIn(username: String, password: String, serverUrl: String): User
+    @Deprecated(message = "Use rxLogOut instead", ReplaceWith("rxLogOut()"))
     fun logOut(): Completable
+    fun rxLogOut(): Completable
     fun blockingLogOut()
     suspend fun suspendLogOut()
+    @Deprecated(message = "Use rxIsLogged instead", ReplaceWith("rxIsLogged()"))
     fun isLogged(): Single<Boolean>
+    fun rxIsLogged(): Single<Boolean>
     fun blockingIsLogged(): Boolean
     suspend fun suspendIsLogged(): Boolean
     fun openIdHandler(): OpenIDConnectHandler

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
@@ -29,6 +29,9 @@ package org.hisp.dhis.android.core.user
 
 import io.reactivex.Completable
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.user.oauth2.OAuth2Handler
 import org.hisp.dhis.android.core.user.openid.OpenIDConnectHandler
 
@@ -42,22 +45,29 @@ interface UserModule {
     fun accountManager(): AccountManager
 
     @Deprecated(message = "Use rxLogIn instead", ReplaceWith("rxLogIn(username, password, serverUrl)"))
-    fun logIn(username: String, password: String, serverUrl: String): Single<User>
-    fun rxLogIn(username: String, password: String, serverUrl: String): Single<User>
-    fun blockingLogIn(username: String, password: String, serverUrl: String): User
+    fun logIn(username: String, password: String, serverUrl: String): Single<User> =
+        rxLogIn(username, password, serverUrl)
+
+    fun rxLogIn(username: String, password: String, serverUrl: String): Single<User> =
+        rxSingle { suspendLogIn(username, password, serverUrl) }
+
+    fun blockingLogIn(username: String, password: String, serverUrl: String): User =
+        runBlocking { suspendLogIn(username, password, serverUrl) }
+
     suspend fun suspendLogIn(username: String, password: String, serverUrl: String): User
 
     @Deprecated(message = "Use rxLogOut instead", ReplaceWith("rxLogOut()"))
-    fun logOut(): Completable
-    fun rxLogOut(): Completable
-    fun blockingLogOut()
+    fun logOut(): Completable = rxLogOut()
+    fun rxLogOut(): Completable = rxCompletable { suspendLogOut() }
+    fun blockingLogOut() = runBlocking { suspendLogOut() }
     suspend fun suspendLogOut()
 
     @Deprecated(message = "Use rxIsLogged instead", ReplaceWith("rxIsLogged()"))
-    fun isLogged(): Single<Boolean>
-    fun rxIsLogged(): Single<Boolean>
-    fun blockingIsLogged(): Boolean
+    fun isLogged(): Single<Boolean> = rxIsLogged()
+    fun rxIsLogged(): Single<Boolean> = rxSingle { suspendIsLogged() }
+    fun blockingIsLogged(): Boolean = runBlocking { suspendIsLogged() }
     suspend fun suspendIsLogged(): Boolean
+
     fun openIdHandler(): OpenIDConnectHandler
     fun oauth2Handler(): OAuth2Handler
     fun twoFactorAuthManager(): TwoFactorAuthManager

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
@@ -40,16 +40,19 @@ interface UserModule {
     fun authorities(): AuthorityCollectionRepository
     fun user(): UserObjectRepository
     fun accountManager(): AccountManager
+
     @Deprecated(message = "Use rxLogIn instead", ReplaceWith("rxLogIn(username, password, serverUrl)"))
     fun logIn(username: String, password: String, serverUrl: String): Single<User>
     fun rxLogIn(username: String, password: String, serverUrl: String): Single<User>
     fun blockingLogIn(username: String, password: String, serverUrl: String): User
     suspend fun suspendLogIn(username: String, password: String, serverUrl: String): User
+
     @Deprecated(message = "Use rxLogOut instead", ReplaceWith("rxLogOut()"))
     fun logOut(): Completable
     fun rxLogOut(): Completable
     fun blockingLogOut()
     suspend fun suspendLogOut()
+
     @Deprecated(message = "Use rxIsLogged instead", ReplaceWith("rxIsLogged()"))
     fun isLogged(): Single<Boolean>
     fun rxIsLogged(): Single<Boolean>

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserModule.kt
@@ -42,10 +42,13 @@ interface UserModule {
     fun accountManager(): AccountManager
     fun logIn(username: String, password: String, serverUrl: String): Single<User>
     fun blockingLogIn(username: String, password: String, serverUrl: String): User
+    suspend fun suspendLogIn(username: String, password: String, serverUrl: String): User
     fun logOut(): Completable
     fun blockingLogOut()
+    suspend fun suspendLogOut()
     fun isLogged(): Single<Boolean>
     fun blockingIsLogged(): Boolean
+    suspend fun suspendIsLogged(): Boolean
     fun openIdHandler(): OpenIDConnectHandler
     fun oauth2Handler(): OAuth2Handler
     fun twoFactorAuthManager(): TwoFactorAuthManager

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -131,7 +131,7 @@ internal class AccountManagerImpl(
     @Throws(D2Error::class)
     private fun deleteAccountInternal(credentials: Credentials, deletionReason: AccountDeletionReason) {
         accountDeletionSubject.onNext(deletionReason)
-        logOutCall.logOut().blockingAwait()
+        runBlocking { logOutCall.logOut() }
         val configuration = databasesConfigurationStore.get()
         if (configuration != null) {
             val loggedAccount = DatabaseConfigurationHelper.getLoggedAccount(

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/IsUserLoggedInCallableFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/IsUserLoggedInCallableFactory.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.user.internal
 
 import io.reactivex.Single
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.koin.core.annotation.Singleton
@@ -38,7 +39,9 @@ internal class IsUserLoggedInCallableFactory(
     private val databaseAdapter: DatabaseAdapter,
 ) {
     val isLogged: Single<Boolean>
-        get() = Single.fromCallable {
-            credentialsSecureStore.get() != null && databaseAdapter.isReady
-        }
+        get() = rxSingle { suspendIsLogged() }
+
+    suspend fun suspendIsLogged(): Boolean {
+        return credentialsSecureStore.get() != null && databaseAdapter.isReady
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/IsUserLoggedInCallableFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/IsUserLoggedInCallableFactory.kt
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.android.core.user.internal
 
-import io.reactivex.Single
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.koin.core.annotation.Singleton
@@ -38,8 +36,6 @@ internal class IsUserLoggedInCallableFactory(
     private val credentialsSecureStore: CredentialsSecureStore,
     private val databaseAdapter: DatabaseAdapter,
 ) {
-    val isLogged: Single<Boolean>
-        get() = rxSingle { suspendIsLogged() }
 
     suspend fun suspendIsLogged(): Boolean {
         return credentialsSecureStore.get() != null && databaseAdapter.isReady

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogOutCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogOutCall.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.user.internal
 
 import io.reactivex.Completable
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.UserIdInMemoryStore
@@ -41,7 +42,7 @@ import org.hisp.dhis.android.core.systeminfo.internal.ServerTimezoneManager
 import org.koin.core.annotation.Singleton
 
 @Singleton
-class LogOutCall internal constructor(
+internal class LogOutCall internal constructor(
     private val databaseManager: DatabaseManager,
     private val credentialsSecureStore: CredentialsSecureStore,
     private val userIdStore: UserIdInMemoryStore,
@@ -51,24 +52,25 @@ class LogOutCall internal constructor(
     private val databaseConfigurationStore: DatabaseConfigurationInsecureStore,
 ) {
 
-    fun logOut(): Completable {
-        return Completable.fromCallable {
-            val credentials = credentialsSecureStore.get()
-            if (credentials == null) {
-                throw D2Error.builder()
-                    .errorCode(D2ErrorCode.NO_AUTHENTICATED_USER)
-                    .errorDescription("There is not any authenticated user")
-                    .errorComponent(D2ErrorComponent.SDK)
-                    .build()
-            }
-
-            updateLastAccessDate(credentials.serverUrl, credentials.username)
-            databaseManager.disableDatabase()
-            credentialsSecureStore.remove()
-            userIdStore.remove()
-            serverTimezoneManager.clearCache()
-            defaultCategoryComboManager.clearCache()
+    suspend fun intenralLogOut() {
+        val credentials = credentialsSecureStore.get()
+        if (credentials == null) {
+            throw D2Error.builder()
+                .errorCode(D2ErrorCode.NO_AUTHENTICATED_USER)
+                .errorDescription("There is not any authenticated user")
+                .errorComponent(D2ErrorComponent.SDK)
+                .build()
         }
+        updateLastAccessDate(credentials.serverUrl, credentials.username)
+        databaseManager.disableDatabase()
+        credentialsSecureStore.remove()
+        userIdStore.remove()
+        serverTimezoneManager.clearCache()
+        defaultCategoryComboManager.clearCache()
+    }
+
+    fun logOut(): Completable {
+        return rxCompletable { intenralLogOut() }
     }
 
     private fun updateLastAccessDate(serverUrl: String, username: String) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogOutCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogOutCall.kt
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.android.core.user.internal
 
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.UserIdInMemoryStore
@@ -52,7 +50,7 @@ internal class LogOutCall internal constructor(
     private val databaseConfigurationStore: DatabaseConfigurationInsecureStore,
 ) {
 
-    suspend fun intenralLogOut() {
+    suspend fun logOut() {
         val credentials = credentialsSecureStore.get()
         if (credentials == null) {
             throw D2Error.builder()
@@ -67,10 +65,6 @@ internal class LogOutCall internal constructor(
         userIdStore.remove()
         serverTimezoneManager.clearCache()
         defaultCategoryComboManager.clearCache()
-    }
-
-    fun logOut(): Completable {
-        return rxCompletable { intenralLogOut() }
     }
 
     private fun updateLastAccessDate(serverUrl: String, username: String) {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.user.internal
 import io.reactivex.Completable
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.user.AccountManager
 import org.hisp.dhis.android.core.user.AuthenticatedUserObjectRepository
@@ -90,7 +91,12 @@ internal class UserModuleImpl(
         return user
     }
 
+    @Deprecated(message = "Use rxLogIn instead", ReplaceWith("rxLogIn(username, password, serverUrl)"))
     override fun logIn(username: String, password: String, serverUrl: String): Single<User> {
+        return rxSingle { logInCall.logIn(username, password, serverUrl) }
+    }
+
+    override fun rxLogIn(username: String, password: String, serverUrl: String): Single<User> {
         return rxSingle { logInCall.logIn(username, password, serverUrl) }
     }
 
@@ -102,7 +108,12 @@ internal class UserModuleImpl(
         return logInCall.logIn(username, password, serverUrl)
     }
 
+    @Deprecated(message = "Use rxLogOut instead", ReplaceWith("rxLogOut()"))
     override fun logOut(): Completable {
+        return logoutCallCallFactory.logOut()
+    }
+
+    override fun rxLogOut(): Completable {
         return logoutCallCallFactory.logOut()
     }
 
@@ -114,7 +125,12 @@ internal class UserModuleImpl(
         logoutCallCallFactory.intenralLogOut()
     }
 
+    @Deprecated(message = "Use rxIsLogged instead", ReplaceWith("rxIsLogged()"))
     override fun isLogged(): Single<Boolean> {
+        return isUserLoggedInCallFactory.isLogged
+    }
+
+    override fun rxIsLogged(): Single<Boolean> {
         return isUserLoggedInCallFactory.isLogged
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
@@ -27,10 +27,6 @@
  */
 package org.hisp.dhis.android.core.user.internal
 
-import io.reactivex.Completable
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.user.AccountManager
 import org.hisp.dhis.android.core.user.AuthenticatedUserObjectRepository
 import org.hisp.dhis.android.core.user.AuthorityCollectionRepository
@@ -90,51 +86,12 @@ internal class UserModuleImpl(
         return user
     }
 
-    @Deprecated(message = "Use rxLogIn instead", ReplaceWith("rxLogIn(username, password, serverUrl)"))
-    override fun logIn(username: String, password: String, serverUrl: String): Single<User> {
-        return rxSingle { logInCall.logIn(username, password, serverUrl) }
-    }
-
-    override fun rxLogIn(username: String, password: String, serverUrl: String): Single<User> {
-        return rxSingle { logInCall.logIn(username, password, serverUrl) }
-    }
-
-    override fun blockingLogIn(username: String, password: String, serverUrl: String): User {
-        return runBlocking { logInCall.logIn(username, password, serverUrl) }
-    }
-
     override suspend fun suspendLogIn(username: String, password: String, serverUrl: String): User {
         return logInCall.logIn(username, password, serverUrl)
     }
 
-    @Deprecated(message = "Use rxLogOut instead", ReplaceWith("rxLogOut()"))
-    override fun logOut(): Completable {
-        return logoutCallCallFactory.logOut()
-    }
-
-    override fun rxLogOut(): Completable {
-        return logoutCallCallFactory.logOut()
-    }
-
-    override fun blockingLogOut() {
-        runBlocking { logoutCallCallFactory.intenralLogOut() }
-    }
-
     override suspend fun suspendLogOut() {
-        logoutCallCallFactory.intenralLogOut()
-    }
-
-    @Deprecated(message = "Use rxIsLogged instead", ReplaceWith("rxIsLogged()"))
-    override fun isLogged(): Single<Boolean> {
-        return isUserLoggedInCallFactory.isLogged
-    }
-
-    override fun rxIsLogged(): Single<Boolean> {
-        return isUserLoggedInCallFactory.isLogged
-    }
-
-    override fun blockingIsLogged(): Boolean {
-        return runBlocking { isUserLoggedInCallFactory.suspendIsLogged() }
+        logoutCallCallFactory.logOut()
     }
 
     override suspend fun suspendIsLogged(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
@@ -30,7 +30,6 @@ package org.hisp.dhis.android.core.user.internal
 import io.reactivex.Completable
 import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.user.AccountManager
 import org.hisp.dhis.android.core.user.AuthenticatedUserObjectRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserModuleImpl.kt
@@ -98,12 +98,20 @@ internal class UserModuleImpl(
         return runBlocking { logInCall.logIn(username, password, serverUrl) }
     }
 
+    override suspend fun suspendLogIn(username: String, password: String, serverUrl: String): User {
+        return logInCall.logIn(username, password, serverUrl)
+    }
+
     override fun logOut(): Completable {
         return logoutCallCallFactory.logOut()
     }
 
     override fun blockingLogOut() {
-        logOut().blockingAwait()
+        runBlocking { logoutCallCallFactory.intenralLogOut() }
+    }
+
+    override suspend fun suspendLogOut() {
+        logoutCallCallFactory.intenralLogOut()
     }
 
     override fun isLogged(): Single<Boolean> {
@@ -111,7 +119,11 @@ internal class UserModuleImpl(
     }
 
     override fun blockingIsLogged(): Boolean {
-        return isLogged().blockingGet()
+        return runBlocking { isUserLoggedInCallFactory.suspendIsLogged() }
+    }
+
+    override suspend fun suspendIsLogged(): Boolean {
+        return isUserLoggedInCallFactory.suspendIsLogged()
     }
 
     override fun accountManager(): AccountManager {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
@@ -48,6 +48,8 @@ interface OAuth2Handler {
 
     fun blockingLogOut()
 
+    suspend fun suspendLogOut()
+
     fun logOutObservable(): Observable<Unit>
 
     fun resetRegistration()

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.user.oauth2
 import io.reactivex.Observable
 import org.hisp.dhis.android.core.user.User
 
+@Suppress("TooManyFunctions")
 interface OAuth2Handler {
 
     fun blockingBuildEnrollmentUrl(serverUrl: String): String

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
@@ -51,7 +51,10 @@ interface OAuth2Handler {
 
     suspend fun suspendLogOut()
 
+    @Deprecated(message = "Use rxLogOutObservable instead", ReplaceWith("rxLogOutObservable()"))
     fun logOutObservable(): Observable<Unit>
+
+    fun rxLogOutObservable(): Observable<Unit>
 
     fun resetRegistration()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -191,6 +191,10 @@ internal class OAuth2HandlerImpl(
         logoutHandler.logOut()
     }
 
+    override suspend fun suspendLogOut() {
+        logoutHandler.logOut()
+    }
+
     override fun logOutObservable(): Observable<Unit> {
         return logoutHandler.logOutObservable()
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -195,7 +195,12 @@ internal class OAuth2HandlerImpl(
         logoutHandler.logOut()
     }
 
+    @Deprecated(message = "Use rxLogOutObservable instead", ReplaceWith("rxLogOutObservable()"))
     override fun logOutObservable(): Observable<Unit> {
+        return logoutHandler.logOutObservable()
+    }
+
+    override fun rxLogOutObservable(): Observable<Unit> {
         return logoutHandler.logOutObservable()
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboServiceShould.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.category
 
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.AccessHelper
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.junit.Assert.assertFalse
@@ -56,11 +57,11 @@ class CategoryOptionComboServiceShould {
     private val thirdJanuary = BaseIdentifiableObject.DATE_FORMAT.parse("2020-01-03T00:00:00.000")
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
         whenever(
             categoryOptionRepository
                 .byCategoryOptionComboUid(categoryOptionComboUid)
-                .blockingGet(),
+                .getInternal(),
         ) doReturn listOf(option1, option2)
 
         whenever(option1.access()) doReturn AccessHelper.createForDataWrite(true)

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.core.dataset
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.AccessHelper
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
@@ -235,11 +236,14 @@ class DataSetInstanceServiceShould {
         whenever(dataSetCollectionRepository.withCompulsoryDataElementOperands().uid(dataSetUid).getInternal())
             .thenReturn(dataSetWithCompulsory)
 
-        val dataValueQuery = mock<DataValueObjectRepository> {
-            on { blockingExists() } doReturn false
-        }
+        val dataValueQuery = mock<DataValueObjectRepository>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
         whenever(
-            dataValueCollectionRepository.value(
+            runBlocking {
+                dataValueQuery.existsInternal()
+            },
+        ) doReturn false
+        whenever(
+            dataValueCollectionRepository.byDeleted().isFalse.value(
                 firstPeriodId,
                 orgUnitUid,
                 "de1",
@@ -249,16 +253,13 @@ class DataSetInstanceServiceShould {
             ),
         ).thenReturn(dataValueQuery)
 
-        dataSetInstanceService.getMissingMandatoryDataElementOperands(
+        val result = dataSetInstanceService.suspendGetMissingMandatoryDataElementOperands(
             dataSetUid,
             firstPeriodId,
             orgUnitUid,
             attOptionComboUid,
         )
-            .test()
-            .assertValue { missingOperands ->
-                missingOperands.size == 1 && missingOperands.first() == operand
-            }
+        assert(result.size == 1 && result.first() == operand)
     }
 
     @Test
@@ -318,18 +319,17 @@ class DataSetInstanceServiceShould {
 
         whenever(finalRepo.getInternal()).thenReturn(listOf(dataValue))
 
-        dataSetInstanceService.getMissingMandatoryFieldsCombination(
+        val result = dataSetInstanceService.suspendGetMissingMandatoryFieldsCombination(
             dataSetUid,
             firstPeriodId,
             orgUnitUid,
             attOptionComboUid,
         )
-            .test()
-            .assertValue { missingFields ->
-                missingFields.size == 1 &&
-                    missingFields.first().dataElement()?.uid() == "de1" &&
-                    missingFields.first().categoryOptionCombo()?.uid() == "coc1" &&
-                    missingFields.first().uid() == "de1.coc1"
-            }
+        assert(
+            result.size == 1 &&
+                result.first().dataElement()?.uid() == "de1" &&
+                result.first().categoryOptionCombo()?.uid() == "coc1" &&
+                result.first().uid() == "de1.coc1",
+        )
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.dataset
 
 import com.google.common.truth.Truth.assertThat
 import io.reactivex.Single
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.AccessHelper
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.BooleanFilterConnector
@@ -112,11 +113,11 @@ class DataSetInstanceServiceShould {
     )
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
         whenever(dataSet.uid()) doReturn dataSetUid
         whenever(categoryOptionRepository.byCategoryOptionComboUid(any()).blockingGet()) doReturn categories
         whenever(dataSetCollectionRepository.uid(any()).blockingGet()) doReturn dataSet
-        whenever(periodHelper.getPeriodForPeriodId(firstPeriodId).blockingGet()) doReturn firstPeriod
+        whenever(periodHelper.suspendGetPeriodForPeriodId(firstPeriodId)) doReturn firstPeriod
         whenever(firstPeriod.startDate()) doReturn firstJanuary
         whenever(firstPeriod.endDate()) doReturn thirdJanuary
         whenever(secondPeriod.startDate()) doReturn firstFebruary
@@ -130,19 +131,19 @@ class DataSetInstanceServiceShould {
     }
 
     @Test
-    fun `Should return true if is in OrgUnit capture scope`() {
+    fun `Should return true if is in OrgUnit capture scope`() = runTest {
         whenever(organisationUnitService.blockingIsInCaptureScope(orgUnitUid)) doReturn true
-        assertThat(dataSetInstanceService.blockingIsOrgUnitInCaptureScope(orgUnitUid)).isTrue()
+        assertThat(dataSetInstanceService.suspendIsOrgUnitInCaptureScope(orgUnitUid)).isTrue()
     }
 
     @Test
-    fun `Should return true if period is in OrgUnit`() {
+    fun `Should return true if period is in OrgUnit`() = runTest {
         val end = firstPeriod.endDate()!!
         val start = firstPeriod.startDate()!!
         whenever(organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, end)) doReturn true
         whenever(organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, start)) doReturn true
 
-        val isPeriodInOrgUnitRange = dataSetInstanceService.blockingIsPeriodInOrgUnitRange(
+        val isPeriodInOrgUnitRange = dataSetInstanceService.suspendIsPeriodInOrgUnitRange(
             period = firstPeriod,
             orgUnitUid = orgUnitUid,
         )
@@ -150,25 +151,25 @@ class DataSetInstanceServiceShould {
     }
 
     @Test
-    fun `Should return true if CategoryOption Has data write access`() {
+    fun `Should return true if CategoryOption Has data write access`() = runTest {
         whenever(categoryOptionComboService.blockingHasWriteAccess(categories)) doReturn true
-        assertThat(dataSetInstanceService.blockingIsCategoryOptionHasDataWriteAccess(attOptionComboUid)).isTrue()
+        assertThat(dataSetInstanceService.suspendIsCategoryOptionHasDataWriteAccess(attOptionComboUid)).isTrue()
     }
 
     @Test
-    fun `Should return true if Period is in Category Option Range`() {
+    fun `Should return true if Period is in Category Option Range`() = runTest {
         whenever(categoryOptionComboService.isInOptionRange(categories, firstPeriod.startDate())) doReturn true
         whenever(categoryOptionComboService.isInOptionRange(categories, firstPeriod.endDate())) doReturn true
         assertThat(
-            dataSetInstanceService.blockingIsPeriodInCategoryOptionRange(firstPeriod, attOptionComboUid),
+            dataSetInstanceService.suspendIsPeriodInCategoryOptionRange(firstPeriod, attOptionComboUid),
         ).isTrue()
     }
 
     @Test
-    fun `Should return true if attributeOptionCombo Assign To OrgUnit`() {
+    fun `Should return true if attributeOptionCombo Assign To OrgUnit`() = runTest {
         whenever(categoryOptionComboService.blockingIsAssignedToOrgUnit(attOptionComboUid, orgUnitUid)).doReturn(true)
         assertThat(
-            dataSetInstanceService.blockingIsAttributeOptionComboAssignToOrgUnit(attOptionComboUid, orgUnitUid),
+            dataSetInstanceService.suspendIsAttributeOptionComboAssignToOrgUnit(attOptionComboUid, orgUnitUid),
         ).isTrue()
     }
 
@@ -177,7 +178,7 @@ class DataSetInstanceServiceShould {
         whenever(dataSet.periodType()) doReturn PeriodType.Monthly
         whenever(periodGenerator.generatePeriod(any(), any(), any())) doReturn firstPeriod
 
-        assertThat(dataSetInstanceService.blockingIsClosed(dataSet, firstPeriod)).isFalse()
+        assertThat(dataSetInstanceService.isClosed(dataSet, firstPeriod)).isFalse()
     }
 
     @Test
@@ -185,40 +186,40 @@ class DataSetInstanceServiceShould {
         whenever(dataSet.periodType()) doReturn PeriodType.Monthly
         whenever(periodGenerator.generatePeriod(any(), any(), any())) doReturn firstPeriod
 
-        assertThat(dataSetInstanceService.blockingIsClosed(dataSet, secondPeriod)).isTrue()
+        assertThat(dataSetInstanceService.isClosed(dataSet, secondPeriod)).isTrue()
     }
 
     @Test
-    fun `Should return true if dataSet is expired`() {
+    fun `Should return true if dataSet is expired`() = runTest {
         whenever(dataSet.periodType()) doReturn PeriodType.Daily
         whenever(dataSet.openFuturePeriods()) doReturn 20
         whenever(dataSet.expiryDays()) doReturn 5.0
-        whenever(periodHelper.getPeriodForPeriodId(any()).blockingGet()) doReturn firstPeriod
+        whenever(periodHelper.suspendGetPeriodForPeriodId(any())) doReturn firstPeriod
         whenever(periodGenerator.generatePeriod(any(), any(), any())) doReturn firstPeriod
 
-        assertThat(dataSetInstanceService.blockingIsExpired(dataSet, firstPeriod)).isTrue()
+        assertThat(dataSetInstanceService.isExpired(dataSet, firstPeriod)).isTrue()
     }
 
     @Test
-    fun `Should return false if dataSet is not expired`() {
+    fun `Should return false if dataSet is not expired`() = runTest {
         val now = Clock.System.now()
         val monthLater = now.plus(30.days)
 
-        whenever(periodHelper.getPeriodForPeriodId(secondPeriodId).blockingGet()) doReturn secondPeriod
+        whenever(periodHelper.suspendGetPeriodForPeriodId(secondPeriodId)) doReturn secondPeriod
         whenever(secondPeriod.endDate()) doReturn Date(monthLater.toEpochMilliseconds())
         whenever(dataSet.periodType()) doReturn PeriodType.Daily
         whenever(periodGenerator.generatePeriod(any(), any(), any())) doReturn secondPeriod
 
-        assertThat(dataSetInstanceService.blockingIsExpired(dataSet, firstPeriod)).isFalse()
+        assertThat(dataSetInstanceService.isExpired(dataSet, firstPeriod)).isFalse()
     }
 
     @Test
     fun `Should return false if expiry days is 0 or negative`() {
         whenever(dataSet.expiryDays()) doReturn 0.0
-        assertThat(dataSetInstanceService.blockingIsExpired(dataSet, firstPeriod)).isFalse()
+        assertThat(dataSetInstanceService.isExpired(dataSet, firstPeriod)).isFalse()
 
         whenever(dataSet.expiryDays()) doReturn -15.0
-        assertThat(dataSetInstanceService.blockingIsExpired(dataSet, firstPeriod)).isFalse()
+        assertThat(dataSetInstanceService.isExpired(dataSet, firstPeriod)).isFalse()
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -29,7 +29,6 @@
 package org.hisp.dhis.android.core.dataset
 
 import com.google.common.truth.Truth.assertThat
-import io.reactivex.Single
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.AccessHelper
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
@@ -115,8 +114,8 @@ class DataSetInstanceServiceShould {
     @Before
     fun setUp() = runTest {
         whenever(dataSet.uid()) doReturn dataSetUid
-        whenever(categoryOptionRepository.byCategoryOptionComboUid(any()).blockingGet()) doReturn categories
-        whenever(dataSetCollectionRepository.uid(any()).blockingGet()) doReturn dataSet
+        whenever(categoryOptionRepository.byCategoryOptionComboUid(any()).getInternal()) doReturn categories
+        whenever(dataSetCollectionRepository.uid(any()).getInternal()) doReturn dataSet
         whenever(periodHelper.suspendGetPeriodForPeriodId(firstPeriodId)) doReturn firstPeriod
         whenever(firstPeriod.startDate()) doReturn firstJanuary
         whenever(firstPeriod.endDate()) doReturn thirdJanuary
@@ -132,7 +131,7 @@ class DataSetInstanceServiceShould {
 
     @Test
     fun `Should return true if is in OrgUnit capture scope`() = runTest {
-        whenever(organisationUnitService.blockingIsInCaptureScope(orgUnitUid)) doReturn true
+        whenever(organisationUnitService.suspendIsInCaptureScope(orgUnitUid)) doReturn true
         assertThat(dataSetInstanceService.suspendIsOrgUnitInCaptureScope(orgUnitUid)).isTrue()
     }
 
@@ -140,8 +139,8 @@ class DataSetInstanceServiceShould {
     fun `Should return true if period is in OrgUnit`() = runTest {
         val end = firstPeriod.endDate()!!
         val start = firstPeriod.startDate()!!
-        whenever(organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, end)) doReturn true
-        whenever(organisationUnitService.blockingIsDateInOrgunitRange(orgUnitUid, start)) doReturn true
+        whenever(organisationUnitService.suspendIsDateInOrgunitRange(orgUnitUid, end)) doReturn true
+        whenever(organisationUnitService.suspendIsDateInOrgunitRange(orgUnitUid, start)) doReturn true
 
         val isPeriodInOrgUnitRange = dataSetInstanceService.suspendIsPeriodInOrgUnitRange(
             period = firstPeriod,
@@ -152,7 +151,7 @@ class DataSetInstanceServiceShould {
 
     @Test
     fun `Should return true if CategoryOption Has data write access`() = runTest {
-        whenever(categoryOptionComboService.blockingHasWriteAccess(categories)) doReturn true
+        whenever(categoryOptionComboService.hasWriteAccess(categories)) doReturn true
         assertThat(dataSetInstanceService.suspendIsCategoryOptionHasDataWriteAccess(attOptionComboUid)).isTrue()
     }
 
@@ -167,7 +166,7 @@ class DataSetInstanceServiceShould {
 
     @Test
     fun `Should return true if attributeOptionCombo Assign To OrgUnit`() = runTest {
-        whenever(categoryOptionComboService.blockingIsAssignedToOrgUnit(attOptionComboUid, orgUnitUid)).doReturn(true)
+        whenever(categoryOptionComboService.suspendIsAssignedToOrgUnit(attOptionComboUid, orgUnitUid)).doReturn(true)
         assertThat(
             dataSetInstanceService.suspendIsAttributeOptionComboAssignToOrgUnit(attOptionComboUid, orgUnitUid),
         ).isTrue()
@@ -223,7 +222,7 @@ class DataSetInstanceServiceShould {
     }
 
     @Test
-    fun `Should return missing mandatory data element operands when data value is missing`() {
+    fun `Should return missing mandatory data element operands when data value is missing`() = runTest {
         val operand = mock<DataElementOperand> {
             on { dataElement() } doReturn ObjectWithUid.create("de1")
             on { categoryOptionCombo() } doReturn ObjectWithUid.create("coc1")
@@ -233,8 +232,8 @@ class DataSetInstanceServiceShould {
             on { compulsoryDataElementOperands() } doReturn listOf(operand)
         }
 
-        whenever(dataSetCollectionRepository.withCompulsoryDataElementOperands().uid(dataSetUid).get())
-            .thenReturn(Single.just(dataSetWithCompulsory))
+        whenever(dataSetCollectionRepository.withCompulsoryDataElementOperands().uid(dataSetUid).getInternal())
+            .thenReturn(dataSetWithCompulsory)
 
         val dataValueQuery = mock<DataValueObjectRepository> {
             on { blockingExists() } doReturn false
@@ -264,7 +263,7 @@ class DataSetInstanceServiceShould {
 
     @Test
     @Suppress("LongMethod")
-    fun `Should return missing mandatory fields combination when data values are incomplete`() {
+    fun `Should return missing mandatory fields combination when data values are incomplete`() = runTest {
         val dataSetElement = mock<DataSetElement> {
             on { categoryCombo() } doReturn ObjectWithUid.create("ccUid")
             on { dataElement() } doReturn ObjectWithUid.create("de1")
@@ -273,14 +272,14 @@ class DataSetInstanceServiceShould {
             on { fieldCombinationRequired() } doReturn true
             on { dataSetElements() } doReturn listOf(dataSetElement)
         }
-        whenever(dataSetCollectionRepository.withDataSetElements().uid(dataSetUid).get())
-            .thenReturn(Single.just(dataSetWithElements))
+        whenever(dataSetCollectionRepository.withDataSetElements().uid(dataSetUid).getInternal())
+            .thenReturn(dataSetWithElements)
 
         val byCatComboUidConnector = mock<StringFilterConnector<CategoryOptionComboCollectionRepository>>()
         val eqRepo = mock<CategoryOptionComboCollectionRepository>()
         whenever(categoryOptionComboCollectionRepository.byCategoryComboUid()).thenReturn(byCatComboUidConnector)
         whenever(byCatComboUidConnector.eq("ccUid")).thenReturn(eqRepo)
-        whenever(eqRepo.blockingGetUids()).thenReturn(listOf("coc1", "coc2"))
+        whenever(eqRepo.getUidsInternal()).thenReturn(listOf("coc1", "coc2"))
 
         val dataValue = mock<DataValue> {
             on { dataElement() } doReturn "de1"
@@ -317,7 +316,7 @@ class DataSetInstanceServiceShould {
         whenever(repoAfterDE.byCategoryOptionComboUid()).thenReturn(cocConnector)
         whenever(cocConnector.`in`(listOf("coc1", "coc2"))).thenReturn(finalRepo)
 
-        whenever(finalRepo.blockingGet()).thenReturn(listOf(dataValue))
+        whenever(finalRepo.getInternal()).thenReturn(listOf(dataValue))
 
         dataSetInstanceService.getMissingMandatoryFieldsCombination(
             dataSetUid,

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentServiceShould.kt
@@ -27,7 +27,6 @@
 */
 package org.hisp.dhis.android.core.enrollment
 
-import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.AccessHelper
@@ -91,7 +90,7 @@ class EnrollmentServiceShould {
 
     @Before
     fun setUp() = runTest {
-        whenever(enrollmentRepository.uid(enrollmentUid).blockingGet()) doReturn enrollment
+        whenever(enrollmentRepository.uid(enrollmentUid).getInternal()) doReturn enrollment
         whenever(
             trackedEntityInstanceRepository
                 .uid(trackedEntityInstanceUid).getInternal(),
@@ -100,6 +99,14 @@ class EnrollmentServiceShould {
 
         whenever(enrollment.uid()) doReturn enrollmentUid
         whenever(trackedEntityInstance.organisationUnit()) doReturn organisationUnitId
+        whenever(
+            runBlocking {
+                organisationUnitRepository
+                    .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
+                    .uid(organisationUnitId)
+                    .existsInternal()
+            },
+        ) doReturn false
 
         enrollmentService = EnrollmentServiceImpl(
             enrollmentRepository,
@@ -114,8 +121,8 @@ class EnrollmentServiceShould {
     }
 
     @Test
-    fun `IsOpen should return true if enrollment is not found`() {
-        whenever(enrollmentRepository.uid(enrollmentUid).blockingGet()) doReturn null
+    fun `IsOpen should return true if enrollment is not found`() = runTest {
+        whenever(enrollmentRepository.uid(enrollmentUid).getInternal()) doReturn null
         assertTrue(enrollmentService.blockingIsOpen(enrollmentUid))
     }
 
@@ -219,7 +226,7 @@ class EnrollmentServiceShould {
         }
 
     @Test
-    fun `Enrollment has any events that allows events creation`() {
+    fun `Enrollment has any events that allows events creation`() = runTest {
         whenever(enrollmentRepository.uid(enrollmentUid).blockingGet()) doReturn enrollment
         whenever(enrollment.program()) doReturn programUid
 
@@ -230,8 +237,8 @@ class EnrollmentServiceShould {
             programStageCollectionRepository.byAccessDataWrite().isTrue,
         ) doReturn programStageCollectionRepository
         whenever(
-            programStageCollectionRepository.get(),
-        ) doReturn Single.just(getProgramStages())
+            programStageCollectionRepository.getInternal(),
+        ) doReturn getProgramStages()
 
         whenever(
             eventCollectionRepository.byEnrollmentUid().eq(enrollmentUid),
@@ -239,14 +246,14 @@ class EnrollmentServiceShould {
         whenever(
             eventCollectionRepository.byDeleted().isFalse,
         ) doReturn eventCollectionRepository
-        whenever(eventCollectionRepository.get()) doReturn Single.just(getEventList())
+        whenever(eventCollectionRepository.getInternal()) doReturn getEventList()
 
         assertTrue(enrollmentService.blockingGetAllowEventCreation(enrollmentUid, listOf("1")))
     }
 
     @Test
-    fun `Enrollment has not any events that allows events creation`() {
-        whenever(enrollmentRepository.uid(enrollmentUid).blockingGet()) doReturn enrollment
+    fun `Enrollment has not any events that allows events creation`() = runTest {
+        whenever(enrollmentRepository.uid(enrollmentUid).getInternal()) doReturn enrollment
         whenever(enrollment.program()) doReturn programUid
 
         whenever(
@@ -256,8 +263,8 @@ class EnrollmentServiceShould {
             programStageCollectionRepository.byAccessDataWrite().isTrue,
         ) doReturn programStageCollectionRepository
         whenever(
-            programStageCollectionRepository.get(),
-        ) doReturn Single.just(getProgramStages())
+            programStageCollectionRepository.getInternal(),
+        ) doReturn getProgramStages()
 
         whenever(
             eventCollectionRepository.byEnrollmentUid().eq(enrollmentUid),
@@ -265,7 +272,7 @@ class EnrollmentServiceShould {
         whenever(
             eventCollectionRepository.byDeleted().isFalse,
         ) doReturn eventCollectionRepository
-        whenever(eventCollectionRepository.get()) doReturn Single.just(getEventList())
+        whenever(eventCollectionRepository.getInternal()) doReturn getEventList()
 
         assertFalse(enrollmentService.blockingGetAllowEventCreation(enrollmentUid, listOf("1", "2")))
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
@@ -94,11 +94,11 @@ class EventServiceShould {
     private val firstJanuary = BaseIdentifiableObject.DATE_FORMAT.parse("2020-01-01T00:00:00.000")
 
     @Before
-    fun setUp() {
-        whenever(eventRepository.uid(any()).blockingGet()) doReturn event
-        whenever(enrollmentRepository.uid(any()).blockingGet()) doReturn enrollment
-        whenever(programRepository.uid(any()).blockingGet()) doReturn program
-        whenever(programStageRepository.uid(any()).blockingGet()) doReturn programStage
+    fun setUp() = runTest {
+        whenever(eventRepository.uid(any()).getInternal()) doReturn event
+        whenever(enrollmentRepository.uid(any()).getInternal()) doReturn enrollment
+        whenever(programRepository.uid(any()).getInternal()) doReturn program
+        whenever(programStageRepository.uid(any()).getInternal()) doReturn programStage
 
         whenever(event.uid()) doReturn eventUid
         whenever(event.eventDate()) doReturn firstJanuary

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
@@ -129,27 +129,27 @@ class EventServiceShould {
     }
 
     @Test
-    fun `Should return true if has access to categoryCombo or attribute option combo is null`() {
+    fun `Should return true if has access to categoryCombo or attribute option combo is null`() = runTest {
         whenever(event.attributeOptionCombo()) doReturn attributeOptionComboUid
-        whenever(categoryOptionComboService.blockingHasAccess(attributeOptionComboUid, firstJanuary)) doReturn true
+        whenever(categoryOptionComboService.suspendHasAccess(attributeOptionComboUid, firstJanuary)) doReturn true
         assertTrue(eventService.blockingHasCategoryComboAccess(event))
 
         whenever(event.attributeOptionCombo()) doReturn null
-        whenever(categoryOptionComboService.blockingHasAccess(attributeOptionComboUid, firstJanuary)) doReturn false
+        whenever(categoryOptionComboService.suspendHasAccess(attributeOptionComboUid, firstJanuary)) doReturn false
         assertTrue(eventService.blockingHasCategoryComboAccess(event))
     }
 
     @Test
-    fun `Should return false if has not access to categoryCombo`() {
+    fun `Should return false if has not access to categoryCombo`() = runTest {
         whenever(event.attributeOptionCombo()) doReturn attributeOptionComboUid
-        whenever(categoryOptionComboService.blockingHasAccess(attributeOptionComboUid, firstJanuary)) doReturn false
+        whenever(categoryOptionComboService.suspendHasAccess(attributeOptionComboUid, firstJanuary)) doReturn false
         assertFalse(eventService.blockingHasCategoryComboAccess(event))
     }
 
     @Test
-    fun `Should return no data write access edition status`() {
+    fun `Should return no data write access edition status`() = runTest {
         whenever(event.attributeOptionCombo()) doReturn attributeOptionComboUid
-        whenever(categoryOptionComboService.blockingHasAccess(attributeOptionComboUid, firstJanuary)) doReturn false
+        whenever(categoryOptionComboService.suspendHasAccess(attributeOptionComboUid, firstJanuary)) doReturn false
         val status = eventService.blockingGetEditableStatus(event.uid())
 
         assertThat(status is EventEditableStatus.NonEditable).isTrue()
@@ -164,10 +164,10 @@ class EventServiceShould {
         whenever(event.enrollment()) doReturn "enrollmentUid"
         whenever(event.program()) doReturn "programUid"
         whenever(enrollment.trackedEntityInstance()) doReturn "teiUid"
-        whenever(organisationUnitService.blockingIsDateInOrgunitRange(any(), any())) doReturn true
-        whenever(organisationUnitService.blockingIsInSearchScope("OU2")) doReturn false
-        whenever(organisationUnitService.blockingIsInSearchScope("OU1")) doReturn true
-        whenever(enrollmentService.blockingIsOpen(any())) doReturn true
+        whenever(organisationUnitService.suspendIsDateInOrgunitRange(any(), any())) doReturn true
+        whenever(organisationUnitService.isInSearchScope("OU2")) doReturn false
+        whenever(organisationUnitService.isInSearchScope("OU1")) doReturn true
+        whenever(enrollmentService.suspendIsOpen(any())) doReturn true
 
         val programOwner: ProgramOwner = mock()
         whenever(programOwner.ownerOrgUnit()) doReturn "OU1"
@@ -184,10 +184,10 @@ class EventServiceShould {
         whenever(event.enrollment()) doReturn "enrollmentUid"
         whenever(event.program()) doReturn "programUid"
         whenever(enrollment.trackedEntityInstance()) doReturn "teiUid"
-        whenever(organisationUnitService.blockingIsDateInOrgunitRange(any(), any())) doReturn true
-        whenever(organisationUnitService.blockingIsInSearchScope("OU2")) doReturn false
-        whenever(organisationUnitService.blockingIsInSearchScope("OU3")) doReturn false
-        whenever(enrollmentService.blockingIsOpen(any())) doReturn true
+        whenever(organisationUnitService.suspendIsDateInOrgunitRange(any(), any())) doReturn true
+        whenever(organisationUnitService.isInSearchScope("OU2")) doReturn false
+        whenever(organisationUnitService.isInSearchScope("OU3")) doReturn false
+        whenever(enrollmentService.suspendIsOpen(any())) doReturn true
 
         val programOwner: ProgramOwner = mock()
         whenever(programOwner.ownerOrgUnit()) doReturn "OU3"

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
@@ -165,8 +165,7 @@ class EventServiceShould {
         whenever(event.program()) doReturn "programUid"
         whenever(enrollment.trackedEntityInstance()) doReturn "teiUid"
         whenever(organisationUnitService.suspendIsDateInOrgunitRange(any(), any())) doReturn true
-        whenever(organisationUnitService.isInSearchScope("OU2")) doReturn false
-        whenever(organisationUnitService.isInSearchScope("OU1")) doReturn true
+        whenever(organisationUnitService.suspendIsInCaptureScope("OU1")) doReturn true
         whenever(enrollmentService.suspendIsOpen(any())) doReturn true
 
         val programOwner: ProgramOwner = mock()

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
@@ -187,6 +187,7 @@ class EventServiceShould {
         whenever(organisationUnitService.suspendIsDateInOrgunitRange(any(), any())) doReturn true
         whenever(organisationUnitService.isInSearchScope("OU2")) doReturn false
         whenever(organisationUnitService.isInSearchScope("OU3")) doReturn false
+        whenever(organisationUnitService.suspendIsInCaptureScope(any())) doReturn false
         whenever(enrollmentService.suspendIsOpen(any())) doReturn true
 
         val programOwner: ProgramOwner = mock()

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitServiceShould.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.organisationunit
 
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -54,8 +55,8 @@ class OrganisationUnitServiceShould {
     private val thirdJanuary = BaseIdentifiableObject.DATE_FORMAT.parse("2020-01-03T00:00:00.000")
 
     @Before
-    fun setUp() {
-        whenever(organisationUnitRepository.uid(organisationUnitUid).blockingGet()) doReturn organisationUnit
+    fun setUp() = runTest {
+        whenever(organisationUnitRepository.uid(organisationUnitUid).getInternal()) doReturn organisationUnit
 
         whenever(organisationUnit.uid()) doReturn organisationUnitUid
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/IsUserLoggedInCallableShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/IsUserLoggedInCallableShould.kt
@@ -28,7 +28,7 @@
 package org.hisp.dhis.android.core.user.internal
 
 import com.google.common.truth.Truth.assertThat
-import io.reactivex.Single
+import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
@@ -46,31 +46,31 @@ class IsUserLoggedInCallableShould {
     private val databaseAdapter: DatabaseAdapter = mock()
     private val credentials: Credentials = mock()
 
-    private lateinit var isUserLoggedInSingle: Single<Boolean>
+    private suspend fun isUserLoggedIn() =
+        IsUserLoggedInCallableFactory(credentialsSecureStore, databaseAdapter).suspendIsLogged()
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
         whenever(credentials.username).doReturn("user")
         whenever(credentials.password).doReturn("password")
-        isUserLoggedInSingle = IsUserLoggedInCallableFactory(credentialsSecureStore, databaseAdapter).isLogged
     }
 
     @Test
-    fun return_false_if_credentials_not_stored() {
-        assertThat(isUserLoggedInSingle.blockingGet()).isFalse()
+    fun return_false_if_credentials_not_stored() = runTest {
+        assertThat(isUserLoggedIn()).isFalse()
     }
 
     @Test
-    fun return_false_if_database_is_not_ready() {
+    fun return_false_if_database_is_not_ready() = runTest {
         whenever(credentialsSecureStore.get()).doReturn(credentials)
         whenever(databaseAdapter.isReady).doReturn(false)
-        assertThat(isUserLoggedInSingle.blockingGet()).isFalse()
+        assertThat(isUserLoggedIn()).isFalse()
     }
 
     @Test
-    fun return_true_if_credentials_stored() {
+    fun return_true_if_credentials_stored() = runTest {
         whenever(credentialsSecureStore.get()).doReturn(credentials)
         whenever(databaseAdapter.isReady).doReturn(true)
-        assertThat(isUserLoggedInSingle.blockingGet()).isTrue()
+        assertThat(isUserLoggedIn()).isTrue()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogOutCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogOutCallShould.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.user.internal
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
@@ -79,7 +80,7 @@ class LogOutCallShould {
     fun clear_user_credentials() {
         whenever(credentialsSecureStore.get()).thenReturn(credentials)
         whenever(userIdStore.get()).thenReturn("user-id")
-        logOutCall.logOut().blockingAwait()
+        rxCompletable { logOutCall.logOut() }.blockingAwait()
         verify(credentialsSecureStore, times(1)).remove()
         verify(serverTimezoneManager, times(1)).clearCache()
     }
@@ -87,20 +88,20 @@ class LogOutCallShould {
     @Test
     fun clear_server_timezone_cache() {
         whenever(credentialsSecureStore.get()).thenReturn(credentials)
-        logOutCall.logOut().blockingAwait()
+        rxCompletable { logOutCall.logOut() }.blockingAwait()
         verify(serverTimezoneManager, times(1)).clearCache()
     }
 
     @Test
     fun clear_default_category_combo_cache() {
         whenever(credentialsSecureStore.get()).thenReturn(credentials)
-        logOutCall.logOut().blockingAwait()
+        rxCompletable { logOutCall.logOut() }.blockingAwait()
         verify(defaultCategoryComboManager, times(1)).clearCache()
     }
 
     @Test
     fun throw_d2_exception_if_no_authenticated_user() {
-        val testObserver = logOutCall.logOut().test()
+        val testObserver = rxCompletable { logOutCall.logOut() }.test()
         testObserver.awaitTerminalEvent()
         val d2Error = testObserver.errors()[0] as D2Error
         assertThat(d2Error.errorCode()).isEqualTo(D2ErrorCode.NO_AUTHENTICATED_USER)


### PR DESCRIPTION
This PR exposes suspend functions from public repositories and services. Only the specific functions from each class have been altered, not the common ones, that will be done in a separate task. Also, the current Rx Java public functions have been duplicated adding the prefix rx-, and the originals have been deprecated in favor of the rx- ones.

Related task: [ANDROSDK-2276](https://dhis2.atlassian.net/browse/ANDROSDK-2276)

[ANDROSDK-2276]: https://dhis2.atlassian.net/browse/ANDROSDK-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ