### PR TITLE
chore: [ANDROSDK-2296] fetch oauth config json and persist device enrollment endpoints

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9540,7 +9540,6 @@ public final class org/hisp/dhis/android/core/server/LoginConfig {
 	public final fun getUseCustomLogoFront ()Z
 	public fun hashCode ()I
 	public final fun isOauthEnabled ()Z
-	public final fun setOauthEnabled (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -9571,21 +9570,6 @@ public final class org/hisp/dhis/android/core/server/LoginPageLayout : java/lang
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/server/LoginPageLayout;
 	public static fun values ()[Lorg/hisp/dhis/android/core/server/LoginPageLayout;
-}
-
-public final class org/hisp/dhis/android/core/server/OauthConfig {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/server/OauthConfig;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/server/OauthConfig;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/server/OauthConfig;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
-	public final fun getJwksUri ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class org/hisp/dhis/android/core/server/ServerModule {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -12788,14 +12788,14 @@ public abstract interface class org/hisp/dhis/android/core/user/oauth2/OAuth2Han
 	public abstract fun blockingHandleLogInResponse (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
 	public abstract fun blockingLogIn (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Config;)Ljava/lang/String;
 	public abstract fun blockingLogOut ()V
-	public abstract fun changePin-gIAlu-s (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun changePin (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun isDeviceRegistered ()Z
 	public abstract fun isLoggedIn ()Z
 	public abstract fun logOutObservable ()Lio/reactivex/Observable;
 	public abstract fun resetRegistration ()V
 	public abstract fun rxLogOutObservable ()Lio/reactivex/Observable;
-	public abstract fun setPin-IoAF18A (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun setPin (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9540,6 +9540,7 @@ public final class org/hisp/dhis/android/core/server/LoginConfig {
 	public final fun getUseCustomLogoFront ()Z
 	public fun hashCode ()I
 	public final fun isOauthEnabled ()Z
+	public final fun setOauthEnabled (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -9570,6 +9571,21 @@ public final class org/hisp/dhis/android/core/server/LoginPageLayout : java/lang
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/server/LoginPageLayout;
 	public static fun values ()[Lorg/hisp/dhis/android/core/server/LoginPageLayout;
+}
+
+public final class org/hisp/dhis/android/core/server/OauthConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/server/OauthConfig;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/server/OauthConfig;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/server/OauthConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getJwksUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class org/hisp/dhis/android/core/server/ServerModule {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -12784,19 +12784,26 @@ public final class org/hisp/dhis/android/core/user/oauth2/OAuth2Config$Companion
 
 public abstract interface class org/hisp/dhis/android/core/user/oauth2/OAuth2Handler {
 	public abstract fun blockingBuildEnrollmentUrl (Ljava/lang/String;)Ljava/lang/String;
+	public fun blockingChangePin (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun blockingHandleEnrollmentResponse (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun blockingHandleLogInResponse (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
 	public abstract fun blockingLogIn (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Config;)Ljava/lang/String;
 	public abstract fun blockingLogOut ()V
-	public abstract fun changePin (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
+	public fun blockingSetPin (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun isDeviceRegistered ()Z
 	public abstract fun isLoggedIn ()Z
 	public abstract fun logOutObservable ()Lio/reactivex/Observable;
 	public abstract fun resetRegistration ()V
 	public abstract fun rxLogOutObservable ()Lio/reactivex/Observable;
-	public abstract fun setPin (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
+	public abstract fun suspendChangePin (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun suspendLogOut (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendSetPin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/user/oauth2/OAuth2Handler$DefaultImpls {
+	public static fun blockingChangePin (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Handler;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
+	public static fun blockingSetPin (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Handler;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 }
 
 public final class org/hisp/dhis/android/core/user/oauth2/OAuth2State {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/server/ServerCheckCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/server/ServerCheckCallMockIntegrationShould.kt
@@ -29,6 +29,7 @@
 package org.hisp.dhis.android.core.server
 
 import com.google.common.truth.Truth.assertThat
+import io.ktor.http.HttpStatusCode
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTest
 import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestDatabaseContent
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
@@ -42,6 +43,7 @@ class ServerCheckCallMockIntegrationShould : BaseMockIntegrationTest() {
     fun setUp() {
         setUpClass(MockIntegrationTestDatabaseContent.EmptyEnqueable)
         dhis2MockServer.enqueueMockResponse(LOGIN_CONFIG_JSON)
+        dhis2MockServer.enqueueMockResponse(HttpStatusCode.NotFound.value)
     }
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/server/LoginConfig.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/LoginConfig.kt
@@ -49,14 +49,9 @@ data class LoginConfig(
     val useCustomLogoFront: Boolean = false,
     val oidcProviders: List<LoginOidcProvider> = emptyList(),
 ) {
-    fun isOauthEnabled(): Boolean {
-        return OAUTH_ENABLED
-    }
+    var isOauthEnabled: Boolean = false
 
     internal companion object {
-        // return false for SDK release 1.14.0 to prevent issues until fully implemented
-        private const val OAUTH_ENABLED = false
-
         fun createDefault(serverUrl: String): LoginConfig {
             return LoginConfig(
                 applicationTitle = serverUrl,

--- a/core/src/main/java/org/hisp/dhis/android/core/server/LoginConfig.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/LoginConfig.kt
@@ -50,6 +50,7 @@ data class LoginConfig(
     val oidcProviders: List<LoginOidcProvider> = emptyList(),
 ) {
     var isOauthEnabled: Boolean = false
+        internal set
 
     internal companion object {
         fun createDefault(serverUrl: String): LoginConfig {

--- a/core/src/main/java/org/hisp/dhis/android/core/server/OauthConfig.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/OauthConfig.kt
@@ -25,45 +25,9 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.network.loginconfig
+package org.hisp.dhis.android.core.server
 
-import org.hisp.dhis.android.core.arch.api.HttpServiceClient
-import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
-import org.hisp.dhis.android.core.server.LoginConfig
-import org.hisp.dhis.android.core.server.OauthConfig
-import org.hisp.dhis.android.core.server.internal.LoginConfigNetworkHandler
-import org.koin.core.annotation.Singleton
-
-@Singleton
-internal class LoginConfigNetworkHandlerImpl(
-    httpClient: HttpServiceClient,
-    private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
-) : LoginConfigNetworkHandler {
-    private val service: LoginConfigService = LoginConfigService(httpClient)
-
-    override suspend fun loginConfigFor(serverUrl: String): LoginConfig {
-        val loginConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getLoginConfigFor(serverUrl)
-        }.getOrThrow()
-
-        return loginConfigDTO.toDomain()
-    }
-
-    override suspend fun loginConfig(): LoginConfig {
-        val loginConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getLoginConfig()
-        }.getOrThrow()
-
-        return loginConfigDTO.toDomain()
-    }
-
-    override suspend fun oauthConfigFor(
-        serverUrl: String,
-        oauthInfoPath: String
-    ): OauthConfig {
-        val oauthConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getOauthConfigFor(serverUrl, oauthInfoPath)
-        }.getOrThrow()
-        return oauthConfigDTO.toDomain()
-    }
-}
+data class OauthConfig(
+    val authorizationEndpoint: String? = null,
+    val jwksUri: String? = null,
+)

--- a/core/src/main/java/org/hisp/dhis/android/core/server/OauthConfig.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/OauthConfig.kt
@@ -27,7 +27,22 @@
  */
 package org.hisp.dhis.android.core.server
 
-data class OauthConfig(
+internal data class OauthConfig(
     val authorizationEndpoint: String? = null,
     val jwksUri: String? = null,
-)
+    val codeChallengeMethodsSupported: List<String> = emptyList(),
+    val grantTypesSupported: List<String> = emptyList(),
+    val responseTypesSupported: List<String> = emptyList(),
+) {
+    fun supportsRequiredFunctions(): Boolean {
+        return codeChallengeMethodsSupported.contains(REQUIRED_CODE_CHALLENGE_METHOD) &&
+            grantTypesSupported.containsAll(REQUIRED_GRANT_TYPES) &&
+            responseTypesSupported.contains(REQUIRED_RESPONSE_TYPE)
+    }
+
+    companion object {
+        const val REQUIRED_CODE_CHALLENGE_METHOD = "S256"
+        const val REQUIRED_RESPONSE_TYPE = "code"
+        val REQUIRED_GRANT_TYPES = listOf("authorization_code", "refresh_token")
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
@@ -34,8 +34,10 @@ import org.hisp.dhis.android.core.configuration.internal.ServerUrlParser
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.server.LoginConfig
+import org.hisp.dhis.android.core.server.OauthConfig
 import org.hisp.dhis.android.core.systeminfo.internal.PingNetworkHandler
 import org.hisp.dhis.android.core.user.internal.LogInExceptions
+import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -44,15 +46,34 @@ internal class LoginConfigCall(
     private val loginExceptions: LogInExceptions,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     private val networkHandler: LoginConfigNetworkHandler,
+    private val oAuth2SecureStore: OAuth2SecureStore,
 ) {
     suspend fun checkServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
         val sanitizedUrl = ServerUrlParser.trimAndRemoveTrailingSlash(serverUrl)!!
         val loginConfig = tryLoginConfig(sanitizedUrl)
 
         return when (loginConfig) {
-            is Result.Success<LoginConfig, D2Error> -> loginConfig
+            is Result.Success<LoginConfig, D2Error> ->
+                Result.Success(withOauthConfig(sanitizedUrl, loginConfig.value))
             is Result.Failure<LoginConfig, D2Error> -> tryPing(sanitizedUrl)
         }
+    }
+
+    private suspend fun withOauthConfig(serverUrl: String, loginConfig: LoginConfig): LoginConfig {
+        val oauthConfig = tryFetchOauthConfig(serverUrl)
+        return if (oauthConfig != null) {
+            oAuth2SecureStore.setEndpoints(oauthConfig)
+            loginConfig.apply { isOauthEnabled = true }
+        } else {
+            oAuth2SecureStore.clearEndpoints()
+            loginConfig.apply { isOauthEnabled = false }
+        }
+    }
+
+    private suspend fun tryFetchOauthConfig(serverUrl: String): OauthConfig? {
+        return coroutineAPICallExecutor.wrap(storeError = false) {
+            networkHandler.oauthConfigFor(serverUrl)
+        }.getOrNull()
     }
 
     private suspend fun tryLoginConfig(serverUrl: String): Result<LoginConfig, D2Error> {

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
@@ -61,7 +61,7 @@ internal class LoginConfigCall(
 
     private suspend fun withOauthConfig(serverUrl: String, loginConfig: LoginConfig): LoginConfig {
         val oauthConfig = tryFetchOauthConfig(serverUrl)
-        return if (oauthConfig != null) {
+        return if (oauthConfig != null && oauthConfig.supportsRequiredFunctions()) {
             oAuth2SecureStore.setEndpoints(oauthConfig)
             loginConfig.apply { isOauthEnabled = true }
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigDownloader.kt
@@ -28,6 +28,7 @@
 
 package org.hisp.dhis.android.core.server.internal
 
+import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.modules.internal.UntypedModuleDownloaderCoroutines
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.configuration.internal.DatabaseConfigurationInsecureStore
@@ -42,6 +43,7 @@ internal class LoginConfigDownloader(
     private val networkHandler: LoginConfigNetworkHandler,
     private val credentialsSecureStore: CredentialsSecureStore,
     private val databaseConfigurationSecureStore: DatabaseConfigurationInsecureStore,
+    private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
 ) : UntypedModuleDownloaderCoroutines {
     override suspend fun downloadMetadata() {
         val serverUrl =
@@ -49,7 +51,7 @@ internal class LoginConfigDownloader(
 
         val loginConfig =
             if (dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_41)) {
-                networkHandler.loginConfig()
+                coroutineAPICallExecutor.wrap { networkHandler.loginConfig() }.getOrThrow()
             } else {
                 LoginConfig.createDefault(serverUrl)
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigNetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigNetworkHandler.kt
@@ -29,8 +29,13 @@
 package org.hisp.dhis.android.core.server.internal
 
 import org.hisp.dhis.android.core.server.LoginConfig
+import org.hisp.dhis.android.core.server.OauthConfig
 
 internal interface LoginConfigNetworkHandler {
     suspend fun loginConfigFor(serverUrl: String): LoginConfig
     suspend fun loginConfig(): LoginConfig
+    suspend fun oauthConfigFor(
+        serverUrl: String,
+        oauthInfoPath: String = "/.well-known/oauth-authorization-server#/"
+    ): OauthConfig
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigNetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigNetworkHandler.kt
@@ -36,6 +36,6 @@ internal interface LoginConfigNetworkHandler {
     suspend fun loginConfig(): LoginConfig
     suspend fun oauthConfigFor(
         serverUrl: String,
-        oauthInfoPath: String = "/.well-known/oauth-authorization-server#/"
+        oauthInfoPath: String = "/.well-known/oauth-authorization-server#/",
     ): OauthConfig
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInExceptions.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInExceptions.kt
@@ -95,4 +95,36 @@ internal class LogInExceptions internal constructor(
             .errorComponent(D2ErrorComponent.SDK)
             .build()
     }
+
+    fun noActiveSessionError(): D2Error {
+        return D2Error.builder()
+            .errorCode(D2ErrorCode.NO_AUTHENTICATED_USER)
+            .errorDescription("No active session")
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
+    }
+
+    fun pinRequiresOAuth2AccountError(): D2Error {
+        return D2Error.builder()
+            .errorCode(D2ErrorCode.INVALID_CONFIGURATION)
+            .errorDescription("PIN can only be set for OAuth2 accounts")
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
+    }
+
+    fun noAuthenticatedUserPersistedError(): D2Error {
+        return D2Error.builder()
+            .errorCode(D2ErrorCode.NO_AUTHENTICATED_USER)
+            .errorDescription("No authenticated user persisted")
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
+    }
+
+    fun incorrectPinError(): D2Error {
+        return D2Error.builder()
+            .errorCode(D2ErrorCode.BAD_CREDENTIALS)
+            .errorDescription("Current PIN is incorrect")
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.user.oauth2
 
 import io.reactivex.Observable
+import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.User
@@ -49,9 +50,14 @@ interface OAuth2Handler {
 
     fun getClientId(): String?
 
-    fun setPin(pin: String): Result<Unit, D2Error>
+    suspend fun suspendSetPin(pin: String): Result<Unit, D2Error>
 
-    fun changePin(currentPin: String, newPin: String): Result<Unit, D2Error>
+    fun blockingSetPin(pin: String): Result<Unit, D2Error> = runBlocking { suspendSetPin(pin) }
+
+    suspend fun suspendChangePin(currentPin: String, newPin: String): Result<Unit, D2Error>
+
+    fun blockingChangePin(currentPin: String, newPin: String): Result<Unit, D2Error> =
+        runBlocking { suspendChangePin(currentPin, newPin) }
 
     fun blockingLogOut()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
@@ -28,6 +28,8 @@
 package org.hisp.dhis.android.core.user.oauth2
 
 import io.reactivex.Observable
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.User
 
 @Suppress("TooManyFunctions")
@@ -47,9 +49,9 @@ interface OAuth2Handler {
 
     fun getClientId(): String?
 
-    fun setPin(pin: String): Result<Unit>
+    fun setPin(pin: String): Result<Unit, D2Error>
 
-    fun changePin(currentPin: String, newPin: String): Result<Unit>
+    fun changePin(currentPin: String, newPin: String): Result<Unit, D2Error>
 
     fun blockingLogOut()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -199,31 +199,34 @@ internal class OAuth2HandlerImpl(
 
     override fun setPin(pin: String): Result<Unit, D2Error> {
         val credentials = credentialsSecureStore.get()
-            ?: return Result.Failure(logInExceptions.noActiveSessionError())
-        if (credentials.oauth2State == null) {
-            return Result.Failure(logInExceptions.pinRequiresOAuth2AccountError())
-        }
-
-        val updated = credentials.copy(password = pin)
-        credentialsSecureStore.set(updated)
-
-        return runBlocking {
-            val existing = authenticatedUserStore.selectFirst()
-                ?: return@runBlocking Result.Failure(logInExceptions.noAuthenticatedUserPersistedError())
-            authenticatedUserStore.updateOrInsertWhere(
-                existing.toBuilder().hash(updated.getHash()).build(),
-            )
-            Result.Success(Unit)
+        return when {
+            credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
+            credentials.oauth2State == null -> Result.Failure(logInExceptions.pinRequiresOAuth2AccountError())
+            else -> {
+                val updated = credentials.copy(password = pin)
+                credentialsSecureStore.set(updated)
+                runBlocking {
+                    val existing = authenticatedUserStore.selectFirst()
+                    if (existing == null) {
+                        Result.Failure(logInExceptions.noAuthenticatedUserPersistedError())
+                    } else {
+                        authenticatedUserStore.updateOrInsertWhere(
+                            existing.toBuilder().hash(updated.getHash()).build(),
+                        )
+                        Result.Success(Unit)
+                    }
+                }
+            }
         }
     }
 
     override fun changePin(currentPin: String, newPin: String): Result<Unit, D2Error> {
         val credentials = credentialsSecureStore.get()
-            ?: return Result.Failure(logInExceptions.noActiveSessionError())
-        if (credentials.password != currentPin) {
-            return Result.Failure(logInExceptions.incorrectPinError())
+        return when {
+            credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
+            credentials.password != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
+            else -> setPin(newPin)
         }
-        return setPin(newPin)
     }
 
     override fun blockingLogOut() {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -32,9 +32,11 @@ import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.configuration.internal.ServerUrlNormalizer
+import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.internal.AuthenticatedUserStore
 import org.hisp.dhis.android.core.user.internal.LogInCall
+import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.hisp.dhis.android.core.user.oauth2.OAuth2Config
 import org.hisp.dhis.android.core.user.oauth2.OAuth2Handler
 import org.hisp.dhis.android.core.user.oauth2.internal.jwt.JWTHelper
@@ -53,6 +55,7 @@ internal class OAuth2HandlerImpl(
     private val oauth2StateSecureStore: OAuth2StateSecureStore,
     private val credentialsSecureStore: CredentialsSecureStore,
     private val authenticatedUserStore: AuthenticatedUserStore,
+    private val logInExceptions: LogInExceptions,
 ) : OAuth2Handler {
 
     private suspend fun buildEnrollmentUrlInternal(serverUrl: String): String {
@@ -194,28 +197,33 @@ internal class OAuth2HandlerImpl(
         return credentialsSecureStore.get()?.oauth2State?.clientId
     }
 
-    override fun setPin(pin: String): kotlin.Result<Unit> = kotlin.runCatching {
+    override fun setPin(pin: String): Result<Unit, D2Error> {
         val credentials = credentialsSecureStore.get()
-            ?: error("PIN cannot be set: no active session")
-        check(credentials.oauth2State != null) { "PIN can only be set for OAuth2 accounts" }
+            ?: return Result.Failure(logInExceptions.noActiveSessionError())
+        if (credentials.oauth2State == null) {
+            return Result.Failure(logInExceptions.pinRequiresOAuth2AccountError())
+        }
 
         val updated = credentials.copy(password = pin)
         credentialsSecureStore.set(updated)
 
-        runBlocking {
+        return runBlocking {
             val existing = authenticatedUserStore.selectFirst()
-                ?: error("PIN cannot be set: no authenticated user persisted")
+                ?: return@runBlocking Result.Failure(logInExceptions.noAuthenticatedUserPersistedError())
             authenticatedUserStore.updateOrInsertWhere(
                 existing.toBuilder().hash(updated.getHash()).build(),
             )
+            Result.Success(Unit)
         }
     }
 
-    override fun changePin(currentPin: String, newPin: String): kotlin.Result<Unit> = kotlin.runCatching {
+    override fun changePin(currentPin: String, newPin: String): Result<Unit, D2Error> {
         val credentials = credentialsSecureStore.get()
-            ?: error("PIN cannot be changed: no active session")
-        require(credentials.password == currentPin) { "Current PIN is incorrect" }
-        setPin(newPin).getOrThrow()
+            ?: return Result.Failure(logInExceptions.noActiveSessionError())
+        if (credentials.password != currentPin) {
+            return Result.Failure(logInExceptions.incorrectPinError())
+        }
+        return setPin(newPin)
     }
 
     override fun blockingLogOut() {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -197,7 +197,7 @@ internal class OAuth2HandlerImpl(
         return credentialsSecureStore.get()?.oauth2State?.clientId
     }
 
-    override fun setPin(pin: String): Result<Unit, D2Error> {
+    override suspend fun suspendSetPin(pin: String): Result<Unit, D2Error> {
         val credentials = credentialsSecureStore.get()
         return when {
             credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
@@ -205,27 +205,25 @@ internal class OAuth2HandlerImpl(
             else -> {
                 val updated = credentials.copy(password = pin)
                 credentialsSecureStore.set(updated)
-                runBlocking {
-                    val existing = authenticatedUserStore.selectFirst()
-                    if (existing == null) {
-                        Result.Failure(logInExceptions.noAuthenticatedUserPersistedError())
-                    } else {
-                        authenticatedUserStore.updateOrInsertWhere(
-                            existing.toBuilder().hash(updated.getHash()).build(),
-                        )
-                        Result.Success(Unit)
-                    }
+                val existing = authenticatedUserStore.selectFirst()
+                if (existing == null) {
+                    Result.Failure(logInExceptions.noAuthenticatedUserPersistedError())
+                } else {
+                    authenticatedUserStore.updateOrInsertWhere(
+                        existing.toBuilder().hash(updated.getHash()).build(),
+                    )
+                    Result.Success(Unit)
                 }
             }
         }
     }
 
-    override fun changePin(currentPin: String, newPin: String): Result<Unit, D2Error> {
+    override suspend fun suspendChangePin(currentPin: String, newPin: String): Result<Unit, D2Error> {
         val credentials = credentialsSecureStore.get()
         return when {
             credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
             credentials.password != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
-            else -> setPin(newPin)
+            else -> suspendSetPin(newPin)
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2SecureStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2SecureStore.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.user.oauth2.internal
 
 import org.hisp.dhis.android.core.arch.storage.internal.SecureStore
+import org.hisp.dhis.android.core.server.OauthConfig
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -62,6 +63,24 @@ internal class OAuth2SecureStore(
         get() = secureStore.getData(KEY_TEMP_CODE_VERIFIER)
         set(value) = secureStore.setData(KEY_TEMP_CODE_VERIFIER, value)
 
+    var authorizationEndpoint: String?
+        get() = secureStore.getData(KEY_AUTHORIZATION_ENDPOINT)
+        set(value) = secureStore.setData(KEY_AUTHORIZATION_ENDPOINT, value)
+
+    var jwksUri: String?
+        get() = secureStore.getData(KEY_JWKS_URI)
+        set(value) = secureStore.setData(KEY_JWKS_URI, value)
+
+    fun setEndpoints(config: OauthConfig) {
+        authorizationEndpoint = config.authorizationEndpoint
+        jwksUri = config.jwksUri
+    }
+
+    fun clearEndpoints() {
+        authorizationEndpoint = null
+        jwksUri = null
+    }
+
     fun clearRegistration() {
         clientId = null
         keyId = null
@@ -78,6 +97,7 @@ internal class OAuth2SecureStore(
     fun clearAll() {
         clearRegistration()
         clearTemporaryData()
+        clearEndpoints()
     }
 
     companion object {
@@ -88,5 +108,7 @@ internal class OAuth2SecureStore(
         private const val KEY_REGISTRATION_DATE = "oauth2_registration_date"
         private const val KEY_TEMP_STATE = "oauth2_temp_state"
         private const val KEY_TEMP_CODE_VERIFIER = "oauth2_temp_code_verifier"
+        private const val KEY_AUTHORIZATION_ENDPOINT = "oauth2_authorization_endpoint"
+        private const val KEY_JWKS_URI = "oauth2_jwks_uri"
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2StateSecureStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2StateSecureStore.kt
@@ -63,7 +63,7 @@ internal class OAuth2StateSecureStore(
     companion object {
         private const val KEY_PREFIX = "oauth2_state_"
         private const val HASH_ALGORITHM = "SHA-256"
-        private const val HASH_BYTE_COUNT = 4
+        private const val HASH_BYTE_COUNT = 8
         private const val HEX_STRING_WIDTH = 2
         private const val HEX_RADIX = 16
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigNetworkHandlerImpl.kt
@@ -59,7 +59,7 @@ internal class LoginConfigNetworkHandlerImpl(
 
     override suspend fun oauthConfigFor(
         serverUrl: String,
-        oauthInfoPath: String
+        oauthInfoPath: String,
     ): OauthConfig {
         val oauthConfigDTO = coroutineAPICallExecutor.wrap {
             service.getOauthConfigFor(serverUrl, oauthInfoPath)

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigNetworkHandlerImpl.kt
@@ -50,9 +50,7 @@ internal class LoginConfigNetworkHandlerImpl(
     }
 
     override suspend fun loginConfig(): LoginConfig {
-        val loginConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getLoginConfig()
-        }.getOrThrow()
+        val loginConfigDTO = service.getLoginConfig()
 
         return loginConfigDTO.toDomain()
     }
@@ -61,9 +59,6 @@ internal class LoginConfigNetworkHandlerImpl(
         serverUrl: String,
         oauthInfoPath: String,
     ): OauthConfig {
-        val oauthConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getOauthConfigFor(serverUrl, oauthInfoPath)
-        }.getOrThrow()
-        return oauthConfigDTO.toDomain()
+        return service.getOauthConfigFor(serverUrl, oauthInfoPath).toDomain()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigService.kt
@@ -45,6 +45,18 @@ internal class LoginConfigService(private val client: HttpServiceClient) {
         }
     }
 
+    suspend fun getOauthConfigFor(serverUrl: String, oauthPath: String): OauthConfigDTO {
+        return client.get {
+            val oauthConfigUrl = if (oauthPath.startsWith("http")) {
+                oauthPath
+            } else {
+                serverUrl.dropLastWhile { it == '/' } + "/" + oauthPath.dropWhile { it == '/' }
+            }
+            absoluteUrl(oauthConfigUrl)
+            excludeCredentials()
+        }
+    }
+
     companion object {
         const val LOGIN_CONFIG = "loginConfig"
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/OauthConfigDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/OauthConfigDTO.kt
@@ -25,45 +25,22 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package org.hisp.dhis.android.network.loginconfig
 
-import org.hisp.dhis.android.core.arch.api.HttpServiceClient
-import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
-import org.hisp.dhis.android.core.server.LoginConfig
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import org.hisp.dhis.android.core.server.OauthConfig
-import org.hisp.dhis.android.core.server.internal.LoginConfigNetworkHandler
-import org.koin.core.annotation.Singleton
 
-@Singleton
-internal class LoginConfigNetworkHandlerImpl(
-    httpClient: HttpServiceClient,
-    private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
-) : LoginConfigNetworkHandler {
-    private val service: LoginConfigService = LoginConfigService(httpClient)
-
-    override suspend fun loginConfigFor(serverUrl: String): LoginConfig {
-        val loginConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getLoginConfigFor(serverUrl)
-        }.getOrThrow()
-
-        return loginConfigDTO.toDomain()
-    }
-
-    override suspend fun loginConfig(): LoginConfig {
-        val loginConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getLoginConfig()
-        }.getOrThrow()
-
-        return loginConfigDTO.toDomain()
-    }
-
-    override suspend fun oauthConfigFor(
-        serverUrl: String,
-        oauthInfoPath: String
-    ): OauthConfig {
-        val oauthConfigDTO = coroutineAPICallExecutor.wrap {
-            service.getOauthConfigFor(serverUrl, oauthInfoPath)
-        }.getOrThrow()
-        return oauthConfigDTO.toDomain()
+@Serializable
+internal data class OauthConfigDTO(
+    @SerialName("authorization_endpoint") val authorizationEndpoint: String?,
+    @SerialName("jwks_uri") val jwksUri: String?,
+) {
+    fun toDomain(): OauthConfig {
+        return OauthConfig(
+            authorizationEndpoint = authorizationEndpoint,
+            jwksUri = jwksUri,
+        )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/OauthConfigDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/OauthConfigDTO.kt
@@ -36,11 +36,17 @@ import org.hisp.dhis.android.core.server.OauthConfig
 internal data class OauthConfigDTO(
     @SerialName("authorization_endpoint") val authorizationEndpoint: String?,
     @SerialName("jwks_uri") val jwksUri: String?,
+    @SerialName("code_challenge_methods_supported") val codeChallengeMethodsSupported: List<String> = emptyList(),
+    @SerialName("grant_types_supported") val grantTypesSupported: List<String> = emptyList(),
+    @SerialName("response_types_supported") val responseTypesSupported: List<String> = emptyList(),
 ) {
     fun toDomain(): OauthConfig {
         return OauthConfig(
             authorizationEndpoint = authorizationEndpoint,
             jwksUri = jwksUri,
+            codeChallengeMethodsSupported = codeChallengeMethodsSupported,
+            grantTypesSupported = grantTypesSupported,
+            responseTypesSupported = responseTypesSupported,
         )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/DCRNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/DCRNetworkHandlerImpl.kt
@@ -35,12 +35,14 @@ import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.oauth2.OAuth2Config
 import org.hisp.dhis.android.core.user.oauth2.internal.DCRNetworkHandler
+import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class DCRNetworkHandlerImpl(
     httpClient: HttpServiceClient,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
+    private val oAuth2SecureStore: OAuth2SecureStore,
 ) : DCRNetworkHandler {
 
     private val service = DCRService(httpClient)
@@ -71,6 +73,8 @@ internal class DCRNetworkHandlerImpl(
         scope: String,
         jwks: String,
     ): Result<String, D2Error> {
+        val jwksUri = oAuth2SecureStore.jwksUri
+            ?: error("jwks_uri not configured. checkServerUrl must run before client registration.")
         return coroutineAPICallExecutor.wrap(storeError = false) {
             val request = ClientRegistrationRequestDTO(
                 clientName = clientName,
@@ -80,7 +84,7 @@ internal class DCRNetworkHandlerImpl(
                 tokenEndpointAuthMethod = "private_key_jwt",
                 tokenEndpointAuthSigningAlg = "RS256",
                 scope = scope,
-                jwksUri = "https://dhis2.org/jwks.json",
+                jwksUri = jwksUri,
                 jwks = json.parseToJsonElement(jwks),
             )
 

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2NetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2NetworkHandlerImpl.kt
@@ -32,6 +32,8 @@ import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.server.OauthConfig.Companion.REQUIRED_CODE_CHALLENGE_METHOD
+import org.hisp.dhis.android.core.server.OauthConfig.Companion.REQUIRED_RESPONSE_TYPE
 import org.hisp.dhis.android.core.user.oauth2.OAuth2Config
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2NetworkHandler
@@ -59,11 +61,11 @@ internal class OAuth2NetworkHandlerImpl(
         return Uri.parse(authorizationEndpoint).buildUpon()
             .appendQueryParameter("client_id", clientId)
             .appendQueryParameter("redirect_uri", OAuth2Config.DEFAULT_REDIRECT_URI)
-            .appendQueryParameter("response_type", "code")
+            .appendQueryParameter("response_type", REQUIRED_RESPONSE_TYPE)
             .appendQueryParameter("scope", scope)
             .appendQueryParameter("state", state)
             .appendQueryParameter("code_challenge", codeChallenge)
-            .appendQueryParameter("code_challenge_method", "S256")
+            .appendQueryParameter("code_challenge_method", REQUIRED_CODE_CHALLENGE_METHOD)
             .build()
             .toString()
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2NetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2NetworkHandlerImpl.kt
@@ -35,12 +35,14 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.oauth2.OAuth2Config
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2NetworkHandler
+import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class OAuth2NetworkHandlerImpl(
     httpClient: HttpServiceClient,
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
+    private val oAuth2SecureStore: OAuth2SecureStore,
 ) : OAuth2NetworkHandler {
 
     private val service = OAuth2Service(httpClient)
@@ -52,7 +54,9 @@ internal class OAuth2NetworkHandlerImpl(
         codeChallenge: String,
         scope: String,
     ): String {
-        return Uri.parse("$serverUrl/oauth2/authorize").buildUpon()
+        val authorizationEndpoint = oAuth2SecureStore.authorizationEndpoint
+            ?: error("Authorization endpoint not configured. checkServerUrl must run before OAuth login.")
+        return Uri.parse(authorizationEndpoint).buildUpon()
             .appendQueryParameter("client_id", clientId)
             .appendQueryParameter("redirect_uri", OAuth2Config.DEFAULT_REDIRECT_URI)
             .appendQueryParameter("response_type", "code")

--- a/core/src/test/java/org/hisp/dhis/android/core/server/LoginConfigShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/LoginConfigShould.kt
@@ -113,7 +113,7 @@ internal class LoginConfigShould : CoreObjectShould<LoginConfigDTO>(
                 false,
             ),
         ).forEach { (config, oauthEnabled) ->
-            assertThat(config.isOauthEnabled()).isEqualTo(oauthEnabled)
+            assertThat(config.isOauthEnabled).isEqualTo(oauthEnabled)
         }
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.server.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutorMock
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.arch.storage.internal.InMemorySecureStore
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.server.LoginConfig
+import org.hisp.dhis.android.core.server.OauthConfig
+import org.hisp.dhis.android.core.systeminfo.internal.PingNetworkHandler
+import org.hisp.dhis.android.core.user.internal.LogInExceptions
+import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verifyBlocking
+
+@RunWith(JUnit4::class)
+class LoginConfigCallShould {
+
+    private val pingNetworkHandler: PingNetworkHandler = mock()
+    private val loginExceptions: LogInExceptions = mock()
+    private val networkHandler: LoginConfigNetworkHandler = mock()
+    private val oauth2SecureStore = OAuth2SecureStore(InMemorySecureStore())
+    private val executor = CoroutineAPICallExecutorMock()
+
+    private lateinit var call: LoginConfigCall
+
+    @Before
+    fun setUp() {
+        call = LoginConfigCall(
+            pingNetworkHandler,
+            loginExceptions,
+            executor,
+            networkHandler,
+            oauth2SecureStore,
+        )
+    }
+
+    @Test
+    fun marks_oauth_enabled_and_persists_endpoints_when_oauth_config_is_available() = runTest {
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample()
+            onBlocking { oauthConfigFor(any(), any()) } doReturn oauthConfigSample()
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
+        assertThat(loginConfig.isOauthEnabled).isTrue()
+        assertThat(oauth2SecureStore.authorizationEndpoint).isEqualTo(AUTHORIZATION_ENDPOINT)
+        assertThat(oauth2SecureStore.jwksUri).isEqualTo(JWKS_URI)
+    }
+
+    @Test
+    fun marks_oauth_disabled_and_clears_endpoints_when_oauth_config_fetch_fails() = runTest {
+        oauth2SecureStore.authorizationEndpoint = "stale-auth"
+        oauth2SecureStore.jwksUri = "stale-jwks"
+
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample()
+            onBlocking { oauthConfigFor(any(), any()) } doAnswer { throw serverError() }
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
+        assertThat(loginConfig.isOauthEnabled).isFalse()
+        assertThat(oauth2SecureStore.authorizationEndpoint).isNull()
+        assertThat(oauth2SecureStore.jwksUri).isNull()
+    }
+
+    @Test
+    fun falls_back_to_ping_without_touching_oauth_store_when_login_config_fails() = runTest {
+        oauth2SecureStore.authorizationEndpoint = "kept-auth"
+        oauth2SecureStore.jwksUri = "kept-jwks"
+
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doAnswer { throw serverError() }
+        }
+        pingNetworkHandler.stub {
+            onBlocking { getPingFor(NORMALIZED_URL) } doReturn mock()
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        verifyBlocking(networkHandler, never()) { oauthConfigFor(any(), any()) }
+        // Pre-existing endpoint state is preserved: the OAuth store is only mutated
+        // along the loginConfig-success branch.
+        assertThat(oauth2SecureStore.authorizationEndpoint).isEqualTo("kept-auth")
+        assertThat(oauth2SecureStore.jwksUri).isEqualTo("kept-jwks")
+    }
+
+    private fun loginConfigSample(): LoginConfig =
+        LoginConfig(applicationTitle = "Demo")
+
+    private fun oauthConfigSample(): OauthConfig =
+        OauthConfig(
+            authorizationEndpoint = AUTHORIZATION_ENDPOINT,
+            jwksUri = JWKS_URI,
+        )
+
+    private fun serverError(): D2Error =
+        D2Error.builder()
+            .errorCode(D2ErrorCode.UNEXPECTED)
+            .errorDescription("test failure")
+            .errorComponent(D2ErrorComponent.Server)
+            .build()
+
+    companion object {
+        private const val NORMALIZED_URL = "https://server.com"
+        private const val AUTHORIZATION_ENDPOINT = "https://server.com/oauth2/authorize"
+        private const val JWKS_URI = "https://server.com/.well-known/jwks.json"
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
@@ -110,6 +110,25 @@ class LoginConfigCallShould {
     }
 
     @Test
+    fun marks_oauth_disabled_and_clears_endpoints_when_oauth_config_does_not_support_required_functions() = runTest {
+        oauth2SecureStore.authorizationEndpoint = "stale-auth"
+        oauth2SecureStore.jwksUri = "stale-jwks"
+
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample()
+            onBlocking { oauthConfigFor(any(), any()) } doReturn unsupportedOauthConfigSample()
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
+        assertThat(loginConfig.isOauthEnabled).isFalse()
+        assertThat(oauth2SecureStore.authorizationEndpoint).isNull()
+        assertThat(oauth2SecureStore.jwksUri).isNull()
+    }
+
+    @Test
     fun falls_back_to_ping_without_touching_oauth_store_when_login_config_fails() = runTest {
         oauth2SecureStore.authorizationEndpoint = "kept-auth"
         oauth2SecureStore.jwksUri = "kept-jwks"
@@ -138,6 +157,18 @@ class LoginConfigCallShould {
         OauthConfig(
             authorizationEndpoint = AUTHORIZATION_ENDPOINT,
             jwksUri = JWKS_URI,
+            codeChallengeMethodsSupported = listOf("S256"),
+            grantTypesSupported = listOf("authorization_code", "refresh_token"),
+            responseTypesSupported = listOf("code"),
+        )
+
+    private fun unsupportedOauthConfigSample(): OauthConfig =
+        OauthConfig(
+            authorizationEndpoint = AUTHORIZATION_ENDPOINT,
+            jwksUri = JWKS_URI,
+            codeChallengeMethodsSupported = listOf("plain"),
+            grantTypesSupported = listOf("authorization_code"),
+            responseTypesSupported = listOf("code"),
         )
 
     private fun serverError(): D2Error =

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -329,7 +329,7 @@ class OAuth2HandlerImplShould {
             onBlocking { selectFirst() }.doReturn(existing)
         }
 
-        val result = handler.setPin(PIN)
+        val result = handler.blockingSetPin(PIN)
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
@@ -346,7 +346,7 @@ class OAuth2HandlerImplShould {
     fun setPin_fails_when_not_logged_in() {
         whenever(credentialsSecureStore.get()).thenReturn(null)
 
-        val result = handler.setPin(PIN)
+        val result = handler.blockingSetPin(PIN)
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         verify(credentialsSecureStore, never()).set(any())
@@ -356,7 +356,7 @@ class OAuth2HandlerImplShould {
     fun setPin_fails_when_account_is_not_oauth2() {
         whenever(credentialsSecureStore.get()).thenReturn(credentialsWithOAuth2(state = null))
 
-        val result = handler.setPin(PIN)
+        val result = handler.blockingSetPin(PIN)
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         verify(credentialsSecureStore, never()).set(any())
@@ -369,7 +369,7 @@ class OAuth2HandlerImplShould {
             onBlocking { selectFirst() }.doReturn(null)
         }
 
-        val result = handler.setPin(PIN)
+        val result = handler.blockingSetPin(PIN)
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
     }
@@ -383,7 +383,7 @@ class OAuth2HandlerImplShould {
             onBlocking { selectFirst() }.doReturn(existing)
         }
 
-        val result = handler.changePin(PIN, NEW_PIN)
+        val result = handler.blockingChangePin(PIN, NEW_PIN)
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
@@ -396,7 +396,7 @@ class OAuth2HandlerImplShould {
         val current = credentialsWithOAuth2(sampleOAuth2State()).copy(password = PIN)
         whenever(credentialsSecureStore.get()).thenReturn(current)
 
-        val result = handler.changePin("wrong", NEW_PIN)
+        val result = handler.blockingChangePin("wrong", NEW_PIN)
 
         assertThat(result).isInstanceOf(Result.Failure::class.java)
         verify(credentialsSecureStore, never()).set(any())

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -44,6 +44,7 @@ import org.hisp.dhis.android.core.user.AuthenticatedUser
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.internal.AuthenticatedUserStore
 import org.hisp.dhis.android.core.user.internal.LogInCall
+import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.keystore.KeyStoreManager
 import org.junit.Before
@@ -77,6 +78,7 @@ class OAuth2HandlerImplShould {
     private val oauth2StateSecureStore: OAuth2StateSecureStore = mock()
     private val credentialsSecureStore: CredentialsSecureStore = mock()
     private val authenticatedUserStore: AuthenticatedUserStore = mock()
+    private val logInExceptions: LogInExceptions = mock()
 
     private lateinit var keyPair: KeyPair
     private lateinit var handler: OAuth2HandlerImpl
@@ -84,6 +86,10 @@ class OAuth2HandlerImplShould {
     @Before
     fun setUp() {
         keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(KEY_SIZE) }.generateKeyPair()
+        whenever(logInExceptions.noActiveSessionError()).thenReturn(sdkError("no session"))
+        whenever(logInExceptions.pinRequiresOAuth2AccountError()).thenReturn(sdkError("not oauth2"))
+        whenever(logInExceptions.noAuthenticatedUserPersistedError()).thenReturn(sdkError("no user"))
+        whenever(logInExceptions.incorrectPinError()).thenReturn(sdkError("bad pin"))
         handler = OAuth2HandlerImpl(
             logInCall,
             logoutHandler,
@@ -94,6 +100,7 @@ class OAuth2HandlerImplShould {
             oauth2StateSecureStore,
             credentialsSecureStore,
             authenticatedUserStore,
+            logInExceptions,
         )
     }
 
@@ -324,7 +331,7 @@ class OAuth2HandlerImplShould {
 
         val result = handler.setPin(PIN)
 
-        assertThat(result.isSuccess).isTrue()
+        assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
         verify(credentialsSecureStore).set(credentialsCaptor.capture())
         assertThat(credentialsCaptor.firstValue.password).isEqualTo(PIN)
@@ -341,7 +348,7 @@ class OAuth2HandlerImplShould {
 
         val result = handler.setPin(PIN)
 
-        assertThat(result.isFailure).isTrue()
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
         verify(credentialsSecureStore, never()).set(any())
     }
 
@@ -351,7 +358,7 @@ class OAuth2HandlerImplShould {
 
         val result = handler.setPin(PIN)
 
-        assertThat(result.isFailure).isTrue()
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
         verify(credentialsSecureStore, never()).set(any())
     }
 
@@ -364,7 +371,7 @@ class OAuth2HandlerImplShould {
 
         val result = handler.setPin(PIN)
 
-        assertThat(result.isFailure).isTrue()
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
     }
 
     @Test
@@ -378,7 +385,7 @@ class OAuth2HandlerImplShould {
 
         val result = handler.changePin(PIN, NEW_PIN)
 
-        assertThat(result.isSuccess).isTrue()
+        assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
         verify(credentialsSecureStore).set(credentialsCaptor.capture())
         assertThat(credentialsCaptor.firstValue.password).isEqualTo(NEW_PIN)
@@ -391,7 +398,7 @@ class OAuth2HandlerImplShould {
 
         val result = handler.changePin("wrong", NEW_PIN)
 
-        assertThat(result.isFailure).isTrue()
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
         verify(credentialsSecureStore, never()).set(any())
     }
 
@@ -505,6 +512,13 @@ class OAuth2HandlerImplShould {
             .errorCode(D2ErrorCode.UNEXPECTED)
             .errorDescription("test failure")
             .errorComponent(D2ErrorComponent.Server)
+            .build()
+
+    private fun sdkError(description: String): D2Error =
+        D2Error.builder()
+            .errorCode(D2ErrorCode.UNEXPECTED)
+            .errorDescription(description)
+            .errorComponent(D2ErrorComponent.SDK)
             .build()
 
     // endregion


### PR DESCRIPTION
Downloading this file and temporarily store it will have two purposes:

1. determine if the server has oauth enabled, answering the app when requested this.
2. knowing the device enrollment endpoints instead of having those hardcoded

isOauthEnabled parameter of LoginConfig should be resolved based on the existence of this “well known json”


Related task [ANDROSDK-2296](https://dhis2.atlassian.net/browse/ANDROSDK-2296)

[ANDROSDK-2296]: https://dhis2.atlassian.net/browse/ANDROSDK-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ