### PR TITLE
fix: [ANDROAPP-7646]   fix: discard online failures in OFFLINE_FIRST to preserve local results

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -81,7 +81,7 @@ internal class TrackedEntityInstanceQueryDataFetcher(
             }
             if (result.size < requestedLoadSize && scope.mode() == RepositoryMode.OFFLINE_FIRST) {
                 val onlineInstances = queryOnline(requestedLoadSize)
-                result.addAll(onlineInstances)
+                result.addAll(onlineInstances.filter { it.succeeded })
             }
         } else {
             val instances = queryOnline(requestedLoadSize)


### PR DESCRIPTION
 Link to [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-7646).

## Problem
  
In `OFFLINE_FIRST` mode, `TrackedEntityInstanceQueryDataFetcher` runs an online query to top up results when the offline page is short. If that online call fails (e.g. HTTP 400, network timeout), the failure item was`LoadResult.Error`. 

Paging3 then discards the offline results already collected for that page and the UI freezes on the previous result set — even though valid local data was available.
  
## Solution
  
Filter out failed (`Result.Failure`) online items before merging them with the local results, so a failing online query no longer wipes out valid offline data — the offline results are still emitted and the UI stays responsive. Local failures originating from `transform()` (e.g. missing `TrackedEntityType`) are unaffected, since they're produced after this merge point and still propagate as before.
  