### PR TITLE
chore: [ANDROSDK-2331] migrate attribute value link and indicator domain models to Kotlin

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3352,55 +3352,154 @@ public final class org/hisp/dhis/android/core/attribute/AttributeValueUtils {
 	public static fun extractValue (Ljava/util/List;Ljava/lang/String;)Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public abstract fun attribute ()Ljava/lang/String;
-	public static fun builder ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
-	public abstract fun dataElement ()Ljava/lang/String;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
-	public abstract fun value ()Ljava/lang/String;
+public final class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun attribute ()Ljava/lang/String;
+	public static final fun builder ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink;
+	public final fun dataElement ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Ljava/lang/String;
+	public final fun getDataElement ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
+	public fun toString ()Ljava/lang/String;
+	public final fun value ()Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder {
+public final class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder : org/hisp/dhis/android/core/attribute/DataElementAttributeValueLinkBuilder {
 	public fun <init> ()V
-	public abstract fun attribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
-	public abstract fun build ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink;
-	public abstract fun dataElement (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
-	public abstract fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
 }
 
-public abstract class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public abstract fun attribute ()Ljava/lang/String;
-	public static fun builder ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
-	public abstract fun program ()Ljava/lang/String;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
-	public abstract fun value ()Ljava/lang/String;
+public final class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
 }
 
-public abstract class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder {
+public class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLinkBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLinkBuilder$Companion;
+	protected field attribute Ljava/lang/String;
+	protected field dataElement Ljava/lang/String;
 	public fun <init> ()V
-	public abstract fun attribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
-	public abstract fun build ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink;
-	public abstract fun program (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
-	public abstract fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+	public final fun attribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
+	public fun build ()Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink;
+	public final fun dataElement (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
+	protected final fun getAttribute ()Ljava/lang/String;
+	protected final fun getDataElement ()Ljava/lang/String;
+	protected final fun getValue ()Ljava/lang/String;
+	protected final fun setAttribute (Ljava/lang/String;)V
+	protected final fun setDataElement (Ljava/lang/String;)V
+	protected final fun setValue (Ljava/lang/String;)V
+	public final fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
 }
 
-public abstract class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public abstract fun attribute ()Ljava/lang/String;
-	public static fun builder ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
-	public abstract fun programStage ()Ljava/lang/String;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
-	public abstract fun value ()Ljava/lang/String;
+public final class org/hisp/dhis/android/core/attribute/DataElementAttributeValueLinkBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink;)Lorg/hisp/dhis/android/core/attribute/DataElementAttributeValueLink$Builder;
 }
 
-public abstract class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder {
+public final class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun attribute ()Ljava/lang/String;
+	public static final fun builder ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Ljava/lang/String;
+	public final fun getProgram ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun program ()Ljava/lang/String;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+	public fun toString ()Ljava/lang/String;
+	public final fun value ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder : org/hisp/dhis/android/core/attribute/ProgramAttributeValueLinkBuilder {
 	public fun <init> ()V
-	public abstract fun attribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
-	public abstract fun build ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink;
-	public abstract fun programStage (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
-	public abstract fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+}
+
+public class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLinkBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLinkBuilder$Companion;
+	protected field attribute Ljava/lang/String;
+	protected field program Ljava/lang/String;
+	public fun <init> ()V
+	public final fun attribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+	public fun build ()Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink;
+	protected final fun getAttribute ()Ljava/lang/String;
+	protected final fun getProgram ()Ljava/lang/String;
+	protected final fun getValue ()Ljava/lang/String;
+	public final fun program (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+	protected final fun setAttribute (Ljava/lang/String;)V
+	protected final fun setProgram (Ljava/lang/String;)V
+	protected final fun setValue (Ljava/lang/String;)V
+	public final fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramAttributeValueLinkBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink;)Lorg/hisp/dhis/android/core/attribute/ProgramAttributeValueLink$Builder;
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun attribute ()Ljava/lang/String;
+	public static final fun builder ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Ljava/lang/String;
+	public final fun getProgramStage ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun programStage ()Ljava/lang/String;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+	public fun toString ()Ljava/lang/String;
+	public final fun value ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder : org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLinkBuilder {
+	public fun <init> ()V
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+}
+
+public class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLinkBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLinkBuilder$Companion;
+	protected field attribute Ljava/lang/String;
+	protected field programStage Ljava/lang/String;
+	public fun <init> ()V
+	public final fun attribute (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+	public fun build ()Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink;
+	protected final fun getAttribute ()Ljava/lang/String;
+	protected final fun getProgramStage ()Ljava/lang/String;
+	protected final fun getValue ()Ljava/lang/String;
+	public final fun programStage (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+	protected final fun setAttribute (Ljava/lang/String;)V
+	protected final fun setProgramStage (Ljava/lang/String;)V
+	protected final fun setValue (Ljava/lang/String;)V
+	public final fun value (Ljava/lang/String;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
+}
+
+public final class org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLinkBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink;)Lorg/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink$Builder;
 }
 
 public final class org/hisp/dhis/android/core/category/Category : org/hisp/dhis/android/core/common/BaseIdentifiableObjectKt, org/hisp/dhis/android/core/common/CoreObject {
@@ -9798,19 +9897,48 @@ public abstract interface class org/hisp/dhis/android/core/imports/internal/WebR
 	public abstract fun getStatus ()Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/indicator/DataSetIndicatorLink : org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
-	public abstract fun dataSet ()Ljava/lang/String;
-	public abstract fun indicator ()Ljava/lang/String;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+public final class org/hisp/dhis/android/core/indicator/DataSetIndicatorLink : org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink;
+	public final fun dataSet ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataSet ()Ljava/lang/String;
+	public final fun getIndicator ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun indicator ()Ljava/lang/String;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder {
+public final class org/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder : org/hisp/dhis/android/core/indicator/DataSetIndicatorLinkBuilder {
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink;
-	public abstract fun dataSet (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
-	public abstract fun indicator (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+}
+
+public final class org/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+}
+
+public class org/hisp/dhis/android/core/indicator/DataSetIndicatorLinkBuilder {
+	public static final field Companion Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLinkBuilder$Companion;
+	protected field dataSet Ljava/lang/String;
+	protected field indicator Ljava/lang/String;
+	public fun <init> ()V
+	public fun build ()Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink;
+	public final fun dataSet (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+	protected final fun getDataSet ()Ljava/lang/String;
+	protected final fun getIndicator ()Ljava/lang/String;
+	public final fun indicator (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
+	protected final fun setDataSet (Ljava/lang/String;)V
+	protected final fun setIndicator (Ljava/lang/String;)V
+}
+
+public final class org/hisp/dhis/android/core/indicator/DataSetIndicatorLinkBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink;)Lorg/hisp/dhis/android/core/indicator/DataSetIndicatorLink$Builder;
 }
 
 public final class org/hisp/dhis/android/core/indicator/Indicator : org/hisp/dhis/android/core/common/BaseNameableObjectKt, org/hisp/dhis/android/core/common/CoreObject, org/hisp/dhis/android/core/common/ObjectWithStyleKt {
@@ -10007,19 +10135,100 @@ public abstract interface class org/hisp/dhis/android/core/indicator/IndicatorMo
 	public abstract fun indicators ()Lorg/hisp/dhis/android/core/indicator/IndicatorCollectionRepository;
 }
 
-public abstract class org/hisp/dhis/android/core/indicator/IndicatorType : org/hisp/dhis/android/core/common/BaseIdentifiableObAuVa, org/hisp/dhis/android/core/common/CoreObject {
-	public fun <init> ()V
-	public static fun builder ()Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
-	public abstract fun factor ()Ljava/lang/Integer;
-	public abstract fun number ()Ljava/lang/Boolean;
-	public abstract fun toBuilder ()Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+public final class org/hisp/dhis/android/core/indicator/IndicatorType : org/hisp/dhis/android/core/common/BaseIdentifiableObjectKt, org/hisp/dhis/android/core/common/CoreObject {
+	public static final field Companion Lorg/hisp/dhis/android/core/indicator/IndicatorType$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)V
+	public static final fun builder ()Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public fun code ()Ljava/lang/String;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/indicator/IndicatorType;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/indicator/IndicatorType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/indicator/IndicatorType;
+	public fun created ()Ljava/util/Date;
+	public fun deleted ()Ljava/lang/Boolean;
+	public fun displayName ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun factor ()Ljava/lang/Integer;
+	public fun getCode ()Ljava/lang/String;
+	public fun getCreated ()Ljava/util/Date;
+	public fun getDeleted ()Ljava/lang/Boolean;
+	public fun getDisplayName ()Ljava/lang/String;
+	public final fun getFactor ()Ljava/lang/Integer;
+	public fun getLastUpdated ()Ljava/util/Date;
+	public fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Boolean;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun lastUpdated ()Ljava/util/Date;
+	public fun name ()Ljava/lang/String;
+	public final fun number ()Ljava/lang/Boolean;
+	public final fun toBuilder ()Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public fun toString ()Ljava/lang/String;
+	public fun uid ()Ljava/lang/String;
 }
 
-public abstract class org/hisp/dhis/android/core/indicator/IndicatorType$Builder : org/hisp/dhis/android/core/common/BaseIdentifiableObAuVa$Builder {
+public final class org/hisp/dhis/android/core/indicator/IndicatorType$Builder : org/hisp/dhis/android/core/indicator/IndicatorTypeBuilder {
 	public fun <init> ()V
-	public abstract fun build ()Lorg/hisp/dhis/android/core/indicator/IndicatorType;
-	public abstract fun factor (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
-	public abstract fun number (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+}
+
+public final class org/hisp/dhis/android/core/indicator/IndicatorType$Companion {
+	public final fun builder ()Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+}
+
+public class org/hisp/dhis/android/core/indicator/IndicatorTypeBuilder : org/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder {
+	public static final field Companion Lorg/hisp/dhis/android/core/indicator/IndicatorTypeBuilder$Companion;
+	protected field uid Ljava/lang/String;
+	public fun <init> ()V
+	public fun build ()Lorg/hisp/dhis/android/core/indicator/IndicatorType;
+	public synthetic fun code (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun code (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public synthetic fun created (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun created (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public synthetic fun created (Ljava/util/Date;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun created (Ljava/util/Date;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public synthetic fun deleted (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun deleted (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public synthetic fun displayName (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun displayName (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public final fun factor (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	protected final fun getCode ()Ljava/lang/String;
+	protected final fun getCreated ()Ljava/util/Date;
+	protected final fun getDeleted ()Ljava/lang/Boolean;
+	protected final fun getDisplayName ()Ljava/lang/String;
+	protected final fun getFactor ()Ljava/lang/Integer;
+	protected final fun getLastUpdated ()Ljava/util/Date;
+	protected final fun getName ()Ljava/lang/String;
+	protected final fun getNumber ()Ljava/lang/Boolean;
+	protected final fun getUid ()Ljava/lang/String;
+	public synthetic fun lastUpdated (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun lastUpdated (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public synthetic fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public synthetic fun name (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun name (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	public final fun number (Ljava/lang/Boolean;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+	protected final fun setCode (Ljava/lang/String;)V
+	protected final fun setCreated (Ljava/util/Date;)V
+	protected final fun setDeleted (Ljava/lang/Boolean;)V
+	protected final fun setDisplayName (Ljava/lang/String;)V
+	protected final fun setFactor (Ljava/lang/Integer;)V
+	protected final fun setLastUpdated (Ljava/util/Date;)V
+	protected final fun setName (Ljava/lang/String;)V
+	protected final fun setNumber (Ljava/lang/Boolean;)V
+	protected final fun setUid (Ljava/lang/String;)V
+	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/common/BaseIdentifiableObject$Builder;
+	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
+}
+
+public final class org/hisp/dhis/android/core/indicator/IndicatorTypeBuilder$Companion {
+	public final fun from (Lorg/hisp/dhis/android/core/indicator/IndicatorType;)Lorg/hisp/dhis/android/core/indicator/IndicatorType$Builder;
 }
 
 public final class org/hisp/dhis/android/core/indicator/IndicatorTypeCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadOnlyIdentifiableCollectionRepositoryImpl {

--- a/core/src/main/java/org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/attribute/DataElementAttributeValueLink.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,36 +26,28 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.indicator;
+package org.hisp.dhis.android.core.attribute
 
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class DataElementAttributeValueLink(
+    val dataElement: String,
+    val attribute: String,
+    val value: String?,
+) : CoreObject {
 
-import org.hisp.dhis.android.core.common.BaseIdentifiableObAuVa;
-import org.hisp.dhis.android.core.common.CoreObject;
+    fun dataElement(): String = dataElement
+    fun attribute(): String = attribute
+    fun value(): String? = value
 
-@AutoValue
-public abstract class IndicatorType extends BaseIdentifiableObAuVa implements CoreObject {
+    fun toBuilder(): Builder = DataElementAttributeValueLinkBuilder.from(this)
 
-    @Nullable
-    public abstract Boolean number();
+    class Builder : DataElementAttributeValueLinkBuilder()
 
-    @Nullable
-    public abstract Integer factor();
-
-    public static Builder builder() {
-        return new AutoValue_IndicatorType.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder extends BaseIdentifiableObAuVa.Builder<Builder> {
-        public abstract Builder number(Boolean number);
-
-        public abstract Builder factor(Integer factor);
-
-        public abstract IndicatorType build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/attribute/ProgramAttributeValueLink.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,42 +26,28 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.attribute;
+package org.hisp.dhis.android.core.attribute
 
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class ProgramAttributeValueLink(
+    val program: String,
+    val attribute: String,
+    val value: String?,
+) : CoreObject {
 
-import org.hisp.dhis.android.core.common.CoreObject;
+    fun program(): String = program
+    fun attribute(): String = attribute
+    fun value(): String? = value
 
-@AutoValue
-public abstract class ProgramAttributeValueLink implements CoreObject {
+    fun toBuilder(): Builder = ProgramAttributeValueLinkBuilder.from(this)
 
-    @Nullable
-    public abstract String program();
+    class Builder : ProgramAttributeValueLinkBuilder()
 
-    @Nullable
-    public abstract String attribute();
-
-    @Nullable
-    public abstract String value();
-
-    public static Builder builder() {
-        return new AutoValue_ProgramAttributeValueLink.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-
-
-        public abstract Builder program(String program);
-
-        public abstract Builder attribute(String attribute);
-
-        public abstract Builder value(String value);
-
-        public abstract ProgramAttributeValueLink build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/attribute/ProgramStageAttributeValueLink.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,42 +26,28 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.attribute;
+package org.hisp.dhis.android.core.attribute
 
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class ProgramStageAttributeValueLink(
+    val programStage: String,
+    val attribute: String,
+    val value: String?,
+) : CoreObject {
 
-import org.hisp.dhis.android.core.common.CoreObject;
+    fun programStage(): String = programStage
+    fun attribute(): String = attribute
+    fun value(): String? = value
 
-@AutoValue
-public abstract class DataElementAttributeValueLink implements CoreObject {
+    fun toBuilder(): Builder = ProgramStageAttributeValueLinkBuilder.from(this)
 
-    @Nullable
-    public abstract String dataElement();
+    class Builder : ProgramStageAttributeValueLinkBuilder()
 
-    @Nullable
-    public abstract String attribute();
-
-    @Nullable
-    public abstract String value();
-
-    public static Builder builder() {
-        return new AutoValue_DataElementAttributeValueLink.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-
-
-        public abstract Builder dataElement(String dataElement);
-
-        public abstract Builder attribute(String attribute);
-
-        public abstract Builder value(String value);
-
-        public abstract DataElementAttributeValueLink build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/DataSetIndicatorLink.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/DataSetIndicatorLink.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,36 +25,27 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.indicator;
 
-import androidx.annotation.Nullable;
+package org.hisp.dhis.android.core.indicator
 
-import com.google.auto.value.AutoValue;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.CoreObject
 
-import org.hisp.dhis.android.core.common.CoreObject;
+@ModelBuilder
+data class DataSetIndicatorLink(
+    val dataSet: String,
+    val indicator: String,
+) : CoreObject {
 
-@AutoValue
-public abstract class DataSetIndicatorLink implements CoreObject {
+    fun dataSet(): String = dataSet
+    fun indicator(): String = indicator
 
-    @Nullable
-    public abstract String dataSet();
+    fun toBuilder(): Builder = DataSetIndicatorLinkBuilder.from(this)
 
-    @Nullable
-    public abstract String indicator();
+    class Builder : DataSetIndicatorLinkBuilder()
 
-    public static Builder builder() {
-        return new AutoValue_DataSetIndicatorLink.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-
-        public abstract Builder dataSet(String dataSet);
-
-        public abstract Builder indicator(String indicator);
-
-        public abstract DataSetIndicatorLink build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorType.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/indicator/IndicatorType.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2026, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,40 +26,35 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.hisp.dhis.android.core.attribute;
+package org.hisp.dhis.android.core.indicator
 
-import androidx.annotation.Nullable;
+import org.hisp.dhis.android.annotations.ModelBuilder
+import org.hisp.dhis.android.core.common.BaseIdentifiableObjectKt
+import org.hisp.dhis.android.core.common.CoreObject
+import java.util.Date
 
-import com.google.auto.value.AutoValue;
+@ModelBuilder
+data class IndicatorType(
+    override val uid: String,
+    override val code: String?,
+    override val name: String?,
+    override val displayName: String?,
+    override val created: Date?,
+    override val lastUpdated: Date?,
+    override val deleted: Boolean?,
+    val number: Boolean?,
+    val factor: Int?,
+) : BaseIdentifiableObjectKt, CoreObject {
 
-import org.hisp.dhis.android.core.common.CoreObject;
+    fun number(): Boolean? = number
+    fun factor(): Int? = factor
 
-@AutoValue
-public abstract class ProgramStageAttributeValueLink implements CoreObject {
+    fun toBuilder(): Builder = IndicatorTypeBuilder.from(this)
 
-    @Nullable
-    public abstract String programStage();
+    class Builder : IndicatorTypeBuilder()
 
-    @Nullable
-    public abstract String attribute();
-
-    @Nullable
-    public abstract String value();
-
-    public static Builder builder() {
-        return new AutoValue_ProgramStageAttributeValueLink.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder programStage(String programStage);
-
-        public abstract Builder attribute(String attribute);
-
-        public abstract Builder value(String value);
-
-        public abstract ProgramStageAttributeValueLink build();
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/DataElementAttributeValueLinkDB.kt
@@ -44,8 +44,8 @@ internal data class DataElementAttributeValueLinkDB(
 
 internal fun DataElementAttributeValueLink.toDB(): DataElementAttributeValueLinkDB {
     return DataElementAttributeValueLinkDB(
-        dataElement = dataElement()!!,
-        attribute = attribute()!!,
+        dataElement = dataElement(),
+        attribute = attribute(),
         value = value(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramAttributeValueLinkDB.kt
@@ -44,8 +44,8 @@ internal data class ProgramAttributeValueLinkDB(
 
 internal fun ProgramAttributeValueLink.toDB(): ProgramAttributeValueLinkDB {
     return ProgramAttributeValueLinkDB(
-        program = program()!!,
-        attribute = attribute()!!,
+        program = program(),
+        attribute = attribute(),
         value = value(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/attribute/ProgramStageAttributeValueLinkDB.kt
@@ -44,8 +44,8 @@ internal data class ProgramStageAttributeValueLinkDB(
 
 internal fun ProgramStageAttributeValueLink.toDB(): ProgramStageAttributeValueLinkDB {
     return ProgramStageAttributeValueLinkDB(
-        programStage = programStage()!!,
-        attribute = attribute()!!,
+        programStage = programStage(),
+        attribute = attribute(),
         value = value(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/indicator/DataSetIndicatorLinkDB.kt
@@ -42,7 +42,7 @@ internal data class DataSetIndicatorLinkDB(
 
 internal fun DataSetIndicatorLink.toDB(): DataSetIndicatorLinkDB {
     return DataSetIndicatorLinkDB(
-        dataSet = dataSet()!!,
-        indicator = indicator()!!,
+        dataSet = dataSet(),
+        indicator = indicator(),
     )
 }


### PR DESCRIPTION
Migrates five Java `@AutoValue` domain models to Kotlin data classes annotated with `@ModelBuilder`: `DataElementAttributeValueLink`, `ProgramAttributeValueLink`, `ProgramStageAttributeValueLink`, `DataSetIndicatorLink`, and `IndicatorType`. The first four are link/join-table models whose primary-key fields (`dataElement`, `program`, `programStage`, `dataSet`, `attribute`, `indicator`) are promoted to non-null `String`, removing the corresponding `!!` operators from each `*DB.toDB()` extension. `IndicatorType` retains nullable `number` and `factor` fields and now implements `BaseIdentifiableObjectKt` in place of the Java `BaseIdentifiableObAuVa` base class.

Related task: [ANDROSDK-2331](https://dhis2.atlassian.net/browse/ANDROSDK-2331)

[ANDROSDK-2331]: https://dhis2.atlassian.net/browse/ANDROSDK-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ