### PR TITLE
chore: [ANDROSDK-2285] make OpenID prompt selector configurable

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11791,18 +11791,21 @@ public final class org/hisp/dhis/android/core/user/openid/IntentWithRequestCode 
 }
 
 public final class org/hisp/dhis/android/core/user/openid/OpenIDConnectConfig {
-	public fun <init> (Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Landroid/net/Uri;
 	public final fun component3 ()Landroid/net/Uri;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;Ljava/lang/String;Landroid/net/Uri;Landroid/net/Uri;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthorizationUri ()Ljava/lang/String;
 	public final fun getClientId ()Ljava/lang/String;
 	public final fun getDiscoveryUri ()Landroid/net/Uri;
+	public final fun getPrompt ()Ljava/lang/String;
 	public final fun getRedirectUri ()Landroid/net/Uri;
 	public final fun getTokenUrl ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectConfig.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectConfig.kt
@@ -36,4 +36,5 @@ data class OpenIDConnectConfig(
     val discoveryUri: Uri?,
     val authorizationUri: String?,
     val tokenUrl: String?,
+    val prompt: String? = null,
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectRequestHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectRequestHelper.kt
@@ -82,6 +82,6 @@ internal class OpenIDConnectRequestHelper(private val config: OpenIDConnectConfi
         config.redirectUri,
     ).apply {
         setScope("openid email profile")
-        setPrompt("select_account")
+        config.prompt?.let { setPrompt(it) }
     }.build()
 }

--- a/docs/content/developer/workflow.md
+++ b/docs/content/developer/workflow.md
@@ -83,10 +83,12 @@ Logout method removes user credentials, so a new login is required before any in
 The SDK includes support for OpenID. To perform a login using OpenID an OpenIDConnectConfig is required:
 
 ```java
-OpenIDConnectConfig openIdConfig = new OpenIDConnectConfig(clientId, redirectUri, discoveryUri, authorizationUrl, tokenUrl);
+OpenIDConnectConfig openIdConfig = new OpenIDConnectConfig(clientId, redirectUri, discoveryUri, authorizationUrl, tokenUrl, prompt);
 ```
 
 It is mandatory to either provide a discoveryUri or both authorizationUrl and tokenUrl.
+
+The `prompt` parameter is optional and, when provided, is forwarded to the OpenID provider as the `prompt` URL parameter (see the [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)). It accepts a space-separated list of values, e.g. `"login"`, `"select_account"` or `"login select_account"`. When set to `null` no prompt parameter is sent.
 
 This configuration can be used to perform a login.
 


### PR DESCRIPTION
 Makes the OpenID Connect `prompt` URL parameter configurable from the app that consumes the SDK, instead of the previously hardcoded `select_account`.                                                                                                                                                                                                                         

  - Add a nullable `prompt: String?` property to `OpenIDConnectConfig` (default `null`).
  - In `OpenIDConnectRequestHelper`, forward the configured `prompt` to `AuthorizationRequest.Builder.setPrompt()` only when it is non-null; no value is sent otherwise (no default prompt is applied by the SDK anymore).
  - The value is a free-text string that accepts a space-separated list of prompt values, as defined by the OpenID Connect Core 1.0 spec (e.g. `"login"`, `"select_account"`, `"login select_account"`, `"consent"`, ...).
  - Public API dump (`core/api/core.api`) and developer documentation (`docs/content/developer/workflow.md`) updated accordingly.

  Related task: [ANDROSDK-2285](https://dhis2.atlassian.net/browse/ANDROSDK-2285)

[ANDROSDK-2285]: https://dhis2.atlassian.net/browse/ANDROSDK-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ