### PR TITLE
chore: [ANDROSDK-2197] add CLAUDE.md and shared Claude skills

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything personal under .claude/ by default.
+# Only shared resources (skills, etc.) should be committed.
+*
+!.gitignore
+!skills/
+!skills/**

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: open-pr
+description: Open a GitHub pull request for an ANDROSDK Jira task. Use when the user asks to "open a PR", "abrir la PR", "create the pull request", "subir la PR", or similar phrasing on a branch named like ANDROSDK-XXXX. Pulls Jira context, formats the title and description, and runs `gh pr create` targeting `develop` by default.
+---
+
+# Open Pull Request (ANDROSDK)
+
+Open a GitHub PR for the current branch following the dhis2-android-sdk conventions: typed title with the Jira code, a short description grounded in the Jira issue, and `develop` as the default target.
+
+## When to use
+
+- The current branch is named after a Jira ticket (e.g. `ANDROSDK-1995`).
+- The user explicitly asks to open / create / push a PR.
+- Changes are already committed and pushed (or about to be — verify before invoking `gh pr create`).
+
+This skill **only opens the PR**. It does not commit, rebase, or run any Gradle / `testAll` task — those happen beforehand.
+
+## Inputs
+
+- **Target branch** (optional): defaults to `develop`. If the user passes a different base ("contra master", "target main", `--base xyz`), use that instead.
+- **Draft mode**: PR is opened in **normal (non-draft) mode** by default. Only pass `--draft` if the user explicitly asks for draft / borrador.
+- **Type override** (optional): the user can pin the type prefix when invoking the skill ("ábrela como feature", "abre la PR tipo chore"). If passed, use it verbatim and skip the inference in step 4.
+
+## Workflow
+
+1. **Confirm prerequisites**
+   - `git rev-parse --abbrev-ref HEAD` — extract the `ANDROSDK-XXXX` code from the branch name. If the branch does not match `ANDROSDK-\d+`, ask the user for the ticket code.
+   - `git status` — ensure working tree is clean. If not, stop and tell the user to commit first.
+   - `git log <base>..HEAD --oneline` — list the commits that will go into the PR (use the chosen target branch as `<base>`, default `origin/develop`).
+   - `gh pr view --json url 2>/dev/null` — if a PR already exists for this branch, surface its URL and stop.
+
+2. **Push the branch if needed**
+   - `git status -sb` shows the upstream state. If the branch has no upstream or is ahead, run `git push -u origin <branch>` before creating the PR.
+
+3. **Fetch the Jira issue**
+   - Use the Atlassian MCP tool `mcp__claude_ai_Atlassian__getJiraIssue` with:
+     - `cloudId`: `b40c24fc-6bb4-4f37-bcbb-7d8813be5fc3` (dhis2.atlassian.net)
+     - `issueIdOrKey`: the ANDROSDK code from the branch
+   - From the response, capture: `summary` (Jira title), `description` (Jira body — Atlassian Document Format, extract the plain text), and `issuetype.name` (Bug / Story / Task / etc.).
+   - If the MCP tool is not available in the current session, ask the user to paste the Jira summary and description, or proceed with what can be inferred from the diff/commits.
+
+4. **Determine the type prefix**
+   - If the user passed a type override when invoking the skill, use it and skip the rest of this step.
+   - `fix:` — **only** when the Jira issuetype is **Bug**. The Jira issuetype is the source of truth for this case.
+   - Otherwise the Jira issuetype is typically **Task** for both new functionality and maintenance work — Jira does not distinguish them. Decide between `feature:` and `chore:` by looking at the **actual changes**:
+     - `feature:` — introduces new SDK capability or user-visible behavior (often coming from the DHIS2 product roadmap). Examples: new module, new public repository method, support for a new DHIS2 API endpoint, new sync flow.
+     - `chore:` — does not change user-visible behavior. Examples: refactors, dependency bumps, internal renames, test additions, build / CI changes, code cleanup, doc-only updates, migration of a model to Kotlin without behavior change.
+   - If the call is genuinely ambiguous (e.g. a refactor that also exposes a small new API), stop and ask the user which prefix to use rather than guessing.
+
+5. **Compose the PR title**
+   - Format: `<type>: [ANDROSDK-XXXX] <short imperative title in English>`
+   - The short title is a tightened version of the Jira summary — drop trailing punctuation, keep it under ~70 characters total, lowercase except for proper nouns / acronyms.
+   - Verify against the project's existing PR style with `gh pr list --limit 5 --json title` before finalizing.
+   - Examples of the style used in this repo:
+     - `chore: [ANDROSDK-2296] add authorization type to databaseAccount`
+     - `fix: [ANDROSDK-1995] build SQL for PI disaggregation`
+     - `feature: [ANDROSDK-2100] support tracker importer v2 sync`
+
+6. **Compose the PR body**
+   - Written in English.
+   - One or two paragraphs, no more.
+   - Paragraph 1: what the PR does, grounded in the Jira description (rephrase, do not paste raw ADF JSON).
+   - Paragraph 2 (optional): notable implementation choices, follow-ups, or caveats — only include if non-obvious from the diff. Skip if not needed.
+   - Final line, separated by a blank line:
+     ```
+     Related task: [ANDROSDK-XXXX](https://dhis2.atlassian.net/browse/ANDROSDK-XXXX)
+     ```
+   - Do NOT add a `Test plan` section, a `Summary` heading, or a "🤖 Generated with Claude Code" footer — they are not part of this repo's PR style.
+   - Do NOT add `Co-Authored-By` lines.
+
+7. **Create the PR**
+   - Run via Bash, passing the body with a heredoc so newlines and markdown survive intact:
+     ```bash
+     gh pr create --base develop --title "<title>" --body "$(cat <<'EOF'
+     <paragraph 1>
+
+     Related task: [ANDROSDK-XXXX](https://dhis2.atlassian.net/browse/ANDROSDK-XXXX)
+     EOF
+     )"
+     ```
+   - Override `--base` if the user specified a different target.
+   - Append `--draft` only if explicitly requested.
+   - Do NOT pass `--fill` — always supply title and body.
+
+8. **Report the PR URL** back to the user. That is the deliverable.
+
+## Edge cases
+
+- **Jira fetch fails / issue not found**: tell the user the code couldn't be resolved and ask whether to proceed with a generic description built from the diff.
+- **Branch name does not match `ANDROSDK-\d+`**: ask for the ticket code explicitly before generating the title.
+- **Multiple Jira codes referenced in commits**: use the branch name's code as the primary; mention the others inline in paragraph 1 if relevant.
+- **No commits ahead of base**: stop and tell the user — there is nothing to open a PR for.
+- **PR already open for this branch**: don't create a duplicate; output the existing URL.
+
+## What NOT to do
+
+- Do not commit, amend, or rebase as part of this skill. The author controls their git history.
+- Do not run `testAll` or any Gradle task — those happen before invoking this skill.
+- Do not open the PR as draft unless asked.
+- Do not target `master` unless explicitly told to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+DHIS2 Android SDK is an Android library that abstracts DHIS2 web API interactions. It maintains a local Room database, syncs metadata/data from DHIS2 servers, and exposes a module-based API to app developers.
+
+## Module Structure
+
+- `core/` — Main Android library module (the SDK itself)
+- `annotations/` — Custom KSP annotations: `@GenerateDaoQueries`, `@ParentColumn`
+- `processor/` — KSP annotation processors that generate DAO queries, entity code, and migration SQL
+- `instrumented-test-app/` — Minimal app used to run instrumented tests on device/emulator
+
+## Build & Development Commands
+
+All commands should be run from the project root. The `core` module is the primary target.
+
+```bash
+# Compile
+./gradlew :core:assembleDebug
+
+# Run unit tests (JVM, no device needed)
+./gradlew :core:testDebugUnitTest
+
+# Run a single unit test class
+./gradlew :core:testDebugUnitTest --tests "org.hisp.dhis.android.core.program.ProgramHandlerShould"
+
+# Run instrumented tests (requires connected device/emulator)
+./gradlew :core:connectedDebugAndroidTest
+
+# Code quality checks (ktlint, detekt, checkstyle, pmd, lint)
+./gradlew :core:ktlintCheck :core:detekt :core:checkstyleDebug :core:pmdDebug :core:lintDebug
+
+# Fix ktlint formatting
+./gradlew :core:ktlintFormat
+
+# All quality checks in one go
+./gradlew runChecks
+
+# Update the public API dump file (required after intentional public API changes)
+./gradlew :core:apiDump
+
+# Verify no unintentional breaking changes to public API
+./gradlew :core:apiCheck
+
+# Coverage report (run in order)
+./gradlew :core:testDebugUnitTest
+./gradlew -Pcoverage :core:connectedDebugAndroidTest
+./gradlew :core:jacocoReport
+
+# Install git hooks
+./gradlew installGitHooks
+```
+
+## Architecture
+
+### Entry Point
+
+`D2` is the main SDK class. Apps obtain it via `D2Manager.instantiateD2(D2Configuration)` and then `D2Manager.getD2()`. `D2` exposes all functionality through module accessors: `d2.programModule()`, `d2.trackedEntityModule()`, `d2.analyticsModule()`, etc.
+
+### Feature Module Structure
+
+Every domain feature (e.g., `program/`, `enrollment/`, `trackedentity/`) follows a consistent layout:
+
+- **Root package** (public API): Domain model (`Program.java`), collection repository (`ProgramCollectionRepository.kt`), module interface (`ProgramModule.kt`)
+- **`internal/`** subpackage: `*Handler.kt` (persists downloaded data), `*Store.kt` (SQL queries), `*Call.kt` (coordinates download), `*NetworkHandler.kt` (API fetch), `*DIModule.kt` (Koin bindings), `*ModuleDownloader.kt`, `*ModuleImpl.kt`, `*ModuleWiper.kt`
+
+### Data Models
+
+Domain models are mostly **Java AutoValue** classes (e.g., `Program.java`, `Enrollment.java`) — immutable with generated builders. Newer models use Kotlin data classes. Each model has a corresponding `*TableInfo` class defining column names used by stores and repositories.
+
+### Database & Migrations
+
+- Room `DatabaseAdapter` wraps SQLite; stores interact with it directly via raw SQL (not DAOs for most cases)
+- Schema migrations live in `core/src/main/assets/migrations/` as numbered SQL files (currently up to 180)
+- **Every schema change requires a new migration file** — the KSP processor can generate the SQL skeleton, but it must be reviewed and added manually
+- Room schema snapshots are in `core/schemas/`
+
+### Store Hierarchy
+
+Stores follow an interface hierarchy for different object types:
+- `ObjectStore` → `IdentifiableObjectStore` → `IdentifiableDataObjectStore` → `IdentifiableDeletableDataObjectStore`
+- `LinkStore` for many-to-many join tables
+- `ObjectWithoutUidStore` for objects without a UID primary key
+
+### Network Layer
+
+- Uses **Ktor** (`HttpServiceClient`) — not Retrofit. Network calls are built with `RequestBuilder` DSL.
+- All network calls go through `CoroutineAPICallExecutor` (coroutine-based)
+- Authentication: `ParentAuthenticatorPlugin` handles Basic auth, cookie sessions, and OAuth2
+- No direct OkHttp usage — Ktor wraps it internally
+
+### Dependency Injection
+
+Uses **Koin** with KSP code generation (Koin Annotations). Each feature has a `*DIModule.kt` annotated with `@Module`. The root component is `D2DIComponent`. Dependencies are declared with `@Singleton` on implementation classes.
+
+### Repository Pattern
+
+- `CollectionRepository` — fluent filter API using typed connectors (`StringFilterConnector`, `IntegerFilterConnector`, `DateFilterConnector`, etc.) via `byFieldName()` methods
+- `ObjectRepository` — single-entity access and mutation
+- Repositories expose both **RxJava** (`Single<T>`, `Flowable<T>`) and **blocking** (`blockingGet()`) variants
+
+### Public API Compatibility
+
+`core/api/core.api` is the binary API dump. The `api-compatibility` plugin checks for breaking changes on every build.
+
+**Never edit `core/api/core.api` by hand.** It is an auto-generated artifact and the only supported way to update it is by running `./gradlew :core:apiDump` after intentional public API changes. Manual edits will drift from what the plugin actually generates and break the build. Commit the regenerated dump alongside the API change.
+
+### DHIS2 Version Compatibility
+
+Supported DHIS2 versions are declared in `DHISVersion.kt`. By default the SDK rejects connections to unsupported versions. Version-specific behavior is gated throughout the codebase using `DHISVersionManager.isGreaterThan(version)` checks.
+
+### Tracker Importer Duality
+
+Two tracker sync paths co-exist:
+- **V1** (legacy): `OldTrackerImporter*` classes, uses `/api/trackedEntityInstances` endpoint
+- **V2** (2.37+): `NewTrackerImporter*` classes, uses `/api/tracker` endpoint
+
+The active path is controlled by `TrackerImporterVersion` in sync settings.
+
+## Test Structure
+
+| Source set | Location | Description |
+|---|---|---|
+| Unit tests | `src/test/` | Pure JVM, mocked dependencies, named `*Should.kt` |
+| Instrumented tests | `src/androidTest/` | Run on device/emulator, named `*IntegrationShould.kt` |
+| Shared test utilities | `src/sharedTest/` | Shared between both test types; includes base classes and mock data |
+
+**Mock integration tests** extend `BaseMockIntegrationTest` and use `Dhis2MockServer` (local WireMock-based server) to simulate the DHIS2 API — no real server needed, but a device/emulator is required.
+
+**Real integration tests** (suffixed `RealIntegrationShould`) connect to a live DHIS2 server. Server URL and credentials are configured in `RealServerMother.java`.
+
+## Key Conventions
+
+- Test classes are named `*Should` (not `*Test`)
+- `internal` Kotlin visibility is used extensively to separate public API from implementation
+- New fields added to existing models generally require: model change + `TableInfo` column addition + migration SQL file + handler/store update + API dump update
+- Jira tickets referenced in commit messages follow the `ANDROSDK-XXXX` format

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-dhis2AndroidSdkVersion = "1.15.0-OAUTH-PIN-SNAPSHOT"
+dhis2AndroidSdkVersion = "1.15.0-SNAPSHOT"
 dhis2AndroidSdkCode = "305"
 
 gradle = "8.13.2"


### PR DESCRIPTION
Adds a project-level `CLAUDE.md` with developing guidelines (module layout, build commands, architecture overview, conventions for stores, network layer, DI, repositories, public API compatibility, version compatibility, tracker importer duality, and test structure) so both humans and AI assistants share the same context when working on the SDK. Also commits the first shared Claude skill, `open-pr`, which automates opening a PR from an `ANDROSDK-XXXX` branch following this repo's title and body style, and a `.claude/.gitignore` that keeps personal Claude state (settings.local.json, scheduled task locks, memory) out of the repo while allowing shared skills through.

Related task: [ANDROSDK-2197](https://dhis2.atlassian.net/browse/ANDROSDK-2197)

[ANDROSDK-2197]: https://dhis2.atlassian.net/browse/ANDROSDK-2197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ