### PR TITLE
chore: [ANDROSDK-2280] expose suspend functions to API on common interfaces

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10525,10 +10525,16 @@ public abstract interface class org/hisp/dhis/android/core/systeminfo/DHISVersio
 }
 
 public abstract interface class org/hisp/dhis/android/core/systeminfo/Ping {
-	public abstract fun blockingGet ()Ljava/lang/String;
-	public abstract fun get ()Lio/reactivex/Single;
-	public abstract fun rxGet ()Lio/reactivex/Single;
+	public fun blockingGet ()Ljava/lang/String;
+	public fun get ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
 	public abstract fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/systeminfo/Ping$DefaultImpls {
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/systeminfo/Ping;)Ljava/lang/String;
+	public static fun get (Lorg/hisp/dhis/android/core/systeminfo/Ping;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/systeminfo/Ping;)Lio/reactivex/Single;
 }
 
 public final class org/hisp/dhis/android/core/systeminfo/SMSVersion : java/lang/Enum {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -7140,21 +7140,32 @@ public abstract interface class org/hisp/dhis/android/core/option/OptionModule {
 }
 
 public abstract interface class org/hisp/dhis/android/core/option/OptionService {
-	public abstract fun blockingSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Ljava/util/List;
+	public fun blockingSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 	public static synthetic fun blockingSearchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ljava/util/List;
-	public abstract fun searchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
+	public fun rxSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
+	public static synthetic fun rxSearchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/reactivex/Single;
+	public fun searchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
 	public static synthetic fun searchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/reactivex/Single;
+	public abstract fun suspendSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendSearchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/option/OptionService$DefaultImpls {
+	public static fun blockingSearchForOptions (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 	public static synthetic fun blockingSearchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ljava/util/List;
+	public static fun rxSearchForOptions (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
+	public static synthetic fun rxSearchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/reactivex/Single;
+	public static fun searchForOptions (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
 	public static synthetic fun searchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/reactivex/Single;
+	public static synthetic fun suspendSearchForOptions$default (Lorg/hisp/dhis/android/core/option/OptionService;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/option/OptionServiceImpl : org/hisp/dhis/android/core/option/OptionService {
 	public fun <init> (Lorg/hisp/dhis/android/core/option/OptionCollectionRepository;)V
 	public fun blockingSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Ljava/util/List;
+	public fun rxSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
 	public fun searchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/reactivex/Single;
+	public fun suspendSearchForOptions (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/option/OptionSet : org/hisp/dhis/android/core/common/BaseIdentifiableObject, org/hisp/dhis/android/core/common/CoreObject {
@@ -12311,8 +12322,16 @@ public final class org/hisp/dhis/android/core/validation/ValidationRuleOperator 
 }
 
 public abstract interface class org/hisp/dhis/android/core/validation/engine/ValidationEngine {
-	public abstract fun blockingValidate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/validation/engine/ValidationResult;
-	public abstract fun validate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public fun blockingValidate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/validation/engine/ValidationResult;
+	public fun rxValidate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public abstract fun suspendValidate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun validate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+}
+
+public final class org/hisp/dhis/android/core/validation/engine/ValidationEngine$DefaultImpls {
+	public static fun blockingValidate (Lorg/hisp/dhis/android/core/validation/engine/ValidationEngine;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/validation/engine/ValidationResult;
+	public static fun rxValidate (Lorg/hisp/dhis/android/core/validation/engine/ValidationEngine;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
+	public static fun validate (Lorg/hisp/dhis/android/core/validation/engine/ValidationEngine;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/reactivex/Single;
 }
 
 public abstract class org/hisp/dhis/android/core/validation/engine/ValidationResult {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2038,53 +2038,198 @@ public abstract interface class org/hisp/dhis/android/core/arch/repositories/col
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload {
-	public abstract fun blockingUpload ()V
-	public abstract fun upload ()Lio/reactivex/Observable;
+	public fun blockingUpload ()V
+	public abstract fun flowUpload ()Lkotlinx/coroutines/flow/Flow;
+	public fun rxUpload ()Lio/reactivex/Observable;
+	public fun upload ()Lio/reactivex/Observable;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload$DefaultImpls {
+	public static fun blockingUpload (Lorg/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload;)V
+	public static fun rxUpload (Lorg/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload;)Lio/reactivex/Observable;
+	public static fun upload (Lorg/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload;)Lio/reactivex/Observable;
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
-	public abstract fun blockingCount ()I
-	public abstract fun blockingGet ()Ljava/util/List;
-	public abstract fun blockingIsEmpty ()Z
-	public abstract fun count ()Lio/reactivex/Single;
-	public abstract fun get ()Lio/reactivex/Single;
+	public fun blockingCount ()I
+	public fun blockingGet ()Ljava/util/List;
+	public fun blockingIsEmpty ()Z
+	public fun count ()Lio/reactivex/Single;
+	public fun get ()Lio/reactivex/Single;
 	public abstract fun getPaged (I)Landroidx/lifecycle/LiveData;
 	public abstract fun getPagingData (I)Lkotlinx/coroutines/flow/Flow;
-	public abstract fun isEmpty ()Lio/reactivex/Single;
+	public fun isEmpty ()Lio/reactivex/Single;
 	public abstract fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
+	public fun rxCount ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun rxIsEmpty ()Lio/reactivex/Single;
+	public abstract fun suspendCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendIsEmpty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository$DefaultImpls {
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Z
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository;)Lio/reactivex/Single;
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository, org/hisp/dhis/android/core/arch/repositories/filters/internal/IdentifiableFilters {
 }
 
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository$DefaultImpls {
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Ljava/util/List;
+	public static fun blockingGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Z
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun getUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository;)Lio/reactivex/Single;
+}
+
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository, org/hisp/dhis/android/core/arch/repositories/filters/internal/NameableFilters {
 }
 
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository$DefaultImpls {
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Ljava/util/List;
+	public static fun blockingGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Z
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun getUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyNameableCollectionRepository;)Lio/reactivex/Single;
+}
+
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository {
-	public abstract fun blockingDownload ()V
-	public abstract fun download ()Lio/reactivex/Completable;
+	public fun blockingDownload ()V
+	public fun download ()Lio/reactivex/Completable;
+	public fun rxDownload ()Lio/reactivex/Completable;
+	public abstract fun suspendDownload (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository$DefaultImpls {
+	public static fun blockingDownload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)V
+	public static fun blockingExists (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Z
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Ljava/lang/Object;
+	public static fun download (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Lio/reactivex/Completable;
+	public static fun exists (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Lio/reactivex/Single;
+	public static fun rxDownload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Lio/reactivex/Completable;
+	public static fun rxExists (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository;)Lio/reactivex/Single;
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository {
-	public abstract fun blockingGetUids ()Ljava/util/List;
-	public abstract fun getUids ()Lio/reactivex/Single;
+	public fun blockingGetUids ()Ljava/util/List;
+	public fun getUids ()Lio/reactivex/Single;
+	public fun rxGetUids ()Lio/reactivex/Single;
+	public abstract fun suspendGetUids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository$DefaultImpls {
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Ljava/util/List;
+	public static fun blockingGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Z
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun getUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository;)Lio/reactivex/Single;
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository {
 }
 
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository$DefaultImpls {
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Z
+	public static fun blockingUpload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)V
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxUpload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Observable;
+	public static fun upload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository;)Lio/reactivex/Observable;
+}
+
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository {
-	public abstract fun add (Ljava/lang/Object;)Lio/reactivex/Single;
-	public abstract fun blockingAdd (Ljava/lang/Object;)Ljava/lang/String;
+	public fun add (Ljava/lang/Object;)Lio/reactivex/Single;
+	public fun blockingAdd (Ljava/lang/Object;)Ljava/lang/String;
+	public fun rxAdd (Ljava/lang/Object;)Lio/reactivex/Single;
+	public abstract fun suspendAdd (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository$DefaultImpls {
+	public static fun add (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;Ljava/lang/Object;)Lio/reactivex/Single;
+	public static fun blockingAdd (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;Ljava/lang/Object;)Ljava/lang/String;
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Ljava/util/List;
+	public static fun blockingGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Z
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun getUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxAdd (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;Ljava/lang/Object;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository;)Lio/reactivex/Single;
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload, org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository {
 }
 
+public final class org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository$DefaultImpls {
+	public static fun add (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;Ljava/lang/Object;)Lio/reactivex/Single;
+	public static fun blockingAdd (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;Ljava/lang/Object;)Ljava/lang/String;
+	public static fun blockingCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)I
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Ljava/util/List;
+	public static fun blockingGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Ljava/util/List;
+	public static fun blockingIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Z
+	public static fun blockingUpload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)V
+	public static fun count (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun getUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxAdd (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;Ljava/lang/Object;)Lio/reactivex/Single;
+	public static fun rxCount (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxGetUids (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxIsEmpty (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Single;
+	public static fun rxUpload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Observable;
+	public static fun upload (Lorg/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUploadWithUidCollectionRepository;)Lio/reactivex/Observable;
+}
+
 public abstract class org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository {
 	public fun blockingGetUids ()Ljava/util/List;
 	public fun getUids ()Lio/reactivex/Single;
+	public fun rxGetUids ()Lio/reactivex/Single;
+	public fun suspendGetUids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
@@ -2108,6 +2253,12 @@ public class org/hisp/dhis/android/core/arch/repositories/collection/internal/Re
 	public fun isEmpty ()Lio/reactivex/Single;
 	public synthetic fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl;
+	public fun rxCount ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun rxIsEmpty ()Lio/reactivex/Single;
+	public fun suspendCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendIsEmpty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyIdentifiableCollectionRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyIdentifiableCollectionRepository {
@@ -2144,9 +2295,10 @@ public class org/hisp/dhis/android/core/arch/repositories/collection/internal/Re
 public abstract class org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository {
 	protected final field transformer Lorg/hisp/dhis/android/core/arch/handlers/internal/Transformer;
 	public fun add (Ljava/lang/Object;)Lio/reactivex/Single;
-	protected fun addInternal (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun blockingAdd (Ljava/lang/Object;)Ljava/lang/String;
 	protected fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxAdd (Ljava/lang/Object;)Lio/reactivex/Single;
+	public fun suspendAdd (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/arch/repositories/filters/internal/AbstractFilterConnector {
@@ -2389,39 +2541,99 @@ public final class org/hisp/dhis/android/core/arch/repositories/filters/internal
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository : org/hisp/dhis/android/core/arch/repositories/collection/BaseRepository {
-	public abstract fun blockingExists ()Z
-	public abstract fun blockingGet ()Ljava/lang/Object;
-	public abstract fun exists ()Lio/reactivex/Single;
-	public abstract fun get ()Lio/reactivex/Single;
+	public fun blockingExists ()Z
+	public fun blockingGet ()Ljava/lang/Object;
+	public fun exists ()Lio/reactivex/Single;
+	public fun get ()Lio/reactivex/Single;
+	public fun rxExists ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public abstract fun suspendExists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository$DefaultImpls {
+	public static fun blockingExists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;)Z
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;)Ljava/lang/Object;
+	public static fun exists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;)Lio/reactivex/Single;
+	public static fun rxExists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;)Lio/reactivex/Single;
 }
 
 public final class org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl {
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository {
-	public abstract fun blockingDelete ()V
-	public abstract fun blockingDeleteIfExist ()V
-	public abstract fun delete ()Lio/reactivex/Completable;
-	public abstract fun deleteIfExist ()Lio/reactivex/Completable;
+	public fun blockingDelete ()V
+	public fun blockingDeleteIfExist ()V
+	public fun delete ()Lio/reactivex/Completable;
+	public fun deleteIfExist ()Lio/reactivex/Completable;
+	public fun rxDelete ()Lio/reactivex/Completable;
+	public fun rxDeleteIfExist ()Lio/reactivex/Completable;
+	public abstract fun suspendDelete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendDeleteIfExist (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository$DefaultImpls {
+	public static fun blockingDelete (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)V
+	public static fun blockingDeleteIfExist (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)V
+	public static fun blockingExists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Z
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lorg/hisp/dhis/android/core/common/CoreObject;
+	public static fun delete (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Completable;
+	public static fun deleteIfExist (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Completable;
+	public static fun exists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Single;
+	public static fun rxDelete (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Completable;
+	public static fun rxDeleteIfExist (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Completable;
+	public static fun rxExists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;)Lio/reactivex/Single;
 }
 
 public abstract interface class org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository {
-	public abstract fun blockingSet (Ljava/lang/String;)V
-	public abstract fun set (Ljava/lang/String;)Lio/reactivex/Completable;
+	public fun blockingSet (Ljava/lang/String;)V
+	public fun rxSet (Ljava/lang/String;)Lio/reactivex/Completable;
+	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
+	public abstract fun suspendSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl {
-	public final fun blockingDownload ()V
-	public final fun blockingExists ()Z
-	public final fun blockingGet ()Ljava/lang/Object;
-	public final fun download ()Lio/reactivex/Completable;
-	public final fun exists ()Lio/reactivex/Single;
-	public final fun get ()Lio/reactivex/Single;
+public final class org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository$DefaultImpls {
+	public static fun blockingDelete (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)V
+	public static fun blockingDeleteIfExist (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)V
+	public static fun blockingExists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Z
+	public static fun blockingGet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lorg/hisp/dhis/android/core/common/CoreObject;
+	public static fun blockingSet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;Ljava/lang/String;)V
+	public static fun delete (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Completable;
+	public static fun deleteIfExist (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Completable;
+	public static fun exists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Single;
+	public static fun get (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Single;
+	public static fun rxDelete (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Completable;
+	public static fun rxDeleteIfExist (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Completable;
+	public static fun rxExists (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Single;
+	public static fun rxGet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;)Lio/reactivex/Single;
+	public static fun rxSet (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;Ljava/lang/String;)Lio/reactivex/Completable;
+	public static fun set (Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository;Ljava/lang/String;)Lio/reactivex/Completable;
+}
+
+public abstract class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
+	public fun blockingDownload ()V
+	public fun blockingExists ()Z
+	public fun blockingGet ()Ljava/lang/Object;
+	public fun download ()Lio/reactivex/Completable;
+	public fun exists ()Lio/reactivex/Single;
+	public fun get ()Lio/reactivex/Single;
+	public fun rxDownload ()Lio/reactivex/Completable;
+	public fun rxExists ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun suspendDownload (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendExists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
 	public fun blockingDownload ()V
 	public fun download ()Lio/reactivex/Completable;
+	public fun rxDownload ()Lio/reactivex/Completable;
+	public fun suspendDownload (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository {
@@ -2433,6 +2645,10 @@ public abstract class org/hisp/dhis/android/core/arch/repositories/object/intern
 	public fun get ()Lio/reactivex/Single;
 	protected final fun getScope ()Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope;
 	protected abstract fun getWithoutChildrenInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxExists ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun suspendExists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl {
@@ -2445,10 +2661,12 @@ public abstract class org/hisp/dhis/android/core/arch/repositories/object/intern
 	public fun blockingDeleteIfExist ()V
 	public fun delete ()Lio/reactivex/Completable;
 	public fun deleteIfExist ()Lio/reactivex/Completable;
-	protected final fun deleteIfExistInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected final fun deleteInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected abstract fun deleteObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected abstract fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxDelete ()Lio/reactivex/Completable;
+	public fun rxDeleteIfExist ()Lio/reactivex/Completable;
+	public fun suspendDelete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendDeleteIfExist (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun updateIfChangedInternal (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected fun updateObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -2461,13 +2679,14 @@ public class org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWr
 	public fun blockingDelete ()V
 	public fun blockingDeleteIfExist ()V
 	public fun delete ()Lio/reactivex/Completable;
-	protected fun delete (Lorg/hisp/dhis/android/core/common/CoreObject;)V
 	public fun deleteIfExist ()Lio/reactivex/Completable;
-	protected final fun deleteIfExistInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected fun deleteInternal (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected fun deleteInternal (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxDelete ()Lio/reactivex/Completable;
+	public fun rxDeleteIfExist ()Lio/reactivex/Completable;
 	protected final fun setObject (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendDelete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun suspendDelete (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendDeleteIfExist (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun updateIfChanged (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lorg/hisp/dhis/android/core/common/Unit;
 	protected final fun updateIfChangedInternal (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -4494,6 +4713,8 @@ public final class org/hisp/dhis/android/core/dataset/DataSetCompleteRegistratio
 	public final fun byState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byStoredBy ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
+	public fun flowUpload ()Lkotlinx/coroutines/flow/Flow;
+	public fun rxUpload ()Lio/reactivex/Observable;
 	public fun upload ()Lio/reactivex/Observable;
 	public final fun value (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationObjectRepository;
 }
@@ -4504,7 +4725,13 @@ public final class org/hisp/dhis/android/core/dataset/DataSetCompleteRegistratio
 	public final fun blockingSet ()V
 	public fun delete ()Lio/reactivex/Completable;
 	public fun deleteIfExist ()Lio/reactivex/Completable;
+	public fun rxDelete ()Lio/reactivex/Completable;
+	public fun rxDeleteIfExist ()Lio/reactivex/Completable;
+	public final fun rxSet ()Lio/reactivex/Completable;
 	public final fun set ()Lio/reactivex/Completable;
+	public fun suspendDelete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendDeleteIfExist (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendSet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/dataset/DataSetCompulsoryDataElementOperandLink : org/hisp/dhis/android/core/common/CoreObject {
@@ -4879,6 +5106,8 @@ public final class org/hisp/dhis/android/core/datastore/DataStoreCollectionRepos
 	public final fun byNamespace ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byValue ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
+	public fun flowUpload ()Lkotlinx/coroutines/flow/Flow;
+	public fun rxUpload ()Lio/reactivex/Observable;
 	public fun upload ()Lio/reactivex/Observable;
 	public final fun value (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/datastore/DataStoreObjectRepository;
 }
@@ -4915,10 +5144,11 @@ public abstract interface class org/hisp/dhis/android/core/datastore/DataStoreMo
 }
 
 public final class org/hisp/dhis/android/core/datastore/DataStoreObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository {
-	public fun blockingDelete ()V
 	public fun blockingSet (Ljava/lang/String;)V
-	public fun delete ()Lio/reactivex/Completable;
+	public fun rxSet (Ljava/lang/String;)Lio/reactivex/Completable;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
+	public fun suspendDelete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/datastore/KeyValuePair : org/hisp/dhis/android/core/common/CoreObject {
@@ -4944,7 +5174,9 @@ public final class org/hisp/dhis/android/core/datastore/LocalDataStoreCollection
 
 public final class org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository {
 	public fun blockingSet (Ljava/lang/String;)V
+	public fun rxSet (Ljava/lang/String;)Lio/reactivex/Completable;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
+	public fun suspendSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/datastore/internal/DataStoreModuleWiper : org/hisp/dhis/android/core/wipe/internal/ModuleWiper {
@@ -5002,6 +5234,8 @@ public final class org/hisp/dhis/android/core/datavalue/DataValueCollectionRepos
 	public final fun byStoredBy ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byValue ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
+	public fun flowUpload ()Lkotlinx/coroutines/flow/Flow;
+	public fun rxUpload ()Lio/reactivex/Observable;
 	public fun upload ()Lio/reactivex/Observable;
 	public final fun value (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/datavalue/DataValueObjectRepository;
 	public final fun value (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/datavalue/DataValueObjectRepository;
@@ -5061,12 +5295,13 @@ public abstract interface class org/hisp/dhis/android/core/datavalue/DataValueMo
 }
 
 public final class org/hisp/dhis/android/core/datavalue/DataValueObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository {
-	public fun blockingDelete ()V
 	public fun blockingSet (Ljava/lang/String;)V
-	public fun delete ()Lio/reactivex/Completable;
+	public fun rxSet (Ljava/lang/String;)Lio/reactivex/Completable;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
 	public final fun setComment (Ljava/lang/String;)V
 	public final fun setFollowUp (Z)V
+	public fun suspendDelete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class org/hisp/dhis/android/core/datavalue/LegacyDataValueApi : java/lang/annotation/Annotation {
@@ -5439,6 +5674,7 @@ public final class org/hisp/dhis/android/core/event/EventCollectionRepository : 
 	public final fun byTrackedEntityInstanceUids (Ljava/util/List;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun countTrackedEntityInstances ()I
+	public fun flowUpload ()Lkotlinx/coroutines/flow/Flow;
 	public final fun orderByCompleteDate (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public final fun orderByCreated (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public final fun orderByCreatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
@@ -5450,6 +5686,7 @@ public final class org/hisp/dhis/android/core/event/EventCollectionRepository : 
 	public final fun orderByOrganisationUnitName (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public final fun orderByTimeline (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxUpload ()Lio/reactivex/Observable;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventObjectRepository;
 	public fun upload ()Lio/reactivex/Observable;
@@ -5719,6 +5956,14 @@ public final class org/hisp/dhis/android/core/event/search/EventQueryCollectionR
 	public final fun orderByLastUpdated ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public final fun orderByOrganisationUnitName ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
 	public final fun orderByTimeline ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EqFilterConnector;
+	public fun rxCount ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun rxGetUids ()Lio/reactivex/Single;
+	public fun rxIsEmpty ()Lio/reactivex/Single;
+	public fun suspendCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGetUids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendIsEmpty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventObjectRepository;
 }
@@ -5931,11 +6176,6 @@ public abstract class org/hisp/dhis/android/core/fileresource/FileResource$Build
 }
 
 public final class org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository {
-	public fun add (Ljava/io/File;)Lio/reactivex/Single;
-	public synthetic fun add (Ljava/lang/Object;)Lio/reactivex/Single;
-	public synthetic fun addInternal (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun blockingAdd (Ljava/io/File;)Ljava/lang/String;
-	public synthetic fun blockingAdd (Ljava/lang/Object;)Ljava/lang/String;
 	public final fun blockingUpload ()V
 	public final fun byContentLength ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/LongFilterConnector;
 	public final fun byContentType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
@@ -5946,6 +6186,8 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceCollectio
 	public final fun byState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
+	public fun suspendAdd (Ljava/io/File;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun suspendAdd (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/fileresource/FileResourceObjectRepository;
 	public final fun upload ()Lio/reactivex/Observable;
@@ -8357,6 +8599,10 @@ public final class org/hisp/dhis/android/core/relationship/RelationshipCollectio
 	public final fun getByItem (Lorg/hisp/dhis/android/core/relationship/RelationshipItem;)Ljava/util/List;
 	public final fun getByItem (Lorg/hisp/dhis/android/core/relationship/RelationshipItem;Z)Ljava/util/List;
 	public final fun getByItem (Lorg/hisp/dhis/android/core/relationship/RelationshipItem;ZZ)Ljava/util/List;
+	public synthetic fun rxAdd (Ljava/lang/Object;)Lio/reactivex/Single;
+	public fun rxAdd (Lorg/hisp/dhis/android/core/relationship/Relationship;)Lio/reactivex/Single;
+	public synthetic fun suspendAdd (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendAdd (Lorg/hisp/dhis/android/core/relationship/Relationship;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository;
 	public final fun withItems ()Lorg/hisp/dhis/android/core/relationship/RelationshipCollectionRepository;
@@ -10607,9 +10853,12 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityAttribu
 public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository {
 	public fun blockingExists ()Z
 	public fun blockingSet (Ljava/lang/String;)V
-	public synthetic fun delete (Lorg/hisp/dhis/android/core/common/CoreObject;)V
 	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxSet (Ljava/lang/String;)Lio/reactivex/Completable;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
+	public synthetic fun suspendDelete (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendExists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValue : org/hisp/dhis/android/core/common/BaseDataObject, org/hisp/dhis/android/core/common/ObjectWithDeleteInterface {
@@ -10651,11 +10900,13 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityDataVal
 }
 
 public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository {
-	public fun blockingExists ()Z
 	public fun blockingSet (Ljava/lang/String;)V
-	public synthetic fun delete (Lorg/hisp/dhis/android/core/common/CoreObject;)V
 	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxSet (Ljava/lang/String;)Lio/reactivex/Completable;
 	public fun set (Ljava/lang/String;)Lio/reactivex/Completable;
+	public synthetic fun suspendDelete (Lorg/hisp/dhis/android/core/common/CoreObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendExists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendSet (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class org/hisp/dhis/android/core/trackedentity/TrackedEntityInstance : org/hisp/dhis/android/core/common/BaseDeletableDataObject, org/hisp/dhis/android/core/common/ObjectWithUidInterface {
@@ -10710,11 +10961,13 @@ public final class org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanc
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byTrackedEntityType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
+	public fun flowUpload ()Lkotlinx/coroutines/flow/Flow;
 	public final fun orderByCreated (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
 	public final fun orderByCreatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
 	public final fun orderByLastUpdated (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
 	public final fun orderByLastUpdatedAtClient (Lorg/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope$OrderByDirection;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
 	public synthetic fun propagateState (Lorg/hisp/dhis/android/core/common/CoreObject;Lorg/hisp/dhis/android/core/arch/handlers/internal/HandleAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rxUpload ()Lio/reactivex/Observable;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceObjectRepository;
 	public fun upload ()Lio/reactivex/Observable;
@@ -11056,6 +11309,14 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 	public fun getUids ()Lio/reactivex/Single;
 	public fun isEmpty ()Lio/reactivex/Single;
 	public fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
+	public fun rxCount ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun rxGetUids ()Lio/reactivex/Single;
+	public fun rxIsEmpty ()Lio/reactivex/Single;
+	public fun suspendCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGetUids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendIsEmpty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 }
 
@@ -11171,6 +11432,14 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 	public fun getUids ()Lio/reactivex/Single;
 	public fun isEmpty ()Lio/reactivex/Single;
 	public fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
+	public fun rxCount ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun rxGetUids ()Lio/reactivex/Single;
+	public fun rxIsEmpty ()Lio/reactivex/Single;
+	public fun suspendCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGetUids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendIsEmpty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 }
 
@@ -11516,6 +11785,14 @@ public final class org/hisp/dhis/android/core/usecase/stock/StockUseCaseCollecti
 	public fun getUids ()Lio/reactivex/Single;
 	public fun isEmpty ()Lio/reactivex/Single;
 	public fun one ()Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
+	public fun rxCount ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun rxGetUids ()Lio/reactivex/Single;
+	public fun rxIsEmpty ()Lio/reactivex/Single;
+	public fun suspendCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGetUids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendIsEmpty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public final fun withTransactions ()Lorg/hisp/dhis/android/core/usecase/stock/StockUseCaseCollectionRepository;
 }
@@ -11717,6 +11994,10 @@ public final class org/hisp/dhis/android/core/user/UserCredentialsObjectReposito
 	public fun blockingGet ()Lorg/hisp/dhis/android/core/user/UserCredentials;
 	public fun exists ()Lio/reactivex/Single;
 	public fun get ()Lio/reactivex/Single;
+	public fun rxExists ()Lio/reactivex/Single;
+	public fun rxGet ()Lio/reactivex/Single;
+	public fun suspendExists (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun suspendGet (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun withUserRoles ()Lorg/hisp/dhis/android/core/user/UserCredentialsObjectRepository;
 }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/repositories/ReadOnlyObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/repositories/ReadOnlyObjectRepositoryMockIntegrationShould.kt
@@ -32,7 +32,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
 
-class ReadOnlyObjectRepositoryMockIntegrationShould: BaseMockIntegrationTestFullDispatcher() {
+class ReadOnlyObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
 
     @Test
     fun should_return_null_if_object_does_not_exist() {
@@ -45,6 +45,8 @@ class ReadOnlyObjectRepositoryMockIntegrationShould: BaseMockIntegrationTestFull
 
         assertThat(dataElement.errors().size).isEqualTo(1)
         assertThat(dataElement.errors().first()).isInstanceOf(NullPointerException::class.java)
-        assertThat(dataElement.errors().first().toString()).isEqualTo("java.lang.NullPointerException: The callable returned a null value")
+        assertThat(
+            dataElement.errors().first().toString(),
+        ).isEqualTo("java.lang.NullPointerException: The callable returned a null value")
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/repositories/ReadOnlyObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/repositories/ReadOnlyObjectRepositoryMockIntegrationShould.kt
@@ -49,4 +49,13 @@ class ReadOnlyObjectRepositoryMockIntegrationShould : BaseMockIntegrationTestFul
             dataElement.errors().first().toString(),
         ).isEqualTo("java.lang.NullPointerException: The callable returned a null value")
     }
+
+    @Test
+    fun should_return_null_if_object_does_not_exist_blocking() {
+        val result = d2.dataElementModule().dataElements()
+            .uid("nonExistent")
+            .blockingGet()
+
+        assertThat(result).isNull()
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/repositories/ReadOnlyObjectRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/repositories/ReadOnlyObjectRepositoryMockIntegrationShould.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,21 +25,26 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
-import org.hisp.dhis.android.core.arch.call.internal.DownloadProvider
-import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
+package org.hisp.dhis.android.testapp.arch.repositories
 
-abstract class ReadOnlyAnyObjectWithDownloadRepositoryImpl<M: Any> internal constructor(
-    private val downloadProvider: DownloadProvider,
-) : ReadOnlyWithDownloadObjectRepository<M> {
-    override suspend fun suspendGet(): M? = getInternal()
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
+import org.junit.Test
 
-    override suspend fun suspendExists(): Boolean = getInternal() != null
+class ReadOnlyObjectRepositoryMockIntegrationShould: BaseMockIntegrationTestFullDispatcher() {
 
-    override suspend fun suspendDownload() {
-        downloadProvider.download(false)
+    @Test
+    fun should_return_null_if_object_does_not_exist() {
+        val result = d2.dataElementModule().dataElements()
+            .uid("nonExistent")
+            .rxGet()
+            .test()
+
+        val dataElement = result.await()
+
+        assertThat(dataElement.errors().size).isEqualTo(1)
+        assertThat(dataElement.errors().first()).isInstanceOf(NullPointerException::class.java)
+        assertThat(dataElement.errors().first().toString()).isEqualTo("java.lang.NullPointerException: The callable returned a null value")
     }
-
-    internal abstract suspend fun getInternal(): M?
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/LegendEvaluator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/LegendEvaluator.kt
@@ -55,7 +55,7 @@ internal class LegendEvaluator(
                 val programIndicator = programIndicatorRepository
                     .byUid().eq(programIndicatorUid)
                     .withLegendSets()
-                    .one().getInternal()
+                    .one().suspendGet()
 
                 val legendSet = programIndicator?.legendSets()!![0]
 
@@ -77,7 +77,7 @@ internal class LegendEvaluator(
                 val dataElement = dataElementRepository
                     .byUid().eq(dataElementUid)
                     .withLegendSets()
-                    .one().getInternal()
+                    .one().suspendGet()
 
                 val legendSet = dataElement?.legendSets()!![0]
 
@@ -99,7 +99,7 @@ internal class LegendEvaluator(
                 val trackedEntityAttribute = trackedEntityAttributeCollectionRepository
                     .byUid().eq(trackedEntityAttributeUid)
                     .withLegendSets()
-                    .one().getInternal()
+                    .one().suspendGet()
 
                 val legendSet = trackedEntityAttribute?.legendSets()!![0]
 
@@ -121,7 +121,7 @@ internal class LegendEvaluator(
                 val indicator = indicatorRepository
                     .byUid().eq(indicatorUid)
                     .withLegendSets()
-                    .one().getInternal()
+                    .one().suspendGet()
 
                 val legendSet = indicator?.legendSets()!![0]
 
@@ -145,7 +145,7 @@ internal class LegendEvaluator(
                     .byEndValue().biggerOrEqualTo(value.toDouble())
                     .byLegendSet().eq(legendSetUid)
                     .one()
-                    .getInternal()?.uid()
+                    .suspendGet()?.uid()
             } catch (e: Exception) {
                 null
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsServiceMetadataHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsServiceMetadataHelper.kt
@@ -149,7 +149,7 @@ internal class AnalyticsServiceMetadataHelper(
                         ?: throw AnalyticsException.InvalidIndicator(item.uid)
 
                 is DimensionItem.DataItem.ProgramIndicatorItem ->
-                    programIndicatorRepository.withAnalyticsPeriodBoundaries().uid(item.uid).getInternal()
+                    programIndicatorRepository.withAnalyticsPeriodBoundaries().uid(item.uid).suspendGet()
                         ?.let { programIndicator -> MetadataItem.ProgramIndicatorItem(programIndicator) }
                         ?: throw AnalyticsException.InvalidProgramIndicator(item.uid)
 

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsVisualizationsService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/AnalyticsVisualizationsService.kt
@@ -76,7 +76,7 @@ internal class AnalyticsVisualizationsService(
         return visualizationCollectionRepository
             .withColumnsRowsAndFilters()
             .uid(visualizationId)
-            .getInternal()
+            .suspendGet()
     }
 
     @Suppress("ComplexMethod")

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/aggregated/internal/evaluator/indicatorengine/dataitem/IndicatorDataItem.kt
@@ -128,7 +128,7 @@ internal interface IndicatorDataItem : ExpressionItem {
                 val programIndicator = visitor.indicatorContext!!.programIndicatorRepository
                     .withAnalyticsPeriodBoundaries()
                     .uid(dataItem.uid)
-                    .getInternal()
+                    .suspendGet()
                     ?: throw AnalyticsException.InvalidProgramIndicator(dataItem.uid)
 
                 dataItem.uid to MetadataItem.ProgramIndicatorItem(programIndicator)

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListServiceImpl.kt
@@ -68,7 +68,7 @@ internal class EventLineListServiceImpl(
     @Suppress("LongMethod", "ComplexMethod")
     private suspend fun evaluateEvents(params: EventLineListParams): List<LineListResponse> {
         val events = getEvents(params)
-        val programStage = programStageRepository.uid(params.programStage).getInternal()
+        val programStage = programStageRepository.uid(params.programStage).suspendGet()
 
         val metadataMap = getMetadataMap(
             params.dataElements,
@@ -80,7 +80,7 @@ internal class EventLineListServiceImpl(
             dataValueRepository
                 .byEvent().`in`(events.map { it.uid() })
                 .byDataElement().`in`(params.dataElements.map { it.uid })
-                .getInternal()
+                .suspendGet()
         } else {
             listOf()
         }
@@ -166,7 +166,7 @@ internal class EventLineListServiceImpl(
         }
 
         return if (params.eventDates.isNullOrEmpty()) {
-            repoBuilder.getInternal()
+            repoBuilder.suspendGet()
         } else {
             params.eventDates.flatMap { filter ->
                 var innerBuilder = repoBuilder
@@ -176,7 +176,7 @@ internal class EventLineListServiceImpl(
                 dateFilterPeriodHelper.getEndDate(filter)?.let {
                     innerBuilder = innerBuilder.byEventDate().beforeOrEqual(it)
                 }
-                innerBuilder.getInternal()
+                innerBuilder.suspendGet()
             }
         }
     }
@@ -189,7 +189,7 @@ internal class EventLineListServiceImpl(
         val dataElementNameMap = if (dataElements.isNotEmpty()) {
             dataElementRepository
                 .byUid().`in`(dataElements.map { it.uid })
-                .getInternal()
+                .suspendGet()
                 .map { it.uid()!! to it.displayName()!! }.toMap()
         } else {
             mapOf()
@@ -198,7 +198,7 @@ internal class EventLineListServiceImpl(
         val programIndicatorNameMap = if (programIndicators.isNotEmpty()) {
             programIndicatorRepository
                 .byUid().`in`(programIndicators.map { it.uid })
-                .getInternal()
+                .suspendGet()
                 .map { it.uid()!! to it.displayName()!! }.toMap()
         } else {
             mapOf()
@@ -206,7 +206,7 @@ internal class EventLineListServiceImpl(
 
         val organisationUnitNameMap = organisationUnitRepository
             .byUid().`in`(organisationUnitUids)
-            .getInternal()
+            .suspendGet()
             .map { it.uid()!! to it.displayName()!! }.toMap()
 
         return dataElementNameMap + programIndicatorNameMap + organisationUnitNameMap

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerLineListService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/trackerlinelist/internal/TrackerLineListService.kt
@@ -116,7 +116,7 @@ internal class TrackerLineListService(
         return trackerVisualizationCollectionRepository
             .withColumnsAndFilters()
             .uid(trackerVisualization)
-            .getInternal()
+            .suspendGet()
     }
 
     private suspend fun getEventSqlClause(params: TrackerLineListParams, context: TrackerLineListContext): String {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
@@ -28,20 +28,38 @@
 package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 
 interface CollectionRepositoryUpload {
+    /**
+     * Uploads the resources in scope in an asynchronous way, returning a `Flow<D2Progress>` that
+     * will emit progress until the whole upload is finished and the `Flow` is completed.
+     * @return the `Flow<D2Progress>` emitting the progress
+     */
+    fun flowUpload(): Flow<D2Progress>
+
     /**
      * Uploads the resources in scope in an asynchronous way. An `Observable<D2Progress>` is returned, which
      * will emit progress until the whole upload is finished and the `Observable` is completed.
      * @return the `Observable<D2Progress>` emitting the progress
      */
-    fun upload(): Observable<D2Progress>
+    @Deprecated(message = "Use rxUpload instead", ReplaceWith("rxUpload()"))
+    fun upload(): Observable<D2Progress> = rxUpload()
+
+    /**
+     * Uploads the resources in scope in an asynchronous way. An `Observable<D2Progress>` is returned, which
+     * will emit progress until the whole upload is finished and the `Observable` is completed.
+     * @return the `Observable<D2Progress>` emitting the progress
+     */
+    fun rxUpload(): Observable<D2Progress> = flowUpload().asObservable()
 
     /**
      * Uploads the resources in scope in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.upload].
+     * executed in the main thread. Consider the asynchronous version [.rxUpload].
      * The method will finish as soon as the whole upload an processing is finished.
      */
-    fun blockingUpload()
+    fun blockingUpload() = rxUpload().blockingSubscribe()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
@@ -29,7 +29,6 @@ package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 
@@ -60,5 +61,5 @@ interface CollectionRepositoryUpload {
      * executed in the main thread. Consider the asynchronous version [.rxUpload].
      * The method will finish as soon as the whole upload an processing is finished.
      */
-    fun blockingUpload() = rxUpload().blockingSubscribe()
+    fun blockingUpload() = runBlocking { flowUpload().collect {} }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/CollectionRepositoryUpload.kt
@@ -29,9 +29,9 @@ package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 
 interface CollectionRepositoryUpload {
     /**
@@ -61,5 +61,5 @@ interface CollectionRepositoryUpload {
      * executed in the main thread. Consider the asynchronous version [.rxUpload].
      * The method will finish as soon as the whole upload an processing is finished.
      */
-    fun blockingUpload() = runBlocking { flowUpload().collect {} }
+    fun blockingUpload() = flowUpload().collectAndWrapException()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyCollectionRepository.kt
@@ -32,23 +32,41 @@ import androidx.paging.PagedList
 import androidx.paging.PagingData
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 
+@Suppress("TooManyFunctions")
 interface ReadOnlyCollectionRepository<M : Any> : BaseRepository {
+    /**
+     * Get the objects in scope in a suspend way.
+     *
+     * @return The list of objects.
+     */
+    suspend fun suspendGet(): List<M>
+
     /**
      * Get the objects in scope in an asynchronous way, returning a `Single<List>`.
      *
      * @return A `Single` object with the list of objects.
      */
-    fun get(): Single<List<M>>
+    @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
+    fun get(): Single<List<M>> = rxGet()
+
+    /**
+     * Get the objects in scope in an asynchronous way, returning a `Single<List>`.
+     *
+     * @return A `Single` object with the list of objects.
+     */
+    fun rxGet(): Single<List<M>> = rxSingle { suspendGet() }
 
     /**
      * Get the list of objects in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get].
+     * executed in the main thread. Consider the asynchronous version [.rxGet].
      *
      * @return List of objects
      */
-    fun blockingGet(): List<M>
+    fun blockingGet(): List<M> = runBlocking { suspendGet() }
 
     /**
      * Handy method to use in conjunction with PagedListAdapter to build paged lists.
@@ -67,34 +85,61 @@ interface ReadOnlyCollectionRepository<M : Any> : BaseRepository {
     fun getPagingData(pageSize: Int): Flow<PagingData<M>>
 
     /**
+     * Get the count of elements in a suspend way.
+     * @return The element count
+     */
+    suspend fun suspendCount(): Int
+
+    /**
      * Get the count of elements in an asynchronous way, returning a `Single`.
      * @return A `Single` object with the element count
      */
-    fun count(): Single<Int>
+    @Deprecated(message = "Use rxCount instead", ReplaceWith("rxCount()"))
+    fun count(): Single<Int> = rxCount()
+
+    /**
+     * Get the count of elements in an asynchronous way, returning a `Single`.
+     * @return A `Single` object with the element count
+     */
+    fun rxCount(): Single<Int> = rxSingle { suspendCount() }
 
     /**
      * Get the count of elements. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.count].
+     * executed in the main thread. Consider the asynchronous version [.rxCount].
      *
      * @return Element count
      */
-    fun blockingCount(): Int
+    fun blockingCount(): Int = runBlocking { suspendCount() }
+
+    /**
+     * Check if selection of objects in current scope with applied filters is empty in a suspend way.
+     * @return If selection is empty
+     */
+    suspend fun suspendIsEmpty(): Boolean
 
     /**
      * Check if selection of objects in current scope with applied filters is empty in an asynchronous way,
      * returning a `Single`.
      * @return If selection is empty
      */
-    fun isEmpty(): Single<Boolean>
+    @Deprecated(message = "Use rxIsEmpty instead", ReplaceWith("rxIsEmpty()"))
+    fun isEmpty(): Single<Boolean> = rxIsEmpty()
+
+    /**
+     * Check if selection of objects in current scope with applied filters is empty in an asynchronous way,
+     * returning a `Single`.
+     * @return If selection is empty
+     */
+    fun rxIsEmpty(): Single<Boolean> = rxSingle { suspendIsEmpty() }
 
     /**
      * Check if selection of objects with applied filters is empty in a synchronous way.
      * Important: this is a blocking method and it should not be executed in the main thread.
-     * Consider the asynchronous version [.isEmpty].
+     * Consider the asynchronous version [.rxIsEmpty].
      *
      * @return If selection is empty
      */
-    fun blockingIsEmpty(): Boolean
+    fun blockingIsEmpty(): Boolean = runBlocking { suspendIsEmpty() }
 
     /**
      * Get a [ReadOnlyObjectRepository] pointing to the first element in the list.

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 
-interface ReadOnlyWithDownloadObjectRepository<M> : ReadOnlyObjectRepository<M> {
+interface ReadOnlyWithDownloadObjectRepository<M: Any> : ReadOnlyObjectRepository<M> {
     /**
      * Downloads the resource in scope in a suspend way. The coroutine will complete when the
      * download and processing is finished.

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 
-interface ReadOnlyWithDownloadObjectRepository<M: Any> : ReadOnlyObjectRepository<M> {
+interface ReadOnlyWithDownloadObjectRepository<M : Any> : ReadOnlyObjectRepository<M> {
     /**
      * Downloads the resource in scope in a suspend way. The coroutine will complete when the
      * download and processing is finished.

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository.kt
@@ -28,20 +28,36 @@
 package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 
 interface ReadOnlyWithDownloadObjectRepository<M> : ReadOnlyObjectRepository<M> {
+    /**
+     * Downloads the resource in scope in a suspend way. The coroutine will complete when the
+     * download and processing is finished.
+     */
+    suspend fun suspendDownload()
+
     /**
      * Downloads the resource in scope in an asynchronous way. As soon as it's downloaded and processed, the Completable
      * is completed.
      * @return a `Completable` that completes when the download and processing is finished
      */
-    fun download(): Completable
+    @Deprecated(message = "Use rxDownload instead", ReplaceWith("rxDownload()"))
+    fun download(): Completable = rxDownload()
+
+    /**
+     * Downloads the resource in scope in an asynchronous way. As soon as it's downloaded and processed, the Completable
+     * is completed.
+     * @return a `Completable` that completes when the download and processing is finished
+     */
+    fun rxDownload(): Completable = rxCompletable { suspendDownload() }
 
     /**
      * Downloads the resource in scope in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get]. The method will finish
+     * executed in the main thread. Consider the asynchronous version [.rxDownload]. The method will finish
      * with a void as soon as the whole download and processing is finished.
      */
-    fun blockingDownload()
+    fun blockingDownload() = runBlocking { suspendDownload() }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface
 
@@ -41,17 +43,32 @@ interface ReadOnlyWithUidCollectionRepository<M : ObjectWithUidInterface> : Read
     fun uid(uid: String?): ReadOnlyObjectRepository<M>
 
     /**
+     * Get the list of uids of objects in scope in a suspend way.
+     *
+     * @return The list of uids.
+     */
+    suspend fun suspendGetUids(): List<String>
+
+    /**
      * Get the list of uids of objects in scope in an asynchronous way, returning a `Single<List<String>>`.
      *
      * @return A `Single` object with the list of uids.
      */
-    fun getUids(): Single<List<String>>
+    @Deprecated(message = "Use rxGetUids instead", ReplaceWith("rxGetUids()"))
+    fun getUids(): Single<List<String>> = rxGetUids()
+
+    /**
+     * Get the list of uids of objects in scope in an asynchronous way, returning a `Single<List<String>>`.
+     *
+     * @return A `Single` object with the list of uids.
+     */
+    fun rxGetUids(): Single<List<String>> = rxSingle { suspendGetUids() }
 
     /**
      * Get the list of uids of objects in scope in a synchronous way. Important: this is a blocking method and it should
-     * not be executed in the main thread. Consider the asynchronous version [.getUids].
+     * not be executed in the main thread. Consider the asynchronous version [.rxGetUids].
      *
      * @return List of uids
      */
-    fun blockingGetUids(): List<String>
+    fun blockingGetUids(): List<String> = runBlocking { suspendGetUids() }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.arch.repositories.collection
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.common.CoreObject
 import org.hisp.dhis.android.core.common.ObjectWithUidInterface
 import org.hisp.dhis.android.core.maintenance.D2Error
@@ -35,24 +37,46 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 interface ReadWriteWithUidCollectionRepository<M, O> :
     ReadOnlyWithUidCollectionRepository<M> where M : CoreObject, M : ObjectWithUidInterface {
     /**
+     * Adds a new object to the given collection in a suspend way based on the provided CreateProjection.
+     * It returns the generated UID when the object is added to the database.
+     * It adds an object with a [State.TO_POST], which will be uploaded to the server in the next
+     * upload.
+     * @param o the CreateProjection of the object to add
+     * @return the UID
+     */
+    @Throws(D2Error::class)
+    suspend fun suspendAdd(o: O): String
+
+    /**
      * Adds a new object to the given collection in an asynchronous way based on the provided CreateProjection.
      * It returns a `Single<String>` with the generated UID, which is completed when the object is added to the
      * database. It adds an object with a [State.TO_POST], which will be uploaded to the server in the next
      * upload.
-     * @param c the CreateProjection of the object to add
+     * @param o the CreateProjection of the object to add
      * @return the Single with the UID
      */
-    fun add(o: O): Single<String>
+    @Deprecated(message = "Use rxAdd instead", ReplaceWith("rxAdd(o)"))
+    fun add(o: O): Single<String> = rxAdd(o)
+
+    /**
+     * Adds a new object to the given collection in an asynchronous way based on the provided CreateProjection.
+     * It returns a `Single<String>` with the generated UID, which is completed when the object is added to the
+     * database. It adds an object with a [State.TO_POST], which will be uploaded to the server in the next
+     * upload.
+     * @param o the CreateProjection of the object to add
+     * @return the Single with the UID
+     */
+    fun rxAdd(o: O): Single<String> = rxSingle { suspendAdd(o) }
 
     /**
      * Adds a new object to the given collection in a synchronous way based on the provided CreateProjection.
      * It blocks the current thread and returns the generated UID.
      * It adds an object with a [State.TO_POST], which will be uploaded to the server in the next
      * upload. Important: this is a blocking method and it should not be executed in the main thread. Consider the
-     * asynchronous version [.add].
-     * @param c the CreateProjection of the object to add
+     * asynchronous version [.rxAdd].
+     * @param o the CreateProjection of the object to add
      * @return the UID
      */
     @Throws(D2Error::class)
-    fun blockingAdd(o: O): String
+    fun blockingAdd(o: O): String = runBlocking { suspendAdd(o) }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
@@ -49,25 +49,11 @@ abstract class BaseReadOnlyWithUidCollectionRepositoryImpl<M, R : ReadOnlyCollec
     ReadOnlyWithUidCollectionRepository<M> where M : CoreObject, M : ObjectWithUidInterface {
 
     /**
-     * Get the list of uids of objects in scope in an asynchronous way, returning a `Single<List<String>>`.
+     * Get the list of uids of objects in scope in a suspend way.
      *
-     * @return A `Single` object with the list of uids.
+     * @return The list of uids.
      */
-    override fun getUids(): Single<List<String>> {
-        return rxSingle { getUidsInternal() }
-    }
-
-    /**
-     * Get the list of uids of objects in scope in a synchronous way. Important: this is a blocking method and it should
-     * not be executed in the main thread. Consider the asynchronous version [.getUids].
-     *
-     * @return List of uids
-     */
-    override fun blockingGetUids(): List<String> {
-        return runBlocking { getUidsInternal() }
-    }
-
-    internal suspend fun getUidsInternal(): List<String> {
+    override suspend fun suspendGetUids(): List<String> {
         return store.selectUidsWhere(
             whereClause,
             OrderByClauseBuilder.orderByFromItems(

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/BaseReadOnlyWithUidCollectionRepositoryImpl.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -35,10 +35,8 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderExecutor
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -84,27 +84,11 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
     }
 
     /**
-     * Get the list of objects in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get].
+     * Get the objects in scope in a suspend way.
      *
-     * @return List of objects
+     * @return The list of objects.
      */
-    override fun blockingGet(): List<M> {
-        return runBlocking {
-            getInternal()
-        }
-    }
-
-    /**
-     * Get the objects in scope in an asynchronous way, returning a `Single<List>`.
-     *
-     * @return A `Single` object with the list of objects.
-     */
-    override fun get(): Single<List<M>> {
-        return rxSingle { getInternal() }
-    }
-
-    internal suspend fun getInternal(): List<M> {
+    override suspend fun suspendGet(): List<M> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             getWithoutChildrenInternal(),
             childrenAppenders,
@@ -148,25 +132,15 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
         get() = RepositoryPagingSource(store, scope, childrenAppenders)
 
     /**
-     * Get the count of elements in an asynchronous way, returning a `Single`.
-     * @return A `Single` object with the element count
+     * Get the count of elements in a suspend way.
+     * @return The element count
      */
-    override fun count(): Single<Int> {
-        return rxSingle { countInternal() }
-    }
-
-    /**
-     * Get the count of elements. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.count].
-     *
-     * @return Element count
-     */
-    override fun blockingCount(): Int {
-        return runBlocking { countInternal() }
-    }
-
-    internal suspend fun countInternal(): Int {
+    override suspend fun suspendCount(): Int {
         return store.countWhere(whereClause)
+    }
+
+    override suspend fun suspendIsEmpty(): Boolean {
+        return isEmptyInternal()
     }
 
     /**
@@ -174,8 +148,13 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
      * returning a `Single`.
      * @return If selection is empty
      */
+    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
     override fun isEmpty(): Single<Boolean> {
-        return rxSingle { isEmptyProtected() }
+        return rxSingle { isEmptyInternal() }
+    }
+
+    override fun rxIsEmpty(): Single<Boolean> {
+        return rxSingle { isEmptyInternal() }
     }
 
     /**
@@ -186,10 +165,10 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
      * @return If selection is empty
      */
     override fun blockingIsEmpty(): Boolean {
-        return runBlocking { isEmptyProtected() }
+        return runBlocking { isEmptyInternal() }
     }
 
-    internal suspend fun isEmptyProtected(): Boolean {
+    internal suspend fun isEmptyInternal(): Boolean {
         return !one().existsInternal()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -51,7 +51,6 @@ import org.hisp.dhis.android.core.common.CoreObject
 import org.hisp.dhis.android.persistence.common.querybuilders.OrderByClauseBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
-@Suppress("TooManyFunctions")
 open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollectionRepository<M>> internal constructor(
     private val store: ReadableStore<M>,
     internal val childrenAppenders: ChildrenAppenderGetter<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -144,7 +144,7 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
      * @return If selection is empty
      */
     override suspend fun suspendIsEmpty(): Boolean {
-        return !one().existsInternal()
+        return !one().suspendExists()
     }
 
     protected val whereClause: String

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl.kt
@@ -139,36 +139,11 @@ open class ReadOnlyCollectionRepositoryImpl<M : CoreObject, R : ReadOnlyCollecti
         return store.countWhere(whereClause)
     }
 
+    /**
+     * Check if selection of objects in current scope with applied filters is empty in a suspend way.
+     * @return If selection is empty
+     */
     override suspend fun suspendIsEmpty(): Boolean {
-        return isEmptyInternal()
-    }
-
-    /**
-     * Check if selection of objects in current scope with applied filters is empty in an asynchronous way,
-     * returning a `Single`.
-     * @return If selection is empty
-     */
-    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
-    override fun isEmpty(): Single<Boolean> {
-        return rxSingle { isEmptyInternal() }
-    }
-
-    override fun rxIsEmpty(): Single<Boolean> {
-        return rxSingle { isEmptyInternal() }
-    }
-
-    /**
-     * Check if selection of objects with applied filters is empty in a synchronous way.
-     * Important: this is a blocking method and it should not be executed in the main thread.
-     * Consider the asynchronous version [.isEmpty].
-     *
-     * @return If selection is empty
-     */
-    override fun blockingIsEmpty(): Boolean {
-        return runBlocking { isEmptyInternal() }
-    }
-
-    internal suspend fun isEmptyInternal(): Boolean {
         return !one().existsInternal()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
@@ -96,25 +96,11 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
     }
 
     /**
-     * Get the list of objects in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get].
+     * Get the objects in scope in a suspend way.
      *
-     * @return List of objects
+     * @return The list of objects.
      */
-    override fun blockingGet(): List<T> {
-        return runBlocking { getInternal() }
-    }
-
-    /**
-     * Get the objects in scope in an asynchronous way, returning a `Single<List>`.
-     *
-     * @return A `Single` object with the list of objects.
-     */
-    override fun get(): Single<List<T>> {
-        return rxSingle { getInternal() }
-    }
-
-    private suspend fun getInternal(): List<T> {
+    override suspend fun suspendGet(): List<T> {
         return ChildrenAppenderExecutor.appendInObjectCollection(
             getWithoutChildrenInternal(),
             childrenAppenders,
@@ -161,49 +147,19 @@ internal open class ReadOnlyWithTransformerCollectionRepositoryImpl<
         get() = RepositoryPagingSourceWithTransformer(store, scope, childrenAppenders, transformer)
 
     /**
-     * Get the count of elements in an asynchronous way, returning a `Single`.
-     * @return A `Single` object with the element count
+     * Get the count of elements in a suspend way.
+     * @return The element count
      */
-    override fun count(): Single<Int> {
-        return rxSingle { countInternal() }
-    }
-
-    /**
-     * Get the count of elements. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.count].
-     *
-     * @return Element count
-     */
-    override fun blockingCount(): Int {
-        return runBlocking { countInternal() }
-    }
-
-    suspend fun countInternal(): Int {
+    override suspend fun suspendCount(): Int {
         return store.countWhere(whereClause)
     }
 
     /**
-     * Check if selection of objects in current scope with applied filters is empty in an asynchronous way,
-     * returning a `Single`.
+     * Check if selection of objects in current scope with applied filters is empty in a suspend way.
      * @return If selection is empty
      */
-    override fun isEmpty(): Single<Boolean> {
-        return Single.fromCallable { blockingIsEmpty() }
-    }
-
-    /**
-     * Check if selection of objects with applied filters is empty in a synchronous way.
-     * Important: this is a blocking method and it should not be executed in the main thread.
-     * Consider the asynchronous version [.isEmpty].
-     *
-     * @return If selection is empty
-     */
-    override fun blockingIsEmpty(): Boolean {
-        return !one().blockingExists()
-    }
-
-    suspend fun isEmptyInternal(): Boolean {
-        return !one().blockingExists()
+    override suspend fun suspendIsEmpty(): Boolean {
+        return !one().suspendExists()
     }
 
     val whereClause: String

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithTransformerCollectionRepositoryImpl.kt
@@ -35,10 +35,8 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
 import org.hisp.dhis.android.core.arch.handlers.internal.TwoWayTransformer
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderExecutor

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyWithUidAndTransformerCollectionRepositoryImpl.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.TwoWayTransformer
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -63,26 +60,13 @@ internal class ReadOnlyWithUidAndTransformerCollectionRepositoryImpl<
 ),
     ReadOnlyWithUidCollectionRepository<T>
     where M : CoreObject, M : ObjectWithUidInterface, T : ObjectWithUidInterface {
-    /**
-     * Get the list of uids of objects in scope in an asynchronous way, returning a `Single<List<String>>`.
-     *
-     * @return A `Single` object with the list of uids.
-     */
-    override fun getUids(): Single<List<String>> {
-        return rxSingle { getUidsInternal() }
-    }
 
     /**
-     * Get the list of uids of objects in scope in a synchronous way. Important: this is a blocking method and it should
-     * not be executed in the main thread. Consider the asynchronous version [.getUids].
+     * Get the list of uids of objects in scope in a suspend way.
      *
-     * @return List of uids
+     * @return The list of uids.
      */
-    override fun blockingGetUids(): List<String> {
-        return runBlocking { getUidsInternal() }
-    }
-
-    suspend fun getUidsInternal(): List<String> {
+    override suspend fun suspendGetUids(): List<String> {
         return store.selectUidsWhere(
             whereClause,
             OrderByClauseBuilder.orderByFromItems(

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.collection.internal
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
@@ -57,35 +57,18 @@ abstract class ReadWriteWithUidCollectionRepositoryImpl<M, P, R : ReadOnlyCollec
     cf,
 ),
     ReadWriteWithUidCollectionRepository<M, P> where M : CoreObject, M : ObjectWithUidInterface {
-    /**
-     * Adds a new object to the given collection in an asynchronous way based on the provided CreateProjection.
-     * It returns a `Single<String>` with the generated UID, which is completed when the object is added to the
-     * database. It adds an object with a [State.TO_POST], which will be uploaded to the server in the next
-     * upload.
-     * @param projection the CreateProjection of the object to add
-     * @return the Single with the UID
-     */
-    override fun add(o: P): Single<String> {
-        return rxSingle { addInternal(o) }
-    }
 
     /**
-     * Adds a new object to the given collection in a synchronous way based on the provided CreateProjection.
-     * It blocks the current thread and returns the generated UID.
+     * Adds a new object to the given collection in a suspend way based on the provided CreateProjection.
+     * It returns the generated UID when the object is added to the database.
      * It adds an object with a [State.TO_POST], which will be uploaded to the server in the next
-     * upload. Important: this is a blocking method and it should not be executed in the main thread. Consider the
-     * asynchronous version [.add].
-     * @param c the CreateProjection of the object to add
+     * upload.
+     * @param o the CreateProjection of the object to add
      * @return the UID
      */
     @Throws(D2Error::class)
-    override fun blockingAdd(o: P): String {
-        return runBlocking { addInternal(o) }
-    }
-
-    @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
-    protected open suspend fun addInternal(o: P): String {
+    override suspend fun suspendAdd(o: P): String {
         val obj = transformer.transform(o)
         return try {
             store.insert(obj)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 
- interface ReadOnlyObjectRepository<M: Any> : BaseRepository {
+interface ReadOnlyObjectRepository<M : Any> : BaseRepository {
     /**
      * Returns the object in a suspend way.
      * @return the object
@@ -50,7 +50,9 @@ import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
      * Returns the object in an asynchronous way, returning a `Single<M>`.
      * @return A `Single` object with the object
      */
-    fun rxGet(): Single<M> = rxSingle { suspendGet() ?: throw NullPointerException("The callable returned a null value") }
+    fun rxGet(): Single<M> = rxSingle {
+        suspendGet() ?: throw NullPointerException("The callable returned a null value")
+    }
 
     /**
      * Returns the object in a synchronous way. Important: this is a blocking method and it should not be

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 
-interface ReadOnlyObjectRepository<M> : BaseRepository {
+ interface ReadOnlyObjectRepository<M: Any> : BaseRepository {
     /**
      * Returns the object in a suspend way.
      * @return the object
@@ -44,13 +44,13 @@ interface ReadOnlyObjectRepository<M> : BaseRepository {
      * @return A `Single` object with the object
      */
     @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
-    fun get(): Single<M?> = rxGet()
+    fun get(): Single<M> = rxGet()
 
     /**
      * Returns the object in an asynchronous way, returning a `Single<M>`.
      * @return A `Single` object with the object
      */
-    fun rxGet(): Single<M?> = Single.fromCallable { blockingGet() }
+    fun rxGet(): Single<M> = rxSingle { suspendGet() ?: throw NullPointerException("The callable returned a null value") }
 
     /**
      * Returns the object in a synchronous way. Important: this is a blocking method and it should not be

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository.kt
@@ -28,32 +28,60 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
 
 interface ReadOnlyObjectRepository<M> : BaseRepository {
     /**
+     * Returns the object in a suspend way.
+     * @return the object
+     */
+    suspend fun suspendGet(): M?
+
+    /**
      * Returns the object in an asynchronous way, returning a `Single<M>`.
      * @return A `Single` object with the object
      */
-    fun get(): Single<M?>
+    @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
+    fun get(): Single<M?> = rxGet()
+
+    /**
+     * Returns the object in an asynchronous way, returning a `Single<M>`.
+     * @return A `Single` object with the object
+     */
+    fun rxGet(): Single<M?> = Single.fromCallable { blockingGet() }
 
     /**
      * Returns the object in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get].
+     * executed in the main thread. Consider the asynchronous version [.rxGet].
      * @return the object
      */
-    fun blockingGet(): M?
+    fun blockingGet(): M? = runBlocking { suspendGet() }
+
+    /**
+     * Returns if the object exists in a suspend way.
+     * @return if the object exists
+     */
+    suspend fun suspendExists(): Boolean
 
     /**
      * Returns if the object exists in an asynchronous way, returning a `Single<Boolean>`.
      * @return if the object exists, wrapped in a `Single`
      */
-    fun exists(): Single<Boolean>
+    @Deprecated(message = "Use rxExists instead", ReplaceWith("rxExists()"))
+    fun exists(): Single<Boolean> = rxExists()
+
+    /**
+     * Returns if the object exists in an asynchronous way, returning a `Single<Boolean>`.
+     * @return if the object exists, wrapped in a `Single`
+     */
+    fun rxExists(): Single<Boolean> = rxSingle { suspendExists() }
 
     /**
      * Returns if the object exists in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.exists].
+     * executed in the main thread. Consider the asynchronous version [.rxExists].
      * @return if the object exists
      */
-    fun blockingExists(): Boolean
+    fun blockingExists(): Boolean = runBlocking { suspendExists() }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepo
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyOneObjectRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
-class ReadOnlyOneObjectRepositoryFinalImpl<M: Any> internal constructor(
+class ReadOnlyOneObjectRepositoryFinalImpl<M : Any> internal constructor(
     store: ReadableStore<M>,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadOnlyOneObjectRepositoryFinalImpl.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepo
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyOneObjectRepositoryImpl
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
-class ReadOnlyOneObjectRepositoryFinalImpl<M> internal constructor(
+class ReadOnlyOneObjectRepositoryFinalImpl<M: Any> internal constructor(
     store: ReadableStore<M>,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadWriteObjectRepository.kt
@@ -28,17 +28,36 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.common.CoreObject
 import org.hisp.dhis.android.core.maintenance.D2Error
 
 interface ReadWriteObjectRepository<M : CoreObject> : ReadOnlyObjectRepository<M> {
+    /**
+     * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
+     * is performed. It throws an exception if the object doesn't exist.
+     * @throws D2Error if any errors occur, including when the object doesn't exist.
+     */
+    @Throws(D2Error::class)
+    suspend fun suspendDelete()
+
     /**
      * Removes the object in scope in an asynchronous way. See the implementation JavaDoc for details on how deletion
      * is performed. It returns a `Completable` that completes as soon as the object is deleted in the database.
      * The `Completable` fails if the object doesn't exist.
      * @return the `Completable` which notifies the completion
      */
-    fun delete(): Completable
+    @Deprecated(message = "Use rxDelete instead", ReplaceWith("rxDelete()"))
+    fun delete(): Completable = rxDelete()
+
+    /**
+     * Removes the object in scope in an asynchronous way. See the implementation JavaDoc for details on how deletion
+     * is performed. It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * The `Completable` fails if the object doesn't exist.
+     * @return the `Completable` which notifies the completion
+     */
+    fun rxDelete(): Completable = rxCompletable { suspendDelete() }
 
     /**
      * Removes the object in scope in a synchronous way. See the implementation JavaDoc for details on how deletion
@@ -47,20 +66,35 @@ interface ReadWriteObjectRepository<M : CoreObject> : ReadOnlyObjectRepository<M
      * @throws D2Error if any errors occur, including when the object doesn't exist.
      */
     @Throws(D2Error::class)
-    fun blockingDelete()
+    fun blockingDelete() = runBlocking { suspendDelete() }
 
     /**
-     * Removes the object in scope in a synchronous way. See the implementation JavaDoc for details on how deletion
+     * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
+     * is performed. Unlike [.suspendDelete], it doesn't throw an exception if the object doesn't exist.
+     */
+    suspend fun suspendDeleteIfExist()
+
+    /**
+     * Removes the object in scope in an asynchronous way. See the implementation JavaDoc for details on how deletion
      * is performed. Unlike [.delete], it doesn't throw an exception if the object doesn't exist.
      * It returns a `Completable` that completes as soon as the object is deleted in the database.
      * @return the `Completable` which notifies the completion
      */
-    fun deleteIfExist(): Completable
+    @Deprecated(message = "Use rxDeleteIfExist instead", ReplaceWith("rxDeleteIfExist()"))
+    fun deleteIfExist(): Completable = rxDeleteIfExist()
 
     /**
      * Removes the object in scope in an asynchronous way. See the implementation JavaDoc for details on how deletion
+     * is performed. Unlike [.rxDelete], it doesn't throw an exception if the object doesn't exist.
+     * It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * @return the `Completable` which notifies the completion
+     */
+    fun rxDeleteIfExist(): Completable = rxCompletable { suspendDeleteIfExist() }
+
+    /**
+     * Removes the object in scope in a synchronous way. See the implementation JavaDoc for details on how deletion
      * is performed. Unlike [.blockingDelete], it doesn't throw an exception if the object doesn't exist.
      * It blocks the thread and finishes as soon as the object is deleted in the database.
      */
-    fun blockingDeleteIfExist()
+    fun blockingDeleteIfExist() = runBlocking { suspendDeleteIfExist() }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/ReadWriteValueObjectRepository.kt
@@ -28,19 +28,44 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.common.CoreObject
 import org.hisp.dhis.android.core.maintenance.D2Error
 
 interface ReadWriteValueObjectRepository<M : CoreObject> : ReadWriteObjectRepository<M> {
     /**
+     * Sets the object in scope in a suspend way. The coroutine will complete when the object
+     * is updated in the database. The object will be uploaded to the server in the next upload.
+     * @param value the value to set
+     */
+    @Throws(D2Error::class)
+    suspend fun suspendSet(value: String?)
+
+    /**
      * Sets the object in scope in an asynchronous way. It returns a `Completable` which
-     * is completed when the object is updated to the database. It adds an object with a ASDASDASDASDASD
-     * which will be uploaded to the server in the next upload.
-     * @param value the object to add
+     * is completed when the object is updated to the database. The object will be uploaded
+     * to the server in the next upload.
+     * @param value the value to set
      * @return the Completable which notifies the completion
      */
-    fun set(value: String?): Completable
+    @Deprecated(message = "Use rxSet instead", ReplaceWith("rxSet(value)"))
+    fun set(value: String?): Completable = rxSet(value)
 
+    /**
+     * Sets the object in scope in an asynchronous way. It returns a `Completable` which
+     * is completed when the object is updated to the database. The object will be uploaded
+     * to the server in the next upload.
+     * @param value the value to set
+     * @return the Completable which notifies the completion
+     */
+    fun rxSet(value: String?): Completable = rxCompletable { suspendSet(value) }
+
+    /**
+     * Sets the object in scope in a synchronous way. Important: this is a blocking method and it should not be
+     * executed in the main thread. Consider the asynchronous version [.rxSet].
+     * @param value the value to set
+     */
     @Throws(D2Error::class)
-    fun blockingSet(value: String?)
+    fun blockingSet(value: String?) = runBlocking { suspendSet(value) }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl.kt
@@ -30,7 +30,7 @@ package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 import org.hisp.dhis.android.core.arch.call.internal.DownloadProvider
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
 
-abstract class ReadOnlyAnyObjectWithDownloadRepositoryImpl<M: Any> internal constructor(
+abstract class ReadOnlyAnyObjectWithDownloadRepositoryImpl<M : Any> internal constructor(
     private val downloadProvider: DownloadProvider,
 ) : ReadOnlyWithDownloadObjectRepository<M> {
     override suspend fun suspendGet(): M? = getInternal()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl.kt
@@ -27,47 +27,20 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
-import io.reactivex.Completable
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.call.internal.DownloadProvider
+import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
 
 abstract class ReadOnlyAnyObjectWithDownloadRepositoryImpl<M> internal constructor(
     private val downloadProvider: DownloadProvider,
-) {
-    fun get(): Single<M?> {
-        return Single.fromCallable { blockingGet() }
-    }
+): ReadOnlyWithDownloadObjectRepository<M> {
+    override suspend fun suspendGet(): M? =  getInternal()
 
-    fun blockingGet(): M? {
-        return runBlocking { getInternal() }
+    override suspend fun suspendExists(): Boolean = getInternal() != null
+
+    override suspend fun suspendDownload() {
+        downloadProvider.download(false)
     }
 
     internal abstract suspend fun getInternal(): M?
 
-    fun exists(): Single<Boolean> {
-        return rxSingle { existsInternal() }
-    }
-
-    fun blockingExists(): Boolean {
-        return runBlocking { existsInternal() }
-    }
-
-    private suspend fun existsInternal(): Boolean {
-        return getInternal() != null
-    }
-
-    fun download(): Completable {
-        return rxCompletable { downloadInternal() }
-    }
-
-    fun blockingDownload() {
-        runBlocking { downloadInternal() }
-    }
-
-    private suspend fun downloadInternal() {
-        downloadProvider.download(false)
-    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl.kt
@@ -32,8 +32,8 @@ import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownl
 
 abstract class ReadOnlyAnyObjectWithDownloadRepositoryImpl<M> internal constructor(
     private val downloadProvider: DownloadProvider,
-): ReadOnlyWithDownloadObjectRepository<M> {
-    override suspend fun suspendGet(): M? =  getInternal()
+) : ReadOnlyWithDownloadObjectRepository<M> {
+    override suspend fun suspendGet(): M? = getInternal()
 
     override suspend fun suspendExists(): Boolean = getInternal() != null
 
@@ -42,5 +42,4 @@ abstract class ReadOnlyAnyObjectWithDownloadRepositoryImpl<M> internal construct
     }
 
     internal abstract suspend fun getInternal(): M?
-
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
@@ -49,24 +49,10 @@ internal constructor(
     ReadOnlyWithDownloadObjectRepository<M> {
 
     /**
-     * Downloads the resource in scope in an asynchronous way. As soon as it's downloaded and processed, the
-     * `Completable` is completed.
-     * @return a `Completable` that completes when the download and processing is finished
+     * Downloads the resource in scope in a suspend way. The coroutine will complete when the
+     * download and processing is finished.
      */
-    override fun download(): Completable {
-        return rxCompletable { downloadInternal() }
-    }
-
-    /**
-     * Downloads the resource in scope in a synchronous way. The method will finish
-     * as soon as the whole download and processing is finished. Important: this is a blocking method and it should
-     * not be executed in the main thread. Consider the asynchronous version [.download].
-     */
-    override fun blockingDownload() {
-        runBlocking { downloadInternal() }
-    }
-
-    private suspend fun downloadInternal() {
+    override suspend fun suspendDownload() {
         downloadProvider.download(true)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyFirstObjectWithDownloadRepositoryImpl.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
-import io.reactivex.Completable
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.call.internal.DownloadProvider
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
-abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
+abstract class ReadOnlyObjectRepositoryImpl<M: Any, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val childrenAppenderGetter: ChildrenAppenderGetter<M>,
     protected val scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
-@Suppress("TooManyFunctions")
 abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val childrenAppenderGetter: ChildrenAppenderGetter<M>,
     protected val scope: RepositoryScope,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderExecutor
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
@@ -36,6 +36,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
+@Suppress("TooManyFunctions")
 abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val childrenAppenderGetter: ChildrenAppenderGetter<M>,
     protected val scope: RepositoryScope,
@@ -47,20 +48,15 @@ abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> 
     protected abstract suspend fun getWithoutChildrenInternal(): M?
 
     /**
-     * Returns the object in an asynchronous way, returning a `Single<M>`.
-     * @return A `Single` object with the object
-     */
-    override fun get(): Single<M?> {
-        return Single.fromCallable { blockingGet() }
-    }
-
-    /**
-     * Returns the object in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get].
+     * Returns the object in a suspend way.
      * @return the object
      */
-    override fun blockingGet(): M? {
-        return runBlocking { getInternal() }
+    override suspend fun suspendGet(): M? {
+        return ChildrenAppenderExecutor.appendInObject(
+            blockingGetWithoutChildren(),
+            childrenAppenderGetter,
+            scope.children(),
+        )
     }
 
     internal suspend fun getInternal(): M? {
@@ -72,23 +68,10 @@ abstract class ReadOnlyObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> 
     }
 
     /**
-     * Returns if the object exists in an asynchronous way, returning a `Single<Boolean>`.
-     * @return if the object exists, wrapped in a `Single`
-     */
-    override fun exists(): Single<Boolean> {
-        return rxSingle { existsInternal() }
-    }
-
-    /**
-     * Returns if the object exists in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.exists].
+     * Returns if the object exists in a suspend way.
      * @return if the object exists
      */
-    override fun blockingExists(): Boolean {
-        return runBlocking { existsInternal() }
-    }
-
-    internal suspend fun existsInternal(): Boolean {
+    override suspend fun suspendExists(): Boolean {
         return getWithoutChildrenInternal() != null
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyObjectRepositoryImpl.kt
@@ -33,7 +33,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 
-abstract class ReadOnlyObjectRepositoryImpl<M: Any, R : ReadOnlyObjectRepository<M>> internal constructor(
+abstract class ReadOnlyObjectRepositoryImpl<M : Any, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val childrenAppenderGetter: ChildrenAppenderGetter<M>,
     protected val scope: RepositoryScope,
     repositoryFactory: ObjectRepositoryFactory<R>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
@@ -35,7 +35,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFromScopeBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
-open class ReadOnlyOneObjectRepositoryImpl<M: Any, R : ReadOnlyObjectRepository<M>> internal constructor(
+open class ReadOnlyOneObjectRepositoryImpl<M : Any, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val store: ReadableStore<M>,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyOneObjectRepositoryImpl.kt
@@ -35,7 +35,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFromScopeBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
-open class ReadOnlyOneObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
+open class ReadOnlyOneObjectRepositoryImpl<M: Any, R : ReadOnlyObjectRepository<M>> internal constructor(
     private val store: ReadableStore<M>,
     childrenAppenders: ChildrenAppenderGetter<M>,
     scope: RepositoryScope,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -39,6 +39,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFromScopeBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
+@Suppress("TooManyFunctions")
 internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T>
 internal constructor(
     private val store: ReadableStore<M>,
@@ -57,23 +58,10 @@ internal constructor(
     }
 
     /**
-     * Returns the object in an asynchronous way, returning a `Single<M>`.
-     * @return A `Single` object with the object
-     */
-    override fun get(): Single<T?> {
-        return Single.fromCallable { blockingGet() }
-    }
-
-    /**
-     * Returns the object in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.get].
+     * Returns the object in a suspend way.
      * @return the object
      */
-    override fun blockingGet(): T? {
-        return runBlocking { getInternal() }
-    }
-
-    internal suspend fun getInternal(): T? {
+    override suspend fun suspendGet(): T? {
         val item = ChildrenAppenderExecutor.appendInObject(
             getWithoutChildrenInternal(),
             childrenAppenders,
@@ -84,23 +72,10 @@ internal constructor(
     }
 
     /**
-     * Returns if the object exists in an asynchronous way, returning a `Single<Boolean>`.
-     * @return if the object exists, wrapped in a `Single`
-     */
-    override fun exists(): Single<Boolean> {
-        return rxSingle { existsInternal() }
-    }
-
-    /**
-     * Returns if the object exists in a synchronous way. Important: this is a blocking method and it should not be
-     * executed in the main thread. Consider the asynchronous version [.exists].
+     * Returns if the object exists in a suspend way.
      * @return if the object exists
      */
-    override fun blockingExists(): Boolean {
-        return runBlocking { existsInternal() }
-    }
-
-    private suspend fun existsInternal(): Boolean {
+    override suspend fun suspendExists(): Boolean {
         return getWithoutChildrenInternal() != null
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -37,7 +37,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFromScopeBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
-internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T>
+internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T: Any>
 internal constructor(
     private val store: ReadableStore<M>,
     private val childrenAppenders: ChildrenAppenderGetter<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -37,7 +37,6 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFromScopeBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
-@Suppress("TooManyFunctions")
 internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T>
 internal constructor(
     private val store: ReadableStore<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -37,7 +37,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.WhereClauseFromScopeBuilder
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
-internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T: Any>
+internal class ReadOnlyWithTransformerObjectRepositoryImpl<M, T : Any>
 internal constructor(
     private val store: ReadableStore<M>,
     private val childrenAppenders: ChildrenAppenderGetter<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyWithTransformerObjectRepositoryImpl.kt
@@ -27,9 +27,7 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
-import io.reactivex.Single
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.db.stores.internal.ReadableStore
 import org.hisp.dhis.android.core.arch.handlers.internal.TwoWayTransformer
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderExecutor

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
@@ -42,7 +42,6 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
-@Suppress("TooManyFunctions")
 abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<M>> internal constructor(
     store: IdentifiableDeletableDataObjectStore<M>,
     childrenAppenders: ChildrenAppenderGetter<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
@@ -28,9 +28,6 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
 import android.util.Log
-import io.reactivex.Completable
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableDeletableDataObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
@@ -53,28 +50,6 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
     repositoryFactory: ObjectRepositoryFactory<R>,
 ) : ReadWriteWithUidObjectRepositoryImpl<M, R>(store, childrenAppenders, scope, repositoryFactory),
     ReadWriteObjectRepository<M> where M : CoreObject, M : ObjectWithUidInterface, M : DeletableDataObject {
-    /**
-     * Removes the object in scope in an asynchronous way. Field [DataObject.syncState] is marked as
-     * [State.TO_UPDATE] and [DeletableDataObject.deleted] as true. In the next upload, it will be deleted
-     * in the server. It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * The `Completable` fails if the object doesn't exist.
-     * @return the `Completable` which notifies the completion
-     */
-    @Deprecated("Use rxDelete instead", replaceWith = ReplaceWith("rxDelete()"))
-    override fun delete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
-
-    /**
-     * Removes the object in scope in an asynchronous way. Field [DataObject.syncState] is marked as
-     * [State.TO_UPDATE] and [DeletableDataObject.deleted] as true. In the next upload, it will be deleted
-     * in the server. It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * The `Completable` fails if the object doesn't exist.
-     * @return the `Completable` which notifies the completion
-     */
-    override fun rxDelete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
 
     /**
      * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
@@ -83,27 +58,6 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
      */
     @Throws(D2Error::class)
     override suspend fun suspendDelete() {
-        deleteInternal()
-    }
-
-    /**
-     * Removes the object in scope in a synchronous way. Field [DataObject.syncState] is marked as
-     * [State.TO_UPDATE] and [DeletableDataObject.deleted] as true. In the next upload, it will be deleted
-     * in the server. It blocks the thread and finishes as soon as the object is deleted in the database.
-     * It throws an exception if the object doesn't exist.
-     *
-     * Important: this is a blocking method and it should not be executed in the main thread. Consider the
-     * asynchronous version [.delete].
-     *
-     * @throws D2Error if any errors occur, including when the object doesn't exist.
-     */
-    @Throws(D2Error::class)
-    override fun blockingDelete() {
-        runBlocking { deleteInternal() }
-    }
-
-    @Throws(D2Error::class)
-    protected suspend fun deleteInternal() {
         val obj = suspendGet()
         if (obj === null) {
             throw D2Error
@@ -118,52 +72,12 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
     }
 
     /**
-     * Removes the object in scope in a synchronous way. Field [DataObject.syncState] is marked as
-     * [State.TO_POST] and [DeletableDataObject.deleted] as true. Unlike [.delete],
-     * it doesn't throw an exception if the object doesn't exist.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * @return the `Completable` which notifies the completion
-     */
-    @Deprecated("Use rxDeleteIfExist instead", replaceWith = ReplaceWith("rxDeleteIfExist()"))
-    override fun deleteIfExist(): Completable {
-        return rxCompletable { deleteIfExistInternal() }
-    }
-
-    /**
-     * Removes the object in scope in a synchronous way. Field [DataObject.syncState] is marked as
-     * [State.TO_POST] and [DeletableDataObject.deleted] as true. Unlike [.delete],
-     * it doesn't throw an exception if the object doesn't exist.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * @return the `Completable` which notifies the completion
-     */
-    override fun rxDeleteIfExist(): Completable {
-        return rxCompletable { deleteIfExistInternal() }
-    }
-
-    /**
      * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
      * is performed. Unlike [.suspendDelete], it doesn't throw an exception if the object doesn't exist.
      */
     override suspend fun suspendDeleteIfExist() {
-        deleteIfExistInternal()
-    }
-
-    /**
-     * Removes the object in scope in an asynchronous way. Field [DataObject.syncState] is marked as
-     * [State.TO_POST] and [DeletableDataObject.deleted] as true.
-     * Unlike [.blockingDelete], it doesn't throw an exception if the object doesn't exist.
-     * It blocks the thread and finishes as soon as the object is deleted in the database.
-     *
-     * Important: this is a blocking method and it should not be executed in the main thread. Consider the
-     * asynchronous version [.delete].
-     */
-    override fun blockingDeleteIfExist() {
-        runBlocking { deleteIfExistInternal() }
-    }
-
-    protected suspend fun deleteIfExistInternal() {
         try {
-            deleteInternal()
+            suspendDelete()
         } catch (d2Error: D2Error) {
             Log.v(ReadWriteWithUidDataObjectRepositoryImpl::class.java.canonicalName, d2Error.errorDescription())
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
@@ -60,8 +60,30 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
      * The `Completable` fails if the object doesn't exist.
      * @return the `Completable` which notifies the completion
      */
+    @Deprecated("Use rxDelete instead", replaceWith = ReplaceWith("rxDelete()"))
     override fun delete(): Completable {
         return rxCompletable { deleteInternal() }
+    }
+
+    /**
+     * Removes the object in scope in an asynchronous way. Field [DataObject.syncState] is marked as
+     * [State.TO_UPDATE] and [DeletableDataObject.deleted] as true. In the next upload, it will be deleted
+     * in the server. It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * The `Completable` fails if the object doesn't exist.
+     * @return the `Completable` which notifies the completion
+     */
+    override fun rxDelete(): Completable {
+        return rxCompletable { deleteInternal() }
+    }
+
+    /**
+     * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
+     * is performed. It throws an exception if the object doesn't exist.
+     * @throws D2Error if any errors occur, including when the object doesn't exist.
+     */
+    @Throws(D2Error::class)
+    override suspend fun suspendDelete() {
+        deleteInternal()
     }
 
     /**
@@ -82,7 +104,7 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
 
     @Throws(D2Error::class)
     protected suspend fun deleteInternal() {
-        val obj = getInternal()
+        val obj = suspendGet()
         if (obj === null) {
             throw D2Error
                 .builder()
@@ -102,8 +124,28 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
      * It returns a `Completable` that completes as soon as the object is deleted in the database.
      * @return the `Completable` which notifies the completion
      */
+    @Deprecated("Use rxDeleteIfExist instead", replaceWith = ReplaceWith("rxDeleteIfExist()"))
     override fun deleteIfExist(): Completable {
         return rxCompletable { deleteIfExistInternal() }
+    }
+
+    /**
+     * Removes the object in scope in a synchronous way. Field [DataObject.syncState] is marked as
+     * [State.TO_POST] and [DeletableDataObject.deleted] as true. Unlike [.delete],
+     * it doesn't throw an exception if the object doesn't exist.
+     * It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * @return the `Completable` which notifies the completion
+     */
+    override fun rxDeleteIfExist(): Completable {
+        return rxCompletable { deleteIfExistInternal() }
+    }
+
+    /**
+     * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
+     * is performed. Unlike [.suspendDelete], it doesn't throw an exception if the object doesn't exist.
+     */
+    override suspend fun suspendDeleteIfExist() {
+        deleteIfExistInternal()
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
@@ -39,7 +39,6 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
-@Suppress("TooManyFunctions")
 open class ReadWriteWithValueObjectRepositoryImpl<M : CoreObject, R : ReadOnlyObjectRepository<M>>
 internal constructor(
     private val store: ObjectWithoutUidStore<M>,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
@@ -28,9 +28,7 @@
 package org.hisp.dhis.android.core.arch.repositories.`object`.internal
 
 import android.util.Log
-import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStore
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
@@ -52,85 +50,13 @@ internal constructor(
     ReadWriteObjectRepository<M> {
 
     /**
-     * Removes the object in scope in an asynchronous way. It removes the value in the database and propagates
-     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
-     * the next upload.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * The `Completable` fails if the object doesn't exist.
-     * @return the `Completable` which notifies the completion
-     */
-    @Deprecated("Use rxDelete instead", replaceWith = ReplaceWith("rxDelete()"))
-    override fun delete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
-
-    /**
-     * Removes the object in scope in an asynchronous way. It removes the value in the database and propagates
-     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
-     * the next upload.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * The `Completable` fails if the object doesn't exist.
-     * @return the `Completable` which notifies the completion
-     */
-    override fun rxDelete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
-
-    /**
      * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
      * is performed. It throws an exception if the object doesn't exist.
      * @throws D2Error if any errors occur, including when the object doesn't exist.
      */
     @Throws(D2Error::class)
     override suspend fun suspendDelete() {
-        deleteInternal()
-    }
-
-    /**
-     * Removes the object in scope in a synchronous way. It removes the value in the database and propagates
-     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
-     * the next upload.
-     * It blocks the thread and finishes as soon as the object is deleted in the database.
-     *
-     * Important: this is a blocking method and it should not be executed in the main thread. Consider the
-     * asynchronous version [.delete].
-     *
-     * It throws an exception if the object doesn't exist.
-     */
-    @Throws(D2Error::class)
-    override fun blockingDelete() {
-        runBlocking { deleteInternal() }
-    }
-
-    @Throws(D2Error::class)
-    protected open suspend fun deleteInternal() {
-        getWithoutChildrenInternal()?.let { delete(it) }
-    }
-
-    /**
-     * Removes the object in scope in an asynchronous way. It removes the value in the database and propagates
-     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
-     * the next upload.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * Unlike [.delete], it doesn't throw an exception if the object doesn't exist.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * @return the `Completable` which notifies the completion
-     */
-    override fun deleteIfExist(): Completable {
-        return rxCompletable { deleteIfExistInternal() }
-    }
-
-    /**
-     * Removes the object in scope in an asynchronous way. It removes the value in the database and propagates
-     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
-     * the next upload.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * Unlike [.delete], it doesn't throw an exception if the object doesn't exist.
-     * It returns a `Completable` that completes as soon as the object is deleted in the database.
-     * @return the `Completable` which notifies the completion
-     */
-    override fun rxDeleteIfExist(): Completable {
-        return rxCompletable { deleteIfExistInternal() }
+        getWithoutChildrenInternal()?.let { suspendDelete(it) }
     }
 
     /**
@@ -138,26 +64,8 @@ internal constructor(
      * is performed. Unlike [.suspendDelete], it doesn't throw an exception if the object doesn't exist.
      */
     override suspend fun suspendDeleteIfExist() {
-        deleteIfExistInternal()
-    }
-
-    /**
-     * Removes the object in scope in a synchronous way. It removes the value in the database and propagates
-     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
-     * the next upload.
-     * Unlike [.blockingDelete], it doesn't throw an exception if the object doesn't exist.
-     * It blocks the thread and finishes as soon as the object is deleted in the database.
-     *
-     * Important: this is a blocking method and it should not be executed in the main thread. Consider the
-     * asynchronous version [.deleteIfExist].
-     */
-    override fun blockingDeleteIfExist() {
-        runBlocking { deleteIfExistInternal() }
-    }
-
-    protected suspend fun deleteIfExistInternal() {
         try {
-            deleteInternal()
+            suspendDelete()
         } catch (d2Error: D2Error) {
             Log.v(ReadWriteWithValueObjectRepositoryImpl::class.java.canonicalName, d2Error.errorDescription())
         }
@@ -165,13 +73,7 @@ internal constructor(
 
     @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
-    protected open fun delete(m: M) {
-        runBlocking { deleteInternal(m) }
-    }
-
-    @Throws(D2Error::class)
-    @Suppress("TooGenericExceptionCaught")
-    protected open suspend fun deleteInternal(m: M) {
+    protected open suspend fun suspendDelete(m: M) {
         try {
             store.deleteWhere(m)
             propagateState(m)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
@@ -59,8 +59,31 @@ internal constructor(
      * The `Completable` fails if the object doesn't exist.
      * @return the `Completable` which notifies the completion
      */
+    @Deprecated("Use rxDelete instead", replaceWith = ReplaceWith("rxDelete()"))
     override fun delete(): Completable {
         return rxCompletable { deleteInternal() }
+    }
+
+    /**
+     * Removes the object in scope in an asynchronous way. It removes the value in the database and propagates
+     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
+     * the next upload.
+     * It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * The `Completable` fails if the object doesn't exist.
+     * @return the `Completable` which notifies the completion
+     */
+    override fun rxDelete(): Completable {
+        return rxCompletable { deleteInternal() }
+    }
+
+    /**
+     * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
+     * is performed. It throws an exception if the object doesn't exist.
+     * @throws D2Error if any errors occur, including when the object doesn't exist.
+     */
+    @Throws(D2Error::class)
+    override suspend fun suspendDelete() {
+        deleteInternal()
     }
 
     /**
@@ -95,6 +118,27 @@ internal constructor(
      */
     override fun deleteIfExist(): Completable {
         return rxCompletable { deleteIfExistInternal() }
+    }
+
+    /**
+     * Removes the object in scope in an asynchronous way. It removes the value in the database and propagates
+     * the changes to modify the [DataObject.syncState] of the parent, so it's updated in the server in
+     * the next upload.
+     * It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * Unlike [.delete], it doesn't throw an exception if the object doesn't exist.
+     * It returns a `Completable` that completes as soon as the object is deleted in the database.
+     * @return the `Completable` which notifies the completion
+     */
+    override fun rxDeleteIfExist(): Completable {
+        return rxCompletable { deleteIfExistInternal() }
+    }
+
+    /**
+     * Removes the object in scope in a suspend way. See the implementation JavaDoc for details on how deletion
+     * is performed. Unlike [.suspendDelete], it doesn't throw an exception if the object doesn't exist.
+     */
+    override suspend fun suspendDeleteIfExist() {
+        deleteIfExistInternal()
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/CategoryOptionComboService.kt
@@ -54,7 +54,7 @@ class CategoryOptionComboService(
     suspend fun suspendHasAccess(categoryOptionComboUid: String, date: Date?, orgUnitUid: String? = null): Boolean {
         val categoryOptions = categoryOptionRepository
             .byCategoryOptionComboUid(categoryOptionComboUid)
-            .getInternal()
+            .suspendGet()
 
         return suspendIsAssignedToOrgUnit(categoryOptionComboUid, orgUnitUid) &&
             hasWriteAccess(categoryOptions) &&
@@ -88,7 +88,7 @@ class CategoryOptionComboService(
             val categoryOptions = categoryOptionRepository
                 .byCategoryOptionComboUid(categoryOptionComboUid)
                 .withOrganisationUnits()
-                .getInternal()
+                .suspendGet()
 
             categoryOptions.all { categoryOption ->
                 categoryOption.organisationUnits()?.any {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationCollectionRepository.kt
@@ -27,11 +27,9 @@
  */
 package org.hisp.dhis.android.core.dataset
 
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationCollectionRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.dataset
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.rx2.asObservable
@@ -97,15 +98,13 @@ class DataSetCompleteRegistrationCollectionRepository internal constructor(
         )
     }
 
-    override fun upload(): Observable<D2Progress> = flow {
-        val dataSetCompleteRegistrations =
-            bySyncState().`in`(*uploadableStatesIncludingError()).getWithoutChildrenInternal()
+    override fun flowUpload(): Flow<D2Progress> {
+        return flow {
+            val dataSetCompleteRegistrations =
+                bySyncState().`in`(*uploadableStatesIncludingError()).getWithoutChildrenInternal()
 
-        emitAll(postCall.uploadDataSetCompleteRegistrations(dataSetCompleteRegistrations))
-    }.asObservable()
-
-    override fun blockingUpload() {
-        upload().blockingSubscribe()
+            emitAll(postCall.uploadDataSetCompleteRegistrations(dataSetCompleteRegistrations))
+        }
     }
 
     fun byPeriod(): StringFilterConnector<DataSetCompleteRegistrationCollectionRepository> {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/DataSetCompleteRegistrationObjectRepository.kt
@@ -44,6 +44,7 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.user.UserCredentialsObjectRepository
 import java.util.Date
 
+@Suppress("TooManyFunctions")
 class DataSetCompleteRegistrationObjectRepository internal constructor(
     private val dataSetCompleteRegistrationStore: DataSetCompleteRegistrationStore,
     private val credentialsRepository: UserCredentialsObjectRepository,
@@ -71,15 +72,19 @@ class DataSetCompleteRegistrationObjectRepository internal constructor(
     },
 ),
     ReadWriteObjectRepository<DataSetCompleteRegistration> {
-    fun set(): Completable {
-        return rxCompletable { setInternal() }
+
+    @Deprecated("Use rxSet instead", replaceWith = ReplaceWith("rxSet()"))
+    fun set(): Completable = rxSet()
+
+    fun rxSet(): Completable {
+        return rxCompletable { suspendSet() }
     }
 
     fun blockingSet() {
-        runBlocking { setInternal() }
+        runBlocking { suspendSet() }
     }
 
-    private suspend fun setInternal() {
+    suspend fun suspendSet() {
         val dataSetCompleteRegistration = getWithoutChildrenInternal()
         if (dataSetCompleteRegistration == null) {
             val username = credentialsRepository.getInternal()!!.username()
@@ -112,17 +117,8 @@ class DataSetCompleteRegistrationObjectRepository internal constructor(
         }
     }
 
-    override fun delete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
-
     @Throws(D2Error::class)
-    override fun blockingDelete() {
-        runBlocking { deleteInternal() }
-    }
-
-    @Throws(D2Error::class)
-    private suspend fun deleteInternal() {
+    override suspend fun suspendDelete() {
         val dataSetCompleteRegistration = getWithoutChildrenInternal()
         if (dataSetCompleteRegistration == null) {
             throw D2Error
@@ -146,17 +142,9 @@ class DataSetCompleteRegistrationObjectRepository internal constructor(
         }
     }
 
-    override fun deleteIfExist(): Completable {
-        return rxCompletable { deleteIfExistInternal() }
-    }
-
-    override fun blockingDeleteIfExist() {
-        runBlocking { deleteIfExistInternal() }
-    }
-
-    private suspend fun deleteIfExistInternal() {
+    override suspend fun suspendDeleteIfExist() {
         try {
-            deleteInternal()
+            suspendDelete()
         } catch (d2Error: D2Error) {
             Log.v(DataSetCompleteRegistrationObjectRepository::class.java.canonicalName, d2Error.errorDescription())
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -335,7 +335,7 @@ internal class DataSetInstanceServiceImpl(
 
             categoryComboUid?.let { catComboUid ->
                 val categoryOptionCombos = getCachedCategoryComboUid(catComboUid, stringListCache) { uid ->
-                    categoryOptionComboCollectionRepository.byCategoryComboUid().eq(uid).getUidsInternal()
+                    categoryOptionComboCollectionRepository.byCategoryComboUid().eq(uid).suspendGetUids()
                 }
 
                 val dataValues = dataValueCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -251,7 +251,7 @@ internal class DataSetInstanceServiceImpl(
                     categoryOptionCombo.uid(),
                     attributeOptionComboUid,
                     dataSetUid,
-                ).existsInternal()
+                ).suspendExists()
             }
         } ?: false
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -114,7 +114,7 @@ internal class DataSetInstanceServiceImpl(
         organisationUnitUid: String,
         attributeOptionComboUid: String,
     ): DataSetEditableStatus {
-        val dataSet = dataSetCollectionRepository.withDataInputPeriods().uid(dataSetUid).getInternal()
+        val dataSet = dataSetCollectionRepository.withDataInputPeriods().uid(dataSetUid).suspendGet()
         val period = periodHelper.suspendGetPeriodForPeriodId(periodId)
         return when {
             !suspendHasDataWriteAccess(dataSetUid) ->
@@ -162,7 +162,7 @@ internal class DataSetInstanceServiceImpl(
     }
 
     override suspend fun suspendHasDataWriteAccess(dataSetUid: String): Boolean {
-        val dataSet = dataSetCollectionRepository.uid(dataSetUid).getInternal() ?: return false
+        val dataSet = dataSetCollectionRepository.uid(dataSetUid).suspendGet() ?: return false
         return dataSet.access().write() ?: false
     }
 
@@ -228,7 +228,7 @@ internal class DataSetInstanceServiceImpl(
         attributeOptionComboUid: String,
     ): List<DataElementOperand> {
         val dataSet = dataSetCollectionRepository.withCompulsoryDataElementOperands()
-            .uid(dataSetUid).getInternal()
+            .uid(dataSetUid).suspendGet()
 
         return dataSet?.compulsoryDataElementOperands()?.filter { dataElementOperand ->
             !hasDataValue(dataSetUid, dataElementOperand, periodId, organisationUnitUid, attributeOptionComboUid)
@@ -321,7 +321,7 @@ internal class DataSetInstanceServiceImpl(
         val stringListCache = ExpirableCache<String, List<String>>(TimeUnit.SECONDS.toMillis(120))
 
         val dataSet = dataSetCollectionRepository.withDataSetElements()
-            .uid(dataSetUid).getInternal()
+            .uid(dataSetUid).suspendGet()
             ?.takeIf { it.fieldCombinationRequired() == true }
             ?: return emptyList()
 
@@ -329,7 +329,7 @@ internal class DataSetInstanceServiceImpl(
             val categoryComboUid = dataSetElement.categoryCombo()?.uid()
                 ?: dataElementCollectionRepository
                     .uid(dataSetElement.dataElement().uid())
-                    .getInternal()
+                    .suspendGet()
                     ?.categoryCombo()
                     ?.uid()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -346,7 +346,7 @@ internal class DataSetInstanceServiceImpl(
                     .byDataElementUid().eq(dataSetElement.dataElement().uid())
                     .byCategoryOptionComboUid()
                     .`in`(categoryOptionCombos)
-                    .getInternal()
+                    .suspendGet()
 
                 dataValues.takeIf { it.isNotEmpty() && it.size != categoryOptionCombos.size }
                     ?.map { dataValue ->
@@ -456,6 +456,6 @@ internal class DataSetInstanceServiceImpl(
     private suspend fun suspendGetCategoryOptions(attributeOptionComboUid: String): List<CategoryOption> {
         return categoryOptionRepository
             .byCategoryOptionComboUid(attributeOptionComboUid)
-            .getInternal()
+            .suspendGet()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository.kt
@@ -29,6 +29,10 @@
 package org.hisp.dhis.android.core.datastore
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository
@@ -58,16 +62,11 @@ class DataStoreCollectionRepository internal constructor(
     FilterConnectorFactory(scope) { s -> DataStoreCollectionRepository(store, call, s) },
 ),
     ReadOnlyWithUploadCollectionRepository<DataStoreEntry> {
-    override fun upload(): Observable<D2Progress> {
-        return Observable
-            .fromCallable {
-                bySyncState().`in`(State.uploadableStatesIncludingError().toList()).blockingGetWithoutChildren()
-            }
-            .flatMap { call.uploadDataStoreEntries(it) }
-    }
 
-    override fun blockingUpload() {
-        upload().blockingSubscribe()
+    override fun flowUpload(): Flow<D2Progress> = flow {
+        val entries = bySyncState().`in`(State.uploadableStatesIncludingError().toList())
+            .blockingGetWithoutChildren()
+        emitAll(call.uploadDataStoreEntries(entries))
     }
 
     fun value(namespace: String, key: String): DataStoreObjectRepository {

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository.kt
@@ -28,11 +28,9 @@
 
 package org.hisp.dhis.android.core.datastore
 
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
@@ -28,9 +28,6 @@
 
 package org.hisp.dhis.android.core.datastore
 
-import io.reactivex.Completable
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
@@ -36,7 +36,6 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datastore.internal.DataStoreEntryStore
 
-@Suppress("TooManyFunctions")
 class DataStoreObjectRepository internal constructor(
     store: DataStoreEntryStore,
     childrenAppenders: ChildrenAppenderGetter<DataStoreEntry>,

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/DataStoreObjectRepository.kt
@@ -39,6 +39,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.datastore.internal.DataStoreEntryStore
 
+@Suppress("TooManyFunctions")
 class DataStoreObjectRepository internal constructor(
     store: DataStoreEntryStore,
     childrenAppenders: ChildrenAppenderGetter<DataStoreEntry>,
@@ -54,31 +55,16 @@ class DataStoreObjectRepository internal constructor(
     },
 ),
     ReadWriteValueObjectRepository<DataStoreEntry> {
-    override fun set(value: String?): Completable {
-        return rxCompletable { setInternal(value) }
-    }
 
-    override fun blockingSet(value: String?) {
-        runBlocking { setInternal(value) }
-    }
-
-    private suspend fun setInternal(value: String?) {
+    override suspend fun suspendSet(value: String?) {
         val entry = setBuilder().value(value).deleted(false).build()
         setObject(entry)
     }
 
-    override fun delete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
-
-    override fun blockingDelete() {
-        runBlocking { deleteInternal() }
-    }
-
-    override suspend fun deleteInternal() {
+    override suspend fun suspendDelete() {
         getWithoutChildrenInternal()?.let { entry ->
             if (entry.syncState() == State.TO_POST) {
-                super.deleteInternal()
+                super.suspendDelete()
             } else {
                 setObject(entry.toBuilder().deleted(true).syncState(State.TO_UPDATE).build())
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
@@ -57,17 +57,9 @@ class LocalDataStoreObjectRepository internal constructor(
     },
 ),
     ReadWriteValueObjectRepository<KeyValuePair> {
-    override fun set(value: String?): Completable {
-        return rxCompletable { setInternal(value) }
-    }
 
     @Throws(D2Error::class)
-    override fun blockingSet(value: String?) {
-        runBlocking { setInternal(value) }
-    }
-
-    @Throws(D2Error::class)
-    private suspend fun setInternal(value: String?) {
+    override suspend fun suspendSet(value: String?) {
         val pair = KeyValuePair.builder()
             .key(key)
             .value(value)

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/LocalDataStoreObjectRepository.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.datastore
 
-import io.reactivex.Completable
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/internal/DataStorePostCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/internal/DataStorePostCall.kt
@@ -28,8 +28,8 @@
 package org.hisp.dhis.android.core.datastore.internal
 
 import io.ktor.http.HttpStatusCode
-import io.reactivex.Observable
-import kotlinx.coroutines.rx2.rxObservable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
 import org.hisp.dhis.android.core.arch.helpers.Result
@@ -45,21 +45,17 @@ internal class DataStorePostCall(
     private val dataStoreEntryImportHandler: DataStoreImportHandler,
     private val store: DataStoreEntryStore,
 ) {
-    fun uploadDataStoreEntries(entries: List<DataStoreEntry>): Observable<D2Progress> =
-        Observable.defer {
-            if (entries.isEmpty()) {
-                Observable.empty()
-            } else {
-                val progressManager = D2ProgressManager(entries.size)
-                rxObservable {
-                    entries.forEach { entry ->
-                        postEntry(entry)
-                        send(progressManager.increaseProgress(DataStoreEntry::class.java, isComplete = false))
-                    }
-                    send(progressManager.increaseProgress(DataStoreEntry::class.java, isComplete = true))
-                }
-            }
+    fun uploadDataStoreEntries(entries: List<DataStoreEntry>): Flow<D2Progress> = flow {
+        if (entries.isEmpty()) {
+            return@flow
         }
+        val progressManager = D2ProgressManager(entries.size)
+        entries.forEach { entry ->
+            postEntry(entry)
+            emit(progressManager.increaseProgress(DataStoreEntry::class.java, isComplete = false))
+        }
+        emit(progressManager.increaseProgress(DataStoreEntry::class.java, isComplete = true))
+    }
 
     private suspend fun postEntry(entry: DataStoreEntry) {
         store.setState(entry, forcedOrOwn(entry, State.UPLOADING))

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueCollectionRepository.kt
@@ -27,12 +27,10 @@
  */
 package org.hisp.dhis.android.core.datavalue
 
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUploadCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueCollectionRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.datavalue
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
@@ -72,14 +73,10 @@ class DataValueCollectionRepository internal constructor(
 ),
     ReadOnlyWithUploadCollectionRepository<DataValue> {
 
-    override fun upload(): Observable<D2Progress> = flow {
+    override fun flowUpload(): Flow<D2Progress> = flow {
         val dataValues =
             bySyncState().`in`(State.uploadableStatesIncludingError().toMutableList()).getWithoutChildrenInternal()
         emitAll(postCall.uploadDataValues(dataValues))
-    }.asObservable()
-
-    override fun blockingUpload() {
-        upload().blockingSubscribe()
     }
 
     fun value(

--- a/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datavalue/DataValueObjectRepository.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.datavalue
 
-import io.reactivex.Completable
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxCompletable
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -69,13 +66,10 @@ class DataValueObjectRepository internal constructor(
     },
 ),
     ReadWriteValueObjectRepository<DataValue> {
-    override fun set(value: String?): Completable {
-        return Completable.fromAction { blockingSet(value) }
-    }
 
     @Throws(D2Error::class)
-    override fun blockingSet(value: String?) {
-        updateIfChanged(value, { it?.value() }) { dataValue: DataValue?, newValue ->
+    override suspend fun suspendSet(value: String?) {
+        updateIfChangedInternal(value, { it?.value() }) { dataValue: DataValue?, newValue ->
             setBuilder(dataValue).value(newValue).deleted(false).build()
         }
     }
@@ -94,20 +88,11 @@ class DataValueObjectRepository internal constructor(
         }
     }
 
-    override fun delete(): Completable {
-        return rxCompletable { deleteInternal() }
-    }
-
     @Throws(D2Error::class)
-    override fun blockingDelete() {
-        runBlocking { deleteInternal() }
-    }
-
-    @Throws(D2Error::class)
-    override suspend fun deleteInternal() {
+    override suspend fun suspendDelete() {
         getWithoutChildrenInternal()?.let { dataValue ->
             if (dataValue.syncState() === State.TO_POST) {
-                super.deleteInternal(dataValue)
+                super.suspendDelete(dataValue)
             } else {
                 setObject(dataValue.toBuilder().deleted(true).syncState(State.TO_UPDATE).build())
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataCallBundleFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataCallBundleFactory.kt
@@ -149,6 +149,6 @@ internal class AggregatedDataCallBundleFactory(
     private suspend fun getDataSets(): List<DataSet> {
         return dataSetRepository
             .withDataSetElements()
-            .getInternal()
+            .suspendGet()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataCallBundleFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/aggregated/data/internal/AggregatedDataCallBundleFactory.kt
@@ -51,10 +51,10 @@ internal class AggregatedDataCallBundleFactory(
         val rootOrganisationUnitUids = organisationUnitRepository
             .byRootOrganisationUnit(true)
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
-            .getUidsInternal()
+            .suspendGetUids()
         val allOrganisationUnitUids = organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
-            .getUidsInternal()
+            .suspendGetUids()
         return getBundlesInternal(
             getDataSets(),
             dataSetSettingsObjectRepository.getInternal(),

--- a/core/src/main/java/org/hisp/dhis/android/core/domain/metadata/MetadataCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/domain/metadata/MetadataCall.kt
@@ -29,12 +29,11 @@ package org.hisp.dhis.android.core.domain.metadata
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.attribute.Attribute
@@ -213,6 +212,6 @@ internal class MetadataCall(
     }
 
     fun blockingDownload() {
-        runBlocking { download().collect() }
+        download().collectAndWrapException()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -79,7 +79,7 @@ internal class EnrollmentServiceImpl(
     }
 
     override suspend fun suspendIsOpen(enrollmentUid: String): Boolean {
-        val enrollment = enrollmentRepository.uid(enrollmentUid).getInternal() ?: return true
+        val enrollment = enrollmentRepository.uid(enrollmentUid).suspendGet() ?: return true
 
         return enrollment.status()?.equals(EnrollmentStatus.ACTIVE) ?: false
     }
@@ -104,7 +104,7 @@ internal class EnrollmentServiceImpl(
         trackedEntityInstanceUid: String,
         programUid: String,
     ): EnrollmentAccess {
-        val program = programRepository.uid(programUid).getInternal() ?: return EnrollmentAccess.NO_ACCESS
+        val program = programRepository.uid(programUid).suspendGet() ?: return EnrollmentAccess.NO_ACCESS
 
         val dataAccess =
             if (program.access()?.data()?.write() == true) {
@@ -139,7 +139,7 @@ internal class EnrollmentServiceImpl(
     }
 
     private suspend fun isTeiInCaptureScope(trackedEntityInstanceUid: String): Boolean {
-        val tei = trackedEntityInstanceRepository.uid(trackedEntityInstanceUid).getInternal()
+        val tei = trackedEntityInstanceRepository.uid(trackedEntityInstanceUid).suspendGet()
 
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -185,14 +185,14 @@ internal class EnrollmentServiceImpl(
 
     override suspend fun suspendGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean {
         val currentProgramStagesUids = eventCollectionRepository.byEnrollmentUid().eq(enrollmentUid)
-            .byDeleted().isFalse.getInternal()
+            .byDeleted().isFalse.suspendGet()
             .map { event: Event -> event.programStage() }
 
-        val enrollment = enrollmentRepository.uid(enrollmentUid).getInternal()
+        val enrollment = enrollmentRepository.uid(enrollmentUid).suspendGet()
         val programStages = programStagesCollectionRepository.byProgramUid().eq(
             enrollment?.program(),
         ).byAccessDataWrite().isTrue
-            .getInternal()
+            .suspendGet()
             .filter { programStage: ProgramStage ->
                 !currentProgramStagesUids.contains(programStage.uid()) ||
                     programStage.repeatable()!!

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -144,7 +144,7 @@ internal class EnrollmentServiceImpl(
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .uid(tei?.organisationUnit())
-            .existsInternal()
+            .suspendExists()
     }
 
     private suspend fun hasProgramOwnership(trackedEntityInstanceUid: String, programUid: String): Boolean {
@@ -164,7 +164,7 @@ internal class EnrollmentServiceImpl(
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .uid(ownerOrgUnit)
-            .existsInternal()
+            .suspendExists()
     }
 
     override fun blockingGetAllowEventCreation(enrollmentUid: String, stagesToHide: List<String>): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.event
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
@@ -95,17 +96,13 @@ class EventCollectionRepository internal constructor(
     ReadWriteWithUploadWithUidCollectionRepository<Event, EventCreateProjection> {
 
     @Suppress("SpreadOperator")
-    override fun upload(): Observable<D2Progress> = flow {
+    override fun flowUpload(): Flow<D2Progress> = flow {
         emitAll(jobQueryCall.queryPendingJobs())
         val events = byAggregatedSyncState()
             .`in`(*uploadableStatesIncludingError())
             .byEnrollmentUid().isNull
             .getWithoutChildrenInternal()
         emitAll(postCall.uploadEvents(events))
-    }.asObservable()
-
-    override fun blockingUpload() {
-        upload().blockingSubscribe()
     }
 
     override suspend fun propagateState(m: Event, action: HandleAction?) {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventCollectionRepository.kt
@@ -27,12 +27,10 @@
  */
 package org.hisp.dhis.android.core.event
 
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -72,7 +72,7 @@ internal class EventQueryBundleInternalFactory(
             eventFilterCollectionRepository
                 .byUid().`in`(it)
                 .withEventDataFilters()
-                .getInternal()
+                .suspendGet()
         }
 
         val finalFilters = eventFilters.takeIf { it.isNotEmpty() } ?: programSettingFilters

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -73,9 +73,9 @@ internal class EventServiceImpl(
     }
 
     override suspend fun suspendHasDataWriteAccess(eventUid: String): Boolean {
-        val event = eventRepository.uid(eventUid).getInternal() ?: return false
+        val event = eventRepository.uid(eventUid).suspendGet() ?: return false
 
-        return programStageRepository.uid(event.programStage()).getInternal()?.access()?.data()?.write() ?: false
+        return programStageRepository.uid(event.programStage()).suspendGet()?.access()?.data()?.write() ?: false
     }
 
     override fun blockingIsInOrgunitRange(event: Event): Boolean {
@@ -150,9 +150,9 @@ internal class EventServiceImpl(
     }
 
     override suspend fun suspendGetEditableStatus(eventUid: String): EventEditableStatus {
-        val event = eventRepository.uid(eventUid).getInternal()!!
-        val program = programRepository.uid(event.program()).getInternal()
-        val programStage = programStageRepository.uid(event.programStage()).getInternal()
+        val event = eventRepository.uid(eventUid).suspendGet()!!
+        val program = programRepository.uid(event.program()).suspendGet()
+        val programStage = programStageRepository.uid(event.programStage()).suspendGet()
 
         return when {
             event.status() == EventStatus.COMPLETED && programStage?.blockEntryForm() == true ->
@@ -203,8 +203,8 @@ internal class EventServiceImpl(
     }
 
     override suspend fun suspendCanAddEventToEnrollment(enrollmentUid: String, programStageUid: String): Boolean {
-        val enrollment = enrollmentRepository.uid(enrollmentUid).getInternal()
-        val programStage = programStageRepository.uid(programStageUid).getInternal()
+        val enrollment = enrollmentRepository.uid(enrollmentUid).suspendGet()
+        val programStage = programStageRepository.uid(programStageUid).suspendGet()
 
         if (enrollment == null || programStage == null) {
             return false
@@ -235,7 +235,7 @@ internal class EventServiceImpl(
     private suspend fun getOwnerOrgUnit(event: Event): String? {
         val program = event.program()
         val tei = event.enrollment()
-            ?.let { enrollmentRepository.uid(it).getInternal() }
+            ?.let { enrollmentRepository.uid(it).suspendGet() }
             ?.trackedEntityInstance()
 
         if (program == null || tei == null) return event.organisationUnit()

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventServiceImpl.kt
@@ -255,6 +255,6 @@ internal class EventServiceImpl(
             .byEnrollmentUid().eq(enrollmentUid)
             .byProgramStageUid().eq(programStageUid)
             .byDeleted().isFalse
-            .countInternal()
+            .suspendCount()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventCollectionRepositoryAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventCollectionRepositoryAdapter.kt
@@ -138,20 +138,20 @@ internal class EventCollectionRepositoryAdapter(
     suspend fun getOrganisationUnits(scope: EventQueryRepositoryScope): List<String>? {
         return when (scope.orgUnitMode()) {
             OrganisationUnitMode.ALL, OrganisationUnitMode.ACCESSIBLE ->
-                organisationUnitCollectionRepository.getUidsInternal()
+                organisationUnitCollectionRepository.suspendGetUids()
 
             OrganisationUnitMode.CAPTURE ->
                 organisationUnitCollectionRepository
-                    .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE).getUidsInternal()
+                    .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE).suspendGetUids()
 
             OrganisationUnitMode.CHILDREN ->
                 scope.orgUnits()?.map { orgUnit ->
-                    organisationUnitCollectionRepository.byParentUid().eq(orgUnit).getUidsInternal() + orgUnit
+                    organisationUnitCollectionRepository.byParentUid().eq(orgUnit).suspendGetUids() + orgUnit
                 }?.flatten()
 
             OrganisationUnitMode.DESCENDANTS ->
                 scope.orgUnits()?.map { orgUnit ->
-                    organisationUnitCollectionRepository.byPath().like(orgUnit).getUidsInternal()
+                    organisationUnitCollectionRepository.byPath().like(orgUnit).suspendGetUids()
                 }?.flatten()
 
             OrganisationUnitMode.SELECTED ->

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -290,21 +290,8 @@ class EventQueryCollectionRepository internal constructor(
         return runBlocking { getDataFetcher().getUids() }
     }
 
-    @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
-    override fun get(): Single<List<Event>> {
-        return rxSingle { getDataFetcher().get() }
-    }
-
-    override fun rxGet(): Single<List<Event>> {
-        return rxSingle { getDataFetcher().get() }
-    }
-
     override suspend fun suspendGet(): List<Event> {
         return getDataFetcher().get()
-    }
-
-    override fun blockingGet(): List<Event> {
-        return runBlocking { getDataFetcher().get() }
     }
 
     @Deprecated("Use {@link #getPagingData()} instead}", replaceWith = ReplaceWith("getPagingData()"))
@@ -323,38 +310,12 @@ class EventQueryCollectionRepository internal constructor(
     val dataSource: DataSource<Int, Event>
         get() = getDataFetcher().dataSource
 
-    @Deprecated("Use rxCount instead", replaceWith = ReplaceWith("rxCount()"))
-    override fun count(): Single<Int> {
-        return rxSingle { getDataFetcher().count() }
-    }
-
-    override fun rxCount(): Single<Int> {
-        return rxSingle { getDataFetcher().count() }
-    }
-
     override suspend fun suspendCount(): Int {
         return getDataFetcher().count()
     }
 
-    override fun blockingCount(): Int {
-        return runBlocking { getDataFetcher().count() }
-    }
-
-    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
-    override fun isEmpty(): Single<Boolean> {
-        return rxSingle { getDataFetcher().isEmpty() }
-    }
-
-    override fun rxIsEmpty(): Single<Boolean> {
-        return rxSingle { getDataFetcher().isEmpty() }
-    }
-
     override suspend fun suspendIsEmpty(): Boolean {
         return getDataFetcher().isEmpty()
-    }
-
-    override fun blockingIsEmpty(): Boolean {
-        return runBlocking { getDataFetcher().isEmpty() }
     }
 
     override fun one(): ReadOnlyObjectRepository<Event> {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -273,21 +273,8 @@ class EventQueryCollectionRepository internal constructor(
         return getDataFetcher().uid(uid)
     }
 
-    @Deprecated("Use rxGetUids instead", replaceWith = ReplaceWith("rxGetUids()"))
-    override fun getUids(): Single<List<String>> {
-        return rxSingle { getDataFetcher().getUids() }
-    }
-
-    override fun rxGetUids(): Single<List<String>> {
-        return rxSingle { getDataFetcher().getUids() }
-    }
-
     override suspend fun suspendGetUids(): List<String> {
         return getDataFetcher().getUids()
-    }
-
-    override fun blockingGetUids(): List<String> {
-        return runBlocking { getDataFetcher().getUids() }
     }
 
     override suspend fun suspendGet(): List<Event> {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -32,10 +32,7 @@ import androidx.paging.DataSource
 import androidx.paging.PagedList
 import androidx.paging.Pager
 import androidx.paging.PagingData
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithUidCollectionRepository
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EqFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.EventDataFilterConnector

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository.kt
@@ -273,22 +273,41 @@ class EventQueryCollectionRepository internal constructor(
         return getDataFetcher().uid(uid)
     }
 
+    @Deprecated("Use rxGetUids instead", replaceWith = ReplaceWith("rxGetUids()"))
     override fun getUids(): Single<List<String>> {
         return rxSingle { getDataFetcher().getUids() }
+    }
+
+    override fun rxGetUids(): Single<List<String>> {
+        return rxSingle { getDataFetcher().getUids() }
+    }
+
+    override suspend fun suspendGetUids(): List<String> {
+        return getDataFetcher().getUids()
     }
 
     override fun blockingGetUids(): List<String> {
         return runBlocking { getDataFetcher().getUids() }
     }
 
+    @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
     override fun get(): Single<List<Event>> {
         return rxSingle { getDataFetcher().get() }
+    }
+
+    override fun rxGet(): Single<List<Event>> {
+        return rxSingle { getDataFetcher().get() }
+    }
+
+    override suspend fun suspendGet(): List<Event> {
+        return getDataFetcher().get()
     }
 
     override fun blockingGet(): List<Event> {
         return runBlocking { getDataFetcher().get() }
     }
 
+    @Deprecated("Use {@link #getPagingData()} instead}", replaceWith = ReplaceWith("getPagingData()"))
     override fun getPaged(pageSize: Int): LiveData<PagedList<Event>> {
         return getDataFetcher().getPaged(pageSize)
     }
@@ -304,16 +323,34 @@ class EventQueryCollectionRepository internal constructor(
     val dataSource: DataSource<Int, Event>
         get() = getDataFetcher().dataSource
 
+    @Deprecated("Use rxCount instead", replaceWith = ReplaceWith("rxCount()"))
     override fun count(): Single<Int> {
         return rxSingle { getDataFetcher().count() }
+    }
+
+    override fun rxCount(): Single<Int> {
+        return rxSingle { getDataFetcher().count() }
+    }
+
+    override suspend fun suspendCount(): Int {
+        return getDataFetcher().count()
     }
 
     override fun blockingCount(): Int {
         return runBlocking { getDataFetcher().count() }
     }
 
+    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
     override fun isEmpty(): Single<Boolean> {
         return rxSingle { getDataFetcher().isEmpty() }
+    }
+
+    override fun rxIsEmpty(): Single<Boolean> {
+        return rxSingle { getDataFetcher().isEmpty() }
+    }
+
+    override suspend fun suspendIsEmpty(): Boolean {
+        return getDataFetcher().isEmpty()
     }
 
     override fun blockingIsEmpty(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryDataFetcher.kt
@@ -62,7 +62,7 @@ internal class EventQueryDataFetcher(
         return if (isOnline()) {
             trackerCallFatory.getEventCall().getQueryUids(getOnlineQuery())
         } else {
-            getOfflineRepositoryInternal().getUidsInternal()
+            getOfflineRepositoryInternal().suspendGetUids()
         }
     }
 
@@ -78,7 +78,7 @@ internal class EventQueryDataFetcher(
         return if (isOnline()) {
             count() > 0
         } else {
-            getOfflineRepositoryInternal().isEmptyInternal()
+            getOfflineRepositoryInternal().suspendIsEmpty()
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventQueryDataFetcher.kt
@@ -54,7 +54,7 @@ internal class EventQueryDataFetcher(
         return if (isOnline()) {
             trackerCallFatory.getEventCall().getQueryCall(getOnlineQuery()).items
         } else {
-            getOfflineRepositoryInternal().getInternal()
+            getOfflineRepositoryInternal().suspendGet()
         }
     }
 
@@ -70,7 +70,7 @@ internal class EventQueryDataFetcher(
         return if (isOnline()) {
             getUids().size
         } else {
-            getOfflineRepositoryInternal().countInternal()
+            getOfflineRepositoryInternal().suspendCount()
         }
     }
 
@@ -78,7 +78,7 @@ internal class EventQueryDataFetcher(
         return if (isOnline()) {
             count() > 0
         } else {
-            getOfflineRepositoryInternal().isEmptyProtected()
+            getOfflineRepositoryInternal().isEmptyInternal()
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -94,9 +94,7 @@ class FileResourceCollectionRepository internal constructor(
     }
 
     @Deprecated("Check {@link #upload()}.")
-    fun blockingUpload() {
-        upload().blockingSubscribe()
-    }
+    fun blockingUpload() = Unit
 
     override suspend fun suspendAdd(o: File): String = withContext(Dispatchers.IO) {
         try {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -101,16 +101,7 @@ class FileResourceCollectionRepository internal constructor(
         upload().blockingSubscribe()
     }
 
-    override fun add(o: File): Single<String> {
-        return rxSingle { addInternal(o) }
-    }
-
-    @Throws(D2Error::class)
-    override fun blockingAdd(o: File): String {
-        return runBlocking { addInternal(o) }
-    }
-
-    override suspend fun addInternal(o: File): String = withContext(Dispatchers.IO) {
+    override suspend fun suspendAdd(o: File): String = withContext(Dispatchers.IO) {
         try {
             val generatedUid = UidGeneratorImpl().generate()
             val dstFile = saveFile(o, generatedUid, context)

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -29,10 +29,7 @@ package org.hisp.dhis.android.core.fileresource
 
 import android.content.Context
 import io.reactivex.Observable
-import io.reactivex.Single
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.fileresource
 
 import android.content.Context
 import io.reactivex.Observable
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.arch.call.D2Progress
@@ -63,6 +64,7 @@ class FileResourceCollectionRepository internal constructor(
     transformer: FileResourceProjectionTransformer,
     dataStatePropagator: DataStatePropagator,
     private val context: Context,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ReadWriteWithUidCollectionRepositoryImpl<FileResource, File, FileResourceCollectionRepository>(
     fileResourceStore,
     childrenAppenders,
@@ -75,6 +77,7 @@ class FileResourceCollectionRepository internal constructor(
             transformer,
             dataStatePropagator,
             context,
+            dispatcher,
         )
     },
 ),
@@ -96,7 +99,7 @@ class FileResourceCollectionRepository internal constructor(
     @Deprecated("Check {@link #upload()}.")
     fun blockingUpload() = Unit
 
-    override suspend fun suspendAdd(o: File): String = withContext(Dispatchers.IO) {
+    override suspend fun suspendAdd(o: File): String = withContext(dispatcher) {
         try {
             val generatedUid = UidGeneratorImpl().generate()
             val dstFile = saveFile(o, generatedUid, context)

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceRoutine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceRoutine.kt
@@ -67,23 +67,23 @@ internal class FileResourceRoutine(
     suspend fun internalDeleteOutdatedFileResources(after: Date? = null) {
         val dataElementsUids = dataElementCollectionRepository
             .byValueType().`in`(ValueType.FILE_RESOURCE, ValueType.IMAGE)
-            .getInternal().map(DataElement::uid)
+            .suspendGet().map(DataElement::uid)
 
         val trackedEntityAttributesUids = trackedEntityAttributeCollectionRepository
             .byValueType().`in`(ValueType.FILE_RESOURCE, ValueType.IMAGE)
-            .getInternal().map(TrackedEntityAttribute::uid)
+            .suspendGet().map(TrackedEntityAttribute::uid)
 
         val trackedEntityDataValues = trackedEntityDataValueCollectionRepository
             .byDataElement().`in`(dataElementsUids)
-            .getInternal()
+            .suspendGet()
 
         val trackedEntityAttributeValues = trackedEntityAttributeValueCollectionRepository
             .byTrackedEntityAttribute().`in`(trackedEntityAttributesUids)
-            .getInternal()
+            .suspendGet()
 
         val dataValues = dataValueCollectionRepository
             .byDataElementUid().`in`(dataElementsUids)
-            .getInternal()
+            .suspendGet()
 
         val customIcons = customIconStore.selectAll()
 
@@ -99,7 +99,7 @@ internal class FileResourceRoutine(
             .byUid().notIn(fileResourceUids.mapNotNull { it })
             .byDomain().`in`(FileResourceDomain.DATA_VALUE, FileResourceDomain.ICON)
             .byLastUpdated().before(lastUpdatedBefore)
-            .getInternal()
+            .suspendGet()
 
         deleteFileResources(fileResources)
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceModuleImpl.kt
@@ -28,6 +28,9 @@
 package org.hisp.dhis.android.core.fileresource.internal
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.fileresource.FileResourceCollectionRepository
 import org.hisp.dhis.android.core.fileresource.FileResourceDataDomainType
@@ -56,11 +59,7 @@ internal class FileResourceModuleImpl(
         ),
     )
     override fun download(): Observable<D2Progress> {
-        return fileResourceDownloader()
-            .byDomainType().eq(FileResourceDomainType.DATA_VALUE)
-            .byDataDomainType().eq(FileResourceDataDomainType.TRACKER)
-            .byValueType().eq(FileResourceValueType.IMAGE)
-            .download()
+        return flowDownload().asObservable()
     }
 
     @Deprecated(
@@ -76,7 +75,7 @@ internal class FileResourceModuleImpl(
         ),
     )
     override fun blockingDownload() {
-        download().blockingSubscribe()
+        runBlocking { flowDownload().collect {} }
     }
 
     override fun fileResources(): FileResourceCollectionRepository {
@@ -85,5 +84,13 @@ internal class FileResourceModuleImpl(
 
     override fun fileResourceDownloader(): FileResourceDownloader {
         return fileResourceDownloader
+    }
+
+    private fun flowDownload(): Flow<D2Progress> {
+        return fileResourceDownloader()
+            .byDomainType().eq(FileResourceDomainType.DATA_VALUE)
+            .byDataDomainType().eq(FileResourceDataDomainType.TRACKER)
+            .byValueType().eq(FileResourceValueType.IMAGE)
+            .flowDownload()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceModuleImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceModuleImpl.kt
@@ -29,9 +29,9 @@ package org.hisp.dhis.android.core.fileresource.internal
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.fileresource.FileResourceCollectionRepository
 import org.hisp.dhis.android.core.fileresource.FileResourceDataDomainType
 import org.hisp.dhis.android.core.fileresource.FileResourceDomainType
@@ -75,7 +75,7 @@ internal class FileResourceModuleImpl(
         ),
     )
     override fun blockingDownload() {
-        runBlocking { flowDownload().collect {} }
+        flowDownload().collectAndWrapException()
     }
 
     override fun fileResources(): FileResourceCollectionRepository {

--- a/core/src/main/java/org/hisp/dhis/android/core/icon/IconCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/icon/IconCollectionRepository.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.icon
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadOnlyObjectRepository
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceStore
 import org.hisp.dhis.android.core.icon.internal.CustomIconStore

--- a/core/src/main/java/org/hisp/dhis/android/core/icon/IconCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/icon/IconCollectionRepository.kt
@@ -33,7 +33,6 @@ import org.hisp.dhis.android.core.icon.internal.CustomIconStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
-@Suppress("TooManyFunctions")
 class IconCollectionRepository internal constructor(
     private val customIconStore: CustomIconStore,
     private val fileResourceStore: FileResourceStore,

--- a/core/src/main/java/org/hisp/dhis/android/core/icon/IconCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/icon/IconCollectionRepository.kt
@@ -44,15 +44,7 @@ class IconCollectionRepository internal constructor(
 
     fun key(key: String): ReadOnlyObjectRepository<Icon> {
         return object : ReadOnlyObjectRepository<Icon> {
-            override fun get(): Single<Icon?> {
-                return rxSingle { getInternal()!! }.map { it }
-            }
-
-            override fun blockingGet(): Icon? {
-                return runBlocking { getInternal() }
-            }
-
-            private suspend fun getInternal(): Icon? {
+            override suspend fun suspendGet(): Icon? {
                 return if (DefaultIcon.all.contains(key)) {
                     Icon.Default(key)
                 } else {
@@ -63,16 +55,8 @@ class IconCollectionRepository internal constructor(
                 }
             }
 
-            override fun exists(): Single<Boolean> {
-                return rxSingle { existInternal() }
-            }
-
-            override fun blockingExists(): Boolean {
-                return runBlocking { existInternal() }
-            }
-
-            private suspend fun existInternal(): Boolean {
-                return getInternal() != null
+            override suspend fun suspendExists(): Boolean {
+                return suspendGet() != null
             }
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/TrackerJobManager.kt
@@ -30,9 +30,9 @@ package org.hisp.dhis.android.core.imports
 
 import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.tracker.importer.internal.JobQueryCall
 import org.koin.core.annotation.Singleton
 
@@ -54,6 +54,6 @@ class TrackerJobManager internal constructor(
     }
 
     fun blockingResumePendingJobs() {
-        runBlocking { flowResumePendingJobs().collect {} }
+        flowResumePendingJobs().collectAndWrapException()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictParser.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/imports/internal/TrackerImportConflictParser.kt
@@ -147,11 +147,11 @@ internal class TrackerImportConflictParser(
         return if (auxConflict.dataElement() != null && auxConflict.event() != null) {
             trackedEntityInstanceDataValueRepository
                 .value(auxConflict.event()!!, auxConflict.dataElement()!!)
-                .getInternal()?.value()
+                .suspendGet()?.value()
         } else if (auxConflict.trackedEntityAttribute() != null && auxConflict.trackedEntityInstance() != null) {
             trackedEntityAttributeValueRepository
                 .value(auxConflict.trackedEntityAttribute()!!, auxConflict.trackedEntityInstance()!!)
-                .getInternal()?.value()
+                .suspendGet()?.value()
         } else {
             null
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/datasetindicatorengine/DataSetIndicatorEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/datasetindicatorengine/DataSetIndicatorEngineImpl.kt
@@ -85,8 +85,8 @@ internal class DataSetIndicatorEngineImpl(
         orgUnitUid: String,
         attributeOptionComboUid: String,
     ): Double {
-        val indicator = indicatorRepository.uid(indicatorUid).getInternal()
-        val indicatorType = indicatorTypeRepository.uid(indicator?.indicatorType()?.uid()).getInternal()
+        val indicator = indicatorRepository.uid(indicatorUid).suspendGet()
+        val indicatorType = indicatorTypeRepository.uid(indicator?.indicatorType()?.uid()).suspendGet()
 
         return if (indicator != null && indicatorType != null) {
             val context = ExpressionServiceContext(

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/datasetindicatorengine/DataSetIndicatorEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/datasetindicatorengine/DataSetIndicatorEngineImpl.kt
@@ -124,7 +124,7 @@ internal class DataSetIndicatorEngineImpl(
     }
 
     private suspend fun getConstantMap(): Map<String, Constant> {
-        val constants: List<Constant> = constantRepository.getInternal()
+        val constants: List<Constant> = constantRepository.suspendGet()
         return mapByUid(constants)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionService.kt
@@ -29,19 +29,41 @@
 package org.hisp.dhis.android.core.option
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 
 interface OptionService {
-    fun blockingSearchForOptions(
+
+    suspend fun suspendSearchForOptions(
         optionSetUid: String,
         searchText: String? = null,
         optionToHideUids: List<String>? = null,
         optionToShowUids: List<String>? = null,
     ): List<Option>
 
+    fun blockingSearchForOptions(
+        optionSetUid: String,
+        searchText: String? = null,
+        optionToHideUids: List<String>? = null,
+        optionToShowUids: List<String>? = null,
+    ): List<Option> = runBlocking {
+        suspendSearchForOptions(optionSetUid, searchText, optionToHideUids, optionToShowUids)
+    }
+
+    @Deprecated("Use rxSearchForOptions instead", ReplaceWith("rxSearchForOptions()"))
     fun searchForOptions(
         optionSetUid: String,
         searchText: String? = null,
         optionToHideUids: List<String>? = null,
         optionToShowUids: List<String>? = null,
-    ): Single<List<Option>>
+    ): Single<List<Option>> = rxSearchForOptions(optionSetUid, searchText, optionToHideUids, optionToShowUids)
+
+    fun rxSearchForOptions(
+        optionSetUid: String,
+        searchText: String? = null,
+        optionToHideUids: List<String>? = null,
+        optionToShowUids: List<String>? = null,
+    ): Single<List<Option>> = rxSingle {
+        suspendSearchForOptions(optionSetUid, searchText, optionToHideUids, optionToShowUids)
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/option/OptionServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/OptionServiceImpl.kt
@@ -28,7 +28,6 @@
 
 package org.hisp.dhis.android.core.option
 
-import io.reactivex.Single
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.koin.core.annotation.Singleton
 
@@ -37,7 +36,7 @@ class OptionServiceImpl(
     private val optionRepository: OptionCollectionRepository,
 ) : OptionService {
 
-    override fun blockingSearchForOptions(
+    override suspend fun suspendSearchForOptions(
         optionSetUid: String,
         searchText: String?,
         optionToHideUids: List<String>?,
@@ -56,17 +55,6 @@ class OptionServiceImpl(
             repository = repository.byDisplayName().like(searchText)
         }
 
-        return repository.orderBySortOrder(RepositoryScope.OrderByDirection.ASC).blockingGet()
-    }
-
-    override fun searchForOptions(
-        optionSetUid: String,
-        searchText: String?,
-        optionToHideUids: List<String>?,
-        optionToShowUids: List<String>?,
-    ): Single<List<Option>> {
-        return Single.fromCallable {
-            blockingSearchForOptions(optionSetUid, searchText, optionToHideUids, optionToShowUids)
-        }
+        return repository.orderBySortOrder(RepositoryScope.OrderByDirection.ASC).suspendGet()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -55,7 +55,7 @@ class OrganisationUnitService(
     }
 
     suspend fun suspendIsDateInOrgunitRange(organisationUnitUid: String, date: Date): Boolean {
-        val organisationUnit = organisationUnitRepository.uid(organisationUnitUid).getInternal() ?: return true
+        val organisationUnit = organisationUnitRepository.uid(organisationUnitUid).suspendGet() ?: return true
 
         return organisationUnit.openingDate()?.before(date) ?: true &&
             organisationUnit.closedDate()?.after(date) ?: true

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitService.kt
@@ -78,13 +78,13 @@ class OrganisationUnitService(
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .byUid().eq(organisationUnitUid)
-            .getInternal().isNotEmpty()
+            .suspendGet().isNotEmpty()
     }
 
     internal suspend fun isInSearchScope(organisationUnitUid: String): Boolean {
         return organisationUnitRepository
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_TEI_SEARCH)
             .byUid().eq(organisationUnitUid)
-            .getInternal().isNotEmpty()
+            .suspendGet().isNotEmpty()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorEngineImpl.kt
@@ -110,7 +110,7 @@ internal class ProgramIndicatorEngineImpl(
             .withTrackedEntityDataValues()
             .byDeleted().isFalse
             .uid(eventUid)
-            .getInternal() ?: throw NoSuchElementException("Event $eventUid does not exist or is deleted.")
+            .suspendGet() ?: throw NoSuchElementException("Event $eventUid does not exist or is deleted.")
 
         val enrollment = event.enrollment()?.let {
             enrollmentStore.selectByUid(it)

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorEngineImpl.kt
@@ -158,7 +158,7 @@ internal class ProgramIndicatorEngineImpl(
     }
 
     private suspend fun getEnrollmentEvents(enrollment: Enrollment): Map<String, List<Event>> {
-        val programStageUids = programRepository.byProgramUid().eq(enrollment.program()).getUidsInternal()
+        val programStageUids = programRepository.byProgramUid().eq(enrollment.program()).suspendGetUids()
 
         return programStageUids.associateWith { programStageUid ->
             val programStageEvents = eventRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/programindicatorengine/internal/ProgramIndicatorEngineImpl.kt
@@ -168,7 +168,7 @@ internal class ProgramIndicatorEngineImpl(
                 .orderByEventDate(RepositoryScope.OrderByDirection.ASC)
                 .orderByLastUpdated(RepositoryScope.OrderByDirection.ASC)
                 .withTrackedEntityDataValues()
-                .getInternal()
+                .suspendGet()
 
             programStageEvents
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.android.core.relationship
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.helpers.DateUtils.toJavaDate
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipCollectionRepository.kt
@@ -88,18 +88,9 @@ class RelationshipCollectionRepository internal constructor(
     },
 ),
     ReadWriteWithUidCollectionRepository<Relationship, Relationship> {
-    override fun add(o: Relationship): Single<String> {
-        return rxSingle { addInternal(o) }
-    }
-
-    @Throws(D2Error::class)
-    override fun blockingAdd(o: Relationship): String {
-        return runBlocking { addInternal(o) }
-    }
-
     @Suppress("ThrowsCount")
     @Throws(D2Error::class)
-    private suspend fun addInternal(o: Relationship): String {
+    override suspend fun suspendAdd(o: Relationship): String {
         val relationshipWithUid: Relationship
         if (relationshipHandler.doesRelationshipExist(o)) {
             throw D2Error

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandler.kt
@@ -64,7 +64,7 @@ internal class RelationshipImportHandler internal constructor(
         relationshipUid: String,
     ) {
         val relationship =
-            (relationshipRepository.withItems().uid(relationshipUid) as RelationshipObjectRepository).getInternal()
+            (relationshipRepository.withItems().uid(relationshipUid) as RelationshipObjectRepository).suspendGet()
         val relationshipNotFoundOnServer = checkRelationshipNotFoundOnServer(importSummary)
 
         if (relationshipNotFoundOnServer) {

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsSettingObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/AnalyticsSettingObjectRepository.kt
@@ -40,7 +40,7 @@ class AnalyticsSettingObjectRepository internal constructor(
 ) : ReadOnlyAnyObjectWithDownloadRepositoryImpl<AnalyticsSettings>(analyticsSettingCall),
     ReadOnlyWithDownloadObjectRepository<AnalyticsSettings> {
     override suspend fun getInternal(): AnalyticsSettings? {
-        val analyticsTeiSettings = analyticsTeiSettingRepository.getInternal()
+        val analyticsTeiSettings = analyticsTeiSettingRepository.suspendGet()
         val analyticsDhisVisualizationsSetting = analyticsDhisVisualizationsSettingObjectRepository.getInternal()
 
         return AnalyticsSettings.builder()

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCall.kt
@@ -54,7 +54,7 @@ internal class LatestAppVersionCall(
     }
 
     internal suspend fun resolveApkDistributionVersion(): ApkDistributionVersion? {
-        val userGroupUids = userModule.userGroups().getUidsInternal()
+        val userGroupUids = userModule.userGroups().suspendGetUids()
 
         val versions = networkHandler.versions().items
 

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/DataSetsStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/DataSetsStore.kt
@@ -99,7 +99,7 @@ internal class DataSetsStore(
             .byPeriod().eq(period)
             .byAttributeOptionComboUid().eq(attributeOptionComboUid)
             .one()
-            .getInternal()
+            .suspendGet()
             ?.let { dataSetStore.setState(it, state) }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/DataSetsStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/DataSetsStore.kt
@@ -58,11 +58,11 @@ internal class DataSetsStore(
         val uploadable = uploadableStatesIncludingError().toList()
         val dataValues = baseQuery
             .bySyncState().`in`(uploadable)
-            .getInternal()
+            .suspendGet()
 
         return dataValues.ifEmpty {
             baseQuery
-                .getInternal()
+                .suspendGet()
                 .takeIf { it.isNotEmpty() }
                 ?.take(1)
                 ?: emptyList()

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
@@ -28,17 +28,25 @@
 package org.hisp.dhis.android.core.systeminfo
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.maintenance.D2Error
 
 interface Ping {
 
     @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
-    fun get(): Single<String>
+    fun get(): Single<String> = rxGet()
 
-    fun rxGet(): Single<String>
+    fun rxGet(): Single<String> = rxSingle { suspendGet() }
 
     @Throws(D2Error::class)
-    fun blockingGet(): String
+    fun blockingGet(): String = runBlocking {
+        try {
+            suspendGet()
+        } catch (e: D2Error) {
+            throw RuntimeException(e)
+        }
+    }
 
     suspend fun suspendGet(): String
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/Ping.kt
@@ -39,6 +39,7 @@ interface Ping {
 
     fun rxGet(): Single<String> = rxSingle { suspendGet() }
 
+    @Suppress("TooGenericExceptionThrown")
     @Throws(D2Error::class)
     fun blockingGet(): String = runBlocking {
         try {

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.systeminfo.internal
 
 import io.ktor.http.isSuccess
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
@@ -53,7 +54,7 @@ class PingImpl internal constructor(
 
     @Throws(D2Error::class)
     override fun blockingGet(): String {
-        return rxGet().blockingGet()
+        return runBlocking { suspendGet() }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -53,7 +53,7 @@ class PingImpl internal constructor(
 
     @Throws(D2Error::class)
     override fun blockingGet(): String {
-        return get().blockingGet()
+        return rxGet().blockingGet()
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/systeminfo/internal/PingImpl.kt
@@ -28,9 +28,6 @@
 package org.hisp.dhis.android.core.systeminfo.internal
 
 import io.ktor.http.isSuccess
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
@@ -42,20 +39,6 @@ import java.io.IOException
 class PingImpl internal constructor(
     private val pingNetworkHandler: PingNetworkHandler,
 ) : Ping {
-
-    @Deprecated(message = "Use rxGet instead", ReplaceWith("rxGet()"))
-    override fun get(): Single<String> {
-        return rxSingle { suspendGet() }
-    }
-
-    override fun rxGet(): Single<String> {
-        return rxSingle { suspendGet() }
-    }
-
-    @Throws(D2Error::class)
-    override fun blockingGet(): String {
-        return runBlocking { suspendGet() }
-    }
 
     @Suppress("TooGenericExceptionCaught")
     override suspend fun suspendGet(): String {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeReservedValueManager.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
+import org.hisp.dhis.android.core.arch.call.internal.collectAndWrapException
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUidOrNull
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeOrderByItem
@@ -131,7 +132,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
         attributeUid: String,
         numberOfValuesToFillUp: Int?,
     ) {
-        runBlocking { flowDownloadReservedValues(attributeUid, numberOfValuesToFillUp).collect {} }
+        flowDownloadReservedValues(attributeUid, numberOfValuesToFillUp).collectAndWrapException()
     }
 
     /**
@@ -179,7 +180,7 @@ class TrackedEntityAttributeReservedValueManager internal constructor(
      * @see .downloadAllReservedValues
      */
     fun blockingDownloadAllReservedValues(numberOfValuesToFillUp: Int?) {
-        runBlocking { flowDownloadAllReservedValues(numberOfValuesToFillUp).collect {} }
+        flowDownloadAllReservedValues(numberOfValuesToFillUp).collectAndWrapException()
     }
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
@@ -64,15 +64,6 @@ class TrackedEntityAttributeValueObjectRepository internal constructor(
 ),
     ReadWriteValueObjectRepository<TrackedEntityAttributeValue> {
 
-    @Deprecated("Use rxSet instead", replaceWith = ReplaceWith("rxSet(value)"))
-    override fun set(value: String?): Completable {
-        return Completable.fromAction { blockingSet(value) }
-    }
-
-    override fun rxSet(value: String?): Completable {
-        return Completable.fromAction { blockingSet(value) }
-    }
-
     override suspend fun suspendSet(value: String?) {
         updateIfChangedInternal(value, { it?.value() }) {
                 trackedEntityAttributeValue: TrackedEntityAttributeValue?, newValue ->
@@ -81,17 +72,9 @@ class TrackedEntityAttributeValueObjectRepository internal constructor(
     }
 
     @Throws(D2Error::class)
-    override fun blockingSet(value: String?) {
-        updateIfChanged(value, { it?.value() }) {
-                trackedEntityAttributeValue: TrackedEntityAttributeValue?, newValue ->
-            setBuilder(trackedEntityAttributeValue).value(newValue).build()
-        }
-    }
-
-    @Throws(D2Error::class)
-    override fun delete(m: TrackedEntityAttributeValue) {
+    override suspend fun suspendDelete(m: TrackedEntityAttributeValue) {
         if (m.syncState() === State.TO_POST) {
-            super.delete(m)
+            super<ReadWriteWithValueObjectRepositoryImpl>.suspendDelete(m)
         } else {
             blockingSet(null)
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -62,13 +63,27 @@ class TrackedEntityAttributeValueObjectRepository internal constructor(
     },
 ),
     ReadWriteValueObjectRepository<TrackedEntityAttributeValue> {
+
+    @Deprecated("Use rxSet instead", replaceWith = ReplaceWith("rxSet(value)"))
     override fun set(value: String?): Completable {
         return Completable.fromAction { blockingSet(value) }
     }
 
+    override fun rxSet(value: String?): Completable {
+        return Completable.fromAction { blockingSet(value) }
+    }
+
+    override suspend fun suspendSet(value: String?) {
+        updateIfChangedInternal(value, { it?.value() }) {
+                trackedEntityAttributeValue: TrackedEntityAttributeValue?, newValue ->
+            setBuilder(trackedEntityAttributeValue).value(newValue).build()
+        }
+    }
+
     @Throws(D2Error::class)
     override fun blockingSet(value: String?) {
-        updateIfChanged(value, { it?.value() }) { trackedEntityAttributeValue: TrackedEntityAttributeValue?, newValue ->
+        updateIfChanged(value, { it?.value() }) {
+                trackedEntityAttributeValue: TrackedEntityAttributeValue?, newValue ->
             setBuilder(trackedEntityAttributeValue).value(newValue).build()
         }
     }
@@ -82,9 +97,13 @@ class TrackedEntityAttributeValueObjectRepository internal constructor(
         }
     }
 
-    override fun blockingExists(): Boolean {
-        val value = blockingGetWithoutChildren()
+    override suspend fun suspendExists(): Boolean {
+        val value = getWithoutChildrenInternal()
         return if (value == null) false else value.deleted() == null || !value.deleted()
+    }
+
+    override fun blockingExists(): Boolean {
+        return runBlocking { suspendExists() }
     }
 
     private fun setBuilder(value: TrackedEntityAttributeValue?): TrackedEntityAttributeValue.Builder {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueObjectRepository.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import io.reactivex.Completable
 import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Completable
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory
@@ -62,13 +63,28 @@ class TrackedEntityDataValueObjectRepository internal constructor(
     },
 ),
     ReadWriteValueObjectRepository<TrackedEntityDataValue> {
+
+    @Deprecated("Use rxSet instead", replaceWith = ReplaceWith("rxSet(value)"))
     override fun set(value: String?): Completable {
         return Completable.fromAction { blockingSet(value) }
     }
 
+    override fun rxSet(value: String?): Completable {
+        return Completable.fromAction { blockingSet(value) }
+    }
+
+    @Throws(D2Error::class)
+    override suspend fun suspendSet(value: String?) {
+        updateIfChangedInternal(value, { it?.value() }) {
+                trackedEntityDataValue: TrackedEntityDataValue?, newValue ->
+            setBuilder(trackedEntityDataValue).value(newValue).build()
+        }
+    }
+
     @Throws(D2Error::class)
     override fun blockingSet(value: String?) {
-        updateIfChanged(value, { it?.value() }) { trackedEntityDataValue: TrackedEntityDataValue?, newValue ->
+        updateIfChanged(value, { it?.value() }) {
+                trackedEntityDataValue: TrackedEntityDataValue?, newValue ->
             setBuilder(trackedEntityDataValue).value(newValue).build()
         }
     }
@@ -82,8 +98,8 @@ class TrackedEntityDataValueObjectRepository internal constructor(
         }
     }
 
-    override fun blockingExists(): Boolean {
-        val value = blockingGetWithoutChildren()
+    override suspend fun suspendExists(): Boolean {
+        val value = getWithoutChildrenInternal()
         return if (value == null) false else value.deleted() == null || !value.deleted()
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
@@ -64,15 +64,6 @@ class TrackedEntityDataValueObjectRepository internal constructor(
 ),
     ReadWriteValueObjectRepository<TrackedEntityDataValue> {
 
-    @Deprecated("Use rxSet instead", replaceWith = ReplaceWith("rxSet(value)"))
-    override fun set(value: String?): Completable {
-        return Completable.fromAction { blockingSet(value) }
-    }
-
-    override fun rxSet(value: String?): Completable {
-        return Completable.fromAction { blockingSet(value) }
-    }
-
     @Throws(D2Error::class)
     override suspend fun suspendSet(value: String?) {
         updateIfChangedInternal(value, { it?.value() }) {
@@ -82,19 +73,11 @@ class TrackedEntityDataValueObjectRepository internal constructor(
     }
 
     @Throws(D2Error::class)
-    override fun blockingSet(value: String?) {
-        updateIfChanged(value, { it?.value() }) {
-                trackedEntityDataValue: TrackedEntityDataValue?, newValue ->
-            setBuilder(trackedEntityDataValue).value(newValue).build()
-        }
-    }
-
-    @Throws(D2Error::class)
-    override fun delete(m: TrackedEntityDataValue) {
+    override suspend fun suspendDelete(m: TrackedEntityDataValue) {
         if (m.syncState() === State.TO_POST) {
-            super.delete(m)
+            super<ReadWriteWithValueObjectRepositoryImpl>.suspendDelete(m)
         } else {
-            blockingSet(null)
+            suspendSet(null)
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueObjectRepository.kt
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import io.reactivex.Completable
-import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.`object`.ReadWriteValueObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ObjectRepositoryFactory

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -27,11 +27,9 @@
  */
 package org.hisp.dhis.android.core.trackedentity
 
-import io.reactivex.Observable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.rx2.asObservable
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.handlers.internal.HandleAction
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.trackedentity
 
 import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.rx2.asObservable
@@ -95,16 +96,12 @@ class TrackedEntityInstanceCollectionRepository internal constructor(
     }
 
     @Suppress("SpreadOperator")
-    override fun upload(): Observable<D2Progress> = flow {
+    override fun flowUpload(): Flow<D2Progress> = flow {
         emitAll(jobQueryCall.queryPendingJobs())
         val trackedEntityInstances = byAggregatedSyncState()
             .`in`(*uploadableStatesIncludingError())
             .getWithoutChildrenInternal()
         emitAll(postCall.uploadTrackedEntityInstances(trackedEntityInstances))
-    }.asObservable()
-
-    override fun blockingUpload() {
-        upload().blockingSubscribe()
     }
 
     override fun uid(uid: String?): TrackedEntityInstanceObjectRepository {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackedEntityEndpointCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackedEntityEndpointCallFactory.kt
@@ -139,7 +139,7 @@ internal class NewTrackedEntityEndpointCallFactory(
         val relationshipType = relationshipTypeRepository
             .withConstraints()
             .uid(item.relationshipTypeUid)
-            .getInternal()
+            .suspendGet()
 
         val constraint = when (item.constraintType) {
             RelationshipConstraintType.FROM -> relationshipType?.fromConstraint()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackedEntityEndpointCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackedEntityEndpointCallFactory.kt
@@ -43,7 +43,6 @@ import org.hisp.dhis.android.core.tracker.exporter.TrackerExporterNetworkHandler
 import org.koin.core.annotation.Singleton
 
 @Singleton
-@Suppress("TooManyFunctions")
 internal class NewTrackedEntityEndpointCallFactory(
     private val networkHandler: TrackerExporterNetworkHandler,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/OldTrackerImporterPayloadGenerator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/OldTrackerImporterPayloadGenerator.kt
@@ -254,7 +254,7 @@ internal class OldTrackerImporterPayloadGenerator internal constructor(
             relationships = relationshipRepository.bySyncState()
                 .`in`(State.uploadableStatesIncludingError().toList())
                 .withItems()
-                .getInternal(),
+                .suspendGet(),
         )
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -244,7 +244,7 @@ internal class TrackedEntityInstanceDownloadCall(
                 .byTrackedEntityInstanceFilterObject().eq(it)
                 .byOrgUnits().eq(orgunitUid)
                 .byOrgUnitMode().eq(bundle.commonParams().ouMode)
-                .onlineOnly().getUidsInternal()
+                .onlineOnly().suspendGetUids()
         } ?: emptyList()
     }
 
@@ -254,7 +254,7 @@ internal class TrackedEntityInstanceDownloadCall(
                 .byProgramStageWorkingListObject().eq(it)
                 .byOrgUnits().eq(orgunitUid)
                 .byOrgUnitMode().eq(bundle.commonParams().ouMode)
-                .onlineOnly().getUidsInternal()
+                .onlineOnly().suspendGetUids()
         } ?: emptyList()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -79,7 +79,7 @@ internal class TrackerQueryBundleInternalFactory(
                 .byUid().`in`(it)
                 .withAttributeValueFilters()
                 .withDataFilters()
-                .getInternal()
+                .suspendGet()
         }
 
         val trackedEntityInstanceFiltersSettings = filters.takeIf { !it.isNullOrEmpty() }?.let {
@@ -87,7 +87,7 @@ internal class TrackerQueryBundleInternalFactory(
                 .byUid().`in`(it)
                 .withTrackedEntityInstanceEventFilters()
                 .withAttributeValueFilters()
-                .getInternal()
+                .suspendGet()
         }
 
         val finalWorkingLists = programStageWorkingLists.takeIf { it.isNotEmpty() }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -223,37 +223,14 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         transformer: Transformer<List<TrackedEntityInstance>, TrackedEntityInstance?>,
     ): ReadOnlyObjectRepository<TrackedEntityInstance> {
         return object : ReadOnlyObjectRepository<TrackedEntityInstance> {
-
             override suspend fun suspendGet(): TrackedEntityInstance? {
                 val list = this@TrackedEntityInstanceQueryCollectionRepository.suspendGet()
                 return transformer.transform(list)
             }
 
-            @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
-            override fun get(): Single<TrackedEntityInstance?> {
-                return Single.fromCallable { this.blockingGet() }
-            }
-
-            override fun rxGet(): Single<TrackedEntityInstance?> {
-                return Single.fromCallable { this.blockingGet() }
-            }
-
-            override fun blockingGet(): TrackedEntityInstance? = runBlocking { suspendGet() }
-
-            @Deprecated("Use rxExists instead", replaceWith = ReplaceWith("rxExists()"))
-            override fun exists(): Single<Boolean> {
-                return Single.fromCallable { blockingExists() }
-            }
-
-            override fun rxExists(): Single<Boolean> {
-                return Single.fromCallable { blockingExists() }
-            }
-
             override suspend fun suspendExists(): Boolean {
                 return suspendGet() != null
             }
-
-            override fun blockingExists(): Boolean = runBlocking { suspendExists() }
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -167,15 +167,6 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         get() = TrackedEntityInstanceQueryDataSourceResult(getDataFetcher())
 
     override suspend fun suspendGet(): List<TrackedEntityInstance> {
-        return getProtected()
-    }
-
-    @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
-    override fun blockingGet(): List<TrackedEntityInstance> {
-        return runBlocking { getProtected() }
-    }
-
-    private suspend fun getProtected(): List<TrackedEntityInstance> {
         val dataFetcher = getDataFetcher()
         val searchResult =
             if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
@@ -192,55 +183,12 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         }
     }
 
-    @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
-    override fun get(): Single<List<TrackedEntityInstance>> {
-        return rxSingle { getProtected() }
-    }
-
-    override fun rxGet(): Single<List<TrackedEntityInstance>> {
-        return rxSingle { getProtected() }
-    }
-
-    @Deprecated("Use rxCount instead", replaceWith = ReplaceWith("rxCount()"))
-    override fun count(): Single<Int> {
-        return rxSingle { countProtected() }
-    }
-
-    override fun rxCount(): Single<Int> {
-        return rxSingle { countProtected() }
-    }
-
     override suspend fun suspendCount(): Int {
-        return countProtected()
-    }
-
-    override fun blockingCount(): Int {
-        return blockingGet().size
-    }
-
-    private suspend fun countProtected(): Int {
-        return getProtected().size
-    }
-
-    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
-    override fun isEmpty(): Single<Boolean> {
-        return rxSingle { isEmptyProtected() }
-    }
-
-    override fun rxIsEmpty(): Single<Boolean> {
-        return rxSingle { isEmptyProtected() }
+        return suspendGet().size
     }
 
     override suspend fun suspendIsEmpty(): Boolean {
-        return isEmptyProtected()
-    }
-
-    override fun blockingIsEmpty(): Boolean {
-        return runBlocking { isEmptyProtected() }
-    }
-
-    private suspend fun isEmptyProtected(): Boolean {
-        return countProtected() == 0
+        return suspendCount() == 0
     }
 
     override fun one(): ReadOnlyObjectRepository<TrackedEntityInstance> {
@@ -284,7 +232,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
             getDataFetcher().queryAllOfflineUids()
         } else {
-            getUids(getProtected()).toList()
+            getUids(suspendGet()).toList()
         }
     }
 
@@ -294,7 +242,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return object : ReadOnlyObjectRepository<TrackedEntityInstance> {
 
             override suspend fun suspendGet(): TrackedEntityInstance? {
-                val list = this@TrackedEntityInstanceQueryCollectionRepository.getProtected()
+                val list = this@TrackedEntityInstanceQueryCollectionRepository.suspendGet()
                 return transformer.transform(list)
             }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -211,24 +211,7 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return byTrackedEntities().eq(uid).objectRepository { o -> o.find { uid == it.uid() } }
     }
 
-    @Deprecated("Use rxGetUids instead", replaceWith = ReplaceWith("rxGetUids()"))
-    override fun getUids(): Single<List<String>> {
-        return rxSingle { getUidsInternal() }
-    }
-
-    override fun rxGetUids(): Single<List<String>> {
-        return rxSingle { getUidsInternal() }
-    }
-
     override suspend fun suspendGetUids(): List<String> {
-        return getUidsInternal()
-    }
-
-    override fun blockingGetUids(): List<String> {
-        return runBlocking { getUidsInternal() }
-    }
-
-    internal suspend fun getUidsInternal(): List<String> {
         return if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
             getDataFetcher().queryAllOfflineUids()
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -166,6 +166,10 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
     val resultDataSource: DataSource<TrackedEntityInstance, Result<TrackedEntityInstance, D2Error>>
         get() = TrackedEntityInstanceQueryDataSourceResult(getDataFetcher())
 
+    override suspend fun suspendGet(): List<TrackedEntityInstance> {
+        return getProtected()
+    }
+
     @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
     override fun blockingGet(): List<TrackedEntityInstance> {
         return runBlocking { getProtected() }
@@ -188,12 +192,26 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         }
     }
 
+    @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
     override fun get(): Single<List<TrackedEntityInstance>> {
-        return Single.fromCallable { blockingGet() }
+        return rxSingle { getProtected() }
     }
 
+    override fun rxGet(): Single<List<TrackedEntityInstance>> {
+        return rxSingle { getProtected() }
+    }
+
+    @Deprecated("Use rxCount instead", replaceWith = ReplaceWith("rxCount()"))
     override fun count(): Single<Int> {
-        return Single.fromCallable { blockingCount() }
+        return rxSingle { countProtected() }
+    }
+
+    override fun rxCount(): Single<Int> {
+        return rxSingle { countProtected() }
+    }
+
+    override suspend fun suspendCount(): Int {
+        return countProtected()
     }
 
     override fun blockingCount(): Int {
@@ -204,8 +222,17 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return getProtected().size
     }
 
+    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
     override fun isEmpty(): Single<Boolean> {
         return rxSingle { isEmptyProtected() }
+    }
+
+    override fun rxIsEmpty(): Single<Boolean> {
+        return rxSingle { isEmptyProtected() }
+    }
+
+    override suspend fun suspendIsEmpty(): Boolean {
+        return isEmptyProtected()
     }
 
     override fun blockingIsEmpty(): Boolean {
@@ -236,8 +263,17 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         return byTrackedEntities().eq(uid).objectRepository { o -> o.find { uid == it.uid() } }
     }
 
+    @Deprecated("Use rxGetUids instead", replaceWith = ReplaceWith("rxGetUids()"))
     override fun getUids(): Single<List<String>> {
-        return Single.fromCallable { blockingGetUids() }
+        return rxSingle { getUidsInternal() }
+    }
+
+    override fun rxGetUids(): Single<List<String>> {
+        return rxSingle { getUidsInternal() }
+    }
+
+    override suspend fun suspendGetUids(): List<String> {
+        return getUidsInternal()
     }
 
     override fun blockingGetUids(): List<String> {
@@ -256,22 +292,37 @@ class TrackedEntityInstanceQueryCollectionRepository internal constructor(
         transformer: Transformer<List<TrackedEntityInstance>, TrackedEntityInstance?>,
     ): ReadOnlyObjectRepository<TrackedEntityInstance> {
         return object : ReadOnlyObjectRepository<TrackedEntityInstance> {
+
+            override suspend fun suspendGet(): TrackedEntityInstance? {
+                val list = this@TrackedEntityInstanceQueryCollectionRepository.getProtected()
+                return transformer.transform(list)
+            }
+
+            @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
             override fun get(): Single<TrackedEntityInstance?> {
                 return Single.fromCallable { this.blockingGet() }
             }
 
-            override fun blockingGet(): TrackedEntityInstance? {
-                val list = this@TrackedEntityInstanceQueryCollectionRepository.blockingGet()
-                return transformer.transform(list)
+            override fun rxGet(): Single<TrackedEntityInstance?> {
+                return Single.fromCallable { this.blockingGet() }
             }
 
+            override fun blockingGet(): TrackedEntityInstance? = runBlocking { suspendGet() }
+
+            @Deprecated("Use rxExists instead", replaceWith = ReplaceWith("rxExists()"))
             override fun exists(): Single<Boolean> {
                 return Single.fromCallable { blockingExists() }
             }
 
-            override fun blockingExists(): Boolean {
-                return blockingGet() != null
+            override fun rxExists(): Single<Boolean> {
+                return Single.fromCallable { blockingExists() }
             }
+
+            override suspend fun suspendExists(): Boolean {
+                return suspendGet() != null
+            }
+
+            override fun blockingExists(): Boolean = runBlocking { suspendExists() }
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.kt
@@ -35,10 +35,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUids

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -181,23 +181,6 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     }
 
     override suspend fun suspendGetUids(): List<String> {
-        return getUidsInternal()
-    }
-
-    @Deprecated("Use rxGetUids instead", replaceWith = ReplaceWith("rxGetUids()"))
-    override fun getUids(): Single<List<String>> {
-        return rxSingle { suspendGetUids() }
-    }
-
-    override fun rxGetUids(): Single<List<String>> {
-        return rxSingle { suspendGetUids() }
-    }
-
-    override fun blockingGetUids(): List<String> {
-        return runBlocking { getUidsInternal() }
-    }
-
-    private suspend fun getUidsInternal(): List<String> {
         return if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
             getDataFetcher().queryAllOfflineUids()
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -39,6 +39,7 @@ import androidx.paging.PagingSource
 import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper
@@ -132,6 +133,10 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     val resultDataSource: DataSource<TrackedEntitySearchItem, Result<TrackedEntitySearchItem, D2Error>>
         get() = TrackedEntitySearchDataSourceResult(getDataFetcher())
 
+    override suspend fun suspendGet(): List<TrackedEntitySearchItem> {
+        return getInternal()
+    }
+
     override fun blockingGet(): List<TrackedEntitySearchItem> {
         return runBlocking { getInternal() }
     }
@@ -154,20 +159,43 @@ class TrackedEntitySearchCollectionRepository internal constructor(
         }
     }
 
+    @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
     override fun get(): Single<List<TrackedEntitySearchItem>> {
-        return Single.fromCallable { blockingGet() }
+        return rxSingle { suspendGet() }
     }
 
+    override fun rxGet(): Single<List<TrackedEntitySearchItem>> {
+        return rxSingle { suspendGet() }
+    }
+
+    override suspend fun suspendCount(): Int {
+        return getInternal().size
+    }
+
+    @Deprecated("Use rxCount instead", replaceWith = ReplaceWith("rxCount()"))
     override fun count(): Single<Int> {
-        return Single.fromCallable { blockingCount() }
+        return rxSingle { suspendCount() }
+    }
+
+    override fun rxCount(): Single<Int> {
+        return rxSingle { suspendCount() }
     }
 
     override fun blockingCount(): Int {
         return blockingGet().size
     }
 
+    override suspend fun suspendIsEmpty(): Boolean {
+        return suspendCount() == 0
+    }
+
+    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
     override fun isEmpty(): Single<Boolean> {
-        return Single.fromCallable { blockingIsEmpty() }
+        return rxSingle { suspendIsEmpty() }
+    }
+
+    override fun rxIsEmpty(): Single<Boolean> {
+        return rxSingle { suspendIsEmpty() }
     }
 
     override fun blockingIsEmpty(): Boolean {
@@ -195,8 +223,17 @@ class TrackedEntitySearchCollectionRepository internal constructor(
         return byTrackedEntities().eq(uid).objectRepository { o -> o.find { uid == it.uid() } }
     }
 
+    override suspend fun suspendGetUids(): List<String> {
+        return getUidsInternal()
+    }
+
+    @Deprecated("Use rxGetUids instead", replaceWith = ReplaceWith("rxGetUids()"))
     override fun getUids(): Single<List<String>> {
-        return Single.fromCallable { blockingGetUids() }
+        return rxSingle { suspendGetUids() }
+    }
+
+    override fun rxGetUids(): Single<List<String>> {
+        return rxSingle { suspendGetUids() }
     }
 
     override fun blockingGetUids(): List<String> {
@@ -215,16 +252,32 @@ class TrackedEntitySearchCollectionRepository internal constructor(
         transformer: Transformer<List<TrackedEntitySearchItem>, TrackedEntitySearchItem?>,
     ): ReadOnlyObjectRepository<TrackedEntitySearchItem> {
         return object : ReadOnlyObjectRepository<TrackedEntitySearchItem> {
+            @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
             override fun get(): Single<TrackedEntitySearchItem?> {
                 return Single.fromCallable { this.blockingGet() }
             }
 
-            override fun blockingGet(): TrackedEntitySearchItem? {
-                val list = this@TrackedEntitySearchCollectionRepository.blockingGet()
+            override fun rxGet(): Single<TrackedEntitySearchItem?> {
+                return Single.fromCallable { this.blockingGet() }
+            }
+
+            override suspend fun suspendGet(): TrackedEntitySearchItem? {
+                val list = this@TrackedEntitySearchCollectionRepository.getInternal()
                 return transformer.transform(list)
             }
 
+            override fun blockingGet(): TrackedEntitySearchItem? = runBlocking { suspendGet() }
+
+            override suspend fun suspendExists(): Boolean {
+                return suspendGet() != null
+            }
+
+            @Deprecated("Use rxExists instead", replaceWith = ReplaceWith("rxExists()"))
             override fun exists(): Single<Boolean> {
+                return Single.fromCallable { blockingExists() }
+            }
+
+            override fun rxExists(): Single<Boolean> {
                 return Single.fromCallable { blockingExists() }
             }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -36,10 +36,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.rxSingle
 import org.hisp.dhis.android.core.arch.handlers.internal.Transformer
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -133,16 +133,8 @@ class TrackedEntitySearchCollectionRepository internal constructor(
     val resultDataSource: DataSource<TrackedEntitySearchItem, Result<TrackedEntitySearchItem, D2Error>>
         get() = TrackedEntitySearchDataSourceResult(getDataFetcher())
 
-    override suspend fun suspendGet(): List<TrackedEntitySearchItem> {
-        return getInternal()
-    }
-
-    override fun blockingGet(): List<TrackedEntitySearchItem> {
-        return runBlocking { getInternal() }
-    }
-
     @Suppress("TooGenericExceptionCaught", "TooGenericExceptionThrown")
-    private suspend fun getInternal(): List<TrackedEntitySearchItem> {
+    override suspend fun suspendGet(): List<TrackedEntitySearchItem> {
         val dataFetcher = getDataFetcher()
         val searchResult =
             if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
@@ -159,47 +151,12 @@ class TrackedEntitySearchCollectionRepository internal constructor(
         }
     }
 
-    @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
-    override fun get(): Single<List<TrackedEntitySearchItem>> {
-        return rxSingle { suspendGet() }
-    }
-
-    override fun rxGet(): Single<List<TrackedEntitySearchItem>> {
-        return rxSingle { suspendGet() }
-    }
-
     override suspend fun suspendCount(): Int {
-        return getInternal().size
-    }
-
-    @Deprecated("Use rxCount instead", replaceWith = ReplaceWith("rxCount()"))
-    override fun count(): Single<Int> {
-        return rxSingle { suspendCount() }
-    }
-
-    override fun rxCount(): Single<Int> {
-        return rxSingle { suspendCount() }
-    }
-
-    override fun blockingCount(): Int {
-        return blockingGet().size
+        return suspendGet().size
     }
 
     override suspend fun suspendIsEmpty(): Boolean {
         return suspendCount() == 0
-    }
-
-    @Deprecated("Use rxIsEmpty instead", replaceWith = ReplaceWith("rxIsEmpty()"))
-    override fun isEmpty(): Single<Boolean> {
-        return rxSingle { suspendIsEmpty() }
-    }
-
-    override fun rxIsEmpty(): Single<Boolean> {
-        return rxSingle { suspendIsEmpty() }
-    }
-
-    override fun blockingIsEmpty(): Boolean {
-        return blockingCount() == 0
     }
 
     override fun one(): ReadOnlyObjectRepository<TrackedEntitySearchItem> {
@@ -244,7 +201,7 @@ class TrackedEntitySearchCollectionRepository internal constructor(
         return if (scope.mode() == RepositoryMode.OFFLINE_ONLY || scope.mode() == RepositoryMode.OFFLINE_FIRST) {
             getDataFetcher().queryAllOfflineUids()
         } else {
-            UidsHelper.getUids(getInternal()).toList()
+            UidsHelper.getUids(suspendGet()).toList()
         }
     }
 
@@ -262,7 +219,7 @@ class TrackedEntitySearchCollectionRepository internal constructor(
             }
 
             override suspend fun suspendGet(): TrackedEntitySearchItem? {
-                val list = this@TrackedEntitySearchCollectionRepository.getInternal()
+                val list = this@TrackedEntitySearchCollectionRepository.suspendGet()
                 return transformer.transform(list)
             }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository.kt
@@ -192,37 +192,13 @@ class TrackedEntitySearchCollectionRepository internal constructor(
         transformer: Transformer<List<TrackedEntitySearchItem>, TrackedEntitySearchItem?>,
     ): ReadOnlyObjectRepository<TrackedEntitySearchItem> {
         return object : ReadOnlyObjectRepository<TrackedEntitySearchItem> {
-            @Deprecated("Use rxGet instead", replaceWith = ReplaceWith("rxGet()"))
-            override fun get(): Single<TrackedEntitySearchItem?> {
-                return Single.fromCallable { this.blockingGet() }
-            }
-
-            override fun rxGet(): Single<TrackedEntitySearchItem?> {
-                return Single.fromCallable { this.blockingGet() }
-            }
-
             override suspend fun suspendGet(): TrackedEntitySearchItem? {
                 val list = this@TrackedEntitySearchCollectionRepository.suspendGet()
                 return transformer.transform(list)
             }
 
-            override fun blockingGet(): TrackedEntitySearchItem? = runBlocking { suspendGet() }
-
             override suspend fun suspendExists(): Boolean {
                 return suspendGet() != null
-            }
-
-            @Deprecated("Use rxExists instead", replaceWith = ReplaceWith("rxExists()"))
-            override fun exists(): Single<Boolean> {
-                return Single.fromCallable { blockingExists() }
-            }
-
-            override fun rxExists(): Single<Boolean> {
-                return Single.fromCallable { blockingExists() }
-            }
-
-            override fun blockingExists(): Boolean {
-                return blockingGet() != null
             }
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcherHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchDataFetcherHelper.kt
@@ -60,7 +60,7 @@ internal class TrackedEntitySearchDataFetcherHelper(
             if (programIndicatorHeader != null) {
                 programIndicatorCollectionRepository
                     .uid(programIndicatorHeader)
-                    .getInternal()
+                    .suspendGet()
                     ?.expression()
             } else {
                 null
@@ -80,11 +80,11 @@ internal class TrackedEntitySearchDataFetcherHelper(
             val programAttributes = programTrackedEntityAttributeCollectionRepository
                 .byProgram().eq(program)
                 .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
-                .getInternal()
+                .suspendGet()
 
             val attributes = trackedEntityAttributeCollectionRepository
                 .byUid().`in`(programAttributes.mapNotNull { it.trackedEntityAttribute()?.uid() })
-                .getInternal()
+                .suspendGet()
 
             programAttributes.mapNotNull { programAttribute ->
                 val attributeUid = programAttribute.trackedEntityAttribute()!!.uid()
@@ -98,11 +98,11 @@ internal class TrackedEntitySearchDataFetcherHelper(
         } else if (trackedEntityType != null) {
             val typeAttributes = trackedEntityTypeAttributeCollectionRepository
                 .byTrackedEntityTypeUid().eq(trackedEntityType)
-                .getInternal()
+                .suspendGet()
 
             val attributes = trackedEntityAttributeCollectionRepository
                 .byUid().`in`(typeAttributes.mapNotNull { it.trackedEntityAttribute()?.uid() })
-                .getInternal()
+                .suspendGet()
 
             typeAttributes.mapNotNull { typeAttribute ->
                 val attributeUid = typeAttribute.trackedEntityAttribute()!!.uid()
@@ -115,7 +115,7 @@ internal class TrackedEntitySearchDataFetcherHelper(
             }
         } else {
             val attributes = trackedEntityAttributeCollectionRepository
-                .getInternal()
+                .suspendGet()
 
             attributes.map { attribute ->
                 getSimpleTrackedEntityAttribute(
@@ -141,7 +141,7 @@ internal class TrackedEntitySearchDataFetcherHelper(
     }
 
     suspend fun getTeType(uid: String): TrackedEntityType? {
-        return trackedEntityTypeCollectionRepository.uid(uid).getInternal()
+        return trackedEntityTypeCollectionRepository.uid(uid).suspendGet()
     }
 }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentialsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/UserCredentialsObjectRepository.kt
@@ -61,7 +61,7 @@ class UserCredentialsObjectRepository internal constructor(
     }
 
     internal suspend fun getInternal(): UserCredentials? {
-        return delegate.getInternal()
+        return delegate.suspendGet()
     }
 
     fun withUserRoles(): UserCredentialsObjectRepository {

--- a/core/src/main/java/org/hisp/dhis/android/core/validation/engine/ValidationEngine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/validation/engine/ValidationEngine.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.validation.engine
 
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 
 interface ValidationEngine {
     /**
@@ -40,12 +42,31 @@ interface ValidationEngine {
      * @param attributeOptionComboUid AttributeOptionCombo uid to run the validation rules
      * @return Validation result
      */
+    @Deprecated(message = "Use rxValidate instead", ReplaceWith("rxValidate()"))
     fun validate(
         dataSetUid: String,
         periodId: String,
         orgUnitUid: String,
         attributeOptionComboUid: String,
-    ): Single<ValidationResult>
+    ): Single<ValidationResult> = rxValidate(dataSetUid, periodId, orgUnitUid, attributeOptionComboUid)
+
+    /**
+     * Run the validation associated to a particular dataSets returning a ValidationResult. This result contains the
+     * list of validation conflicts.
+     *
+     * @param dataSetUid DataSet uid to run the validation rules
+     * @param periodId Validation period
+     * @param orgUnitUid Organisation unit uid to run the validation rules
+     * @param attributeOptionComboUid AttributeOptionCombo uid to run the validation rules
+     * @return Validation result
+     */
+    fun rxValidate(
+        dataSetUid: String,
+        periodId: String,
+        orgUnitUid: String,
+        attributeOptionComboUid: String,
+    ): Single<ValidationResult> =
+        rxSingle { suspendValidate(dataSetUid, periodId, orgUnitUid, attributeOptionComboUid) }
 
     /**
      * Run the validation associated to a particular dataSets returning a ValidationResult. This result contains the
@@ -60,6 +81,24 @@ interface ValidationEngine {
      * @return Validation result
      */
     fun blockingValidate(
+        dataSetUid: String,
+        periodId: String,
+        orgUnitUid: String,
+        attributeOptionComboUid: String,
+    ): ValidationResult = runBlocking { suspendValidate(dataSetUid, periodId, orgUnitUid, attributeOptionComboUid) }
+
+    /**
+     * Run the validation associated to a particular dataSets returning a ValidationResult. This result contains the
+     * list of validation conflicts. Important: this is a suspend method.
+     * [.validate].
+     *
+     * @param dataSetUid DataSet uid to run the validation rules
+     * @param periodId Validation period
+     * @param orgUnitUid Organisation unit uid to run the validation rules
+     * @param attributeOptionComboUid AttributeOptionCombo uid to run the validation rules
+     * @return Validation result
+     */
+    suspend fun suspendValidate(
         dataSetUid: String,
         periodId: String,
         orgUnitUid: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/validation/engine/internal/ValidationEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/validation/engine/internal/ValidationEngineImpl.kt
@@ -63,11 +63,11 @@ internal class ValidationEngineImpl(
         orgUnitUid: String,
         attributeOptionComboUid: String,
     ): ValidationResult {
-        val rules = suspendGetValidationRulesForDataSetValidation(dataSetUid)
+        val rules = getValidationRulesForDataSetValidation(dataSetUid)
 
         val violations = if (rules.isNotEmpty()) {
             val constantMap = getConstantMap()
-            val valueMap = suspendGetValueMap(
+            val valueMap = getValueMap(
                 dataSetUid,
                 attributeOptionComboUid,
                 orgUnitUid,
@@ -93,14 +93,14 @@ internal class ValidationEngineImpl(
             .build()
     }
 
-    private suspend fun suspendGetValidationRulesForDataSetValidation(datasetUid: String): List<ValidationRule> {
+    private suspend fun getValidationRulesForDataSetValidation(datasetUid: String): List<ValidationRule> {
         return validationRuleRepository
             .byDataSetUids(listOf(datasetUid))
             .bySkipFormValidation().isFalse
             .suspendGet()
     }
 
-    private suspend fun suspendGetValueMap(
+    private suspend fun getValueMap(
         dataSetUid: String,
         attributeOptionComboUid: String,
         orgUnitUid: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/validation/engine/internal/ValidationEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/validation/engine/internal/ValidationEngineImpl.kt
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.android.core.validation.engine.internal
 
-import io.reactivex.Single
-import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.helpers.UidsHelper.mapByUid
 import org.hisp.dhis.android.core.constant.Constant
 import org.hisp.dhis.android.core.constant.ConstantCollectionRepository

--- a/core/src/main/java/org/hisp/dhis/android/core/validation/engine/internal/ValidationEngineImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/validation/engine/internal/ValidationEngineImpl.kt
@@ -59,32 +59,23 @@ internal class ValidationEngineImpl(
     private val periodHelper: PeriodHelper,
     private val orgunitGroupLinkStore: OrganisationUnitOrganisationUnitGroupLinkStore,
 ) : ValidationEngine {
-    override fun validate(
-        dataSetUid: String,
-        periodId: String,
-        orgUnitUid: String,
-        attributeOptionComboUid: String,
-    ): Single<ValidationResult> {
-        return Single.fromCallable { blockingValidate(dataSetUid, periodId, orgUnitUid, attributeOptionComboUid) }
-    }
-
-    override fun blockingValidate(
+    override suspend fun suspendValidate(
         dataSetUid: String,
         periodId: String,
         orgUnitUid: String,
         attributeOptionComboUid: String,
     ): ValidationResult {
-        val rules = getValidationRulesForDataSetValidation(dataSetUid)
+        val rules = suspendGetValidationRulesForDataSetValidation(dataSetUid)
 
         val violations = if (rules.isNotEmpty()) {
-            val constantMap = constantMap
-            val valueMap = getValueMap(
+            val constantMap = getConstantMap()
+            val valueMap = suspendGetValueMap(
                 dataSetUid,
                 attributeOptionComboUid,
                 orgUnitUid,
                 periodId,
             )
-            val orgunitGroupMap = orgunitGroupMap
+            val orgunitGroupMap = getOrgunitGroupMap()
             val organisationUnit = getOrganisationUnit(orgUnitUid)
             val period = getPeriod(periodId)
             val context = ExpressionServiceContext(valueMap, constantMap, orgunitGroupMap, PeriodHelper.getDays(period))
@@ -104,14 +95,14 @@ internal class ValidationEngineImpl(
             .build()
     }
 
-    private fun getValidationRulesForDataSetValidation(datasetUid: String): List<ValidationRule> {
+    private suspend fun suspendGetValidationRulesForDataSetValidation(datasetUid: String): List<ValidationRule> {
         return validationRuleRepository
             .byDataSetUids(listOf(datasetUid))
             .bySkipFormValidation().isFalse
-            .blockingGet()
+            .suspendGet()
     }
 
-    private fun getValueMap(
+    private suspend fun suspendGetValueMap(
         dataSetUid: String,
         attributeOptionComboUid: String,
         orgUnitUid: String,
@@ -123,26 +114,24 @@ internal class ValidationEngineImpl(
             .byOrganisationUnitUid().eq(orgUnitUid)
             .byPeriod().eq(periodId)
             .byDeleted().isFalse
-            .blockingGet()
+            .suspendGet()
         return getValueMap(dataValues)
     }
 
-    private val constantMap: Map<String, Constant>
-        get() {
-            val constants = constantRepository.blockingGet()
-            return mapByUid(constants)
-        }
-
-    private fun getOrganisationUnit(orgunitId: String): OrganisationUnit? {
-        return organisationUnitRepository.uid(orgunitId).blockingGet()
+    private suspend fun getConstantMap(): Map<String, Constant> {
+        val constants = constantRepository.suspendGet()
+        return mapByUid(constants)
     }
 
-    private val orgunitGroupMap: Map<String, Int>
-        get() = runBlocking {
-            orgunitGroupLinkStore.groupAndGetCountBy(
-                OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT_GROUP,
-            )
-        }
+    private suspend fun getOrganisationUnit(orgunitId: String): OrganisationUnit? {
+        return organisationUnitRepository.uid(orgunitId).suspendGet()
+    }
+
+    private suspend fun getOrgunitGroupMap(): Map<String, Int> {
+        return orgunitGroupLinkStore.groupAndGetCountBy(
+            OrganisationUnitOrganisationUnitGroupLinkTableInfo.Columns.ORGANISATION_UNIT_GROUP,
+        )
+    }
 
     private fun getPeriod(periodId: String): Period {
         return periodHelper.blockingGetPeriodForPeriodId(periodId)

--- a/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/category/CategoryOptionComboServiceShould.kt
@@ -61,7 +61,7 @@ class CategoryOptionComboServiceShould {
         whenever(
             categoryOptionRepository
                 .byCategoryOptionComboUid(categoryOptionComboUid)
-                .getInternal(),
+                .suspendGet(),
         ) doReturn listOf(option1, option2)
 
         whenever(option1.access()) doReturn AccessHelper.createForDataWrite(true)

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -115,7 +115,7 @@ class DataSetInstanceServiceShould {
     @Before
     fun setUp() = runTest {
         whenever(dataSet.uid()) doReturn dataSetUid
-        whenever(categoryOptionRepository.byCategoryOptionComboUid(any()).getInternal()) doReturn categories
+        whenever(categoryOptionRepository.byCategoryOptionComboUid(any()).suspendGet()) doReturn categories
         whenever(dataSetCollectionRepository.uid(any()).getInternal()) doReturn dataSet
         whenever(periodHelper.suspendGetPeriodForPeriodId(firstPeriodId)) doReturn firstPeriod
         whenever(firstPeriod.startDate()) doReturn firstJanuary
@@ -317,7 +317,7 @@ class DataSetInstanceServiceShould {
         whenever(repoAfterDE.byCategoryOptionComboUid()).thenReturn(cocConnector)
         whenever(cocConnector.`in`(listOf("coc1", "coc2"))).thenReturn(finalRepo)
 
-        whenever(finalRepo.getInternal()).thenReturn(listOf(dataValue))
+        whenever(finalRepo.suspendGet()).thenReturn(listOf(dataValue))
 
         val result = dataSetInstanceService.suspendGetMissingMandatoryFieldsCombination(
             dataSetUid,

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -116,7 +116,7 @@ class DataSetInstanceServiceShould {
     fun setUp() = runTest {
         whenever(dataSet.uid()) doReturn dataSetUid
         whenever(categoryOptionRepository.byCategoryOptionComboUid(any()).suspendGet()) doReturn categories
-        whenever(dataSetCollectionRepository.uid(any()).getInternal()) doReturn dataSet
+        whenever(dataSetCollectionRepository.uid(any()).suspendGet()) doReturn dataSet
         whenever(periodHelper.suspendGetPeriodForPeriodId(firstPeriodId)) doReturn firstPeriod
         whenever(firstPeriod.startDate()) doReturn firstJanuary
         whenever(firstPeriod.endDate()) doReturn thirdJanuary
@@ -233,7 +233,7 @@ class DataSetInstanceServiceShould {
             on { compulsoryDataElementOperands() } doReturn listOf(operand)
         }
 
-        whenever(dataSetCollectionRepository.withCompulsoryDataElementOperands().uid(dataSetUid).getInternal())
+        whenever(dataSetCollectionRepository.withCompulsoryDataElementOperands().uid(dataSetUid).suspendGet())
             .thenReturn(dataSetWithCompulsory)
 
         val dataValueQuery = mock<DataValueObjectRepository>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
@@ -273,7 +273,7 @@ class DataSetInstanceServiceShould {
             on { fieldCombinationRequired() } doReturn true
             on { dataSetElements() } doReturn listOf(dataSetElement)
         }
-        whenever(dataSetCollectionRepository.withDataSetElements().uid(dataSetUid).getInternal())
+        whenever(dataSetCollectionRepository.withDataSetElements().uid(dataSetUid).suspendGet())
             .thenReturn(dataSetWithElements)
 
         val byCatComboUidConnector = mock<StringFilterConnector<CategoryOptionComboCollectionRepository>>()

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -280,7 +280,7 @@ class DataSetInstanceServiceShould {
         val eqRepo = mock<CategoryOptionComboCollectionRepository>()
         whenever(categoryOptionComboCollectionRepository.byCategoryComboUid()).thenReturn(byCatComboUidConnector)
         whenever(byCatComboUidConnector.eq("ccUid")).thenReturn(eqRepo)
-        whenever(eqRepo.getUidsInternal()).thenReturn(listOf("coc1", "coc2"))
+        whenever(eqRepo.suspendGetUids()).thenReturn(listOf("coc1", "coc2"))
 
         val dataValue = mock<DataValue> {
             on { dataElement() } doReturn "de1"

--- a/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/dataset/DataSetInstanceServiceShould.kt
@@ -239,7 +239,7 @@ class DataSetInstanceServiceShould {
         val dataValueQuery = mock<DataValueObjectRepository>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
         whenever(
             runBlocking {
-                dataValueQuery.existsInternal()
+                dataValueQuery.suspendExists()
             },
         ) doReturn false
         whenever(

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentServiceShould.kt
@@ -90,12 +90,12 @@ class EnrollmentServiceShould {
 
     @Before
     fun setUp() = runTest {
-        whenever(enrollmentRepository.uid(enrollmentUid).getInternal()) doReturn enrollment
+        whenever(enrollmentRepository.uid(enrollmentUid).suspendGet()) doReturn enrollment
         whenever(
             trackedEntityInstanceRepository
-                .uid(trackedEntityInstanceUid).getInternal(),
+                .uid(trackedEntityInstanceUid).suspendGet(),
         ) doReturn trackedEntityInstance
-        whenever(programRepository.uid(programUid).getInternal()) doReturn program
+        whenever(programRepository.uid(programUid).suspendGet()) doReturn program
 
         whenever(enrollment.uid()) doReturn enrollmentUid
         whenever(trackedEntityInstance.organisationUnit()) doReturn organisationUnitId
@@ -122,7 +122,7 @@ class EnrollmentServiceShould {
 
     @Test
     fun `IsOpen should return true if enrollment is not found`() = runTest {
-        whenever(enrollmentRepository.uid(enrollmentUid).getInternal()) doReturn null
+        whenever(enrollmentRepository.uid(enrollmentUid).suspendGet()) doReturn null
         assertTrue(enrollmentService.blockingIsOpen(enrollmentUid))
     }
 
@@ -237,7 +237,7 @@ class EnrollmentServiceShould {
             programStageCollectionRepository.byAccessDataWrite().isTrue,
         ) doReturn programStageCollectionRepository
         whenever(
-            programStageCollectionRepository.getInternal(),
+            programStageCollectionRepository.suspendGet(),
         ) doReturn getProgramStages()
 
         whenever(
@@ -246,14 +246,14 @@ class EnrollmentServiceShould {
         whenever(
             eventCollectionRepository.byDeleted().isFalse,
         ) doReturn eventCollectionRepository
-        whenever(eventCollectionRepository.getInternal()) doReturn getEventList()
+        whenever(eventCollectionRepository.suspendGet()) doReturn getEventList()
 
         assertTrue(enrollmentService.blockingGetAllowEventCreation(enrollmentUid, listOf("1")))
     }
 
     @Test
     fun `Enrollment has not any events that allows events creation`() = runTest {
-        whenever(enrollmentRepository.uid(enrollmentUid).getInternal()) doReturn enrollment
+        whenever(enrollmentRepository.uid(enrollmentUid).suspendGet()) doReturn enrollment
         whenever(enrollment.program()) doReturn programUid
 
         whenever(
@@ -263,7 +263,7 @@ class EnrollmentServiceShould {
             programStageCollectionRepository.byAccessDataWrite().isTrue,
         ) doReturn programStageCollectionRepository
         whenever(
-            programStageCollectionRepository.getInternal(),
+            programStageCollectionRepository.suspendGet(),
         ) doReturn getProgramStages()
 
         whenever(
@@ -272,7 +272,7 @@ class EnrollmentServiceShould {
         whenever(
             eventCollectionRepository.byDeleted().isFalse,
         ) doReturn eventCollectionRepository
-        whenever(eventCollectionRepository.getInternal()) doReturn getEventList()
+        whenever(eventCollectionRepository.suspendGet()) doReturn getEventList()
 
         assertFalse(enrollmentService.blockingGetAllowEventCreation(enrollmentUid, listOf("1", "2")))
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/enrollment/EnrollmentServiceShould.kt
@@ -104,7 +104,7 @@ class EnrollmentServiceShould {
                 organisationUnitRepository
                     .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                     .uid(organisationUnitId)
-                    .existsInternal()
+                    .suspendExists()
             },
         ) doReturn false
 
@@ -173,7 +173,7 @@ class EnrollmentServiceShould {
                 organisationUnitRepository
                     .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                     .uid(ownerOrganisationUnitId)
-                    .existsInternal()
+                    .suspendExists()
             },
         ) doReturn true
 
@@ -193,7 +193,7 @@ class EnrollmentServiceShould {
                     organisationUnitRepository
                         .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                         .uid(ownerOrganisationUnitId)
-                        .existsInternal()
+                        .suspendExists()
                 },
             ) doReturn false
             whenever(programTempOwnerStore.selectWhere(any())) doReturn listOf(programTempOwner)
@@ -215,7 +215,7 @@ class EnrollmentServiceShould {
                     organisationUnitRepository
                         .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                         .uid(ownerOrganisationUnitId)
-                        .existsInternal()
+                        .suspendExists()
                 },
             ) doReturn false
             whenever(programTempOwnerStore.selectWhere(any())) doReturn listOf(programTempOwner)
@@ -299,7 +299,7 @@ class EnrollmentServiceShould {
                 organisationUnitRepository
                     .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                     .uid(ownerOrganisationUnitId)
-                    .existsInternal()
+                    .suspendExists()
             },
         ) doReturn true
 
@@ -318,7 +318,7 @@ class EnrollmentServiceShould {
                 organisationUnitRepository
                     .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
                     .uid(ownerOrganisationUnitId)
-                    .existsInternal()
+                    .suspendExists()
             },
         ) doReturn false
 

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventServiceShould.kt
@@ -95,10 +95,10 @@ class EventServiceShould {
 
     @Before
     fun setUp() = runTest {
-        whenever(eventRepository.uid(any()).getInternal()) doReturn event
-        whenever(enrollmentRepository.uid(any()).getInternal()) doReturn enrollment
-        whenever(programRepository.uid(any()).getInternal()) doReturn program
-        whenever(programStageRepository.uid(any()).getInternal()) doReturn programStage
+        whenever(eventRepository.uid(any()).suspendGet()) doReturn event
+        whenever(enrollmentRepository.uid(any()).suspendGet()) doReturn enrollment
+        whenever(programRepository.uid(any()).suspendGet()) doReturn program
+        whenever(programStageRepository.uid(any()).suspendGet()) doReturn programStage
 
         whenever(event.uid()) doReturn eventUid
         whenever(event.eventDate()) doReturn firstJanuary

--- a/core/src/test/java/org/hisp/dhis/android/core/event/search/EventCollectionRepositoryAdapterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/search/EventCollectionRepositoryAdapterShould.kt
@@ -67,9 +67,9 @@ class EventCollectionRepositoryAdapterShould {
             dateFilterPeriodHelper,
         )
 
-        whenever(ouRepository.getUidsInternal()) doReturn orgunitDescendants
-        whenever(ouRepository.byPath().like(orgunit).getUidsInternal()) doReturn orgunitDescendants
-        whenever(ouRepository.byParentUid().like(orgunit).getUidsInternal()) doReturn orgunitChildren
+        whenever(ouRepository.suspendGetUids()) doReturn orgunitDescendants
+        whenever(ouRepository.byPath().like(orgunit).suspendGetUids()) doReturn orgunitDescendants
+        whenever(ouRepository.byParentUid().like(orgunit).suspendGetUids()) doReturn orgunitChildren
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitServiceShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/organisationunit/OrganisationUnitServiceShould.kt
@@ -56,7 +56,7 @@ class OrganisationUnitServiceShould {
 
     @Before
     fun setUp() = runTest {
-        whenever(organisationUnitRepository.uid(organisationUnitUid).getInternal()) doReturn organisationUnit
+        whenever(organisationUnitRepository.uid(organisationUnitUid).suspendGet()) doReturn organisationUnit
 
         whenever(organisationUnit.uid()) doReturn organisationUnitUid
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/internal/RelationshipImportHandlerShould.kt
@@ -73,7 +73,7 @@ class RelationshipImportHandlerShould {
             RelationshipImportHandler(relationshipStore, dataStatePropagator, relationshipCollectionRepository)
 
         whenever(relationshipCollectionRepository.withItems().uid(any())).doReturn(relationshipObjectRepository)
-        whenever(relationshipObjectRepository.getInternal()).doReturn(relationship)
+        whenever(relationshipObjectRepository.suspendGet()).doReturn(relationship)
         whenever(relationship.from()).doReturn(relationshipItem)
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionCallShould.kt
@@ -82,7 +82,7 @@ class LatestAppVersionCallShould {
 
     private fun mockUserGroups(userGroupUids: List<String>) = runTest {
         whenever(userModule.userGroups()).thenReturn(userGroupCollectionRepository)
-        whenever(userGroupCollectionRepository.getUidsInternal()).thenReturn(userGroupUids)
+        whenever(userGroupCollectionRepository.suspendGetUids()).thenReturn(userGroupUids)
     }
 
     private suspend fun mockVersions(versions: List<ApkDistributionVersion>) {

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
@@ -89,11 +89,15 @@ class PingImplShould {
         try {
             pingImpl.blockingGet()
             fail("D2Error was expected but not thrown.")
-        } catch (error: D2Error) {
-            assertThat(error.errorCode()).isEqualTo(D2ErrorCode.API_UNSUCCESSFUL_RESPONSE)
-            assertThat(error.errorDescription()).isEqualTo("Unable to ping the server.")
+        } catch (e: RuntimeException) {
+            val cause = e.cause
+            assertTrue("Cause of RuntimeException should be D2Error", cause is D2Error)
+
+            val d2Error = cause as D2Error
+            assertThat(d2Error.errorCode()).isEqualTo(D2ErrorCode.API_UNSUCCESSFUL_RESPONSE)
+            assertThat(d2Error.errorDescription()).isEqualTo("Unable to ping the server.")
             assertThat(
-                error.originalException()?.message,
+                d2Error.originalException()?.message,
             ).isEqualTo("Ping to the server failed with status code: 500")
         }
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/systeminfo/internal/PingImplShould.kt
@@ -89,15 +89,11 @@ class PingImplShould {
         try {
             pingImpl.blockingGet()
             fail("D2Error was expected but not thrown.")
-        } catch (e: RuntimeException) {
-            val cause = e.cause
-            assertTrue("Cause of RuntimeException should be D2Error", cause is D2Error)
-
-            val d2Error = cause as D2Error
-            assertThat(d2Error.errorCode()).isEqualTo(D2ErrorCode.API_UNSUCCESSFUL_RESPONSE)
-            assertThat(d2Error.errorDescription()).isEqualTo("Unable to ping the server.")
+        } catch (error: D2Error) {
+            assertThat(error.errorCode()).isEqualTo(D2ErrorCode.API_UNSUCCESSFUL_RESPONSE)
+            assertThat(error.errorDescription()).isEqualTo("Unable to ping the server.")
             assertThat(
-                d2Error.originalException()?.message,
+                error.originalException()?.message,
             ).isEqualTo("Ping to the server failed with status code: 500")
         }
     }


### PR DESCRIPTION
This PR exposes suspend functions from public repositories and services. In this case, the interfaces of object and collection repositories have been modified, adding the new functions and default logic that relies only on implementing the flow/suspend functions on their implementations. 

Related task: [ANDROSDK-2280](https://dhis2.atlassian.net/browse/ANDROSDK-2280)

[ANDROSDK-2280]: https://dhis2.atlassian.net/browse/ANDROSDK-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ