### PR TITLE
chore: [ANDROSDK-2337] use ChildElementHandler for AnalyticsPeriodBoundaryHandler

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandler.kt
@@ -29,6 +29,6 @@ package org.hisp.dhis.android.core.arch.handlers.internal
 
 import org.hisp.dhis.android.core.common.CoreObject
 
-internal interface ChildElementHandler<O : CoreObject> {
+internal fun interface ChildElementHandler<O : CoreObject> {
     suspend fun handleMany(masterUid: String, items: Collection<O>?)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandler.kt
@@ -30,6 +30,5 @@ package org.hisp.dhis.android.core.arch.handlers.internal
 import org.hisp.dhis.android.core.common.CoreObject
 
 internal interface ChildElementHandler<O : CoreObject> {
-    suspend fun handleMany(masterUid: String, slaves: Collection<O>?)
-    suspend fun resetAllLinks()
+    suspend fun handleMany(masterUid: String, items: Collection<O>?)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
@@ -34,15 +34,13 @@ internal open class ChildElementHandlerImpl<O : CoreObject>(private val store: L
 
     override suspend fun handleMany(masterUid: String, slaves: Collection<O>?) {
         store.deleteLinksForMasterUid(masterUid)
-        slaves?.forEach { slave ->
-            handleInternal(slave)
-        }
-    }
+        if (slaves != null) {
+            val preHandledCollection = slaves.map { beforeObjectHandled(it) }
 
-    private suspend fun handleInternal(s: O) {
-        val s2 = beforeObjectHandled(s)
-        store.insertIfNotExists(s2)
-        afterObjectHandled(s2)
+            store.updateOrInsert(preHandledCollection)
+
+            preHandledCollection.forEach { afterObjectHandled(it) }
+        }
     }
 
     protected open suspend fun beforeObjectHandled(o: O): O {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
@@ -30,30 +30,11 @@ package org.hisp.dhis.android.core.arch.handlers.internal
 import org.hisp.dhis.android.core.arch.db.stores.internal.LinkStore
 import org.hisp.dhis.android.core.common.CoreObject
 
-internal open class ChildElementHandlerImpl<O : CoreObject>(private val store: LinkStore<O>) : ChildElementHandler<O> {
+internal open class ChildElementHandlerImpl<O : CoreObject>(
+    store: LinkStore<O>,
+) : LinkHandlerImpl<O, O>(store), ChildElementHandler<O> {
 
     override suspend fun handleMany(masterUid: String, slaves: Collection<O>?) {
-        store.deleteLinksForMasterUid(masterUid)
-        if (slaves != null) {
-            val preHandledCollection = slaves.map { beforeObjectHandled(it) }
-
-            store.updateOrInsert(preHandledCollection)
-
-            preHandledCollection.forEach { afterObjectHandled(it) }
-        }
-    }
-
-    protected open suspend fun beforeObjectHandled(o: O): O {
-        return o
-    }
-
-    protected open suspend fun afterObjectHandled(o: O) {
-        /* Method is not abstract since empty action is the default action and we don't want it to
-         * be unnecessarily written in every child.
-         */
-    }
-
-    override suspend fun resetAllLinks() {
-        store.deleteAllLinks()
+        handleMany(masterUid, slaves) { it }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
@@ -35,6 +35,6 @@ internal open class ChildElementHandlerImpl<O : CoreObject>(
 ) : LinkHandlerImpl<O, O>(store), ChildElementHandler<O> {
 
     override suspend fun handleMany(masterUid: String, slaves: Collection<O>?) {
-        handleMany(masterUid, slaves) { it }
+        persist(masterUid, slaves?.map { beforeObjectHandled(it) })
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/ChildElementHandlerImpl.kt
@@ -34,7 +34,8 @@ internal open class ChildElementHandlerImpl<O : CoreObject>(
     store: LinkStore<O>,
 ) : LinkHandlerImpl<O, O>(store), ChildElementHandler<O> {
 
-    override suspend fun handleMany(masterUid: String, slaves: Collection<O>?) {
-        persist(masterUid, slaves?.map { beforeObjectHandled(it) })
+    override suspend fun handleMany(masterUid: String, items: Collection<O>?) {
+        val transformedLinks = items?.map { beforeObjectHandled(it) }
+        persist(masterUid, transformedLinks)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandler.kt
@@ -31,6 +31,6 @@ import org.hisp.dhis.android.core.common.CoreObject
 
 internal interface LinkHandler<S, O : CoreObject> {
     @JvmSuppressWildcards
-    suspend fun handleMany(masterUid: String, slaves: Collection<S>?, transformer: (S) -> O)
+    suspend fun handleMany(masterUid: String, items: Collection<S>?, transformer: (S) -> O)
     suspend fun resetAllLinks()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandlerImpl.kt
@@ -39,7 +39,6 @@ internal open class LinkHandlerImpl<S, O : CoreObject>(private val store: LinkSt
                 .map { beforeObjectHandled(it) }
                 .map { transformer.invoke(it) }
 
-            // TODO Previously it was store.insertIfNotExists(). Check if we should change anything
             store.updateOrInsert(preHandledCollection)
 
             preHandledCollection.forEach { afterObjectHandled(it) }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandlerImpl.kt
@@ -32,16 +32,17 @@ import org.hisp.dhis.android.core.common.CoreObject
 
 internal open class LinkHandlerImpl<S, O : CoreObject>(private val store: LinkStore<O>) : LinkHandler<S, O> {
 
-    override suspend fun handleMany(masterUid: String, slaves: Collection<S>?, transformer: Function1<S, O>) {
-        persist(masterUid, slaves?.map { transformer.invoke(beforeObjectHandled(it)) })
+    override suspend fun handleMany(masterUid: String, items: Collection<S>?, transformer: Function1<S, O>) {
+        val transformedLinks = items?.map { transformer.invoke(beforeObjectHandled(it)) }
+        persist(masterUid, transformedLinks)
     }
 
-    protected suspend fun persist(masterUid: String, transformedSlaves: Collection<O>?) {
+    protected suspend fun persist(masterUid: String, transformedLinks: Collection<O>?) {
         store.deleteLinksForMasterUid(masterUid)
-        if (transformedSlaves != null) {
-            store.updateOrInsert(transformedSlaves)
+        if (transformedLinks != null) {
+            store.updateOrInsert(transformedLinks)
 
-            transformedSlaves.forEach { afterObjectHandled(it) }
+            transformedLinks.forEach { afterObjectHandled(it) }
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/LinkHandlerImpl.kt
@@ -33,15 +33,15 @@ import org.hisp.dhis.android.core.common.CoreObject
 internal open class LinkHandlerImpl<S, O : CoreObject>(private val store: LinkStore<O>) : LinkHandler<S, O> {
 
     override suspend fun handleMany(masterUid: String, slaves: Collection<S>?, transformer: Function1<S, O>) {
+        persist(masterUid, slaves?.map { transformer.invoke(beforeObjectHandled(it)) })
+    }
+
+    protected suspend fun persist(masterUid: String, transformedSlaves: Collection<O>?) {
         store.deleteLinksForMasterUid(masterUid)
-        if (slaves != null) {
-            val preHandledCollection = slaves
-                .map { beforeObjectHandled(it) }
-                .map { transformer.invoke(it) }
+        if (transformedSlaves != null) {
+            store.updateOrInsert(transformedSlaves)
 
-            store.updateOrInsert(preHandledCollection)
-
-            preHandledCollection.forEach { afterObjectHandled(it) }
+            transformedSlaves.forEach { afterObjectHandled(it) }
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionOrganisationUnitsCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/category/internal/CategoryOptionOrganisationUnitsCall.kt
@@ -92,7 +92,7 @@ internal class CategoryOptionOrganisationUnitsCall(
     private suspend fun handleEntry(entry: Map.Entry<String, List<CategoryOptionRestriction>>) {
         handler.handleMany(
             masterUid = entry.key,
-            slaves = entry.value,
+            items = entry.value,
             transformer = { o ->
                 val orgUnit = when (o) {
                     is CategoryOptionRestriction.NotAccessibleToUser -> null

--- a/core/src/main/java/org/hisp/dhis/android/core/datastore/internal/DataStoreHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/datastore/internal/DataStoreHandler.kt
@@ -44,10 +44,10 @@ internal class DataStoreHandler(
 
     override suspend fun handleMany(
         masterUid: String,
-        slaves: Collection<DataStoreEntry>?,
+        items: Collection<DataStoreEntry>?,
         transformer: (DataStoreEntry) -> DataStoreEntry,
     ) {
-        val entriesToHandle = filterNotSyncedEntries(masterUid, slaves)
+        val entriesToHandle = filterNotSyncedEntries(masterUid, items)
         handleMany(entriesToHandle)
         cleanOrphan(masterUid, entriesToHandle)
     }
@@ -65,9 +65,9 @@ internal class DataStoreHandler(
 
     private suspend fun filterNotSyncedEntries(
         namespace: String,
-        slaves: Collection<DataStoreEntry>?,
+        items: Collection<DataStoreEntry>?,
     ): List<DataStoreEntry>? {
-        return slaves?.let {
+        return items?.let {
             val whereClause = WhereClauseBuilder().run {
                 appendKeyStringValue(DataStoreTableInfo.Columns.NAMESPACE, namespace)
                 appendNotInKeyStringValues(
@@ -78,7 +78,7 @@ internal class DataStoreHandler(
             }
             val entriesPendingToSync = store.selectWhere(whereClause)
 
-            slaves.filter { entry ->
+            items.filter { entry ->
                 entriesPendingToSync.none { it.key() == entry.key() }
             }
         }
@@ -86,8 +86,8 @@ internal class DataStoreHandler(
 
     private suspend fun cleanOrphan(
         namespace: String,
-        slaves: Collection<DataStoreEntry>?,
+        items: Collection<DataStoreEntry>?,
     ) {
-        store.cleanOrphan(namespace, slaves)
+        store.cleanOrphan(namespace, items)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/AnalyticsPeriodBoundaryHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/AnalyticsPeriodBoundaryHandler.kt
@@ -28,9 +28,7 @@
 
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.handlers.internal.ChildElementHandler
 import org.hisp.dhis.android.core.arch.handlers.internal.ChildElementHandlerImpl
-import org.hisp.dhis.android.core.arch.handlers.internal.LinkHandlerImpl
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
 import org.koin.core.annotation.Singleton
 

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/AnalyticsPeriodBoundaryHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/AnalyticsPeriodBoundaryHandler.kt
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.android.core.program.internal
 
+import org.hisp.dhis.android.core.arch.handlers.internal.ChildElementHandler
+import org.hisp.dhis.android.core.arch.handlers.internal.ChildElementHandlerImpl
 import org.hisp.dhis.android.core.arch.handlers.internal.LinkHandlerImpl
 import org.hisp.dhis.android.core.program.AnalyticsPeriodBoundary
 import org.koin.core.annotation.Singleton
@@ -35,4 +37,4 @@ import org.koin.core.annotation.Singleton
 @Singleton
 internal class AnalyticsPeriodBoundaryHandler(
     store: AnalyticsPeriodBoundaryStore,
-) : LinkHandlerImpl<AnalyticsPeriodBoundary, AnalyticsPeriodBoundary>(store)
+) : ChildElementHandlerImpl<AnalyticsPeriodBoundary>(store)

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/CategoryMappingHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/CategoryMappingHandler.kt
@@ -28,7 +28,7 @@
 
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.handlers.internal.LinkHandlerImpl
+import org.hisp.dhis.android.core.arch.handlers.internal.ChildElementHandlerImpl
 import org.hisp.dhis.android.core.program.CategoryMapping
 import org.koin.core.annotation.Singleton
 
@@ -36,12 +36,12 @@ import org.koin.core.annotation.Singleton
 internal class CategoryMappingHandler(
     store: CategoryMappingStore,
     private val categoryOptionMappingHandler: CategoryOptionMappingHandler,
-) : LinkHandlerImpl<CategoryMapping, CategoryMapping>(store) {
+) : ChildElementHandlerImpl<CategoryMapping>(store) {
 
     override suspend fun afterObjectHandled(o: CategoryMapping) {
         categoryOptionMappingHandler.handleMany(
             o.uid(),
             o.optionMappings(),
-        ) { it }
+        )
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/CategoryOptionMappingHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/CategoryOptionMappingHandler.kt
@@ -28,11 +28,11 @@
 
 package org.hisp.dhis.android.core.program.internal
 
-import org.hisp.dhis.android.core.arch.handlers.internal.LinkHandlerImpl
+import org.hisp.dhis.android.core.arch.handlers.internal.ChildElementHandlerImpl
 import org.hisp.dhis.android.core.program.CategoryOptionMapping
 import org.koin.core.annotation.Singleton
 
 @Singleton
 internal class CategoryOptionMappingHandler(
     store: CategoryOptionMappingStore,
-) : LinkHandlerImpl<CategoryOptionMapping, CategoryOptionMapping>(store)
+) : ChildElementHandlerImpl<CategoryOptionMapping>(store)

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramHandler.kt
@@ -57,7 +57,7 @@ internal class ProgramHandler(
         categoryMappingHandler.handleMany(
             o.uid(),
             o.categoryMappings(),
-        ) { it }
+        )
 
         if (action === HandleAction.Update) {
             orphanCleaner.deleteOrphan(o)

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorHandler.kt
@@ -62,6 +62,6 @@ internal class ProgramIndicatorHandler(
                 .sortOrder(sortOrder)
                 .build()
         }
-        analyticsPeriodBoundaryHandler.handleMany(o.uid(), o.analyticsPeriodBoundaries() ?: emptyList()) { it }
+        analyticsPeriodBoundaryHandler.handleMany(o.uid(), o.analyticsPeriodBoundaries() ?: emptyList())
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/program/internal/CategoryMappingHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/internal/CategoryMappingHandlerShould.kt
@@ -71,8 +71,8 @@ class CategoryMappingHandlerShould {
             .optionMappings(listOf(optionMapping))
             .build()
 
-        categoryMappingHandler.handleMany("program1", listOf(categoryMapping)) { it }
+        categoryMappingHandler.handleMany("program1", listOf(categoryMapping))
 
-        verify(categoryOptionMappingHandler).handleMany(eq("mapping1"), any(), any())
+        verify(categoryOptionMappingHandler).handleMany(eq("mapping1"), any())
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramHandlerShould.kt
@@ -199,6 +199,6 @@ class ProgramHandlerShould {
     @Test
     fun call_category_mapping_handler() = runTest {
         programHandler.handle(program)
-        verify(categoryMappingHandler).handleMany(eq(program.uid()), any(), any())
+        verify(categoryMappingHandler).handleMany(eq(program.uid()), any())
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramIndicatorHandlerShould.kt
@@ -126,6 +126,6 @@ class ProgramIndicatorHandlerShould {
     @Test
     fun call_program_indicator_analytics_period_boundary_handler_and_store() = runTest {
         programIndicatorHandler.handleMany(programIndicators)
-        verify(analyticsPeriodBoundaryHandler).handleMany(any(), any(), any())
+        verify(analyticsPeriodBoundaryHandler).handleMany(any(), any())
     }
 }


### PR DESCRIPTION
Switches `AnalyticsPeriodBoundaryHandler` from a `LinkHandler` to a `ChildElementHandler`, since the boundaries are stored as-is and no transformer is needed. As part of this, `ChildElementHandlerImpl` now reuses `LinkHandlerImpl` (the child handler is just the `S == O` case with an identity transformer) and persists the collection with a single bulk upsert instead of inserting each element one by one.

While at it, the handlers that were declared as `LinkHandlerImpl` but only ever called with an identity transformer (`CategoryMappingHandler`, `CategoryOptionMappingHandler`) were also moved to `ChildElementHandler`, dropping the redundant `{ it }` at their call sites. There is no change in database behavior: every path ends up in `store.updateOrInsert(collection)`.

Related task: [ANDROSDK-2337](https://dhis2.atlassian.net/browse/ANDROSDK-2337)

[ANDROSDK-2337]: https://dhis2.atlassian.net/browse/ANDROSDK-2337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ