### PR TITLE
[ANDROSDK-2319] fix: avoid re-downloading exhausted programs in tracker download

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -194,6 +194,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         val iterationResult = IterationResult()
 
         bundleResult.bundleOrgUnitPrograms[orgUnitUid]?.let { bundlePrograms ->
+            var remainingPrograms = bundlePrograms
             for (bundleProgram in bundlePrograms) {
                 if (bundleResult.bundleCount < bundle.commonParams().limit) {
                     val trackerQuery = getQuery(bundle, bundleProgram.program, orgUnitUid, limit)
@@ -224,9 +225,10 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                     progressManager.updateProgramSyncStatus(bundleProgram.program, syncStatus)
 
                     if (result.exhaustedProgram || !result.successfulSync) {
-                        bundleResult.bundleOrgUnitPrograms[orgUnitUid] = bundlePrograms
+                        remainingPrograms = remainingPrograms
                             .filter { it.program != bundleProgram.program }
                             .toMutableList()
+                        bundleResult.bundleOrgUnitPrograms[orgUnitUid] = remainingPrograms
 
                         val hasOtherOrgunits = bundleResult.bundleOrgUnitPrograms.values.any { list ->
                             list.any { it.program == bundleProgram.program }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -120,7 +120,10 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                     val result = iterateBundle(bundle, params, bundleResult, relatives, progressManager)
                     successfulSync = successfulSync && result.successfulSync
                     iterationCount++
-                } while (iterationNotFinished(bundle, params, bundleResult, iterationCount))
+                } while (
+                    result.downloadedCount > 0 &&
+                    iterationNotFinished(bundle, params, bundleResult, iterationCount)
+                )
 
                 if (successfulSync) {
                     updateLastUpdated(bundle)
@@ -176,6 +179,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                 progressManager,
             )
             iterationResult.successfulSync = iterationResult.successfulSync && result.successfulSync
+            iterationResult.downloadedCount += result.downloadedCount
         }
 
         return iterationResult
@@ -213,6 +217,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
                     bundleResult.bundleCount += result.count
                     bundleProgram.itemCount += result.count
+                    iterationResult.downloadedCount += result.count
                     iterationResult.successfulSync = iterationResult.successfulSync && result.successfulSync
 
                     val syncStatus =
@@ -406,6 +411,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
     protected class IterationResult(
         var successfulSync: Boolean = true,
+        var downloadedCount: Int = 0,
     )
 
     companion object {

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -37,16 +37,21 @@ import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.internal.AppDatabase
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityEndpointCallFactory
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceDownloadCall
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceLastUpdatedManager
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstancePersistenceCallFactory
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryBundle
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryBundleFactory
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParams
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryCollectionRepository
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterBreakTheGlassHelper
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
@@ -56,9 +61,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -168,5 +175,47 @@ class TrackerDownloadCallShould {
 
         assertThat(progressList).isNotEmpty()
         assertThat(progressList.last().isComplete).isTrue()
+    }
+
+    @Test
+    fun not_download_the_same_program_more_than_once_when_it_is_exhausted() = runTest {
+        val programUids = listOf("program1", "program2", "program3")
+        val orgUnitUid = "orgUnit1"
+
+        val commonParams = TrackerQueryCommonParams(
+            uids = emptyList(),
+            programs = programUids,
+            program = null,
+            startDate = null,
+            hasLimitByOrgUnit = false,
+            ouMode = OrganisationUnitMode.DESCENDANTS,
+            orgUnitsBeforeDivision = listOf(orgUnitUid),
+            limit = ProgramDataDownloadParams.DEFAULT_LIMIT,
+        )
+        val bundle = TrackerQueryBundle.builder()
+            .commonParams(commonParams)
+            .orgUnits(listOf(orgUnitUid))
+            .build()
+
+        whenever(queryFactory.getQueries(any())).doReturn(listOf(bundle))
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>())).doReturn(emptyList())
+
+        val endpointCallFactory: TrackedEntityEndpointCallFactory = mock()
+        whenever(trackerCallFactory.getTrackedEntityCall()).doReturn(endpointCallFactory)
+
+        // Each program has fewer TEIs than the page size, so it is exhausted in its first page
+        // and should not be queried again in subsequent bundle iterations.
+        val payload: Payload<TrackedEntityInstance> = mock()
+        val teis = (1..6).map { mock<TrackedEntityInstance>() }
+        whenever(payload.items).doReturn(teis)
+        whenever(endpointCallFactory.getCollectionCall(any())).doReturn(payload)
+
+        call.download(ProgramDataDownloadParams.builder().build()).toList()
+
+        val captor = argumentCaptor<TrackerAPIQuery>()
+        verify(endpointCallFactory, times(programUids.size)).getCollectionCall(captor.capture())
+
+        val downloadedPrograms = captor.allValues.map { it.commonParams.program }
+        assertThat(downloadedPrograms).containsExactlyElementsIn(programUids)
     }
 }


### PR DESCRIPTION
## Summary

Fixes redundant tracked-entity downloads during a global sync. For a single program with few TEIs, the SDK was issuing the same paginated request several times across bundle iterations, re-downloading and re-persisting already-fetched data. The number of redundant calls grew quadratically with the number of programs in the bundle.

## Root cause

In `TrackerDownloadCall.iterateBundleOrgunit`, when a program was exhausted it was removed by filtering the **original captured `bundlePrograms` list** instead of the current value in `bundleOrgUnitPrograms`. Each exhaustion overwrote the previous assignment, so only the **last** exhausted program was actually removed per iteration. With M programs sharing the same org units (the global download case), this forced one extra bundle iteration per program and re-issued the same network calls — `M(M+1)/2` requests instead of `M`.

## Changes

1. **Main fix:** the removal of exhausted programs now operates cumulatively on the remaining programs, so each org-unit/program combination is queried only once when it is exhausted.
2. **Safety net:** track the number of items downloaded per iteration and stop the bundle loop as soon as a full iteration downloads nothing new, so termination no longer depends solely on the org-unit list being emptied.

## Testing

- Added a regression test (`TrackerDownloadCallShould`) that sets up a global bundle with multiple programs (each exhausted in its first page) and asserts each program is requested exactly once. The test fails against the previous logic (`TooManyActualInvocations`) and passes with the fix.
- `./gradlew :core:testDebugUnitTest --tests *TrackerDownloadCallShould` → green.