### PR TITLE
use same url login validation for loginConfig check

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/ServerUrlParser.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/ServerUrlParser.kt
@@ -36,19 +36,24 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 
 internal object ServerUrlParser {
     @JvmStatic
-    @Suppress("ThrowsCount")
     @Throws(D2Error::class)
-    fun parse(url: String?): Url {
+    fun validate(url: String?) {
         when {
             url.isNullOrBlank() -> throw nullOrBlankUrlD2Error()
             !url.startsWith("http") -> throw malformedUrlD2Error()
-            else -> try {
-                val urlBuilder = URLBuilder(removeTrailingApi(url))
-                urlBuilder.encodedPathSegments += "api/"
-                return urlBuilder.build()
-            } catch (_: URLParserException) {
-                throw malformedUrlD2Error()
-            }
+        }
+    }
+
+    @JvmStatic
+    @Throws(D2Error::class)
+    fun parse(url: String?): Url {
+        validate(url)
+        return try {
+            val urlBuilder = URLBuilder(removeTrailingApi(url!!))
+            urlBuilder.encodedPathSegments += "api/"
+            urlBuilder.build()
+        } catch (_: URLParserException) {
+            throw malformedUrlD2Error()
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
@@ -46,6 +46,12 @@ internal class LoginConfigCall(
     private val networkHandler: LoginConfigNetworkHandler,
 ) {
     suspend fun checkServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
+        try {
+            ServerUrlParser.validate(serverUrl)
+        } catch (d2Error: D2Error) {
+            return Result.Failure(d2Error)
+        }
+
         val sanitizedUrl = ServerUrlParser.trimAndRemoveTrailingSlash(serverUrl)!!
         val loginConfig = tryLoginConfig(sanitizedUrl)
 


### PR DESCRIPTION
ServerModule.checkServerUrl (used as a pre-login step to validate the URL the user types in) only applied basic string sanitization, while the actual login flow validates the URL strictly via ServerUrlParser.parse (rejects null/blank and non-http URLs). Because Ktor silently prepends a scheme when issuing requests, a malformed URL could pass checkServerUrl and only fail later at login, leaving the user without a clear error early on.

Changes:

  - Extracted the null/blank + http prefix checks from ServerUrlParser.parse into a new ServerUrlParser.validate(url) so the same rules can be reused without the URL-building logic that is only relevant for login.
  - LoginConfigCall.checkServerUrl now calls ServerUrlParser.validate upfront and returns Result.Failure(D2Error) (SERVER_URL_NULL / SERVER_URL_MALFORMED) when validation fails, matching the behavior of the login call.

Both URL-validation paths are now equivalent.

Related task: [ANDROSDK-2286](https://dhis2.atlassian.net/browse/ANDROSDK-2286)


[ANDROSDK-2286]: https://dhis2.atlassian.net/browse/ANDROSDK-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ