### PR TITLE
chore: [ANDROSDK-2301] fetch and persist the token exchange and refresh endpoint

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -17121,15 +17121,16 @@ public final class org/hisp/dhis/android/core/user/oauth2/OAuth2Handler$DefaultI
 
 public final class org/hisp/dhis/android/core/user/oauth2/OAuth2State {
 	public static final field Companion Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()J
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;)Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/user/oauth2/OAuth2State;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccessToken ()Ljava/lang/String;
 	public final fun getClientId ()Ljava/lang/String;
@@ -17137,6 +17138,7 @@ public final class org/hisp/dhis/android/core/user/oauth2/OAuth2State {
 	public final fun getKeyId ()Ljava/lang/String;
 	public final fun getRefreshToken ()Ljava/lang/String;
 	public final fun getScope ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun jsonSerializeString ()Ljava/lang/String;
 	public final fun needsTokenRefresh ()Z

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/OAuth2Authenticator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/OAuth2Authenticator.kt
@@ -60,7 +60,7 @@ internal class OAuth2Authenticator(
         if (call.response.status.value == UNAUTHORIZED) {
             val state = credentials.oauth2State
             if (state != null) {
-                val refreshedState = tokenRefresher.value.refreshToken(state, credentials.serverUrl)
+                val refreshedState = tokenRefresher.value.refreshToken(state, credentials.oauth2State.tokenEndpoint)
                 if (refreshedState != null) {
                     val updatedCredentials = credentials.copy(oauth2State = refreshedState)
                     credentialsSecureStore.set(updatedCredentials)
@@ -76,7 +76,7 @@ internal class OAuth2Authenticator(
     private suspend fun getUpdatedToken(credentials: Credentials): String {
         val state = credentials.oauth2State!!
         return if (state.needsTokenRefresh()) {
-            val newState = tokenRefresher.value.refreshToken(state, credentials.serverUrl)
+            val newState = tokenRefresher.value.refreshToken(state, credentials.oauth2State.tokenEndpoint)
             if (newState != null) {
                 credentialsSecureStore.set(credentials.copy(oauth2State = newState))
                 newState.accessToken!!

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2NetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2NetworkHandler.kt
@@ -48,10 +48,11 @@ internal interface OAuth2NetworkHandler {
         clientId: String,
         codeVerifier: String,
         clientAssertion: String,
+        oauthConfigPath: String = "/.well-known/oauth-authorization-server#/",
     ): Result<OAuth2State, D2Error>
 
     suspend fun refreshToken(
-        url: String,
+        endpoint: String,
         refreshToken: String,
         clientId: String,
         keyId: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2TokenRefresher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2TokenRefresher.kt
@@ -39,7 +39,7 @@ internal class OAuth2TokenRefresher(
     private val logoutHandler: OAuth2LogoutHandler,
 ) {
     @Suppress("ReturnCount")
-    suspend fun refreshToken(state: OAuth2State, serverUrl: String): OAuth2State? {
+    suspend fun refreshToken(state: OAuth2State, tokenEndpoint: String): OAuth2State? {
         return try {
             if (state.refreshToken == null) {
                 logoutHandler.logOut()
@@ -50,13 +50,13 @@ internal class OAuth2TokenRefresher(
 
             val clientAssertion = JWTHelper.createClientAssertion(
                 clientId = state.clientId,
-                tokenEndpoint = "$serverUrl/oauth2/token",
+                tokenEndpoint = tokenEndpoint,
                 privateKey = privateKey,
                 keyId = state.keyId,
             )
 
             val result = oauth2NetworkHandler.refreshToken(
-                url = serverUrl,
+                endpoint = tokenEndpoint,
                 refreshToken = state.refreshToken,
                 clientId = state.clientId,
                 keyId = state.keyId,

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/LoginConfigService.kt
@@ -57,6 +57,18 @@ internal class LoginConfigService(private val client: HttpServiceClient) {
         }
     }
 
+    suspend fun getOauthTokenConfigFor(serverUrl: String, oauthPath: String): OauthTokenConfigDTO {
+        return client.get {
+            val oauthConfigUrl = if (oauthPath.startsWith("http")) {
+                oauthPath
+            } else {
+                serverUrl.dropLastWhile { it == '/' } + "/" + oauthPath.dropWhile { it == '/' }
+            }
+            absoluteUrl(oauthConfigUrl)
+            excludeCredentials()
+        }
+    }
+
     companion object {
         const val LOGIN_CONFIG = "loginConfig"
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/loginconfig/OauthTokenConfigDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/loginconfig/OauthTokenConfigDTO.kt
@@ -25,34 +25,13 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.user.oauth2
+
+package org.hisp.dhis.android.network.loginconfig
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 
 @Serializable
-data class OAuth2State(
-    @SerialName("client_id") val clientId: String,
-    @SerialName("key_id") val keyId: String,
-    @SerialName("access_token") val accessToken: String?,
-    @SerialName("refresh_token") val refreshToken: String?,
-    @SerialName("expires_at") val expiresAt: Long,
-    @SerialName("scope") val scope: String?,
+internal data class OauthTokenConfigDTO(
     @SerialName("token_endpoint") val tokenEndpoint: String,
-) {
-    @Suppress("MagicNumber")
-    fun needsTokenRefresh(): Boolean {
-        val currentTime = System.currentTimeMillis().div(1000)
-        return (currentTime + BUFFER) >= expiresAt
-    }
-
-    fun jsonSerializeString(): String = Json.encodeToString(serializer(), this)
-
-    companion object {
-        private const val BUFFER = 60
-
-        fun jsonDeserialize(json: String): OAuth2State =
-            Json.decodeFromString(serializer(), json)
-    }
-}
+)

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2NetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2NetworkHandlerImpl.kt
@@ -38,6 +38,7 @@ import org.hisp.dhis.android.core.user.oauth2.OAuth2Config
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2NetworkHandler
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
+import org.hisp.dhis.android.network.loginconfig.LoginConfigService
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -48,6 +49,7 @@ internal class OAuth2NetworkHandlerImpl(
 ) : OAuth2NetworkHandler {
 
     private val service = OAuth2Service(httpClient)
+    private val configService = LoginConfigService(httpClient)
 
     override fun buildAuthorizationUrl(
         serverUrl: String,
@@ -77,10 +79,12 @@ internal class OAuth2NetworkHandlerImpl(
         clientId: String,
         codeVerifier: String,
         clientAssertion: String,
+        oauthConfigPath: String,
     ): Result<OAuth2State, D2Error> {
         return coroutineAPICallExecutor.wrap(storeError = false) {
+            val oauthConfig = configService.getOauthTokenConfigFor(url, oauthConfigPath)
             val response = service.exchangeCodeForToken(
-                url = url,
+                endpoint = oauthConfig.tokenEndpoint,
                 grantType = "authorization_code",
                 code = code,
                 redirectUri = redirectUri,
@@ -96,12 +100,13 @@ internal class OAuth2NetworkHandlerImpl(
                 refreshToken = response.refreshToken,
                 expiresAt = System.currentTimeMillis() / 1000 + response.expiresIn,
                 scope = response.scope,
+                tokenEndpoint = oauthConfig.tokenEndpoint,
             )
         }
     }
 
     override suspend fun refreshToken(
-        url: String,
+        endpoint: String,
         refreshToken: String,
         clientId: String,
         keyId: String,
@@ -109,7 +114,7 @@ internal class OAuth2NetworkHandlerImpl(
     ): Result<OAuth2State, D2Error> {
         return coroutineAPICallExecutor.wrap(storeError = false) {
             val response = service.refreshToken(
-                url = url,
+                endpoint = endpoint,
                 grantType = "refresh_token",
                 refreshToken = refreshToken,
                 clientId = clientId,
@@ -123,6 +128,7 @@ internal class OAuth2NetworkHandlerImpl(
                 refreshToken = response.refreshToken ?: refreshToken,
                 expiresAt = System.currentTimeMillis() / 1000 + response.expiresIn,
                 scope = response.scope,
+                tokenEndpoint = endpoint,
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2Service.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/OAuth2Service.kt
@@ -33,7 +33,7 @@ internal class OAuth2Service(private val client: HttpServiceClient) {
 
     @Suppress("LongParameterList")
     suspend fun exchangeCodeForToken(
-        url: String,
+        endpoint: String,
         grantType: String,
         code: String,
         redirectUri: String,
@@ -42,7 +42,7 @@ internal class OAuth2Service(private val client: HttpServiceClient) {
         clientAssertion: String,
     ): TokenResponseDTO {
         return client.post {
-            absoluteUrl(url + "/oauth2/token")
+            absoluteUrl(endpoint)
             contentType("x-www-form-urlencoded")
             body(
                 buildFormUrlEncoded(
@@ -61,14 +61,14 @@ internal class OAuth2Service(private val client: HttpServiceClient) {
     }
 
     suspend fun refreshToken(
-        url: String,
+        endpoint: String,
         grantType: String,
         refreshToken: String,
         clientId: String,
         clientAssertion: String,
     ): TokenResponseDTO {
         return client.post {
-            absoluteUrl(url + "/oauth2/token")
+            absoluteUrl(endpoint)
             contentType("x-www-form-urlencoded")
             body(
                 buildFormUrlEncoded(

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/TokenResponseDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/TokenResponseDTO.kt
@@ -32,18 +32,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class TokenResponseDTO(
-    @SerialName("access_token")
-    val accessToken: String,
-
-    @SerialName("token_type")
-    val tokenType: String,
-
-    @SerialName("expires_in")
-    val expiresIn: Long,
-
-    @SerialName("refresh_token")
-    val refreshToken: String?,
-
-    @SerialName("scope")
-    val scope: String?,
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("expires_in") val expiresIn: Long,
+    @SerialName("refresh_token") val refreshToken: String?,
+    @SerialName("scope") val scope: String?,
 )

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -329,6 +329,7 @@ class LogInCallUnitShould : BaseCallShould() {
             refreshToken = "refresh",
             expiresAt = 1_700_000_000L,
             scope = null,
+            tokenEndpoint = "https://dhis-instance.org/oauth/token",
         )
 
     companion object {

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -199,7 +199,7 @@ class OAuth2HandlerImplShould {
         seedSuccessfulLogInPrerequisites()
         whenever(keyStoreManager.getPrivateKey(KEY_ID)).thenReturn(keyPair.private)
         oauth2NetworkHandler.stub {
-            onBlocking { exchangeCodeForToken(any(), any(), any(), any(), any(), any()) }
+            onBlocking { exchangeCodeForToken(any(), any(), any(), any(), any(), any(), any()) }
                 .doReturn(Result.Failure(serverError()))
         }
 
@@ -216,7 +216,7 @@ class OAuth2HandlerImplShould {
         whenever(keyStoreManager.getPrivateKey(KEY_ID)).thenReturn(keyPair.private)
         val exchangedState = exchangedState()
         oauth2NetworkHandler.stub {
-            onBlocking { exchangeCodeForToken(any(), any(), any(), any(), any(), any()) }
+            onBlocking { exchangeCodeForToken(any(), any(), any(), any(), any(), any(), any()) }
                 .doReturn(Result.Success(exchangedState))
         }
         val expectedUser: User = mock()
@@ -462,6 +462,7 @@ class OAuth2HandlerImplShould {
             refreshToken = "refresh",
             expiresAt = 1_700_000_000L,
             scope = "openid",
+            tokenEndpoint = "https://server.com/oauth2/token",
         )
 
     private fun sampleOAuth2State(): OAuth2State =
@@ -472,6 +473,7 @@ class OAuth2HandlerImplShould {
             refreshToken = "refresh",
             expiresAt = 1_700_000_000L,
             scope = null,
+            tokenEndpoint = "https://server.com/oauth2/token",
         )
 
     private fun credentialsWithOAuth2(state: OAuth2State?): Credentials =

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2StateSecureStoreShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2StateSecureStoreShould.kt
@@ -45,6 +45,7 @@ class OAuth2StateSecureStoreShould {
         refreshToken = "refresh-A",
         expiresAt = 1_700_000_000L,
         scope = "openid",
+        tokenEndpoint = "https://dhis-instance.org/oauth/token",
     )
 
     private val stateB = OAuth2State(
@@ -54,6 +55,8 @@ class OAuth2StateSecureStoreShould {
         refreshToken = "refresh-B",
         expiresAt = 1_800_000_000L,
         scope = null,
+        tokenEndpoint = "https://dhis-instance.org/oauth/token",
+
     )
 
     @Before


### PR DESCRIPTION
this PR fetches the endpoint from the oauth config file during the first login with OAuth and uses it to request and refresh the token

Related task: [ANDROSDK-2301](https://dhis2.atlassian.net/browse/ANDROSDK-2301)

[ANDROSDK-2301]: https://dhis2.atlassian.net/browse/ANDROSDK-2301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ