### PR TITLE
chore: [ANDROSDK-2305] Migrate internal classes (partially)

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6687,19 +6687,48 @@ public final class org/hisp/dhis/android/core/dataset/internal/DataSetModuleImpl
 	public fun sections ()Lorg/hisp/dhis/android/core/dataset/SectionCollectionRepository;
 }
 
-public abstract class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
-	public abstract fun indicator ()Ljava/lang/String;
-	public abstract fun section ()Ljava/lang/String;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+public final class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndicator ()Ljava/lang/String;
+	public final fun getSection ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun indicator ()Ljava/lang/String;
+	public final fun section ()Ljava/lang/String;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder {
+public final class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder : org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLinkBuilder {
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink;
-	public abstract fun indicator (Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
-	public abstract fun section (Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+}
+
+public final class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+}
+
+public class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLinkBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLinkBuilder$Companion;
+	protected field indicator Ljava/lang/String;
+	protected field section Ljava/lang/String;
+	public fun <init> ()V
+	public fun build ()Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink;
+	protected final fun getIndicator ()Ljava/lang/String;
+	protected final fun getSection ()Ljava/lang/String;
+	public final fun indicator (Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+	public final fun section (Ljava/lang/String;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
+	protected final fun setIndicator (Ljava/lang/String;)V
+	protected final fun setSection (Ljava/lang/String;)V
+}
+
+public final class org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLinkBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink;)Lorg/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink$Builder;
 }
 
 public final class org/hisp/dhis/android/core/datastore/DataStoreCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUploadCollectionRepository {
@@ -7509,15 +7538,65 @@ public final class org/hisp/dhis/android/core/event/internal/EventStatusFilterCo
 	public final fun notIn ([Lorg/hisp/dhis/android/core/event/EventStatus;)Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
 }
 
-public abstract class org/hisp/dhis/android/core/event/internal/EventSync : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+public final class org/hisp/dhis/android/core/event/internal/EventSync : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync {
+	public static final field Companion Lorg/hisp/dhis/android/core/event/internal/EventSync$Companion;
+	public fun <init> (Ljava/lang/String;IILjava/lang/Integer;Ljava/util/Date;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Ljava/lang/String;IILjava/lang/Integer;Ljava/util/Date;)Lorg/hisp/dhis/android/core/event/internal/EventSync;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/event/internal/EventSync;Ljava/lang/String;IILjava/lang/Integer;Ljava/util/Date;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/event/internal/EventSync;
+	public fun downloadLimit ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDownloadLimit ()I
+	public fun getLastUpdated ()Ljava/util/Date;
+	public fun getOrganisationUnitIdsHash ()I
+	public fun getProgram ()Ljava/lang/String;
+	public fun getWorkingListsHash ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun lastUpdated ()Ljava/util/Date;
+	public fun organisationUnitIdsHash ()I
+	public fun program ()Ljava/lang/String;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	public fun toString ()Ljava/lang/String;
+	public fun workingListsHash ()Ljava/lang/Integer;
 }
 
-public abstract class org/hisp/dhis/android/core/event/internal/EventSync$Builder : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync$Builder {
+public final class org/hisp/dhis/android/core/event/internal/EventSync$Builder : org/hisp/dhis/android/core/event/internal/EventSyncBuilder {
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/event/internal/EventSync;
+}
+
+public final class org/hisp/dhis/android/core/event/internal/EventSync$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+}
+
+public class org/hisp/dhis/android/core/event/internal/EventSyncBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/event/internal/EventSyncBuilder$Companion;
+	protected field lastUpdated Ljava/util/Date;
+	public fun <init> ()V
+	public fun build ()Lorg/hisp/dhis/android/core/event/internal/EventSync;
+	public final fun downloadLimit (I)Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	protected final fun getDownloadLimit ()I
+	protected final fun getLastUpdated ()Ljava/util/Date;
+	protected final fun getOrganisationUnitIdsHash ()I
+	protected final fun getProgram ()Ljava/lang/String;
+	protected final fun getWorkingListsHash ()Ljava/lang/Integer;
+	public final fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	public final fun organisationUnitIdsHash (I)Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	public final fun program (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+	protected final fun setDownloadLimit (I)V
+	protected final fun setLastUpdated (Ljava/util/Date;)V
+	protected final fun setOrganisationUnitIdsHash (I)V
+	protected final fun setProgram (Ljava/lang/String;)V
+	protected final fun setWorkingListsHash (Ljava/lang/Integer;)V
+	public final fun workingListsHash (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
+}
+
+public final class org/hisp/dhis/android/core/event/internal/EventSyncBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/event/internal/EventSync;)Lorg/hisp/dhis/android/core/event/internal/EventSync$Builder;
 }
 
 public final class org/hisp/dhis/android/core/event/search/EventQueryCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository {
@@ -14567,34 +14646,91 @@ public class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/File
 	public fun <init> (Lorg/hisp/dhis/android/core/dataelement/DataElementModule;Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityModule;Lorg/hisp/dhis/android/core/fileresource/FileResourceModule;)V
 }
 
-public abstract class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
-	public abstract fun type ()Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;
-	public abstract fun uid ()Ljava/lang/String;
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Companion;
+	public fun <init> (Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;Ljava/lang/String;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
+	public final fun component1 ()Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;Ljava/lang/String;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId;Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getType ()Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
+	public fun toString ()Ljava/lang/String;
+	public final fun type ()Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;
+	public final fun uid ()Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder {
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder : org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataIdBuilder {
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId;
-	public abstract fun type (Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
-	public abstract fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
 }
 
-public abstract class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
-	public abstract fun submissionId ()Ljava/lang/Integer;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
-	public abstract fun type ()Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
 }
 
-public abstract class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder {
+public class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataIdBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataIdBuilder$Companion;
+	protected field type Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;
+	protected field uid Ljava/lang/String;
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission;
-	public abstract fun submissionId (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
-	public abstract fun type (Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
+	public fun build ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId;
+	protected final fun getType ()Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;
+	protected final fun getUid ()Ljava/lang/String;
+	protected final fun setType (Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;)V
+	protected final fun setUid (Ljava/lang/String;)V
+	public final fun type (Lorg/hisp/dhis/smscompression/SMSConsts$MetadataType;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
+	public final fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
+}
+
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataIdBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId$Builder;
+}
+
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Companion;
+	public fun <init> (ILorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
+	public final fun component1 ()I
+	public final fun component2 ()Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;
+	public final fun copy (ILorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission;ILorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSubmissionId ()I
+	public final fun getType ()Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;
+	public fun hashCode ()I
+	public final fun submissionId ()I
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
+	public fun toString ()Ljava/lang/String;
+	public final fun type ()Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;
+}
+
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder : org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionBuilder {
+	public fun <init> ()V
+}
+
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
+}
+
+public class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionBuilder$Companion;
+	protected field type Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;
+	public fun <init> ()V
+	public fun build ()Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission;
+	protected final fun getSubmissionId ()I
+	protected final fun getType ()Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;
+	protected final fun setSubmissionId (I)V
+	protected final fun setType (Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;)V
+	public final fun submissionId (I)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
+	public final fun type (Lorg/hisp/dhis/android/core/sms/domain/repository/internal/SubmissionType;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
+}
+
+public final class org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmissionBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission;)Lorg/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission$Builder;
 }
 
 public class org/hisp/dhis/android/core/sms/data/smsrepository/internal/SmsRepositoryImpl : org/hisp/dhis/android/core/sms/domain/repository/SmsRepository {
@@ -16010,47 +16146,86 @@ public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEnti
 public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceFilterCall$Companion {
 }
 
-public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync {
+	public static final field Companion Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Companion;
+	public fun <init> (Ljava/lang/String;IILjava/lang/Integer;Ljava/util/Date;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Ljava/lang/String;IILjava/lang/Integer;Ljava/util/Date;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;Ljava/lang/String;IILjava/lang/Integer;Ljava/util/Date;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;
+	public fun downloadLimit ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDownloadLimit ()I
+	public fun getLastUpdated ()Ljava/util/Date;
+	public fun getOrganisationUnitIdsHash ()I
+	public fun getProgram ()Ljava/lang/String;
+	public fun getWorkingListsHash ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun lastUpdated ()Ljava/util/Date;
+	public fun organisationUnitIdsHash ()I
+	public fun program ()Ljava/lang/String;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	public fun toString ()Ljava/lang/String;
+	public fun workingListsHash ()Ljava/lang/Integer;
 }
 
-public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder : org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync$Builder {
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder : org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSyncBuilder {
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;
+}
+
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+}
+
+public class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSyncBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSyncBuilder$Companion;
+	protected field lastUpdated Ljava/util/Date;
+	public fun <init> ()V
+	public fun build ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;
+	public final fun downloadLimit (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	protected final fun getDownloadLimit ()I
+	protected final fun getLastUpdated ()Ljava/util/Date;
+	protected final fun getOrganisationUnitIdsHash ()I
+	protected final fun getProgram ()Ljava/lang/String;
+	protected final fun getWorkingListsHash ()Ljava/lang/Integer;
+	public final fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	public final fun organisationUnitIdsHash (I)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	public final fun program (Ljava/lang/String;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+	protected final fun setDownloadLimit (I)V
+	protected final fun setLastUpdated (Ljava/util/Date;)V
+	protected final fun setOrganisationUnitIdsHash (I)V
+	protected final fun setProgram (Ljava/lang/String;)V
+	protected final fun setWorkingListsHash (Ljava/lang/Integer;)V
+	public final fun workingListsHash (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
+}
+
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSyncBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync$Builder;
 }
 
 public abstract interface class org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync : org/hisp/dhis/android/core/common/CoreObject {
-	public abstract fun downloadLimit ()Ljava/lang/Integer;
-	public abstract fun lastUpdated ()Ljava/util/Date;
-	public abstract fun organisationUnitIdsHash ()Ljava/lang/Integer;
-	public abstract fun program ()Ljava/lang/String;
-	public abstract fun workingListsHash ()Ljava/lang/Integer;
+	public fun downloadLimit ()I
+	public abstract fun getDownloadLimit ()I
+	public abstract fun getLastUpdated ()Ljava/util/Date;
+	public abstract fun getOrganisationUnitIdsHash ()I
+	public abstract fun getProgram ()Ljava/lang/String;
+	public abstract fun getWorkingListsHash ()Ljava/lang/Integer;
+	public fun lastUpdated ()Ljava/util/Date;
+	public fun organisationUnitIdsHash ()I
+	public fun program ()Ljava/lang/String;
+	public fun workingListsHash ()Ljava/lang/Integer;
 }
 
-public abstract interface class org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync$Builder {
-	public abstract fun downloadLimit (Ljava/lang/Integer;)Ljava/lang/Object;
-	public abstract fun lastUpdated (Ljava/util/Date;)Ljava/lang/Object;
-	public abstract fun organisationUnitIdsHash (Ljava/lang/Integer;)Ljava/lang/Object;
-	public abstract fun program (Ljava/lang/String;)Ljava/lang/Object;
-	public abstract fun workingListsHash (Ljava/lang/Integer;)Ljava/lang/Object;
-}
-
-public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle : org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
-	public abstract fun programStageWorkingLists ()Ljava/util/List;
-	public abstract fun programStatus ()Lorg/hisp/dhis/android/core/enrollment/EnrollmentStatus;
-	public abstract fun trackedEntityInstanceFilters ()Ljava/util/List;
-}
-
-public abstract class org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder : org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle$Builder {
-	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle;
-	public abstract fun programStageWorkingLists (Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
-	public abstract fun programStatus (Lorg/hisp/dhis/android/core/enrollment/EnrollmentStatus;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
-	public abstract fun trackedEntityInstanceFilters (Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle$Builder;
+public final class org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync$DefaultImpls {
+	public static fun downloadLimit (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync;)I
+	public static fun lastUpdated (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync;)Ljava/util/Date;
+	public static fun organisationUnitIdsHash (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync;)I
+	public static fun program (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync;)Ljava/lang/String;
+	public static fun workingListsHash (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync;)Ljava/lang/Integer;
 }
 
 public abstract interface class org/hisp/dhis/android/core/trackedentity/ownership/OwnershipManager {
@@ -16434,18 +16609,6 @@ public final class org/hisp/dhis/android/core/tracker/TrackerImporterVersion : j
 public final class org/hisp/dhis/android/core/tracker/TrackerImporterVersion$Companion {
 }
 
-public abstract class org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle {
-	public fun <init> ()V
-	public abstract fun commonParams ()Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryCommonParams;
-	public abstract fun orgUnits ()Ljava/util/List;
-}
-
-public abstract class org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle$Builder {
-	public fun <init> ()V
-	public abstract fun commonParams (Lorg/hisp/dhis/android/core/trackedentity/internal/TrackerQueryCommonParams;)Lorg/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle$Builder;
-	public abstract fun orgUnits (Ljava/util/List;)Lorg/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle$Builder;
-}
-
 public final class org/hisp/dhis/android/core/tracker/exporter/TrackerD2Progress : org/hisp/dhis/android/core/arch/call/D2Progress {
 	public static final field Companion Lorg/hisp/dhis/android/core/tracker/exporter/TrackerD2Progress$Companion;
 	public fun <init> ()V
@@ -16494,26 +16657,6 @@ public final class org/hisp/dhis/android/core/tracker/exporter/TrackerD2Progress
 public final class org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobModuleWiper : org/hisp/dhis/android/core/wipe/internal/ModuleWiper {
 	public fun wipeData (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun wipeMetadata (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder;
-	public abstract fun fileResources ()Ljava/util/List;
-	public abstract fun jobUid ()Ljava/lang/String;
-	public abstract fun lastUpdated ()Ljava/util/Date;
-	public abstract fun objectUid ()Ljava/lang/String;
-	public abstract fun trackerType ()Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterObjectType;
-}
-
-public abstract class org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder {
-	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject;
-	public abstract fun fileResources (Ljava/util/List;)Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder;
-	public abstract fun jobUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder;
-	public abstract fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder;
-	public abstract fun objectUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder;
-	public abstract fun trackerType (Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterObjectType;)Lorg/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject$Builder;
 }
 
 public abstract interface class org/hisp/dhis/android/core/usecase/UseCaseModule {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLinkStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLinkStoreIntegrationShould.kt
@@ -43,7 +43,7 @@ class SectionIndicatorLinkStoreIntegrationShould : LinkStoreAbstractIntegrationS
 ) {
 
     override fun addMasterUid(): String {
-        return SectionIndicatorLinkSamples.getSectionIndicatorLink().section()!!
+        return SectionIndicatorLinkSamples.getSectionIndicatorLink().section()
     }
 
     override fun buildObject(): SectionIndicatorLink {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObjectStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObjectStoreIntegrationShould.kt
@@ -36,19 +36,20 @@ import org.hisp.dhis.android.persistence.tracker.TrackerJobObjectTableInfo
 import org.junit.runner.RunWith
 
 @RunWith(D2JunitRunner::class)
-class TrackerJobObjectStoreIntegrationShould : ObjectWithoutUidStoreAbstractIntegrationShould<TrackerJobObject>(
-    TrackerJobObjectStoreImpl(TestDatabaseAdapterFactory.get()),
-    TrackerJobObjectTableInfo.TABLE_INFO,
-    TestDatabaseAdapterFactory.get(),
-) {
+internal class TrackerJobObjectStoreIntegrationShould :
+    ObjectWithoutUidStoreAbstractIntegrationShould<TrackerJobObject>(
+        TrackerJobObjectStoreImpl(TestDatabaseAdapterFactory.get()),
+        TrackerJobObjectTableInfo.TABLE_INFO,
+        TestDatabaseAdapterFactory.get(),
+    ) {
     override fun buildObject(): TrackerJobObject {
         return TrackerJobObjectSamples.get1()
     }
 
     override fun buildObjectToUpdate(): TrackerJobObject {
         return TrackerJobObjectSamples.get1()
-            .toBuilder()
-            .fileResources(listOf("file_resource_uid"))
-            .build()
+            .copy(
+                fileResources = listOf("file_resource_uid"),
+            )
     }
 }

--- a/core/src/main/assets/migrations/181.sql
+++ b/core/src/main/assets/migrations/181.sql
@@ -43,3 +43,14 @@ ALTER TABLE AnalyticsDhisVisualization RENAME TO AnalyticsDhisVisualization_Old;
 CREATE TABLE AnalyticsDhisVisualization (_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, uid TEXT NOT NULL, scopeUid TEXT, scope TEXT NOT NULL, groupUid TEXT NOT NULL, groupName TEXT NOT NULL, timestamp TEXT, name TEXT, type TEXT NOT NULL);
 INSERT INTO AnalyticsDhisVisualization(_id, uid, scopeUid, scope, groupUid, groupName, timestamp, name, type) SELECT _id, uid, scopeUid, scope, groupUid, groupName, timestamp, name, type FROM AnalyticsDhisVisualization_Old;
 DROP TABLE IF EXISTS AnalyticsDhisVisualization_Old;
+
+# SMSOngoingSubmission: make type non-null (ANDROSDK-2295)
+
+# Remove rows with null type
+DELETE FROM SMSOngoingSubmission WHERE type IS NULL;
+
+# Recreate table with type as NOT NULL
+ALTER TABLE SMSOngoingSubmission RENAME TO SMSOngoingSubmission_Old;
+CREATE TABLE SMSOngoingSubmission(submissionId INTEGER NOT NULL, type TEXT NOT NULL, PRIMARY KEY(submissionId));
+INSERT INTO SMSOngoingSubmission(submissionId, type) SELECT submissionId, type FROM SMSOngoingSubmission_Old;
+DROP TABLE IF EXISTS SMSOngoingSubmission_Old;

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/SectionIndicatorLink.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,41 +26,25 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.trackedentity.internal;
+package org.hisp.dhis.android.core.dataset.internal
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
 
-import org.hisp.dhis.android.core.common.CoreObject;
+@ModelBuilder
+data class SectionIndicatorLink(
+    val section: String,
+    val indicator: String,
+) : CoreObject {
+    fun section(): String = section
+    fun indicator(): String = indicator
 
-import java.util.Date;
+    fun toBuilder(): Builder = SectionIndicatorLinkBuilder.from(this)
 
-public interface TrackerBaseSync extends CoreObject {
+    class Builder : SectionIndicatorLinkBuilder()
 
-    @Nullable
-    String program();
-
-    @NonNull
-    Integer organisationUnitIdsHash();
-
-    @NonNull
-    Integer downloadLimit();
-
-    @Nullable
-    Integer workingListsHash();
-
-    @NonNull
-    Date lastUpdated();
-
-    interface Builder<T> {
-        T program(String program);
-
-        T organisationUnitIdsHash(Integer organisationUnitIdsHash);
-
-        T downloadLimit(Integer limit);
-
-        T workingListsHash(Integer workingListsHash);
-
-        T lastUpdated(Date lastUpdated);
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -102,11 +102,11 @@ internal class EventDownloadCall internal constructor(
         val result = ItemsWithPagingResult(0, true, null, false)
 
         val eventQuery = TrackerAPIQuery(
-            commonParams = bundle.commonParams().copy(
-                program = bundle.commonParams().program,
-                limit = bundle.commonParams().uids.size,
+            commonParams = bundle.commonParams.copy(
+                program = bundle.commonParams.program,
+                limit = bundle.commonParams.uids.size,
             ),
-            uids = bundle.commonParams().uids,
+            uids = bundle.commonParams.uids,
         )
 
         try {
@@ -139,7 +139,7 @@ internal class EventDownloadCall internal constructor(
         orgunitUid: String?,
         limit: Int,
     ): TrackerAPIQuery? {
-        val eventUids = if (bundle.eventFilters() != null) {
+        val eventUids = if (bundle.eventFilters != null) {
             val filteredUids = getEventUidsByFilters(bundle, orgunitUid)
 
             filteredUids.takeIf { it.isNotEmpty() }
@@ -149,11 +149,11 @@ internal class EventDownloadCall internal constructor(
 
         return eventUids?.let {
             TrackerAPIQuery(
-                commonParams = bundle.commonParams().copy(
+                commonParams = bundle.commonParams.copy(
                     program = program,
                     limit = limit,
                 ),
-                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
+                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams),
                 orgUnit = orgunitUid,
                 uids = eventUids.distinct(),
             )
@@ -164,10 +164,10 @@ internal class EventDownloadCall internal constructor(
         bundle: EventQueryBundle,
         orgunitUid: String?,
     ): List<String> {
-        return bundle.eventFilters()?.flatMap {
+        return bundle.eventFilters?.flatMap {
             eventQueryCollectionRepository
                 .byOrgUnits().eq(orgunitUid)
-                .byOrgUnitMode().eq(bundle.commonParams().ouMode)
+                .byOrgUnitMode().eq(bundle.commonParams.ouMode)
                 .byEventFilterObject().eq(it)
                 .onlineOnly().getDataFetcher().getUids()
         } ?: emptyList()

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventLastUpdatedManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventLastUpdatedManager.kt
@@ -39,11 +39,11 @@ internal class EventLastUpdatedManager(
 
     suspend fun update(bundle: EventQueryBundle) {
         val sync = EventSync.builder()
-            .program(bundle.commonParams().program)
-            .organisationUnitIdsHash(bundle.orgUnits().toSet().hashCode())
-            .downloadLimit(bundle.commonParams().limit)
-            .workingListsHash(bundle.commonParams().workingListsHash)
-            .lastUpdated(resourceHandler.serverDate)
+            .program(bundle.commonParams.program)
+            .organisationUnitIdsHash(bundle.orgUnits.toSet().hashCode())
+            .downloadLimit(bundle.commonParams.limit)
+            .workingListsHash(bundle.commonParams.workingListsHash)
+            .lastUpdated(resourceHandler.serverDate!!)
             .build()
         super.update(sync)
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundle.kt
@@ -25,24 +25,14 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.android.core.event.internal
 
-package org.hisp.dhis.android.core.event.internal;
+import org.hisp.dhis.android.core.event.EventFilter
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParams
+import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle
 
-import com.google.auto.value.AutoValue;
-
-import org.hisp.dhis.android.core.trackedentity.internal.TrackerBaseSync;
-
-@AutoValue
-public abstract class EventSync implements TrackerBaseSync {
-
-    public static Builder builder() {
-        return new AutoValue_EventSync.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder implements TrackerBaseSync.Builder<Builder> {
-        public abstract EventSync build();
-    }
-}
+internal data class EventQueryBundle(
+    override val commonParams: TrackerQueryCommonParams,
+    override val orgUnits: List<String>,
+    val eventFilters: List<EventFilter>?,
+) : BaseTrackerQueryBundle

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -80,15 +80,17 @@ internal class EventQueryBundleInternalFactory(
         val workingListsHash = WorkingListsHashHelper.calculateHashFromObjects(finalFilters)
         val commonParamsWithHash = commonParams.copy(workingListsHash = workingListsHash)
 
-        val builder = EventQueryBundle.builder()
-            .eventFilters(finalFilters)
-            .commonParams(commonParamsWithHash)
-
-        return commonHelper.divideByOrgUnits(
+        val orgUnitBundles = commonHelper.divideByOrgUnits(
             commonParams.orgUnitsBeforeDivision,
             commonParams.hasLimitByOrgUnit,
-        ) {
-            builder.orgUnits(it).build()
+        )
+
+        return orgUnitBundles.map { orgUnits ->
+            EventQueryBundle(
+                commonParams = commonParamsWithHash,
+                orgUnits = orgUnits,
+                eventFilters = finalFilters,
+            )
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventSync.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventSync.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,46 +26,27 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.trackedentity.internal;
+package org.hisp.dhis.android.core.event.internal
 
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerBaseSync
+import java.util.Date
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class EventSync(
+    override val program: String?,
+    override val organisationUnitIdsHash: Int,
+    override val downloadLimit: Int,
+    override val workingListsHash: Int?,
+    override val lastUpdated: Date,
+) : TrackerBaseSync {
 
-import org.hisp.dhis.android.core.enrollment.EnrollmentStatus;
-import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList;
-import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter;
-import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle;
+    fun toBuilder(): Builder = EventSyncBuilder.from(this)
 
-import java.util.List;
+    class Builder : EventSyncBuilder()
 
-@AutoValue
-public abstract class TrackerQueryBundle extends BaseTrackerQueryBundle {
-
-    @Nullable
-    public abstract EnrollmentStatus programStatus();
-
-    @Nullable
-    public abstract List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters();
-
-    @Nullable
-    public abstract List<ProgramStageWorkingList> programStageWorkingLists();
-
-    public static Builder builder() {
-        return new AutoValue_TrackerQueryBundle.Builder();
-    }
-
-    @AutoValue.Builder
-    public abstract static class Builder extends BaseTrackerQueryBundle.Builder<Builder> {
-
-        public abstract Builder programStatus(EnrollmentStatus programStatus);
-
-        public abstract Builder trackedEntityInstanceFilters(
-                List<TrackedEntityInstanceFilter> trackedEntityInstanceFilters);
-
-        public abstract Builder programStageWorkingLists(
-                List<ProgramStageWorkingList> programStageWorkingLists);
-
-        public abstract TrackerQueryBundle build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSMetadataId.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,36 +26,26 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.sms.data.localdbrepository.internal;
+package org.hisp.dhis.android.core.sms.data.localdbrepository.internal
 
-import androidx.annotation.NonNull;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
+import org.hisp.dhis.smscompression.SMSConsts
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class SMSMetadataId(
+    val type: SMSConsts.MetadataType,
+    val uid: String,
+) : CoreObject {
+    fun type(): SMSConsts.MetadataType = type
+    fun uid(): String = uid
 
-import org.hisp.dhis.android.core.common.CoreObject;
-import org.hisp.dhis.smscompression.SMSConsts;
+    fun toBuilder(): Builder = SMSMetadataIdBuilder.from(this)
 
-@AutoValue
-public abstract class SMSMetadataId implements CoreObject {
+    class Builder : SMSMetadataIdBuilder()
 
-    @NonNull
-    public abstract SMSConsts.MetadataType type();
-
-    @NonNull
-    public abstract String uid();
-
-    public static Builder builder() {
-        return new AutoValue_SMSMetadataId.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder type(SMSConsts.MetadataType smsMetadataIdType);
-
-        public abstract Builder uid(String uid);
-
-        public abstract SMSMetadataId build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/sms/data/localdbrepository/internal/SMSOngoingSubmission.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,26 +26,26 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.tracker.exporter;
+package org.hisp.dhis.android.core.sms.data.localdbrepository.internal
 
-import androidx.annotation.NonNull;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
+import org.hisp.dhis.android.core.sms.domain.repository.internal.SubmissionType
 
-import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParams;
+@ModelBuilder
+data class SMSOngoingSubmission(
+    val submissionId: Int,
+    val type: SubmissionType,
+) : CoreObject {
+    fun submissionId(): Int = submissionId
+    fun type(): SubmissionType = type
 
-import java.util.List;
+    fun toBuilder(): Builder = SMSOngoingSubmissionBuilder.from(this)
 
-public abstract class BaseTrackerQueryBundle {
+    class Builder : SMSOngoingSubmissionBuilder()
 
-    @NonNull
-    public abstract TrackerQueryCommonParams commonParams();
-
-    @NonNull
-    public abstract List<String> orgUnits();
-
-    public abstract static class Builder<T extends Builder> {
-        public abstract T commonParams(TrackerQueryCommonParams commonParams);
-
-        public abstract T orgUnits(List<String> orgUnits);
-
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackerImporterTrackedEntityPostStateManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackerImporterTrackedEntityPostStateManager.kt
@@ -84,21 +84,21 @@ internal class NewTrackerImporterTrackedEntityPostStateManager internal construc
         val fileResourcesMap = mutableMapOf<State, MutableList<String>>()
 
         objects.forEach {
-            when (it.trackerType()) {
-                TrackerImporterObjectType.EVENT -> eventStore.selectByUid(it.objectUid())?.let { e ->
+            when (it.trackerType) {
+                TrackerImporterObjectType.EVENT -> eventStore.selectByUid(it.objectUid)?.let { e ->
                     h.addState(eventMap, e, forcedState)
                 }
-                TrackerImporterObjectType.ENROLLMENT -> enrollmentStore.selectByUid(it.objectUid())?.let { e ->
+                TrackerImporterObjectType.ENROLLMENT -> enrollmentStore.selectByUid(it.objectUid)?.let { e ->
                     h.addState(enrollmentMap, e, forcedState)
                 }
                 TrackerImporterObjectType.TRACKED_ENTITY ->
-                    trackedEntityInstanceStore.selectByUid(it.objectUid())
+                    trackedEntityInstanceStore.selectByUid(it.objectUid)
                         ?.let { t -> h.addState(teiMap, t, forcedState) }
-                TrackerImporterObjectType.RELATIONSHIP -> relationshipStore.selectByUid(it.objectUid())?.let { r ->
+                TrackerImporterObjectType.RELATIONSHIP -> relationshipStore.selectByUid(it.objectUid)?.let { r ->
                     h.addState(relationshipMap, r, forcedState)
                 }
             }
-            it.fileResources().forEach { id ->
+            it.fileResources.forEach { id ->
                 fileResourceStore.selectByUid(id)?.let { fr -> h.addState(fileResourcesMap, fr, forcedState) }
             }
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -106,8 +106,8 @@ internal class TrackedEntityInstanceDownloadCall(
         val result = ItemsWithPagingResult(0, true, null, false)
 
         val teiQuery = TrackerAPIQuery(
-            commonParams = bundle.commonParams(),
-            programStatus = bundle.programStatus(),
+            commonParams = bundle.commonParams,
+            programStatus = bundle.programStatus,
         )
 
         val useEntityEndpoint = teiQuery.commonParams.program != null
@@ -115,7 +115,7 @@ internal class TrackedEntityInstanceDownloadCall(
         try {
             val teisList = mutableListOf<TrackedEntityInstance>()
 
-            for (uid in bundle.commonParams().uids) {
+            for (uid in bundle.commonParams.uids) {
                 val tei = querySingleTei(uid, useEntityEndpoint, teiQuery).getOrThrow()
 
                 if (tei != null) {
@@ -213,8 +213,8 @@ internal class TrackedEntityInstanceDownloadCall(
         limit: Int,
     ): TrackerAPIQuery? {
         val teiUids = if (
-            bundle.trackedEntityInstanceFilters() != null ||
-            bundle.programStageWorkingLists() != null
+            bundle.trackedEntityInstanceFilters != null ||
+            bundle.programStageWorkingLists != null
         ) {
             val filteredUids = getTeiUidsByFilter(bundle, orgunitUid) +
                 getTeiUidsByWorkingList(bundle, orgunitUid)
@@ -226,12 +226,12 @@ internal class TrackedEntityInstanceDownloadCall(
 
         return teiUids?.let {
             TrackerAPIQuery(
-                commonParams = bundle.commonParams().copy(
+                commonParams = bundle.commonParams.copy(
                     program = program,
                     limit = limit,
                 ),
-                programStatus = bundle.programStatus(),
-                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams()),
+                programStatus = bundle.programStatus,
+                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams),
                 orgUnit = orgunitUid,
                 uids = teiUids.distinct(),
             )
@@ -239,21 +239,21 @@ internal class TrackedEntityInstanceDownloadCall(
     }
 
     private suspend fun getTeiUidsByFilter(bundle: TrackerQueryBundle, orgunitUid: String?): List<String> {
-        return bundle.trackedEntityInstanceFilters()?.flatMap {
+        return bundle.trackedEntityInstanceFilters?.flatMap {
             teiQueryCollectionRepository
                 .byTrackedEntityInstanceFilterObject().eq(it)
                 .byOrgUnits().eq(orgunitUid)
-                .byOrgUnitMode().eq(bundle.commonParams().ouMode)
+                .byOrgUnitMode().eq(bundle.commonParams.ouMode)
                 .onlineOnly().suspendGetUids()
         } ?: emptyList()
     }
 
     private suspend fun getTeiUidsByWorkingList(bundle: TrackerQueryBundle, orgunitUid: String?): List<String> {
-        return bundle.programStageWorkingLists()?.flatMap {
+        return bundle.programStageWorkingLists?.flatMap {
             teiQueryCollectionRepository
                 .byProgramStageWorkingListObject().eq(it)
                 .byOrgUnits().eq(orgunitUid)
-                .byOrgUnitMode().eq(bundle.commonParams().ouMode)
+                .byOrgUnitMode().eq(bundle.commonParams.ouMode)
                 .onlineOnly().suspendGetUids()
         } ?: emptyList()
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceLastUpdatedManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceLastUpdatedManager.kt
@@ -38,11 +38,11 @@ internal class TrackedEntityInstanceLastUpdatedManager(
 
     suspend fun update(trackerQuery: TrackerQueryBundle) {
         val sync = TrackedEntityInstanceSync.builder()
-            .program(trackerQuery.commonParams().program)
-            .organisationUnitIdsHash(trackerQuery.orgUnits().toSet().hashCode())
-            .downloadLimit(trackerQuery.commonParams().limit)
-            .workingListsHash(trackerQuery.commonParams().workingListsHash)
-            .lastUpdated(resourceHandler.serverDate)
+            .program(trackerQuery.commonParams.program)
+            .organisationUnitIdsHash(trackerQuery.orgUnits.toSet().hashCode())
+            .downloadLimit(trackerQuery.commonParams.limit)
+            .workingListsHash(trackerQuery.commonParams.workingListsHash)
+            .lastUpdated(resourceHandler.serverDate!!)
             .build()
         super.update(sync)
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceSync.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,36 +26,26 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.dataset.internal;
+package org.hisp.dhis.android.core.trackedentity.internal
 
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import java.util.Date
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class TrackedEntityInstanceSync(
+    override val program: String?,
+    override val organisationUnitIdsHash: Int,
+    override val downloadLimit: Int,
+    override val workingListsHash: Int?,
+    override val lastUpdated: Date,
+) : TrackerBaseSync {
 
-import org.hisp.dhis.android.core.common.CoreObject;
+    fun toBuilder(): Builder = TrackedEntityInstanceSyncBuilder.from(this)
 
-@AutoValue
-public abstract class SectionIndicatorLink implements CoreObject {
+    class Builder : TrackedEntityInstanceSyncBuilder()
 
-    @Nullable
-    public abstract String section();
-
-    @Nullable
-    public abstract String indicator();
-
-    public static Builder builder() {
-        return new AutoValue_SectionIndicatorLink.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-
-        public abstract Builder section(@Nullable String section);
-
-        public abstract Builder indicator(@Nullable String indicator);
-
-        public abstract SectionIndicatorLink build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerBaseSync.kt
@@ -25,23 +25,21 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.android.core.trackedentity.internal
 
-package org.hisp.dhis.android.core.trackedentity.internal;
+import org.hisp.dhis.android.core.common.CoreObject
+import java.util.Date
 
-import com.google.auto.value.AutoValue;
+interface TrackerBaseSync : CoreObject {
+    val program: String?
+    val organisationUnitIdsHash: Int
+    val downloadLimit: Int
+    val workingListsHash: Int?
+    val lastUpdated: Date
 
-@AutoValue
-public abstract class TrackedEntityInstanceSync implements TrackerBaseSync {
-
-    public static Builder builder() {
-        return new AutoValue_TrackedEntityInstanceSync.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder implements TrackerBaseSync.Builder<Builder> {
-
-        public abstract TrackedEntityInstanceSync build();
-    }
+    fun program(): String? = program
+    fun organisationUnitIdsHash(): Int = organisationUnitIdsHash
+    fun downloadLimit(): Int = downloadLimit
+    fun workingListsHash(): Int? = workingListsHash
+    fun lastUpdated(): Date = lastUpdated
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.kt
@@ -25,37 +25,17 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.android.core.trackedentity.internal
 
-package org.hisp.dhis.android.core.sms.data.localdbrepository.internal;
+import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
+import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
+import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle
 
-import androidx.annotation.NonNull;
-
-import com.google.auto.value.AutoValue;
-
-import org.hisp.dhis.android.core.common.CoreObject;
-import org.hisp.dhis.android.core.sms.domain.repository.internal.SubmissionType;
-
-@AutoValue
-public abstract class SMSOngoingSubmission implements CoreObject {
-
-    @NonNull
-    public abstract Integer submissionId();
-
-    @NonNull
-    public abstract SubmissionType type();
-
-    public static Builder builder() {
-        return new AutoValue_SMSOngoingSubmission.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder submissionId(Integer submissionId);
-
-        public abstract Builder type(SubmissionType type);
-
-        public abstract SMSOngoingSubmission build();
-    }
-}
+internal data class TrackerQueryBundle(
+    override val commonParams: TrackerQueryCommonParams,
+    override val orgUnits: List<String>,
+    val programStatus: EnrollmentStatus?,
+    val trackedEntityInstanceFilters: List<TrackedEntityInstanceFilter>?,
+    val programStageWorkingLists: List<ProgramStageWorkingList>?,
+) : BaseTrackerQueryBundle

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -98,16 +98,20 @@ internal class TrackerQueryBundleInternalFactory(
         val workingListsHash = WorkingListsHashHelper.calculateHashFromObjects(finalFilters, finalWorkingLists)
         val commonParamsWithHash = commonParams.copy(workingListsHash = workingListsHash)
 
-        val builder = TrackerQueryBundle.builder()
-            .commonParams(commonParamsWithHash)
-            .programStatus(programStatus)
-            .programStageWorkingLists(finalWorkingLists)
-            .trackedEntityInstanceFilters(finalFilters)
-
-        return commonHelper.divideByOrgUnits(
+        val orgUnitBundles = commonHelper.divideByOrgUnits(
             commonParams.orgUnitsBeforeDivision,
             commonParams.hasLimitByOrgUnit,
-        ) { builder.orgUnits(it).build() }
+        )
+
+        return orgUnitBundles.map { orgUnits ->
+            TrackerQueryBundle(
+                commonParams = commonParamsWithHash,
+                orgUnits = orgUnits,
+                programStatus = programStatus,
+                trackedEntityInstanceFilters = finalFilters,
+                programStageWorkingLists = finalWorkingLists,
+            )
+        }
     }
 
     @Suppress("ReturnCount")

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
@@ -201,15 +201,14 @@ internal class TrackerQueryFactoryCommonHelper(
         return false
     }
 
-    fun <O> divideByOrgUnits(
+    fun divideByOrgUnits(
         orgUnits: List<String>,
         hasLimitByOrgUnit: Boolean,
-        builder: (List<String>) -> O,
-    ): List<O> {
+    ): List<List<String>> {
         return if (hasLimitByOrgUnit && orgUnits.isNotEmpty()) {
-            orgUnits.map { builder.invoke(listOf(it)) }
+            orgUnits.map { listOf(it) }
         } else {
-            listOf(builder.invoke(orgUnits))
+            listOf(orgUnits)
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
@@ -25,33 +25,11 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package org.hisp.dhis.android.core.tracker.exporter
 
-package org.hisp.dhis.android.core.event.internal;
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParams
 
-import androidx.annotation.Nullable;
-
-import com.google.auto.value.AutoValue;
-
-import org.hisp.dhis.android.core.event.EventFilter;
-import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle;
-
-import java.util.List;
-
-@AutoValue
-abstract class EventQueryBundle extends BaseTrackerQueryBundle {
-
-    @Nullable
-    public abstract List<EventFilter> eventFilters();
-
-    static Builder builder() {
-        return new AutoValue_EventQueryBundle.Builder();
-    }
-
-    @AutoValue.Builder
-    abstract static class Builder extends BaseTrackerQueryBundle.Builder<Builder> {
-
-        abstract Builder eventFilters(List<EventFilter> eventFilters);
-
-        abstract EventQueryBundle build();
-    }
+internal interface BaseTrackerQueryBundle {
+    val commonParams: TrackerQueryCommonParams
+    val orgUnits: List<String>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -90,28 +90,28 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         relatives: RelationshipItemRelatives,
     ): Flow<TrackerD2Progress> = flow {
         val bundles: List<Q> = getBundles(params)
-        val programs = bundles.flatMap { it.commonParams().programs }
+        val programs = bundles.flatMap { it.commonParams.programs }
 
         progressManager.setTotalCalls(programs.size + 2)
         progressManager.setPrograms(programs)
         emit(progressManager.getProgress())
 
         for (bundle in bundles) {
-            if (bundle.commonParams().uids.isNotEmpty()) {
+            if (bundle.commonParams.uids.isNotEmpty()) {
                 val result = queryByUids(bundle, params.overwrite(), relatives)
 
                 result.d2Error?.let {
                     throw it
                 }
             } else {
-                val orgunitPrograms = bundle.orgUnits()
+                val orgunitPrograms = bundle.orgUnits
                     .associateWith {
-                        bundle.commonParams().programs
+                        bundle.commonParams.programs
                             .map { ItemsByProgramCount(it, 0) }
                             .toMutableList()
                     }.toMutableMap()
 
-                val bundleResult = BundleResult(0, orgunitPrograms, bundle.orgUnits().toMutableList())
+                val bundleResult = BundleResult(0, orgunitPrograms, bundle.orgUnits.toMutableList())
 
                 var iterationCount = 0
                 var successfulSync = true
@@ -141,9 +141,9 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         iterationCount: Int,
     ): Boolean {
         return params.limitByProgram() != true &&
-            bundleResult.bundleCount < bundle.commonParams().limit &&
+            bundleResult.bundleCount < bundle.commonParams.limit &&
             bundleResult.bundleOrgUnitsToDownload.isNotEmpty() &&
-            iterationCount < max(bundle.commonParams().limit * BUNDLE_SECURITY_FACTOR, BUNDLE_ITERATION_LIMIT)
+            iterationCount < max(bundle.commonParams.limit * BUNDLE_SECURITY_FACTOR, BUNDLE_ITERATION_LIMIT)
     }
 
     @Suppress("LongParameterList")
@@ -158,7 +158,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         val limitPerCombo = getBundleLimit(bundle, params, bundleResult)
 
         for ((orgUnitUid, orgunitPrograms) in bundleResult.bundleOrgUnitPrograms.entries) {
-            val pendingTeis = bundle.commonParams().limit - bundleResult.bundleCount
+            val pendingTeis = bundle.commonParams.limit - bundleResult.bundleCount
             val bundleLimit = min(limitPerCombo, pendingTeis)
 
             if (bundleLimit <= 0 || orgunitPrograms.isEmpty()) {
@@ -195,7 +195,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
         bundleResult.bundleOrgUnitPrograms[orgUnitUid]?.let { bundlePrograms ->
             for (bundleProgram in bundlePrograms) {
-                if (bundleResult.bundleCount < bundle.commonParams().limit) {
+                if (bundleResult.bundleCount < bundle.commonParams.limit) {
                     val trackerQuery = getQuery(bundle, bundleProgram.program, orgUnitUid, limit)
 
                     val result = if (trackerQuery != null) {
@@ -252,7 +252,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
             params.uids().isNotEmpty() -> params.uids().size
             params.limitByProgram() != true -> {
                 val numOfCombinations = bundleResult.bundleOrgUnitPrograms.values.sumOf { it.size }
-                val pendingTeis = bundle.commonParams().limit - bundleResult.bundleCount
+                val pendingTeis = bundle.commonParams.limit - bundleResult.bundleCount
 
                 if (numOfCombinations == 0 || pendingTeis == 0) {
                     0
@@ -261,7 +261,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                 }
             }
 
-            else -> bundle.commonParams().limit - bundleResult.bundleCount
+            else -> bundle.commonParams.limit - bundleResult.bundleCount
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobQueryCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobQueryCall.kt
@@ -60,8 +60,8 @@ internal class JobQueryCall internal constructor(
 
     fun queryPendingJobs(): Flow<D2Progress> = flow {
         val pendingJobs = trackerJobObjectStore.selectAll()
-            .sortedBy { it.lastUpdated() }
-            .groupBy { it.jobUid() }
+            .sortedBy { it.lastUpdated }
+            .groupBy { it.jobUid }
             .toList()
 
         pendingJobs.withIndex().map {

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportFileResourceHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportFileResourceHandler.kt
@@ -40,7 +40,7 @@ internal class JobReportFileResourceHandler internal constructor(
     suspend fun updateFileResourceStates(jobObjects: List<TrackerJobObject>) {
         val progress = D2ProgressManager(null)
 
-        val fileResources = jobObjects.flatMap { it.fileResources() }
+        val fileResources = jobObjects.flatMap { it.fileResources }
 
         fileResourceHelper.updateFileResourceStates(fileResources, FileResourceDataDomainType.TRACKER)
 

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportHandler.kt
@@ -42,7 +42,7 @@ internal class JobReportHandler internal constructor(
 ) {
 
     suspend fun handle(o: JobReport, jobObjects: List<TrackerJobObject>) {
-        val jobObjectsMap = jobObjects.associateBy { jo -> Pair(jo.trackerType(), jo.objectUid()) }
+        val jobObjectsMap = jobObjects.associateBy { jo -> Pair(jo.trackerType, jo.objectUid) }
         val relatedUids = getRelatedUids(jobObjects)
 
         handleErrors(o, jobObjectsMap)
@@ -58,7 +58,7 @@ internal class JobReportHandler internal constructor(
     ) {
         o.validationReport.errorReports.forEach { errorReport ->
             jobObjectsMap[Pair(errorReport.trackerType, errorReport.uid)]?.let {
-                getHandler(it.trackerType()).handleError(it, errorReport)
+                getHandler(it.trackerType).handleError(it, errorReport)
             }
         }
     }
@@ -99,7 +99,7 @@ internal class JobReportHandler internal constructor(
 
         notPresentObjects
             .mapNotNull { jobObjectsMap[it] }
-            .forEach { getHandler(it.trackerType()).handleNotPresent(it) }
+            .forEach { getHandler(it.trackerType).handleNotPresent(it) }
     }
 
     private suspend fun applySuccess(
@@ -114,10 +114,10 @@ internal class JobReportHandler internal constructor(
 
     private suspend fun getRelatedUids(jobObjects: List<TrackerJobObject>): DataStateUidHolder {
         return dataStatePropagator.getRelatedUids(
-            jobObjects.filter { it.trackerType() == TRACKED_ENTITY }.map { it.objectUid() },
-            jobObjects.filter { it.trackerType() == ENROLLMENT }.map { it.objectUid() },
-            jobObjects.filter { it.trackerType() == EVENT }.map { it.objectUid() },
-            jobObjects.filter { it.trackerType() == RELATIONSHIP }.map { it.objectUid() },
+            jobObjects.filter { it.trackerType == TRACKED_ENTITY }.map { it.objectUid },
+            jobObjects.filter { it.trackerType == ENROLLMENT }.map { it.objectUid },
+            jobObjects.filter { it.trackerType == EVENT }.map { it.objectUid },
+            jobObjects.filter { it.trackerType == RELATIONSHIP }.map { it.objectUid },
         )
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTypeHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/JobReportTypeHandler.kt
@@ -37,20 +37,20 @@ internal abstract class JobReportTypeHandler(
 ) {
 
     suspend fun handleSuccess(jo: TrackerJobObject) {
-        val handleAction = handleObject(jo.objectUid(), State.SYNCED)
+        val handleAction = handleObject(jo.objectUid, State.SYNCED)
 
         if (handleAction === HandleAction.Delete) {
-            getRelatedRelationships(jo.objectUid()).forEach { relationshipStore.deleteByEntity(it) }
+            getRelatedRelationships(jo.objectUid).forEach { relationshipStore.deleteByEntity(it) }
         }
     }
 
     suspend fun handleError(jo: TrackerJobObject, errorReport: JobValidationError) {
-        handleObject(jo.objectUid(), State.ERROR)
+        handleObject(jo.objectUid, State.ERROR)
         storeConflict(errorReport)
     }
 
     suspend fun handleNotPresent(jo: TrackerJobObject) {
-        handleObject(jo.objectUid(), State.TO_UPDATE)
+        handleObject(jo.objectUid, State.TO_UPDATE)
     }
 
     internal abstract suspend fun handleObject(uid: String, state: State): HandleAction

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterPostCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterPostCall.kt
@@ -138,32 +138,32 @@ internal class TrackerImporterPostCall internal constructor(
         payload: NewTrackerImporterPayload,
         jobUid: String,
     ): List<TrackerJobObject> {
-        val builder = TrackerJobObject
-            .builder()
-            .jobUid(jobUid)
-            .lastUpdated(Date())
+        val date = Date()
 
         val enrollments = payload.trackedEntities.flatMap { it.enrollments ?: emptyList() } + payload.enrollments
         val events = enrollments.flatMap { it.events ?: emptyList() } + payload.events
 
-        return generateTypeObjects(builder, TRACKED_ENTITY, payload.trackedEntities, payload.fileResourcesMap) +
-            generateTypeObjects(builder, ENROLLMENT, enrollments, payload.fileResourcesMap) +
-            generateTypeObjects(builder, EVENT, events, payload.fileResourcesMap) +
-            generateTypeObjects(builder, RELATIONSHIP, payload.relationships, payload.fileResourcesMap)
+        return generateTypeObjects(jobUid, date, TRACKED_ENTITY, payload.trackedEntities, payload.fileResourcesMap) +
+            generateTypeObjects(jobUid, date, ENROLLMENT, enrollments, payload.fileResourcesMap) +
+            generateTypeObjects(jobUid, date, EVENT, events, payload.fileResourcesMap) +
+            generateTypeObjects(jobUid, date, RELATIONSHIP, payload.relationships, payload.fileResourcesMap)
     }
 
     private fun generateTypeObjects(
-        builder: TrackerJobObject.Builder,
+        jobUid: String,
+        date: Date,
         objectType: TrackerImporterObjectType,
         objects: List<ObjectWithUidInterface>,
         fileResourcesMap: Map<String, List<String>>,
     ): List<TrackerJobObject> {
         return objects.map {
-            builder
-                .trackerType(objectType)
-                .objectUid(it.uid())
-                .fileResources(fileResourcesMap[it.uid()] ?: emptyList())
-                .build()
+            TrackerJobObject(
+                trackerType = objectType,
+                objectUid = it.uid(),
+                jobUid = jobUid,
+                lastUpdated = date,
+                fileResources = fileResourcesMap[it.uid()] ?: emptyList(),
+            )
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerJobObject.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,53 +26,15 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.tracker.importer.internal;
+package org.hisp.dhis.android.core.tracker.importer.internal
 
-import androidx.annotation.NonNull;
+import org.hisp.dhis.android.core.common.CoreObject
+import java.util.Date
 
-import com.google.auto.value.AutoValue;
-
-import org.hisp.dhis.android.core.common.CoreObject;
-
-import java.util.Date;
-import java.util.List;
-
-@AutoValue
-public abstract class TrackerJobObject implements CoreObject {
-
-    @NonNull
-    public abstract TrackerImporterObjectType trackerType();
-
-    @NonNull
-    public abstract String objectUid();
-
-    @NonNull
-    public abstract String jobUid();
-
-    @NonNull
-    public abstract Date lastUpdated();
-
-    @NonNull
-    public abstract List<String> fileResources();
-
-    public static Builder builder() {
-        return new AutoValue_TrackerJobObject.Builder();
-    }
-
-    abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder trackerType(TrackerImporterObjectType trackerType);
-
-        public abstract Builder objectUid(String objectUid);
-
-        public abstract Builder jobUid(String jobUid);
-
-        public abstract Builder lastUpdated(Date lastUpdated);
-
-        public abstract Builder fileResources(List<String> fileResources);
-
-        public abstract TrackerJobObject build();
-    }
-}
+internal data class TrackerJobObject(
+    val trackerType: TrackerImporterObjectType,
+    val objectUid: String,
+    val jobUid: String,
+    val lastUpdated: Date,
+    val fileResources: List<String>,
+) : CoreObject

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/SectionIndicatorLinkDB.kt
@@ -42,7 +42,7 @@ internal data class SectionIndicatorLinkDB(
 
 internal fun SectionIndicatorLink.toDB(): SectionIndicatorLinkDB {
     return SectionIndicatorLinkDB(
-        section = section()!!,
-        indicator = indicator()!!,
+        section = section(),
+        indicator = indicator(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/event/EventSyncDB.kt
@@ -7,7 +7,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.event.internal.EventSync
 import org.hisp.dhis.android.core.util.dateFormatNonNull
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
@@ -47,7 +47,7 @@ internal data class EventSyncDB(
             .organisationUnitIdsHash(organisationUnitIdsHash)
             .downloadLimit(downloadLimit)
             .workingListsHash(workingListsHash)
-            .lastUpdated(lastUpdated.toJavaDate())
+            .lastUpdated(lastUpdated.toJavaDateNonNull())
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSOngoingSubmissionDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/sms/SMSOngoingSubmissionDB.kt
@@ -10,13 +10,13 @@ import org.hisp.dhis.android.persistence.common.EntityDB
 internal data class SMSOngoingSubmissionDB(
     @PrimaryKey
     val submissionId: Int,
-    val type: String?,
+    val type: String,
 ) : EntityDB<SMSOngoingSubmission> {
 
     override fun toDomain(): SMSOngoingSubmission {
         return SMSOngoingSubmission.builder()
             .submissionId(submissionId)
-            .type(type?.let { SubmissionType.valueOf(it) })
+            .type(SubmissionType.valueOf(type))
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityInstanceSyncDB.kt
@@ -7,7 +7,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceSync
 import org.hisp.dhis.android.core.util.dateFormatNonNull
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.program.ProgramDB
 
@@ -46,7 +46,7 @@ internal data class TrackedEntityInstanceSyncDB(
             .organisationUnitIdsHash(organisationUnitIdsHash)
             .downloadLimit(downloadLimit)
             .workingListsHash(workingListsHash)
-            .lastUpdated(lastUpdated.toJavaDate())
+            .lastUpdated(lastUpdated.toJavaDateNonNull())
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/tracker/TrackerJobObjectDB.kt
@@ -4,7 +4,7 @@ import androidx.room.Entity
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterObjectType
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerJobObject
 import org.hisp.dhis.android.core.util.dateFormatNonNull
-import org.hisp.dhis.android.core.util.toJavaDate
+import org.hisp.dhis.android.core.util.toJavaDateNonNull
 import org.hisp.dhis.android.persistence.common.EntityDB
 import org.hisp.dhis.android.persistence.common.StringListDB
 import org.hisp.dhis.android.persistence.common.toDB
@@ -21,22 +21,22 @@ internal data class TrackerJobObjectDB(
     val fileResources: StringListDB?,
 ) : EntityDB<TrackerJobObject> {
     override fun toDomain(): TrackerJobObject {
-        return TrackerJobObject.builder()
-            .trackerType(trackerType.let { TrackerImporterObjectType.valueOf(it) })
-            .objectUid(objectUid)
-            .jobUid(jobUid)
-            .lastUpdated(lastUpdated.toJavaDate())
-            .fileResources(fileResources?.toDomain())
-            .build()
+        return TrackerJobObject(
+            trackerType = TrackerImporterObjectType.valueOf(trackerType),
+            objectUid = objectUid,
+            jobUid = jobUid,
+            lastUpdated = lastUpdated.toJavaDateNonNull(),
+            fileResources = fileResources?.toDomain() ?: emptyList(),
+        )
     }
 }
 
 internal fun TrackerJobObject.toDB(): TrackerJobObjectDB {
     return TrackerJobObjectDB(
-        trackerType = trackerType().name,
-        objectUid = objectUid(),
-        jobUid = jobUid(),
-        lastUpdated = lastUpdated().dateFormatNonNull(),
-        fileResources = fileResources().toDB(),
+        trackerType = trackerType.name,
+        objectUid = objectUid,
+        jobUid = jobUid,
+        lastUpdated = lastUpdated.dateFormatNonNull(),
+        fileResources = fileResources.toDB(),
     )
 }

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/tracker/importer/internal/TrackerJobObjectSamples.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/tracker/importer/internal/TrackerJobObjectSamples.kt
@@ -33,13 +33,13 @@ import org.hisp.dhis.android.core.tracker.importer.internal.TrackerJobObject
 
 object TrackerJobObjectSamples {
 
-    fun get1(): TrackerJobObject {
-        return TrackerJobObject.builder()
-            .trackerType(TrackerImporterObjectType.EVENT)
-            .objectUid("oUid")
-            .jobUid("jUid")
-            .lastUpdated(parseDate("2017-11-29T11:27:46.935"))
-            .fileResources(listOf("resource1", "resource2"))
-            .build()
+    internal fun get1(): TrackerJobObject {
+        return TrackerJobObject(
+            trackerType = TrackerImporterObjectType.EVENT,
+            objectUid = "oUid",
+            jobUid = "jUid",
+            lastUpdated = parseDate("2017-11-29T11:27:46.935"),
+            fileResources = listOf("resource1", "resource2"),
+        )
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
@@ -120,9 +120,9 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
         assertThat(bundles.size).isEqualTo(1)
         val bundle = bundles[0]
-        assertThat(bundle.orgUnits()).isEqualTo(rootOrgUnits)
-        assertThat(bundle.commonParams().programs).isEqualTo(programList)
-        assertThat(bundle.commonParams().ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
+        assertThat(bundle.orgUnits).isEqualTo(rootOrgUnits)
+        assertThat(bundle.commonParams.programs).isEqualTo(programList)
+        assertThat(bundle.commonParams.ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
     }
 
     @Test
@@ -133,15 +133,15 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
         assertThat(bundles.size).isEqualTo(2)
         for (bundle in bundles) {
-            when (bundle.commonParams().programs.size) {
+            when (bundle.commonParams.programs.size) {
                 1 -> {
-                    assertThat(bundle.commonParams().programs[0]).isEqualTo(p1)
-                    assertThat(bundle.commonParams().limit).isEqualTo(200)
+                    assertThat(bundle.commonParams.programs[0]).isEqualTo(p1)
+                    assertThat(bundle.commonParams.limit).isEqualTo(200)
                 }
 
                 2 -> {
-                    assertThat(bundle.commonParams().programs.contains(p2)).isTrue()
-                    assertThat(bundle.commonParams().programs.contains(p3)).isTrue()
+                    assertThat(bundle.commonParams.programs.contains(p2)).isTrue()
+                    assertThat(bundle.commonParams.programs.contains(p3)).isTrue()
                 }
 
                 else -> {
@@ -158,8 +158,8 @@ class EventQueryBundleFactoryShould {
         val queries = bundleFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         val query = queries.first()
-        assertThat(query.eventFilters()?.size).isEqualTo(1)
-        assertThat(query.eventFilters()?.first()).isEqualTo(f1)
+        assertThat(query.eventFilters?.size).isEqualTo(1)
+        assertThat(query.eventFilters?.first()).isEqualTo(f1)
     }
 
     @Test
@@ -170,9 +170,9 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
         assertThat(bundles.size).isEqualTo(2)
         for (bundle in bundles) {
-            if (bundle.commonParams().programs.size == 1) {
-                assertThat(bundle.commonParams().programs[0]).isEqualTo(p1)
-                assertThat(bundle.commonParams().startDate).isNotNull()
+            if (bundle.commonParams.programs.size == 1) {
+                assertThat(bundle.commonParams.programs[0]).isEqualTo(p1)
+                assertThat(bundle.commonParams.startDate).isNotNull()
             }
         }
     }
@@ -187,11 +187,11 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
         assertThat(bundles.size).isEqualTo(2)
         for (bundle in bundles) {
-            if (bundle.commonParams().programs.size == 1) {
-                assertThat(bundle.commonParams().programs[0]).isEqualTo(p1)
-                assertThat(bundle.commonParams().limit).isEqualTo(100)
+            if (bundle.commonParams.programs.size == 1) {
+                assertThat(bundle.commonParams.programs[0]).isEqualTo(p1)
+                assertThat(bundle.commonParams.limit).isEqualTo(100)
             } else {
-                assertThat(bundle.commonParams().limit).isEqualTo(4800)
+                assertThat(bundle.commonParams.limit).isEqualTo(4800)
             }
         }
     }
@@ -212,8 +212,8 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
 
         assertThat(bundles.size).isEqualTo(3)
-        assertThat(bundles.filter { it.commonParams().program == p1 }.size).isEqualTo(2)
-        assertThat(bundles.filter { it.commonParams().program == null }.size).isEqualTo(1)
+        assertThat(bundles.filter { it.commonParams.program == p1 }.size).isEqualTo(2)
+        assertThat(bundles.filter { it.commonParams.program == null }.size).isEqualTo(1)
     }
 
     @Test
@@ -234,8 +234,8 @@ class EventQueryBundleFactoryShould {
         val limits = bundleFactory.getQueries(params)
 
         assertThat(limits.size).isEqualTo(4)
-        assertThat(limits.filter { it.commonParams().program == p1 }.size).isEqualTo(1)
-        assertThat(limits.filter { it.commonParams().program == null }.size).isEqualTo(3)
+        assertThat(limits.filter { it.commonParams.program == p1 }.size).isEqualTo(1)
+        assertThat(limits.filter { it.commonParams.program == null }.size).isEqualTo(3)
     }
 
     @Test
@@ -257,6 +257,6 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
 
         assertThat(bundles.size).isEqualTo(2)
-        assertThat(bundles.filter { it.commonParams().program == p1 }.size).isEqualTo(2)
+        assertThat(bundles.filter { it.commonParams.program == p1 }.size).isEqualTo(2)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
@@ -138,9 +138,9 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         val query = queries[0]
-        assertThat(query.orgUnits()).isEqualTo(rootOrgUnits)
-        assertThat(query.commonParams().ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
-        assertThat(query.commonParams().program).isNull()
+        assertThat(query.orgUnits).isEqualTo(rootOrgUnits)
+        assertThat(query.commonParams.ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
+        assertThat(query.commonParams.program).isNull()
     }
 
     @Test
@@ -153,9 +153,9 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(2)
         for (query in queries) {
-            if (query.commonParams().program != null) {
-                assertThat(query.commonParams().program).isEqualTo(p1)
-                assertThat(query.commonParams().startDate).isNotNull()
+            if (query.commonParams.program != null) {
+                assertThat(query.commonParams.program).isEqualTo(p1)
+                assertThat(query.commonParams.startDate).isNotNull()
             }
         }
     }
@@ -166,8 +166,8 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         for (query in queries) {
-            assertThat(query.commonParams().program).isEqualTo(p1)
-            assertThat(query.commonParams().limit).isEqualTo(5000)
+            assertThat(query.commonParams.program).isEqualTo(p1)
+            assertThat(query.commonParams.limit).isEqualTo(5000)
         }
     }
 
@@ -178,8 +178,8 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         val query = queries.first()
-        assertThat(query.programStageWorkingLists()?.size).isEqualTo(1)
-        assertThat(query.programStageWorkingLists()?.first()).isEqualTo(w1)
+        assertThat(query.programStageWorkingLists?.size).isEqualTo(1)
+        assertThat(query.programStageWorkingLists?.first()).isEqualTo(w1)
     }
 
     @Test
@@ -189,8 +189,8 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         val query = queries.first()
-        assertThat(query.trackedEntityInstanceFilters()?.size).isEqualTo(1)
-        assertThat(query.trackedEntityInstanceFilters()?.first()).isEqualTo(f1)
+        assertThat(query.trackedEntityInstanceFilters?.size).isEqualTo(1)
+        assertThat(query.trackedEntityInstanceFilters?.first()).isEqualTo(f1)
     }
 
     @Test
@@ -203,11 +203,11 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(2)
         for (query in queries) {
-            if (query.commonParams().program != null) {
-                assertThat(query.commonParams().program).isEqualTo(p1)
-                assertThat(query.commonParams().limit).isEqualTo(100)
+            if (query.commonParams.program != null) {
+                assertThat(query.commonParams.program).isEqualTo(p1)
+                assertThat(query.commonParams.limit).isEqualTo(100)
             } else {
-                assertThat(query.commonParams().limit).isEqualTo(4800)
+                assertThat(query.commonParams.limit).isEqualTo(4800)
             }
         }
     }


### PR DESCRIPTION
Migrate some classes located in internal packages.

Those classes that are actually internal have been migrated to a plain data class (no accessor methods, no builder).