### PR TITLE
chore: [ANDROSDK-2281] Add job to clean cache on PR closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
   checkout:
     name: Checkout
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || endsWith(github.ref, '-rc') }}
 
     steps:
       - name: Checkout code
@@ -63,7 +62,6 @@ jobs:
     name: Build APKs for Testing
     runs-on: ubuntu-latest
     needs: [checkout]
-    if: always() && !cancelled()
     timeout-minutes: 15
 
     steps:
@@ -97,7 +95,6 @@ jobs:
     name: Code Quality Checks
     runs-on: ubuntu-latest
     needs: [checkout]
-    if: always() && !cancelled()
     timeout-minutes: 15
 
     steps:
@@ -129,7 +126,6 @@ jobs:
     name: API Validation
     runs-on: ubuntu-latest
     needs: [checkout]
-    if: always() && !cancelled()
     timeout-minutes: 10
 
     steps:
@@ -160,7 +156,6 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: [checkout]
-    if: always() && !cancelled()
     timeout-minutes: 15
 
     steps:
@@ -203,7 +198,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [build-apks]
-    if: always() && !cancelled()
 
     steps:
       - name: Checkout code
@@ -253,7 +247,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [unit-tests, instrumented-tests]
-    if: always() && needs.instrumented-tests.result == 'success'
 
     steps:
       - name: Checkout code
@@ -359,7 +352,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [jacoco-report]
-    if: always() && !cancelled()
 
     steps:
       - name: Checkout code

--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup caches on closed PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
Changes:
- Add a workflow to clean up caches entries on closed pull requests.
- Remove unnecessary `if` conditions in jobs. The `checkout` job is executed in all the branches, including pull requests.