### PR TITLE
chore: [ANDROSDK-2313] persist authorization type in DatabaseAccountDB

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDB.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.persistence.configuration
 
 import kotlinx.serialization.Serializable
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.common.AuthorizationType
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.util.dateFormat
@@ -49,6 +50,7 @@ internal data class DatabaseAccountDB(
     val syncState: String?,
     val importDB: DatabaseAccountImportDB?,
     val loginConfig: LoginConfigDB?,
+    val authorizationType: AuthorizationType?,
 ) : EntityDB<DatabaseAccount> {
 
     override fun toDomain(): DatabaseAccount {
@@ -62,6 +64,7 @@ internal data class DatabaseAccountDB(
             syncState(syncState?.let { State.valueOf(it) })
             importDB(importDB?.toDomain())
             loginConfig(loginConfig?.toDomain())
+            authorizationType(authorizationType ?: AuthorizationType.BASIC)
         }.build()
     }
 }
@@ -77,5 +80,6 @@ internal fun DatabaseAccount.toDB(): DatabaseAccountDB {
         syncState = syncState()?.name,
         importDB = importDB()?.toDB(),
         loginConfig = loginConfig()?.toDB(),
+        authorizationType = authorizationType() ?: AuthorizationType.BASIC,
     )
 }

--- a/core/src/sharedTest/resources/configuration/databases_configuration.json
+++ b/core/src/sharedTest/resources/configuration/databases_configuration.json
@@ -7,14 +7,16 @@
       "serverUrl": "server1",
       "databaseName": "dbname1.db",
       "encrypted": true,
-      "databaseCreationDate": "2014-06-06T20:44:21.375"
+      "databaseCreationDate": "2014-06-06T20:44:21.375",
+      "authorizationType": "OAUTH2"
     },
     {
       "username": "user2",
       "serverUrl": "server2",
       "databaseName": "dbname2.db",
       "encrypted": true,
-      "databaseCreationDate": "2014-06-04T20:44:21.375"
+      "databaseCreationDate": "2014-06-04T20:44:21.375",
+      "authorizationType": "OPEN_ID_CONNECT"
     }
   ]
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationHelperShould.kt
@@ -50,6 +50,7 @@ class DatabasesConfigurationHelperShould {
         .encrypted(false)
         .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
+        .authorizationType(AuthorizationType.BASIC)
         .build()
 
     private val userConfig12 = DatabaseAccount.builder()
@@ -59,6 +60,7 @@ class DatabasesConfigurationHelperShould {
         .encrypted(false)
         .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
+        .authorizationType(AuthorizationType.BASIC)
         .build()
 
     private val userConfig22 = DatabaseAccount.builder()
@@ -68,6 +70,7 @@ class DatabasesConfigurationHelperShould {
         .encrypted(false)
         .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
+        .authorizationType(AuthorizationType.BASIC)
         .build()
 
     private val singleServerSingleUserConfig = DatabasesConfiguration.builder()
@@ -129,19 +132,37 @@ class DatabasesConfigurationHelperShould {
 
     @Test
     fun add_new_configuration_to_empty() {
-        val config = helper.addOrUpdateAccount(null, url1, username1, false)
+        val config = helper.addOrUpdateAccount(
+            configuration = null,
+            serverUrl = url1,
+            username = username1,
+            encrypt = false,
+            authorizationType = AuthorizationType.BASIC,
+        )
         assertThat(config).isEqualTo(singleServerSingleUserConfig)
     }
 
     @Test
     fun add_new_configuration_to_single_server_single_user_in_same_server() {
-        val config = helper.addOrUpdateAccount(singleServerSingleUserConfig, url1, username2, false)
+        val config = helper.addOrUpdateAccount(
+            configuration = singleServerSingleUserConfig,
+            serverUrl = url1,
+            username = username2,
+            encrypt = false,
+            authorizationType = AuthorizationType.BASIC,
+        )
         assertThat(config).isEqualTo(singleServer2UserConfig)
     }
 
     @Test
     fun add_new_configuration_to_single_server_single_user_in_other_server() {
-        val config = helper.addOrUpdateAccount(singleServerSingleUserConfig, url2, username2, false)
+        val config = helper.addOrUpdateAccount(
+            configuration = singleServerSingleUserConfig,
+            serverUrl = url2,
+            username = username2,
+            encrypt = false,
+            authorizationType = AuthorizationType.BASIC,
+        )
         assertThat(
             DatabaseConfigurationHelper
                 .getLoggedAccount(config, username2, url2),
@@ -300,7 +321,13 @@ class DatabasesConfigurationHelperShould {
     @Test
     fun add_account_with_backslashes_updates_existing_account_with_forward_slashes() {
         val config = createConfigWithAccount(URL_WITH_SLASHES)
-        val updatedConfig = helper.addOrUpdateAccount(config, URL_WITH_BACKSLASHES, username1, false)
+        val updatedConfig = helper.addOrUpdateAccount(
+            configuration = config,
+            serverUrl = URL_WITH_BACKSLASHES,
+            username = username1,
+            encrypt = false,
+            authorizationType = AuthorizationType.BASIC,
+        )
 
         assertThat(updatedConfig.accounts().size).isEqualTo(1)
     }
@@ -308,7 +335,13 @@ class DatabasesConfigurationHelperShould {
     @Test
     fun add_account_with_forward_slashes_updates_existing_account_with_backslashes() {
         val config = createConfigWithAccount(URL_WITH_BACKSLASHES)
-        val updatedConfig = helper.addOrUpdateAccount(config, URL_WITH_SLASHES, username1, false)
+        val updatedConfig = helper.addOrUpdateAccount(
+            configuration = config,
+            serverUrl = URL_WITH_SLASHES,
+            username = username1,
+            encrypt = false,
+            authorizationType = AuthorizationType.BASIC,
+        )
 
         assertThat(updatedConfig.accounts().size).isEqualTo(1)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.configuration.internal
 
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.common.AuthorizationType
 import org.hisp.dhis.android.core.common.CoreObjectShould
 import org.hisp.dhis.android.persistence.configuration.DatabasesConfigurationDB
 import org.hisp.dhis.android.persistence.configuration.toDB
@@ -54,6 +55,10 @@ internal class DatabasesConfigurationShould : CoreObjectShould<DatabasesConfigur
         assertThat(user1.databaseName()).isEqualTo("dbname1.db")
         assertThat(user1.encrypted()).isTrue()
         assertThat(user1.databaseCreationDate()).isEqualTo(DateUtils.DATE_FORMAT.parse("2014-06-06T20:44:21.375"))
+        assertThat(user1.authorizationType()).isEqualTo(AuthorizationType.OAUTH2)
+
+        val user2 = configuration.accounts()[1]
+        assertThat(user2.authorizationType()).isEqualTo(AuthorizationType.OPEN_ID_CONNECT)
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationUtil.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/DatabasesConfigurationUtil.kt
@@ -29,12 +29,14 @@
 package org.hisp.dhis.android.core.configuration.internal
 
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.common.AuthorizationType
 
 object DatabasesConfigurationUtil {
     fun buildUserConfiguration(
         username: String,
         creationDate: String,
         serverUrl: String = "server",
+        authorizationType: AuthorizationType? = AuthorizationType.BASIC,
     ): DatabaseAccount {
         return DatabaseAccount.builder()
             .username(username)
@@ -43,6 +45,7 @@ object DatabasesConfigurationUtil {
             .encrypted(false)
             .databaseCreationDate(DateUtils.DATE_FORMAT.parse(creationDate))
             .lastAccessDate(DateUtils.DATE_FORMAT.parse(creationDate))
+            .authorizationType(authorizationType)
             .build()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2ManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2ManagerUnitShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.configuration.internal
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
+import org.hisp.dhis.android.core.common.AuthorizationType
 import org.hisp.dhis.android.core.common.BaseCallShould
 import org.junit.Before
 import org.junit.Test
@@ -56,6 +57,7 @@ class MultiUserDatabaseManagerForD2ManagerUnitShould : BaseCallShould() {
         .encrypted(false)
         .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
         .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
+        .authorizationType(AuthorizationType.BASIC)
         .build()
 
     private val databasesConfiguration = DatabasesConfiguration.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
@@ -64,6 +64,7 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
         .serverUrl(serverUrl)
         .encrypted(false)
         .databaseCreationDate(DATE)
+        .authorizationType(AuthorizationType.BASIC)
         .build()
 
     private val userConfigurationEncrypted = DatabaseAccount.builder()
@@ -72,6 +73,7 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
         .serverUrl(serverUrl)
         .encrypted(true)
         .databaseCreationDate(DATE)
+        .authorizationType(AuthorizationType.BASIC)
         .build()
 
     private val unencryptedConfiguration = DatabasesConfiguration.builder()
@@ -181,6 +183,34 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
         manager.loadExistingKeepingEncryption(serverUrl, username)
 
         verify(databaseManager).createOrOpenUnencryptedDatabase(unencryptedDbName)
+    }
+
+    @Test
+    fun forward_oauth2_authorization_type_to_configurationHelper_on_createNew() {
+        whenever(databaseManager.databaseExists(any())).doReturn(true)
+        whenever(
+            configurationHelper.addOrUpdateAccount(
+                null,
+                serverUrl,
+                username,
+                false,
+                null,
+                null,
+                AuthorizationType.OAUTH2,
+            ),
+        ).doReturn(unencryptedConfiguration)
+
+        manager.createNew(serverUrl, username, false, AuthorizationType.OAUTH2)
+
+        verify(configurationHelper).addOrUpdateAccount(
+            null,
+            serverUrl,
+            username,
+            false,
+            null,
+            null,
+            AuthorizationType.OAUTH2,
+        )
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/AccountManagerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/AccountManagerImplShould.kt
@@ -32,6 +32,7 @@ import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.db.access.DatabaseManager
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
+import org.hisp.dhis.android.core.common.AuthorizationType
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.configuration.internal.DatabaseConfigurationHelper
 import org.hisp.dhis.android.core.configuration.internal.DatabaseConfigurationInsecureStore
@@ -130,12 +131,18 @@ class AccountManagerImplShould {
     private fun activeCredentials(): Credentials =
         Credentials(USERNAME, SERVER_URL, "pwd", null)
 
-    private fun mockDatabaseAccount(serverUrl: String, username: String, dbName: String): DatabaseAccount =
+    private fun mockDatabaseAccount(
+        serverUrl: String,
+        username: String,
+        dbName: String,
+        authorizationType: AuthorizationType? = AuthorizationType.BASIC,
+    ): DatabaseAccount =
         mock {
             on { serverUrl() } doReturn serverUrl
             on { username() } doReturn username
             on { databaseName() } doReturn dbName
             on { encrypted() } doReturn false
+            on { authorizationType() } doReturn authorizationType
         }
 
     private fun seedConfiguration(accounts: List<DatabaseAccount>) {

--- a/core/src/test/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDBShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/persistence/configuration/DatabaseAccountDBShould.kt
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.configuration
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.common.AuthorizationType
+import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class DatabaseAccountDBShould {
+
+    private val json = Json { encodeDefaults = true }
+
+    private fun account(authorizationType: AuthorizationType?): DatabaseAccount =
+        DatabaseAccount.builder()
+            .username("user")
+            .serverUrl("https://dhis2.org")
+            .databaseName("user.db")
+            .encrypted(false)
+            .databaseCreationDate(DateUtils.DATE_FORMAT.parse(DATE))
+            .lastAccessDate(DateUtils.DATE_FORMAT.parse(DATE))
+            .authorizationType(authorizationType)
+            .build()
+
+    @Test
+    fun persist_basic_authorization_type_through_toDB_conversion() {
+        val db = account(AuthorizationType.BASIC).toDB()
+
+        assertThat(db.authorizationType).isEqualTo(AuthorizationType.BASIC)
+    }
+
+    @Test
+    fun persist_open_id_connect_authorization_type_through_toDB_conversion() {
+        val db = account(AuthorizationType.OPEN_ID_CONNECT).toDB()
+
+        assertThat(db.authorizationType).isEqualTo(AuthorizationType.OPEN_ID_CONNECT)
+    }
+
+    @Test
+    fun persist_oauth2_authorization_type_through_toDB_conversion() {
+        val db = account(AuthorizationType.OAUTH2).toDB()
+
+        assertThat(db.authorizationType).isEqualTo(AuthorizationType.OAUTH2)
+    }
+
+    @Test
+    fun default_to_basic_authorization_type_when_persisting_null() {
+        val db = account(null).toDB()
+
+        assertThat(db.authorizationType).isEqualTo(AuthorizationType.BASIC)
+    }
+
+    @Test
+    fun read_authorization_type_from_db_when_calling_toDomain() {
+        val db = account(AuthorizationType.OAUTH2).toDB()
+
+        val restored = db.toDomain()
+
+        assertThat(restored.authorizationType()).isEqualTo(AuthorizationType.OAUTH2)
+    }
+
+    @Test
+    fun preserve_authorization_type_across_full_serialization_roundtrip() {
+        AuthorizationType.values().forEach { type ->
+            val db = account(type).toDB()
+
+            val encoded = json.encodeToString(DatabaseAccountDB.serializer(), db)
+            val decoded = json.decodeFromString(DatabaseAccountDB.serializer(), encoded)
+
+            assertThat(decoded.authorizationType).isEqualTo(type)
+            assertThat(decoded.toDomain().authorizationType()).isEqualTo(type)
+        }
+    }
+
+    @Test
+    fun fall_back_to_basic_when_decoded_authorization_type_is_missing() {
+        val legacyJson = """
+            {
+              "username":"user",
+              "serverUrl":"https://dhis2.org",
+              "databaseName":"user.db",
+              "databaseCreationDate":"$DATE",
+              "lastAccessDate":"$DATE",
+              "encrypted":false,
+              "syncState":null,
+              "importDB":null,
+              "loginConfig":null,
+              "authorizationType":null
+            }
+        """.trimIndent()
+
+        val decoded = Json.decodeFromString(DatabaseAccountDB.serializer(), legacyJson)
+
+        assertThat(decoded.authorizationType).isNull()
+        assertThat(decoded.toDomain().authorizationType()).isEqualTo(AuthorizationType.BASIC)
+    }
+
+    companion object {
+        private const val DATE = "2024-01-01T00:00:00.000"
+    }
+}


### PR DESCRIPTION
The authorization type was being computed and passed to the `DatabaseAccount` builder, but it was missing from `DatabaseAccountDB`, so it was never serialized nor persisted in shared preferences. This change wires the field through `DatabaseAccountDB`'s `toDB` / `toDomain` conversions, defaulting to `BASIC` when absent for backwards compatibility, and extends the related unit tests (`DatabasesConfigurationHelperShould`, `MultiUserDatabaseManagerForD2ManagerUnitShould`, `MultiUserDatabaseManagerUnitShould`, `AccountManagerImplShould`, `DatabasesConfigurationShould`) to account for the new parameter. A new `DatabaseAccountDBShould` test verifies the full serialization round-trip for every `AuthorizationType` value.

Related task: [ANDROSDK-2313](https://dhis2.atlassian.net/browse/ANDROSDK-2313)

[ANDROSDK-2313]: https://dhis2.atlassian.net/browse/ANDROSDK-2313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ