### PR TITLE
chore: [ANDROSDK-2327] filter out category option mappings without filter

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/network/program/CategoryMappingDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/program/CategoryMappingDTO.kt
@@ -44,7 +44,7 @@ internal data class CategoryMappingDTO(
             .program(programUid)
             .categoryId(categoryId)
             .mappingName(mappingName)
-            .optionMappings(optionMappings.map { it.toDomain(id) })
+            .optionMappings(optionMappings.filter { it.filter != null }.map { it.toDomain(id) })
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/program/CategoryMappingDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/program/CategoryMappingDTO.kt
@@ -44,7 +44,7 @@ internal data class CategoryMappingDTO(
             .program(programUid)
             .categoryId(categoryId)
             .mappingName(mappingName)
-            .optionMappings(optionMappings.filter { it.filter != null }.map { it.toDomain(id) })
+            .optionMappings(optionMappings.mapNotNull { it.toDomain(id) })
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/program/CategoryOptionMappingDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/program/CategoryOptionMappingDTO.kt
@@ -34,13 +34,13 @@ import org.hisp.dhis.android.core.program.CategoryOptionMapping
 @Serializable
 internal data class CategoryOptionMappingDTO(
     val optionId: String,
-    val filter: String,
+    val filter: String? = null,
 ) {
     fun toDomain(categoryMappingId: String): CategoryOptionMapping {
         return CategoryOptionMapping.builder()
             .categoryMapping(categoryMappingId)
             .optionId(optionId)
-            .filter(filter)
+            .filter(filter!!)
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/program/CategoryOptionMappingDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/program/CategoryOptionMappingDTO.kt
@@ -36,11 +36,13 @@ internal data class CategoryOptionMappingDTO(
     val optionId: String,
     val filter: String? = null,
 ) {
-    fun toDomain(categoryMappingId: String): CategoryOptionMapping {
-        return CategoryOptionMapping.builder()
-            .categoryMapping(categoryMappingId)
-            .optionId(optionId)
-            .filter(filter!!)
-            .build()
+    fun toDomain(categoryMappingId: String): CategoryOptionMapping? {
+        return filter?.let {
+            CategoryOptionMapping.builder()
+                .optionId(optionId)
+                .categoryMapping(categoryMappingId)
+                .filter(it)
+                .build()
+        }
     }
 }

--- a/core/src/sharedTest/resources/program/program.json
+++ b/core/src/sharedTest/resources/program/program.json
@@ -109,6 +109,9 @@
         {
           "optionId": "xYerKDKCefk",
           "filter": "#{condition1}"
+        },
+        {
+          "optionId": "bRowv6yZOF2"
         }
       ]
     }


### PR DESCRIPTION
Category option mappings are expected to always carry a filter, but some objects arrive from the server without one. Since the field was non-nullable, deserialization failed on those objects. This makes `CategoryOptionMappingDTO.filter` nullable and drops the option mappings without a filter when mapping a category mapping to its domain model, so the program download no longer fails on these entries.

A `program.json` test case with an option mapping lacking a filter was added to verify it is excluded after deserialization and `toDomain`.

Related task: [ANDROSDK-2327](https://dhis2.atlassian.net/browse/ANDROSDK-2327)

[ANDROSDK-2327]: https://dhis2.atlassian.net/browse/ANDROSDK-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ