### PR TITLE
fix: [ANDROSDK-2279] Check orgunit in actual search scope for glass verification

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/dataset/DataSetCollectionRepositoryMockIntegrationShould.kt
@@ -261,12 +261,12 @@ class DataSetCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTest
         val dataSetCapture = d2.dataSetModule().dataSets()
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .blockingGet()
-        assertThat(dataSetCapture.size).isEqualTo(3)
+        assertThat(dataSetCapture.size).isEqualTo(2)
 
         val dataSetSearch = d2.dataSetModule().dataSets()
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_TEI_SEARCH)
             .blockingGet()
-        assertThat(dataSetSearch.size).isEqualTo(0)
+        assertThat(dataSetSearch.size).isEqualTo(3)
     }
 
     @Test

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/organisationunit/OrganisationUnitCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/organisationunit/OrganisationUnitCollectionRepositoryMockIntegrationShould.kt
@@ -110,12 +110,12 @@ class OrganisationUnitCollectionRepositoryMockIntegrationShould : BaseMockIntegr
         val captureOrganisationUnits = d2.organisationUnitModule().organisationUnits()
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
             .blockingGet()
-        assertThat(captureOrganisationUnits.size).isEqualTo(3)
+        assertThat(captureOrganisationUnits.size).isEqualTo(1)
 
         val searchOrganisationUnits = d2.organisationUnitModule().organisationUnits()
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_TEI_SEARCH)
             .blockingGet()
-        assertThat(searchOrganisationUnits.size).isEqualTo(0)
+        assertThat(searchOrganisationUnits.size).isEqualTo(3)
     }
 
     @Test
@@ -123,7 +123,7 @@ class OrganisationUnitCollectionRepositoryMockIntegrationShould : BaseMockIntegr
         val rootOrganisationUnits = d2.organisationUnitModule().organisationUnits()
             .byRootOrganisationUnit(true)
             .blockingGet()
-        assertThat(rootOrganisationUnits.size).isEqualTo(1)
+        assertThat(rootOrganisationUnits.size).isEqualTo(2)
 
         val notRootOrganisationUnits = d2.organisationUnitModule().organisationUnits()
             .byRootOrganisationUnit(false)

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/program/ProgramCollectionRepositoryMockIntegrationShould.kt
@@ -383,7 +383,7 @@ class ProgramCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTest
         val programSearch = d2.programModule().programs()
             .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_TEI_SEARCH)
             .blockingGet()
-        assertThat(programSearch.size).isEqualTo(0)
+        assertThat(programSearch.size).isEqualTo(3)
     }
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.kt
@@ -541,7 +541,7 @@ class Dhis2MockServer(private val fileReader: IFileReader, port: Int) {
         private const val DATA_SET_COMPLETE_REGISTRATIONS_JSON =
             "dataset/data_set_complete_registrations.json"
         private const val DATA_APPROVALS_MULTIPLE_JSON = "dataapproval/data_approvals_multiple.json"
-        private const val ORGANISATION_UNITS_JSON = "organisationunit/organisation_units.json"
+        private const val ORGANISATION_UNITS_JSON = "organisationunit/search_organisation_units.json"
         private const val RESERVE_VALUES_JSON =
             "trackedentity/tracked_entity_attribute_reserved_values.json"
         private const val SMS_METADATA = "sms/metadata_ids.json"

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityEnrollmentOrphanCleaner.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityEnrollmentOrphanCleaner.kt
@@ -31,7 +31,6 @@ import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
-import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterBreakTheGlassHelper
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
 import org.koin.core.annotation.Singleton
@@ -39,7 +38,6 @@ import org.koin.core.annotation.Singleton
 @Singleton
 internal class TrackedEntityEnrollmentOrphanCleaner(
     private val enrollmentStore: EnrollmentStore,
-    private val breakTheGlassHelper: TrackerImporterBreakTheGlassHelper,
 ) {
 
     suspend fun deleteOrphan(
@@ -47,7 +45,7 @@ internal class TrackedEntityEnrollmentOrphanCleaner(
         children: Collection<Enrollment>?,
         program: String?,
     ): Boolean {
-        return if (parent != null && children != null) {
+        return if (parent != null && children != null && program != null) {
             val orphanEnrollmentsClause = WhereClauseBuilder().run {
                 appendKeyStringValue(EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE, parent.uid())
                 appendNotInKeyStringValues(EnrollmentTableInfo.Columns.UID, children.map { it.uid() })
@@ -55,32 +53,19 @@ internal class TrackedEntityEnrollmentOrphanCleaner(
                     EnrollmentTableInfo.Columns.SYNC_STATE,
                     listOf(State.SYNCED, State.SYNCED_VIA_SMS),
                 )
-                if (program != null) {
-                    appendKeyStringValue(EnrollmentTableInfo.Columns.PROGRAM, program)
-                }
+                appendKeyStringValue(EnrollmentTableInfo.Columns.PROGRAM, program)
                 build()
             }
 
             val orphanEnrollments = enrollmentStore.selectWhere(orphanEnrollmentsClause)
 
-            val deletedEnrollments = orphanEnrollments.filter { e -> isAccessibleByGlass(e, program) }
-
-            if (deletedEnrollments.isNotEmpty()) {
-                enrollmentStore.deleteByUid(deletedEnrollments)
+            if (orphanEnrollments.isNotEmpty()) {
+                enrollmentStore.deleteByUid(orphanEnrollments)
             }
 
-            deletedEnrollments.isNotEmpty()
+            orphanEnrollments.isNotEmpty()
         } else {
             false
         }
-    }
-
-    private suspend fun isAccessibleByGlass(enrollment: Enrollment, program: String?): Boolean {
-        val isProtected = breakTheGlassHelper.isProtectedInSearchScope(
-            program = enrollment.program(),
-            organisationUnit = enrollment.organisationUnit(),
-        )
-
-        return !isProtected || enrollment.program() == program
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/ownership/ProgramOwnerStore.kt
@@ -30,4 +30,6 @@ package org.hisp.dhis.android.core.trackedentity.ownership
 
 import org.hisp.dhis.android.core.arch.db.stores.internal.ObjectWithoutUidStore
 
-internal interface ProgramOwnerStore : ObjectWithoutUidStore<ProgramOwner>
+internal interface ProgramOwnerStore : ObjectWithoutUidStore<ProgramOwner> {
+    suspend fun selectForTeiProgram(tei: String, program: String): ProgramOwner?
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelper.kt
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.android.core.tracker.importer.internal
 
+import org.hisp.dhis.android.core.enrollment.Enrollment
+import org.hisp.dhis.android.core.enrollment.NewTrackerImporterEnrollment
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.imports.internal.TEIWebResponseHandlerSummary
 import org.hisp.dhis.android.core.imports.internal.TrackerImportConflictStore
@@ -36,6 +38,7 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceInternalAccessor
 import org.hisp.dhis.android.core.trackedentity.internal.NewTrackerImporterPayload
 import org.hisp.dhis.android.core.trackedentity.ownership.OwnershipManagerImpl
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStore
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.imports.TrackerImportConflictTableInfo
@@ -47,6 +50,7 @@ internal class TrackerImporterBreakTheGlassHelper(
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
     private val enrollmentStore: EnrollmentStore,
     private val programStore: ProgramStore,
+    private val programOwnerStore: ProgramOwnerStore,
     private val ownershipManagerImpl: OwnershipManagerImpl,
 ) {
 
@@ -58,7 +62,7 @@ internal class TrackerImporterBreakTheGlassHelper(
         instances: List<TrackedEntityInstance>,
     ): List<TrackedEntityInstance> {
         return summary.enrollments.ignored.filter { enrollment ->
-            isProtectedInSearchScope(enrollment.program(), enrollment.organisationUnit())
+            isProtectedInSearchScope(enrollment)
         }.mapNotNull { enrollment ->
             instances.mapNotNull { tei ->
                 val teiEnrollment =
@@ -98,9 +102,9 @@ internal class TrackerImporterBreakTheGlassHelper(
         candidateEnrollments
             .mapNotNull { error -> error.enrollment()?.let { id -> payload.enrollments.find { it.uid() == id } } }
             .filter { enrollment ->
-                isProtectedInSearchScope(enrollment.program, enrollment.organisationUnit)
+                isProtectedInSearchScope(enrollment)
             }
-            .map { enrollment ->
+            .forEach { enrollment ->
                 glassErrors.enrollments.add(enrollment)
                 glassErrors.trackedEntities.addAll(
                     payload.trackedEntities.filter {
@@ -119,10 +123,10 @@ internal class TrackerImporterBreakTheGlassHelper(
             .mapNotNull { error -> error.event()?.let { id -> payload.events.find { it.uid() == id } } }
             .filter { event ->
                 event.enrollment?.let { enrollmentStore.selectByUid(it) }?.let {
-                    isProtectedInSearchScope(it.program(), it.organisationUnit())
+                    isProtectedInSearchScope(it)
                 } ?: false
             }
-            .map { event ->
+            .forEach { event ->
                 glassErrors.events.add(event)
             }
 
@@ -171,9 +175,25 @@ internal class TrackerImporterBreakTheGlassHelper(
         }
     }
 
-    suspend fun isProtectedInSearchScope(program: String?, organisationUnit: String?): Boolean {
-        return if (program != null && organisationUnit != null) {
-            isProtectedProgram(program) && isNotCaptureScope(organisationUnit)
+    @Suppress("ReturnCount")
+    private suspend fun isProtectedInSearchScope(enrollment: NewTrackerImporterEnrollment): Boolean {
+        val tei = enrollment.trackedEntity ?: return false
+        val program = enrollment.program ?: return false
+        val programOwner = programOwnerStore.selectForTeiProgram(tei, program) ?: return false
+        return isProtectedInSearchScope(program, programOwner.ownerOrgUnit())
+    }
+
+    @Suppress("ReturnCount")
+    private suspend fun isProtectedInSearchScope(enrollment: Enrollment): Boolean {
+        val tei = enrollment.trackedEntityInstance() ?: return false
+        val program = enrollment.program() ?: return false
+        val programOwner = programOwnerStore.selectForTeiProgram(tei, program) ?: return false
+        return isProtectedInSearchScope(program, programOwner.ownerOrgUnit())
+    }
+
+    suspend fun isProtectedInSearchScope(program: String?, ownerOrgUnit: String?): Boolean {
+        return if (program != null && ownerOrgUnit != null) {
+            isProtectedProgram(program) && isSearchScopeAndNoCapture(ownerOrgUnit)
         } else {
             false
         }
@@ -183,7 +203,10 @@ internal class TrackerImporterBreakTheGlassHelper(
         return program?.let { programStore.selectByUid(it)?.accessLevel() == AccessLevel.PROTECTED } ?: false
     }
 
-    private suspend fun isNotCaptureScope(organisationUnit: String?): Boolean {
-        return organisationUnit?.let { !userOrganisationUnitLinkStore.isCaptureScope(it) } ?: false
+    private suspend fun isSearchScopeAndNoCapture(organisationUnit: String?): Boolean {
+        return organisationUnit?.let {
+            userOrganisationUnitLinkStore.isSearchScope(it) &&
+                !userOrganisationUnitLinkStore.isCaptureScope(it)
+        } ?: false
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/UserOrganisationUnitLinkStore.kt
@@ -39,4 +39,5 @@ internal interface UserOrganisationUnitLinkStore : LinkStore<UserOrganisationUni
     suspend fun queryOrganisationUnitUidsByScope(scope: OrganisationUnit.Scope): List<String>
     suspend fun queryAssignedOrganisationUnitUidsByScope(scope: OrganisationUnit.Scope): List<String>
     suspend fun isCaptureScope(organisationUnit: String): Boolean
+    suspend fun isSearchScope(organisationUnit: String): Boolean
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramOwnerStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/ProgramOwnerStoreImpl.kt
@@ -32,6 +32,7 @@ import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwner
 import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.common.stores.ObjectWithoutUidStoreImpl
 import org.koin.core.annotation.Singleton
 
@@ -42,4 +43,14 @@ internal class ProgramOwnerStoreImpl(
     { databaseAdapter.getCurrentDatabase().programOwnerDao() },
     ProgramOwner::toDB,
     SQLStatementBuilderImpl(ProgramOwnerTableInfo.TABLE_INFO),
-)
+) {
+    override suspend fun selectForTeiProgram(tei: String, program: String): ProgramOwner? {
+        val whereClause = WhereClauseBuilder().run {
+            appendKeyStringValue(ProgramOwnerTableInfo.Columns.TRACKED_ENTITY_INSTANCE, tei)
+            appendKeyStringValue(ProgramOwnerTableInfo.Columns.PROGRAM, program)
+            build()
+        }
+
+        return selectOneWhere(whereClause)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/user/UserOrganisationUnitLinkStoreImpl.kt
@@ -96,4 +96,16 @@ internal class UserOrganisationUnitLinkStoreImpl(
 
         return countWhere(whereClause) == 1
     }
+
+    override suspend fun isSearchScope(organisationUnit: String): Boolean {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(UserOrganisationUnitTableInfo.Columns.ORGANISATION_UNIT, organisationUnit)
+            .appendKeyStringValue(
+                UserOrganisationUnitTableInfo.Columns.ORGANISATION_UNIT_SCOPE,
+                OrganisationUnit.Scope.SCOPE_TEI_SEARCH,
+            )
+            .build()
+
+        return countWhere(whereClause) == 1
+    }
 }

--- a/core/src/sharedTest/resources/organisationunit/organisation_units.json
+++ b/core/src/sharedTest/resources/organisationunit/organisation_units.json
@@ -1,37 +1,6 @@
 {
   "organisationUnits": [
     {
-      "code": "OU_539",
-      "level": 3,
-      "created": "2012-02-17T15:54:39.987",
-      "lastUpdated": "2015-03-27T18:32:48.597",
-      "name": "Badjia",
-      "id": "YuQRtpLP10I",
-      "shortName": "Badjia",
-      "displayName": "Badjia",
-      "displayShortName": "Badjia",
-      "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I",
-      "openingDate": "1970-01-01T00:00:00.000",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          -11.618041992187502,
-          9.508486893003065
-        ]
-      },
-      "parent": {
-        "id": "O6uvpzGd5pu"
-      },
-      "ancestors": [
-      ],
-      "organisationUnitGroups": [
-      ],
-      "dataSets": [
-      ],
-      "programs": [
-      ]
-    },
-    {
       "code": "OU_559",
       "level": 4,
       "created": "2012-02-17T15:54:39.987",
@@ -64,81 +33,6 @@
         },
         {
           "id": "BfMAe6Itzgt"
-        }
-      ],
-      "organisationUnitGroups": [
-        {
-          "code": "CHC",
-          "lastUpdated": "2014-09-29T20:28:01.093",
-          "id": "CXw2yu5fodb",
-          "created": "2012-11-13T14:35:22.574",
-          "name": "CHC",
-          "shortName": "CHC short",
-          "symbol": "16.png",
-          "displayName": "CHC",
-          "publicAccess": "rw------",
-          "displayShortName": "CHC display short",
-          "externalAccess": false,
-          "featureType": "NONE",
-          "dimensionItem": "CXw2yu5fodb",
-          "favorite": false,
-          "dimensionItemType": "ORGANISATION_UNIT_GROUP",
-          "access": {
-            "read": true,
-            "update": true,
-            "externalize": false,
-            "delete": true,
-            "write": true,
-            "manage": true
-          },
-          "user": {
-            "id": "GOLswS44mh8"
-          },
-          "favorites": [],
-          "translations": [],
-          "organisationUnits": [],
-          "userGroupAccesses": [],
-          "attributeValues": [],
-          "groupSets": [
-            {
-              "id": "J5jldMd8OHv"
-            }
-          ],
-          "userAccesses": [],
-          "legendSets": []
-        }
-      ],
-      "ancestors": []
-    },
-    {
-      "code": "OU_167609",
-      "level": 4,
-      "created": "2012-02-17T15:54:39.987",
-      "lastUpdated": "2021-08-12T06:54:20.634",
-      "name": "Njandama MCHP",
-      "id": "g8upMTyEZGZ",
-      "shortName": "Njandama MCHP",
-      "displayName": "Njandama MCHP",
-      "displayShortName": "Njandama MCHP",
-      "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/g8upMTyEZGZ",
-      "openingDate": "2009-01-01T00:00:00.000",
-      "parent": {
-        "id": "YuQRtpLP10I"
-      },
-      "programs": [
-        {
-          "id": "IpHINAT79UW"
-        }
-      ],
-      "dataSets": [
-        {
-          "id": "lyLU2wR22tC"
-        },
-        {
-          "id": "BfMAe6Itzgt"
-        },
-        {
-          "id": "TaMAefItzgt"
         }
       ],
       "organisationUnitGroups": [

--- a/core/src/sharedTest/resources/organisationunit/search_organisation_units.json
+++ b/core/src/sharedTest/resources/organisationunit/search_organisation_units.json
@@ -1,0 +1,189 @@
+{
+  "organisationUnits": [
+    {
+      "code": "OU_539",
+      "level": 3,
+      "created": "2012-02-17T15:54:39.987",
+      "lastUpdated": "2015-03-27T18:32:48.597",
+      "name": "Badjia",
+      "id": "YuQRtpLP10I",
+      "shortName": "Badjia",
+      "displayName": "Badjia",
+      "displayShortName": "Badjia",
+      "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I",
+      "openingDate": "1970-01-01T00:00:00.000",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -11.618041992187502,
+          9.508486893003065
+        ]
+      },
+      "parent": {
+        "id": "O6uvpzGd5pu"
+      },
+      "ancestors": [
+      ],
+      "organisationUnitGroups": [
+      ],
+      "dataSets": [
+      ],
+      "programs": [
+      ]
+    },
+    {
+      "code": "OU_559",
+      "level": 4,
+      "created": "2012-02-17T15:54:39.987",
+      "lastUpdated": "2017-05-22T15:21:48.516",
+      "closedDate": "2025-05-22T15:21:48.516",
+      "name": "Ngelehun CHC",
+      "id": "DiszpKrYNg8",
+      "shortName": "Ngelehun CHC",
+      "displayName": "Ngelehun CHC",
+      "displayShortName": "Ngelehun CHC",
+      "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/DiszpKrYNg8",
+      "openingDate": "1968-01-01T00:00:00.000",
+      "parent": {
+        "id": "YuQRtpLP10I"
+      },
+      "programs": [
+        {
+          "id": "lxAQ7Zs9VYR"
+        },
+        {
+          "id": "IpHINAT79UW"
+        },
+        {
+          "id": "TpRIN3TE9UW"
+        }
+      ],
+      "dataSets": [
+        {
+          "id": "lyLU2wR22tC"
+        },
+        {
+          "id": "BfMAe6Itzgt"
+        }
+      ],
+      "organisationUnitGroups": [
+        {
+          "code": "CHC",
+          "lastUpdated": "2014-09-29T20:28:01.093",
+          "id": "CXw2yu5fodb",
+          "created": "2012-11-13T14:35:22.574",
+          "name": "CHC",
+          "shortName": "CHC short",
+          "symbol": "16.png",
+          "displayName": "CHC",
+          "publicAccess": "rw------",
+          "displayShortName": "CHC display short",
+          "externalAccess": false,
+          "featureType": "NONE",
+          "dimensionItem": "CXw2yu5fodb",
+          "favorite": false,
+          "dimensionItemType": "ORGANISATION_UNIT_GROUP",
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": false,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "user": {
+            "id": "GOLswS44mh8"
+          },
+          "favorites": [],
+          "translations": [],
+          "organisationUnits": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "groupSets": [
+            {
+              "id": "J5jldMd8OHv"
+            }
+          ],
+          "userAccesses": [],
+          "legendSets": []
+        }
+      ],
+      "ancestors": []
+    },
+    {
+      "code": "OU_167609",
+      "level": 4,
+      "created": "2012-02-17T15:54:39.987",
+      "lastUpdated": "2021-08-12T06:54:20.634",
+      "name": "Njandama MCHP",
+      "id": "g8upMTyEZGZ",
+      "shortName": "Njandama MCHP",
+      "displayName": "Njandama MCHP",
+      "displayShortName": "Njandama MCHP",
+      "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/g8upMTyEZGZ",
+      "openingDate": "2009-01-01T00:00:00.000",
+      "parent": {
+        "id": "YuQRtpLP10I"
+      },
+      "programs": [
+        {
+          "id": "IpHINAT79UW"
+        }
+      ],
+      "dataSets": [
+        {
+          "id": "lyLU2wR22tC"
+        },
+        {
+          "id": "BfMAe6Itzgt"
+        },
+        {
+          "id": "TaMAefItzgt"
+        }
+      ],
+      "organisationUnitGroups": [
+        {
+          "code": "CHC",
+          "lastUpdated": "2014-09-29T20:28:01.093",
+          "id": "CXw2yu5fodb",
+          "created": "2012-11-13T14:35:22.574",
+          "name": "CHC",
+          "shortName": "CHC short",
+          "symbol": "16.png",
+          "displayName": "CHC",
+          "publicAccess": "rw------",
+          "displayShortName": "CHC display short",
+          "externalAccess": false,
+          "featureType": "NONE",
+          "dimensionItem": "CXw2yu5fodb",
+          "favorite": false,
+          "dimensionItemType": "ORGANISATION_UNIT_GROUP",
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": false,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "user": {
+            "id": "GOLswS44mh8"
+          },
+          "favorites": [],
+          "translations": [],
+          "organisationUnits": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "groupSets": [
+            {
+              "id": "J5jldMd8OHv"
+            }
+          ],
+          "userAccesses": [],
+          "legendSets": []
+        }
+      ],
+      "ancestors": []
+    }
+  ]
+}

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program.json
@@ -20,7 +20,7 @@
   "enrollments": [],
   "programOwners": [
     {
-      "orgUnit": "SearchOnlyOrgUnit",
+      "orgUnit": "g8upMTyEZGZ",
       "trackedEntity": "PgmUFEQYZdt",
       "program": "lxAQ7Zs9VYR"
     }

--- a/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program_old.json
+++ b/core/src/sharedTest/resources/trackedentity/glass/glass_v42_tei_without_program_old.json
@@ -17,7 +17,7 @@
   "enrollments": [],
   "programOwners": [
     {
-      "ownerOrgUnit": "SearchOnlyOrgUnit",
+      "ownerOrgUnit": "g8upMTyEZGZ",
       "program": "lxAQ7Zs9VYR",
       "trackedEntityInstance": "PgmUFEQYZdt"
     }

--- a/core/src/sharedTest/resources/user/user38.json
+++ b/core/src/sharedTest/resources/user/user38.json
@@ -39,11 +39,16 @@
       "id": "Kk12LkEWtXp"
     }
   ],
-  "teiSearchOrganisationUnits": [],
-  "organisationUnits": [
+  "teiSearchOrganisationUnits": [
     {
       "id": "YuQRtpLP10I",
       "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I"
+    }
+  ],
+  "organisationUnits": [
+    {
+      "id": "DiszpKrYNg8",
+      "path": "/ImspTQPwCqd/O6uvpzGd5pu/YuQRtpLP10I/DiszpKrYNg8"
     }
   ]
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelperShould.kt
@@ -35,6 +35,7 @@ import org.hisp.dhis.android.core.program.AccessLevel
 import org.hisp.dhis.android.core.program.Program
 import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.trackedentity.ownership.OwnershipManagerImpl
+import org.hisp.dhis.android.core.trackedentity.ownership.ProgramOwnerStore
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.junit.Before
 import org.junit.Test
@@ -51,6 +52,7 @@ class TrackerImporterBreakTheGlassHelperShould {
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
     private val enrollmentStore: EnrollmentStore = mock()
     private val programStore: ProgramStore = mock()
+    private val programOwnerStore: ProgramOwnerStore = mock()
     private val ownershipManagerImpl: OwnershipManagerImpl = mock()
 
     private lateinit var helper: TrackerImporterBreakTheGlassHelper
@@ -65,6 +67,7 @@ class TrackerImporterBreakTheGlassHelperShould {
             userOrganisationUnitLinkStore,
             enrollmentStore,
             programStore,
+            programOwnerStore,
             ownershipManagerImpl,
         )
     }
@@ -72,7 +75,7 @@ class TrackerImporterBreakTheGlassHelperShould {
     @Test
     fun return_true_when_program_is_protected_and_orgunit_is_not_capture_scope() = runTest {
         mockProtectedProgram()
-        mockNotCaptureScope()
+        mockSearchScope()
 
         val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
 
@@ -92,7 +95,7 @@ class TrackerImporterBreakTheGlassHelperShould {
     @Test
     fun return_false_when_program_is_open_and_orgunit_is_not_capture_scope() = runTest {
         mockOpenProgram()
-        mockNotCaptureScope()
+        mockSearchScope()
 
         val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
 
@@ -135,7 +138,7 @@ class TrackerImporterBreakTheGlassHelperShould {
     @Test
     fun return_false_when_program_not_found() = runTest {
         whenever(programStore.selectByUid(programUid)).doReturn(null)
-        mockNotCaptureScope()
+        mockSearchScope()
 
         val result = helper.isProtectedInSearchScope(programUid, orgUnitUid)
 
@@ -164,9 +167,11 @@ class TrackerImporterBreakTheGlassHelperShould {
 
     private suspend fun mockCaptureScope() {
         whenever(userOrganisationUnitLinkStore.isCaptureScope(orgUnitUid)).doReturn(true)
+        whenever(userOrganisationUnitLinkStore.isSearchScope(orgUnitUid)).doReturn(true)
     }
 
-    private suspend fun mockNotCaptureScope() {
+    private suspend fun mockSearchScope() {
         whenever(userOrganisationUnitLinkStore.isCaptureScope(orgUnitUid)).doReturn(false)
+        whenever(userOrganisationUnitLinkStore.isSearchScope(orgUnitUid)).doReturn(true)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/User38Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/User38Should.kt
@@ -50,6 +50,7 @@ internal class User38Should : CoreObjectShould<UserDTO>("user/user38.json", User
         assertThat(user.email()).isEqualTo("john@hmail.com")
         assertThat(user.displayName()).isEqualTo("John Barnes")
         assertThat(user.userRoles()!![0].uid()).isEqualTo("Ufph3mGRmMo")
-        assertThat(user.organisationUnits()!![0].uid()).isEqualTo("YuQRtpLP10I")
+        assertThat(user.organisationUnits()!![0].uid()).isEqualTo("DiszpKrYNg8")
+        assertThat(user.teiSearchOrganisationUnits()!![0].uid()).isEqualTo("YuQRtpLP10I")
     }
 }


### PR DESCRIPTION
The verification to determine if a program-orgunit was protected by the glass was based on the orgunit NOT belonging to the capture scope. Before v1.14, this check will implicitly mean that the orgunit belongs to the search scope (otherwise, the orgunit wouldn't have been downloaded). But from v1.14, the database might contain orgunits that belong neither to the capture nor search scope.

Additionally, this PR creates search orgunits in the integration test sample data, which is required to test this scenario.

Also, it does some clean up in part of the logic.