### PR TITLE
chore: [ANDROSDK-2315] Implement multi account and offline for OpenId connections

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -19503,11 +19503,20 @@ public final class org/hisp/dhis/android/core/user/openid/OpenIDConnectConfig {
 }
 
 public abstract interface class org/hisp/dhis/android/core/user/openid/OpenIDConnectHandler {
+	public fun blockingChangePin (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun blockingHandleLogInResponse (Ljava/lang/String;Landroid/content/Intent;I)Lorg/hisp/dhis/android/core/user/User;
 	public abstract fun blockingLogIn (Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;)Lorg/hisp/dhis/android/core/user/openid/IntentWithRequestCode;
+	public fun blockingSetPin (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun handleLogInResponse (Ljava/lang/String;Landroid/content/Intent;I)Lio/reactivex/Single;
 	public abstract fun logIn (Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectConfig;)Lio/reactivex/Single;
 	public abstract fun logOutObservable ()Lio/reactivex/Observable;
+	public abstract fun suspendChangePin (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun suspendSetPin (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/hisp/dhis/android/core/user/openid/OpenIDConnectHandler$DefaultImpls {
+	public static fun blockingChangePin (Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectHandler;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
+	public static fun blockingSetPin (Lorg/hisp/dhis/android/core/user/openid/OpenIDConnectHandler;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 }
 
 public final class org/hisp/dhis/android/core/util/StringUtils {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectStateSecureStoreShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectStateSecureStoreShould.kt
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.user.openid
+
+import com.google.common.truth.Truth.assertThat
+import net.openid.appauth.AuthState
+import org.hisp.dhis.android.core.arch.storage.internal.ChunkedSecureStore
+import org.hisp.dhis.android.core.arch.storage.internal.InMemorySecureStore
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Instrumented test: [AuthState] serialization relies on org.json (and Uri) which are only
+ * available on a device/emulator, and AuthState has no value-based equals, so states are
+ * compared through their serialized JSON.
+ */
+class OpenIDConnectStateSecureStoreShould {
+
+    private lateinit var store: OpenIDConnectStateSecureStore
+
+    // refreshToken is one of the simple top-level keys preserved by AuthState (de)serialization.
+    private val stateA = AuthState.jsonDeserialize("""{"refreshToken":"refresh-A"}""")
+    private val stateB = AuthState.jsonDeserialize("""{"refreshToken":"refresh-B"}""")
+
+    @Before
+    fun setUp() {
+        store = OpenIDConnectStateSecureStore(ChunkedSecureStore(InMemorySecureStore()))
+    }
+
+    @Test
+    fun should_return_null_for_unknown_account() {
+        assertThat(store.get("https://play.dhis2.org", "admin")).isNull()
+    }
+
+    @Test
+    fun should_round_trip_state() {
+        store.set("https://play.dhis2.org", "admin", stateA)
+
+        assertThat(store.get("https://play.dhis2.org", "admin")?.jsonSerializeString())
+            .isEqualTo(stateA.jsonSerializeString())
+    }
+
+    @Test
+    fun should_isolate_entries_per_account() {
+        store.set("https://play.dhis2.org", "admin", stateA)
+        store.set("https://play.dhis2.org", "user", stateB)
+        store.set("https://other.dhis2.org", "admin", stateB)
+
+        assertThat(store.get("https://play.dhis2.org", "admin")?.jsonSerializeString())
+            .isEqualTo(stateA.jsonSerializeString())
+        assertThat(store.get("https://play.dhis2.org", "user")?.jsonSerializeString())
+            .isEqualTo(stateB.jsonSerializeString())
+        assertThat(store.get("https://other.dhis2.org", "admin")?.jsonSerializeString())
+            .isEqualTo(stateB.jsonSerializeString())
+    }
+
+    @Test
+    fun should_treat_normalized_server_url_variants_as_same_account() {
+        store.set("https://play.dhis2.org", "admin", stateA)
+
+        assertThat(store.get("HTTPS://PLAY.DHIS2.ORG/", "admin")?.jsonSerializeString())
+            .isEqualTo(stateA.jsonSerializeString())
+        assertThat(store.get("https://play.dhis2.org/api", "admin")?.jsonSerializeString())
+            .isEqualTo(stateA.jsonSerializeString())
+    }
+
+    @Test
+    fun should_remove_only_the_target_account() {
+        store.set("https://play.dhis2.org", "admin", stateA)
+        store.set("https://play.dhis2.org", "user", stateB)
+
+        store.remove("https://play.dhis2.org", "admin")
+
+        assertThat(store.get("https://play.dhis2.org", "admin")).isNull()
+        assertThat(store.get("https://play.dhis2.org", "user")?.jsonSerializeString())
+            .isEqualTo(stateB.jsonSerializeString())
+    }
+
+    @Test
+    fun should_overwrite_existing_state_for_same_account() {
+        store.set("https://play.dhis2.org", "admin", stateA)
+        store.set("https://play.dhis2.org", "admin", stateB)
+
+        assertThat(store.get("https://play.dhis2.org", "admin")?.jsonSerializeString())
+            .isEqualTo(stateB.jsonSerializeString())
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/OpenIDConnectAuthenticator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/OpenIDConnectAuthenticator.kt
@@ -34,6 +34,7 @@ import io.ktor.client.request.header
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.user.openid.OpenIDConnectLogoutHandler
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
 import org.hisp.dhis.android.core.user.openid.OpenIDConnectTokenRefresher
 import org.koin.core.annotation.Singleton
 
@@ -45,6 +46,7 @@ internal class OpenIDConnectAuthenticator(
     private val tokenRefresher: OpenIDConnectTokenRefresher,
     private val userIdHelper: UserIdAuthenticatorHelper,
     private val logoutHandler: OpenIDConnectLogoutHandler,
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore,
 ) {
 
     suspend fun handleTokenCall(
@@ -68,6 +70,8 @@ internal class OpenIDConnectAuthenticator(
         return if (state.needsTokenRefresh) {
             val token = tokenRefresher.blockingGetFreshToken(state)
             credentialsSecureStore.set(credentials) // Auth state internally updated
+            // Keep the per-account persisted state fresh so relogin uses the latest refresh token.
+            openIDConnectStateSecureStore.set(credentials.serverUrl, credentials.username, state)
             token
         } else {
             state.idToken!!

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -47,6 +47,7 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.user.AccountDeletionReason
 import org.hisp.dhis.android.core.user.AccountManager
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2StateSecureStore
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -60,6 +61,7 @@ internal class AccountManagerImpl(
     private val context: Context,
     private val databaseConfigurationHelper: DatabaseConfigurationHelper,
     private val oauth2StateSecureStore: OAuth2StateSecureStore,
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore,
 ) : AccountManager {
     private val accountDeletionSubject = PublishSubject.create<AccountDeletionReason>()
 
@@ -147,6 +149,7 @@ internal class AccountManagerImpl(
             FileResourceDirectoryHelper.deleteFileResourceDirectories(context, loggedAccount)
             databaseManager.deleteDatabase(loggedAccount.databaseName(), loggedAccount.encrypted())
             oauth2StateSecureStore.remove(credentials.serverUrl, credentials.username)
+            openIDConnectStateSecureStore.remove(credentials.serverUrl, credentials.username)
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -42,6 +42,8 @@ import org.hisp.dhis.android.core.user.AuthenticatedUser
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2StateSecureStore
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectTokenRefresher
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -60,6 +62,8 @@ internal class LogInCall(
     private val accountManager: AccountManagerImpl,
     private val apiCallErrorCatcher: UserAuthenticateCallErrorCatcher,
     private val oauth2StateSecureStore: OAuth2StateSecureStore,
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore,
+    private val openIDConnectTokenRefresher: Lazy<OpenIDConnectTokenRefresher>,
 ) {
     @Throws(D2Error::class)
     suspend fun logIn(username: String?, password: String?, serverUrl: String?): User {
@@ -71,11 +75,16 @@ internal class LogInCall(
         ServerURLWrapper.setServerUrl(parsedServerUrl.toString())
 
         val oauth2State = oauth2StateSecureStore.get(trimmedServerUrl!!, username!!)
-        return if (oauth2State != null) {
-            logInWithOAuth2State(trimmedServerUrl, username, password, oauth2State)
-        } else {
-            exceptions.throwExceptionIfPasswordNull(password)
-            logInWithPassword(trimmedServerUrl, username, password)
+        val openIdState = openIDConnectStateSecureStore.get(trimmedServerUrl, username)
+        return when {
+            oauth2State != null ->
+                logInWithOAuth2State(trimmedServerUrl, username, password, oauth2State)
+            openIdState != null ->
+                logInWithOpenIdState(trimmedServerUrl, username, password, openIdState)
+            else -> {
+                exceptions.throwExceptionIfPasswordNull(password)
+                logInWithPassword(trimmedServerUrl, username, password)
+            }
         }
     }
 
@@ -90,6 +99,31 @@ internal class LogInCall(
             val user = coroutineAPICallExecutor.wrap(errorCatcher = apiCallErrorCatcher) {
                 networkHandler.authenticate("Bearer ${state.accessToken!!}")
             }.getOrThrow()
+            loginOnline(user, credentials)
+        } catch (d2Error: D2Error) {
+            if (d2Error.isOffline) {
+                tryLoginOffline(credentials, d2Error)
+            } else {
+                throw handleOnlineException(d2Error, credentials)
+            }
+        }
+    }
+
+    private suspend fun logInWithOpenIdState(
+        serverUrl: String,
+        username: String,
+        pin: String?,
+        state: AuthState,
+    ): User {
+        val credentials = Credentials(username, serverUrl, pin, state, null)
+        // Try to refresh the idToken first; if it fails (offline or invalid refresh token) fall
+        // back to the stored idToken and let the network call decide between online and offline.
+        val token = openIDConnectTokenRefresher.value.blockingGetFreshTokenOrNull(state) ?: state.idToken!!
+        return try {
+            val user = coroutineAPICallExecutor.wrap(errorCatcher = apiCallErrorCatcher) {
+                networkHandler.authenticate("Bearer $token")
+            }.getOrThrow()
+            openIDConnectStateSecureStore.set(serverUrl, username, state)
             loginOnline(user, credentials)
         } catch (d2Error: D2Error) {
             if (d2Error.isOffline) {
@@ -159,7 +193,7 @@ internal class LogInCall(
 
         return coroutineAPICallExecutor.wrapTransactionallyRoom {
             try {
-                if (credentials.oauth2State != null) {
+                if (credentials.oauth2State != null || credentials.openIDConnectState != null) {
                     verifyPinAgainstStoredHash(credentials)
                 }
                 val authenticatedUser = AuthenticatedUser.builder()

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInExceptions.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInExceptions.kt
@@ -104,10 +104,10 @@ internal class LogInExceptions internal constructor(
             .build()
     }
 
-    fun pinRequiresOAuth2AccountError(): D2Error {
+    fun pinRequiresTokenBasedAccountError(): D2Error {
         return D2Error.builder()
             .errorCode(D2ErrorCode.INVALID_CONFIGURATION)
-            .errorDescription("PIN can only be set for OAuth2 accounts")
+            .errorDescription("PIN can only be set for OAuth2 or OpenID Connect accounts")
             .errorComponent(D2ErrorComponent.SDK)
             .build()
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -201,7 +201,7 @@ internal class OAuth2HandlerImpl(
         val credentials = credentialsSecureStore.get()
         return when {
             credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
-            credentials.oauth2State == null -> Result.Failure(logInExceptions.pinRequiresOAuth2AccountError())
+            credentials.oauth2State == null -> Result.Failure(logInExceptions.pinRequiresTokenBasedAccountError())
             else -> {
                 val updated = credentials.copy(password = pin)
                 credentialsSecureStore.set(updated)

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandler.kt
@@ -31,6 +31,9 @@ package org.hisp.dhis.android.core.user.openid
 import android.content.Intent
 import io.reactivex.Observable
 import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.User
 
 interface OpenIDConnectHandler {
@@ -39,4 +42,13 @@ interface OpenIDConnectHandler {
     fun handleLogInResponse(serverUrl: String, intent: Intent?, requestCode: Int): Single<User>
     fun blockingHandleLogInResponse(serverUrl: String, intent: Intent?, requestCode: Int): User
     fun logOutObservable(): Observable<Unit>
+
+    suspend fun suspendSetPin(pin: String): Result<Unit, D2Error>
+
+    fun blockingSetPin(pin: String): Result<Unit, D2Error> = runBlocking { suspendSetPin(pin) }
+
+    suspend fun suspendChangePin(currentPin: String, newPin: String): Result<Unit, D2Error>
+
+    fun blockingChangePin(currentPin: String, newPin: String): Result<Unit, D2Error> =
+        runBlocking { suspendChangePin(currentPin, newPin) }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImpl.kt
@@ -35,17 +35,27 @@ import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.runBlocking
 import net.openid.appauth.*
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
+import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.user.User
+import org.hisp.dhis.android.core.user.internal.AuthenticatedUserStore
 import org.hisp.dhis.android.core.user.internal.LogInCall
+import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.koin.core.annotation.Singleton
 
 private const val RC_AUTH = 2021
 
+@Suppress("LongParameterList")
 @Singleton
 internal class OpenIDConnectHandlerImpl(
     private val context: Context,
     private val logInCall: LogInCall,
     private val logoutHandler: OpenIDConnectLogoutHandler,
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore,
+    private val credentialsSecureStore: CredentialsSecureStore,
+    private val authenticatedUserStore: AuthenticatedUserStore,
+    private val logInExceptions: LogInExceptions,
 ) : OpenIDConnectHandler {
 
     override fun logIn(config: OpenIDConnectConfig): Single<IntentWithRequestCode> {
@@ -74,9 +84,11 @@ internal class OpenIDConnectHandlerImpl(
                 val response = AuthorizationResponse.fromIntent(intent)!!
                 downloadToken(response.createTokenExchangeRequest())
                     .observeOn(Schedulers.io())
-                    .map {
+                    .map { authState ->
                         runBlocking {
-                            logInCall.blockingLogInOpenIDConnect(serverUrl, it)
+                            val user = logInCall.blockingLogInOpenIDConnect(serverUrl, authState)
+                            openIDConnectStateSecureStore.set(serverUrl, user.username()!!, authState)
+                            user
                         }
                     }
             }
@@ -95,6 +107,37 @@ internal class OpenIDConnectHandlerImpl(
 
     override fun logOutObservable(): Observable<Unit> {
         return logoutHandler.logOutObservable()
+    }
+
+    override suspend fun suspendSetPin(pin: String): Result<Unit, D2Error> {
+        val credentials = credentialsSecureStore.get()
+        return when {
+            credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
+            credentials.openIDConnectState == null ->
+                Result.Failure(logInExceptions.pinRequiresTokenBasedAccountError())
+            else -> {
+                val updated = credentials.copy(password = pin)
+                credentialsSecureStore.set(updated)
+                val existing = authenticatedUserStore.selectFirst()
+                if (existing == null) {
+                    Result.Failure(logInExceptions.noAuthenticatedUserPersistedError())
+                } else {
+                    authenticatedUserStore.updateOrInsertWhere(
+                        existing.toBuilder().hash(updated.getHash()).build(),
+                    )
+                    Result.Success(Unit)
+                }
+            }
+        }
+    }
+
+    override suspend fun suspendChangePin(currentPin: String, newPin: String): Result<Unit, D2Error> {
+        val credentials = credentialsSecureStore.get()
+        return when {
+            credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
+            credentials.password != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
+            else -> suspendSetPin(newPin)
+        }
     }
 
     private fun downloadToken(tokenRequest: TokenRequest): Single<AuthState> {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectStateSecureStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectStateSecureStore.kt
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.user.openid
+
+import net.openid.appauth.AuthState
+import org.hisp.dhis.android.core.arch.storage.internal.ChunkedSecureStore
+import org.hisp.dhis.android.core.configuration.internal.ServerUrlNormalizer
+import org.koin.core.annotation.Singleton
+import java.security.MessageDigest
+
+@Singleton
+internal class OpenIDConnectStateSecureStore(
+    private val secureStore: ChunkedSecureStore,
+) {
+    fun set(serverUrl: String, username: String, state: AuthState) {
+        secureStore.setData(buildKey(serverUrl, username), state.jsonSerializeString())
+    }
+
+    fun get(serverUrl: String, username: String): AuthState? {
+        return secureStore.getData(buildKey(serverUrl, username))
+            ?.let { AuthState.jsonDeserialize(it) }
+    }
+
+    fun remove(serverUrl: String, username: String) {
+        secureStore.removeData(buildKey(serverUrl, username))
+    }
+
+    private fun buildKey(serverUrl: String, username: String): String {
+        val normalized = ServerUrlNormalizer.normalize(serverUrl)
+        val digest = MessageDigest.getInstance(HASH_ALGORITHM)
+            .digest("$normalized|$username".toByteArray())
+        val hash = digest.take(HASH_BYTE_COUNT).joinToString("") {
+            it.toUByte().toString(HEX_RADIX).padStart(HEX_STRING_WIDTH, '0')
+        }
+        return "$KEY_PREFIX$hash"
+    }
+
+    companion object {
+        private const val KEY_PREFIX = "openid_state_"
+        private const val HASH_ALGORITHM = "SHA-256"
+        private const val HASH_BYTE_COUNT = 8
+        private const val HEX_STRING_WIDTH = 2
+        private const val HEX_RADIX = 16
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectTokenRefresher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectTokenRefresher.kt
@@ -56,4 +56,30 @@ internal class OpenIDConnectTokenRefresher(
             }
         }.blockingGet()
     }
+
+    /**
+     * Attempts to obtain a fresh idToken without side effects. Unlike [blockingGetFreshToken],
+     * it does NOT log the user out and returns null on any failure (offline or invalid refresh
+     * token). Used during relogin so that the caller can fall back to the offline flow.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun blockingGetFreshTokenOrNull(authState: AuthState): String? {
+        val service = AuthorizationService(context)
+        return try {
+            Single.create<String> {
+                authState.performActionWithFreshTokens(service) {
+                        _: String?, idToken: String?, ex: AuthorizationException? ->
+                    service.dispose()
+                    if (idToken != null) {
+                        it.onSuccess(idToken)
+                    } else {
+                        it.onError(RuntimeException(ex))
+                    }
+                }
+            }.blockingGet()
+        } catch (e: Exception) {
+            service.dispose()
+            null
+        }
+    }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPluginShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPluginShould.kt
@@ -41,6 +41,7 @@ import org.hisp.dhis.android.core.arch.storage.internal.UserIdInMemoryStore
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2LogoutHandler
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2TokenRefresher
 import org.hisp.dhis.android.core.user.openid.OpenIDConnectLogoutHandler
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
 import org.hisp.dhis.android.core.user.openid.OpenIDConnectTokenRefresher
 import org.junit.*
 import org.junit.runner.RunWith
@@ -69,6 +70,9 @@ class ParentAuthenticatorPluginShould {
     @Mock
     private lateinit var logoutHandler: OpenIDConnectLogoutHandler
 
+    @Mock
+    private lateinit var openIDConnectStateSecureStore: OpenIDConnectStateSecureStore
+
     private lateinit var mockEngine: MockEngine
     private lateinit var authenticator: ParentAuthenticatorPlugin
     private lateinit var ktorClient: HttpClient
@@ -95,6 +99,7 @@ class ParentAuthenticatorPluginShould {
                 tokenRefresher,
                 userIdHelper,
                 logoutHandler,
+                openIDConnectStateSecureStore,
             ),
             OAuth2Authenticator(
                 credentialsSecureStore,

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/AccountManagerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/AccountManagerImplShould.kt
@@ -41,6 +41,7 @@ import org.hisp.dhis.android.core.configuration.internal.MultiUserDatabaseManage
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2StateSecureStore
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -67,6 +68,7 @@ class AccountManagerImplShould {
     private val context: Context = mock()
     private val databaseConfigurationHelper: DatabaseConfigurationHelper = mock()
     private val oauth2StateSecureStore: OAuth2StateSecureStore = mock()
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore = mock()
 
     private lateinit var tempDir: File
     private lateinit var accountManager: AccountManagerImpl
@@ -86,6 +88,7 @@ class AccountManagerImplShould {
             context,
             databaseConfigurationHelper,
             oauth2StateSecureStore,
+            openIDConnectStateSecureStore,
         )
     }
 
@@ -115,6 +118,7 @@ class AccountManagerImplShould {
 
         verify(databaseManager).deleteDatabase(DB_NAME, false)
         verify(oauth2StateSecureStore).remove(SERVER_URL, USERNAME)
+        verify(openIDConnectStateSecureStore).remove(SERVER_URL, USERNAME)
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.user.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import net.openid.appauth.AuthState
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutorMock
 import org.hisp.dhis.android.core.arch.helpers.UserHelper
@@ -46,6 +47,8 @@ import org.hisp.dhis.android.core.user.AuthenticatedUser
 import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2StateSecureStore
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
+import org.hisp.dhis.android.core.user.openid.OpenIDConnectTokenRefresher
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -78,6 +81,9 @@ class LogInCallUnitShould : BaseCallShould() {
     private val generalSettingCall: GeneralSettingCall = mock()
     private val accountManager: AccountManagerImpl = mock()
     private val oauth2StateSecureStore: OAuth2StateSecureStore = mock()
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore = mock()
+    private val openIDConnectTokenRefresher: OpenIDConnectTokenRefresher = mock()
+    private val openIdAuthState: AuthState = mock()
 
     @Before
     @Throws(Exception::class)
@@ -113,7 +119,7 @@ class LogInCallUnitShould : BaseCallShould() {
             userIdStore, userHandler, authenticatedUserStore, systemInfoCall, userStore,
             LogInDatabaseManager(multiUserDatabaseManager, generalSettingCall),
             LogInExceptions(credentialsSecureStore), accountManager, apiErrorCatcher,
-            oauth2StateSecureStore,
+            oauth2StateSecureStore, openIDConnectStateSecureStore, lazyOf(openIDConnectTokenRefresher),
         ).logIn(username, password, serverUrl)
     }
 
@@ -321,6 +327,92 @@ class LogInCallUnitShould : BaseCallShould() {
         )
     }
 
+    // OpenID Connect dispatcher tests
+
+    @Test
+    fun route_to_openid_path_with_refreshed_bearer_when_state_exists_for_account() = runTest {
+        whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
+        whenever(openIDConnectTokenRefresher.blockingGetFreshTokenOrNull(openIdAuthState))
+            .thenReturn(FRESH_ID_TOKEN)
+        whenever(authenticatedUser.hash()).thenReturn(null)
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+        whenever(
+            userNetworkHandler.authenticate(credentialsCaptor.capture()),
+        ).thenReturn(apiUser)
+
+        // password is null — must NOT throw because the OpenID path skips the null check
+        instantiateCall(USERNAME, null, SERVER_URL)
+
+        verify(openIDConnectTokenRefresher).blockingGetFreshTokenOrNull(openIdAuthState)
+        assertThat(credentialsCaptor.firstValue).isEqualTo("Bearer $FRESH_ID_TOKEN")
+    }
+
+    @Test
+    fun fall_back_to_stored_id_token_when_refresh_returns_null() = runTest {
+        whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
+        whenever(openIDConnectTokenRefresher.blockingGetFreshTokenOrNull(openIdAuthState)).thenReturn(null)
+        whenever(openIdAuthState.idToken).thenReturn(ID_TOKEN)
+        whenever(authenticatedUser.hash()).thenReturn(null)
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+        whenever(
+            userNetworkHandler.authenticate(credentialsCaptor.capture()),
+        ).thenReturn(apiUser)
+
+        instantiateCall(USERNAME, null, SERVER_URL)
+
+        assertThat(credentialsCaptor.firstValue).isEqualTo("Bearer $ID_TOKEN")
+    }
+
+    @Test
+    fun persist_credentials_with_openid_state_and_null_password_after_openid_login() = runTest {
+        whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
+        whenever(openIDConnectTokenRefresher.blockingGetFreshTokenOrNull(openIdAuthState))
+            .thenReturn(FRESH_ID_TOKEN)
+        whenever(authenticatedUser.hash()).thenReturn(null)
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+
+        instantiateCall(USERNAME, null, SERVER_URL)
+
+        verify(credentialsSecureStore).set(
+            Credentials(USERNAME, SERVER_URL, null, openIdAuthState, null),
+        )
+        verify(openIDConnectStateSecureStore).set(SERVER_URL, USERNAME, openIdAuthState)
+    }
+
+    @Test
+    fun reject_openid_login_when_pin_does_not_match_stored_hash() = runTest {
+        whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
+        whenever(openIDConnectTokenRefresher.blockingGetFreshTokenOrNull(openIdAuthState))
+            .thenReturn(FRESH_ID_TOKEN)
+        // Stored hash corresponds to a different PIN.
+        whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, "correct"))
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+
+        assertD2Error(D2ErrorCode.BAD_CREDENTIALS) {
+            instantiateCall(USERNAME, "wrong-pin", SERVER_URL)
+        }
+    }
+
+    @Test
+    fun fall_back_to_offline_login_for_openid_when_authenticate_throws_offline() = runTest {
+        whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
+        // Offline: refresh returns null and we fall back to the stored idToken.
+        whenever(openIDConnectTokenRefresher.blockingGetFreshTokenOrNull(openIdAuthState)).thenReturn(null)
+        whenever(openIdAuthState.idToken).thenReturn(ID_TOKEN)
+        whenAPICall { throw d2Error } // d2Error.isOffline = true (set in setUp)
+        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
+            .thenReturn(true)
+        // OpenID accounts without PIN have hash() == null because password is null on both sides.
+        whenever(authenticatedUser.hash()).thenReturn(null)
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+
+        instantiateCall(USERNAME, null, SERVER_URL)
+
+        verify(credentialsSecureStore).set(
+            Credentials(USERNAME, SERVER_URL, null, openIdAuthState, null),
+        )
+    }
+
     private fun oauth2State(accessToken: String): OAuth2State =
         OAuth2State(
             clientId = "client",
@@ -339,5 +431,7 @@ class LogInCallUnitShould : BaseCallShould() {
         private const val BASE_URL = "https://dhis-instance.org"
         private const val SERVER_URL = BASE_URL
         private const val ACCESS_TOKEN = "access-token-1"
+        private const val ID_TOKEN = "id-token-1"
+        private const val FRESH_ID_TOKEN = "fresh-id-token-1"
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -87,7 +87,7 @@ class OAuth2HandlerImplShould {
     fun setUp() {
         keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(KEY_SIZE) }.generateKeyPair()
         whenever(logInExceptions.noActiveSessionError()).thenReturn(sdkError("no session"))
-        whenever(logInExceptions.pinRequiresOAuth2AccountError()).thenReturn(sdkError("not oauth2"))
+        whenever(logInExceptions.pinRequiresTokenBasedAccountError()).thenReturn(sdkError("not oauth2"))
         whenever(logInExceptions.noAuthenticatedUserPersistedError()).thenReturn(sdkError("no user"))
         whenever(logInExceptions.incorrectPinError()).thenReturn(sdkError("bad pin"))
         handler = OAuth2HandlerImpl(

--- a/core/src/test/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImplShould.kt
@@ -1,0 +1,192 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.user.openid
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import net.openid.appauth.AuthState
+import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.arch.storage.internal.Credentials
+import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.user.AuthenticatedUser
+import org.hisp.dhis.android.core.user.internal.AuthenticatedUserStore
+import org.hisp.dhis.android.core.user.internal.LogInCall
+import org.hisp.dhis.android.core.user.internal.LogInExceptions
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+
+@RunWith(JUnit4::class)
+class OpenIDConnectHandlerImplShould {
+
+    private val context: Context = mock()
+    private val logInCall: LogInCall = mock()
+    private val logoutHandler: OpenIDConnectLogoutHandler = mock()
+    private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore = mock()
+    private val credentialsSecureStore: CredentialsSecureStore = mock()
+    private val authenticatedUserStore: AuthenticatedUserStore = mock()
+    private val logInExceptions: LogInExceptions = mock()
+
+    private val authState: AuthState = mock()
+
+    private lateinit var handler: OpenIDConnectHandlerImpl
+
+    @Before
+    fun setUp() {
+        whenever(logInExceptions.noActiveSessionError()).thenReturn(sdkError("no session"))
+        whenever(logInExceptions.pinRequiresTokenBasedAccountError()).thenReturn(sdkError("not openid"))
+        whenever(logInExceptions.noAuthenticatedUserPersistedError()).thenReturn(sdkError("no user"))
+        whenever(logInExceptions.incorrectPinError()).thenReturn(sdkError("bad pin"))
+        handler = OpenIDConnectHandlerImpl(
+            context,
+            logInCall,
+            logoutHandler,
+            openIDConnectStateSecureStore,
+            credentialsSecureStore,
+            authenticatedUserStore,
+            logInExceptions,
+        )
+    }
+
+    @Test
+    fun setPin_persists_pin_as_credentials_password_and_updates_authenticated_user_hash() {
+        whenever(credentialsSecureStore.get()).thenReturn(credentialsWithOpenId(authState))
+        val existing = AuthenticatedUser.builder().user("uid").hash(null).build()
+        authenticatedUserStore.stub {
+            onBlocking { selectFirst() }.doReturn(existing)
+        }
+
+        val result = handler.blockingSetPin(PIN)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val credentialsCaptor = argumentCaptor<Credentials>()
+        verify(credentialsSecureStore).set(credentialsCaptor.capture())
+        assertThat(credentialsCaptor.firstValue.password).isEqualTo(PIN)
+        assertThat(credentialsCaptor.firstValue.openIDConnectState).isNotNull()
+        val userCaptor = argumentCaptor<AuthenticatedUser>()
+        verifyBlocking(authenticatedUserStore) { updateOrInsertWhere(userCaptor.capture()) }
+        assertThat(userCaptor.firstValue.hash())
+            .isEqualTo(Credentials(USERNAME, SERVER_URL, PIN, null).getHash())
+    }
+
+    @Test
+    fun setPin_fails_when_not_logged_in() {
+        whenever(credentialsSecureStore.get()).thenReturn(null)
+
+        val result = handler.blockingSetPin(PIN)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        verify(credentialsSecureStore, never()).set(any())
+    }
+
+    @Test
+    fun setPin_fails_when_account_is_not_openid() {
+        whenever(credentialsSecureStore.get()).thenReturn(credentialsWithOpenId(state = null))
+
+        val result = handler.blockingSetPin(PIN)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        verify(credentialsSecureStore, never()).set(any())
+    }
+
+    @Test
+    fun setPin_fails_when_no_authenticated_user_persisted() {
+        whenever(credentialsSecureStore.get()).thenReturn(credentialsWithOpenId(authState))
+        authenticatedUserStore.stub {
+            onBlocking { selectFirst() }.doReturn(null)
+        }
+
+        val result = handler.blockingSetPin(PIN)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun changePin_replaces_pin_when_current_matches() {
+        val current = credentialsWithOpenId(authState).copy(password = PIN)
+        whenever(credentialsSecureStore.get()).thenReturn(current)
+        val existing = AuthenticatedUser.builder().user("uid").hash(current.getHash()).build()
+        authenticatedUserStore.stub {
+            onBlocking { selectFirst() }.doReturn(existing)
+        }
+
+        val result = handler.blockingChangePin(PIN, NEW_PIN)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val credentialsCaptor = argumentCaptor<Credentials>()
+        verify(credentialsSecureStore).set(credentialsCaptor.capture())
+        assertThat(credentialsCaptor.firstValue.password).isEqualTo(NEW_PIN)
+    }
+
+    @Test
+    fun changePin_fails_when_current_pin_does_not_match() {
+        val current = credentialsWithOpenId(authState).copy(password = PIN)
+        whenever(credentialsSecureStore.get()).thenReturn(current)
+
+        val result = handler.blockingChangePin("wrong", NEW_PIN)
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        verify(credentialsSecureStore, never()).set(any())
+    }
+
+    private fun credentialsWithOpenId(state: AuthState?): Credentials =
+        Credentials(
+            username = USERNAME,
+            serverUrl = SERVER_URL,
+            password = null,
+            openIDConnectState = state,
+            oauth2State = null,
+        )
+
+    private fun sdkError(description: String): D2Error =
+        D2Error.builder()
+            .errorCode(D2ErrorCode.UNEXPECTED)
+            .errorDescription(description)
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
+
+    companion object {
+        private const val USERNAME = "user-1"
+        private const val SERVER_URL = "https://server.com"
+        private const val PIN = "1234"
+        private const val NEW_PIN = "5678"
+    }
+}


### PR DESCRIPTION
Similarly to what was implemented for OAuth accounts, the OpenId Auth state and a PIN is persisted so several accounts with this configuration can be created and restored, allowing offline connections as well.

Related task: [ANDROSDK-2315](https://dhis2.atlassian.net/browse/ANDROSDK-2315)

[ANDROSDK-2315]: https://dhis2.atlassian.net/browse/ANDROSDK-2315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ