### PR TITLE
feature: [ANDROSDK-2309] support isEmpty/isNotEmpty filter operators

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2494,6 +2494,7 @@ public final class org/hisp/dhis/android/core/arch/repositories/filters/internal
 	public final fun gt (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun in (Ljava/util/Set;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun inRelativePeriod (Lorg/hisp/dhis/android/core/common/RelativePeriod;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
+	public final fun isEmpty (Z)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun le (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun like (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun lt (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
@@ -2627,6 +2628,8 @@ public final class org/hisp/dhis/android/core/arch/repositories/filters/internal
 	public final fun ge (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun gt (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun in (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
+	public final fun isNotNullAndIsNotBlank ()Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
+	public final fun isNullOrBlank ()Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun le (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun like (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
 	public final fun lt (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/collection/BaseRepository;
@@ -2887,6 +2890,8 @@ public final class org/hisp/dhis/android/core/arch/repositories/scope/internal/F
 	public static final field LT Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
 	public static final field NOT_EQ Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
 	public static final field NOT_IN Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
+	public static final field NOT_NULL_AND_NOT_BLANK Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
+	public static final field NULL_OR_BLANK Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
 	public static final field SW Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
 	public static final field VOID Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
 	public final fun getApiOperator ()Ljava/lang/String;
@@ -2977,7 +2982,6 @@ public class org/hisp/dhis/android/core/arch/repositories/scope/internal/Reposit
 	public static final field Companion Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItemBuilder$Companion;
 	protected field key Ljava/lang/String;
 	protected field operator Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator;
-	protected field value Ljava/lang/String;
 	public fun <init> ()V
 	public fun build ()Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;
 	protected final fun getKey ()Ljava/lang/String;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventDataFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventDataFilterStoreIntegrationShould.kt
@@ -55,6 +55,7 @@ class EventDataFilterStoreIntegrationShould : ObjectStoreAbstractIntegrationShou
             .eq(null)
             .like(null)
             .dateFilter(null)
+            .isEmpty(null)
             .build()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListAttributeValueFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListAttributeValueFilterStoreIntegrationShould.kt
@@ -56,6 +56,7 @@ class ProgramStageWorkingListAttributeValueFilterStoreIntegrationShould :
             .lt(null)
             .like(null)
             .dateFilter(null)
+            .isEmpty(null)
             .build()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListEventDataFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListEventDataFilterStoreIntegrationShould.kt
@@ -54,6 +54,7 @@ class ProgramStageWorkingListEventDataFilterStoreIntegrationShould :
             .lt(null)
             .like(null)
             .dateFilter(null)
+            .isEmpty(null)
             .build()
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/AttributeValueFilterStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/AttributeValueFilterStoreIntegrationShould.kt
@@ -57,6 +57,7 @@ class AttributeValueFilterStoreIntegrationShould : ObjectStoreAbstractIntegratio
             .eq(null)
             .like(null)
             .dateFilter(null)
+            .isEmpty(null)
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/EventDataFilterConnector.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/EventDataFilterConnector.kt
@@ -74,6 +74,11 @@ class EventDataFilterConnector<R : BaseRepository> internal constructor(
         return repositoryFactory.updated(filter)
     }
 
+    fun isEmpty(empty: Boolean): R {
+        val filter = EventDataFilter.builder().dataItem(key).isEmpty(empty).build()
+        return repositoryFactory.updated(filter)
+    }
+
     fun inRelativePeriod(period: RelativePeriod): R {
         val dateFilter = DateFilterPeriod.builder().type(DatePeriodType.RELATIVE).period(period).build()
         val filter = EventDataFilter.builder().dataItem(key).dateFilter(dateFilter).build()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ValueSubQueryFilterConnector.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/ValueSubQueryFilterConnector.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOperator
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 
+@Suppress("TooManyFunctions")
 class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
     repositoryFactory: BaseRepositoryFactory<R>,
     scope: RepositoryScope,
@@ -50,7 +51,7 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
 
     /**
      * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
-     * The like filter checks if the given field has a value equal to the value provided.
+     * The eq filter checks if the given field has a value equal to the value provided.
      * @param value value to compare with the target field
      * @return the new repository
      */
@@ -60,7 +61,7 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
 
     /**
      * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
-     * The like filter checks if the given field has a value lower or equal than the value provided.
+     * The le filter checks if the given field has a value lower or equal than the value provided.
      * @param value value to compare with the target field
      * @return the new repository
      */
@@ -70,7 +71,7 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
 
     /**
      * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
-     * The like filter checks if the given field has a value strictly lower than the value provided.
+     * The lt filter checks if the given field has a value strictly lower than the value provided.
      * @param value value to compare with the target field
      * @return the new repository
      */
@@ -80,7 +81,7 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
 
     /**
      * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
-     * The like filter checks if the given field has a value strictly greater or equal than the value provided.
+     * The ge filter checks if the given field has a value strictly greater or equal than the value provided.
      * @param value value to compare with the target field
      * @return the new repository
      */
@@ -90,7 +91,7 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
 
     /**
      * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
-     * The like filter checks if the given field has a value strictly greater than the value provided.
+     * The gt filter checks if the given field has a value strictly greater than the value provided.
      * @param value value to compare with the target field
      * @return the new repository
      */
@@ -100,7 +101,7 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
 
     /**
      * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
-     * The like filter checks if the given field has a value included in the list provided.
+     * The in filter checks if the given field has a value included in the list provided.
      * @param values value list to compare with the target field
      * @return the new repository
      */
@@ -117,6 +118,37 @@ class ValueSubQueryFilterConnector<R : BaseRepository> internal constructor(
      */
     fun like(value: String): R {
         return inLinkTable(FilterItemOperator.LIKE, wrapValue("%$value%"))
+    }
+
+    /**
+     * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
+     * The isNullOrBlank filter checks if the given field is null or blank.
+     * @return the new repository
+     */
+    fun isNullOrBlank(): R {
+        val whereClause = WhereClauseBuilder()
+            .appendIsNullOrValue(linkChild, "")
+            .appendKeyStringValue(dataElementColumn, dataElementId)
+            .build()
+        return inTableWhere(whereClause)
+    }
+
+    /**
+     * Returns a new repository whose scope is the one of the current repository plus the new filter being applied.
+     * The isNotNullAndIsNotBlank filter checks if the given field is not null and not blank.
+     * @return the new repository
+     */
+    fun isNotNullAndIsNotBlank(): R {
+        val whereClause = WhereClauseBuilder()
+            .appendComplexQuery(
+                WhereClauseBuilder()
+                    .appendIsNotNullValue(linkChild)
+                    .appendNotKeyStringValue(linkChild, "")
+                    .build(),
+            )
+            .appendKeyStringValue(dataElementColumn, dataElementId)
+            .build()
+        return inTableWhere(whereClause)
     }
 
     private fun inLinkTable(operator: FilterItemOperator, value: String): R {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
@@ -40,6 +40,19 @@ enum class FilterItemOperator(val sqlOperator: String, val apiOperator: String, 
     SW("LIKE", "sw", "SW"),
     EW("LIKE", "ew", "EW"),
     VOID("", "", ""),
-    NULL_OR_BLANK("IS NULL OR =''", "null_or_blank", "NULL_OR_BLANK"),
-    NOT_NULL_AND_NOT_BLANK("IS NOT NULL AND !=''", "not_null_and_not_blank", "NOT_NULL_AND_NOT_BLANK"),
+    NULL_OR_BLANK("", "null_or_blank", "NULL_OR_BLANK"),
+    NOT_NULL_AND_NOT_BLANK("", "not_null_and_not_blank", "NOT_NULL_AND_NOT_BLANK"),
+    ;
+
+    /**
+     * Builds the full SQL condition for this operator. NULL_OR_BLANK and NOT_NULL_AND_NOT_BLANK cannot be expressed
+     * as "column sqlOperator value" because they need the column name in both sides of the OR/AND condition.
+     */
+    internal fun getSqlCondition(column: String, valueStr: String? = null): String {
+        return when (this) {
+            NULL_OR_BLANK -> "($column IS NULL OR $column = '')"
+            NOT_NULL_AND_NOT_BLANK -> "($column IS NOT NULL AND $column != '')"
+            else -> "$column $sqlOperator $valueStr"
+        }
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
@@ -40,4 +40,6 @@ enum class FilterItemOperator(val sqlOperator: String, val apiOperator: String, 
     SW("LIKE", "sw", "SW"),
     EW("LIKE", "ew", "EW"),
     VOID("", "", ""),
+    NULL_OR_BLANK("IS NULL OR =''", "null_or_blank", "NULL_OR_BLANK"),
+    NOT_NULL_AND_NOT_BLANK("IS NOT NULL AND !=''", "not_null_and_not_blank", "NOT_NULL_AND_NOT_BLANK"),
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
@@ -40,8 +40,8 @@ enum class FilterItemOperator(val sqlOperator: String, val apiOperator: String, 
     SW("LIKE", "sw", "SW"),
     EW("LIKE", "ew", "EW"),
     VOID("", "", ""),
-    NULL_OR_BLANK("", "null_or_blank", "NULL_OR_BLANK"),
-    NOT_NULL_AND_NOT_BLANK("", "not_null_and_not_blank", "NOT_NULL_AND_NOT_BLANK"),
+    NULL_OR_BLANK("", "null", "NULL"),
+    NOT_NULL_AND_NOT_BLANK("", "!null", "!NULL"),
     ;
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem.kt
@@ -33,11 +33,11 @@ import org.hisp.dhis.android.annotations.ModelBuilder
 data class RepositoryScopeFilterItem(
     val key: String,
     val operator: FilterItemOperator,
-    val value: String,
+    val value: String?,
 ) {
     fun key(): String = key
     fun operator(): FilterItemOperator = operator
-    fun value(): String = value
+    fun value(): String? = value
 
     fun toBuilder(): Builder = RepositoryScopeFilterItemBuilder.from(this)
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/WhereClauseFromScopeBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/WhereClauseFromScopeBuilder.kt
@@ -36,7 +36,12 @@ internal class WhereClauseFromScopeBuilder(private val builder: WhereClauseBuild
             return "1"
         }
         for (item in scope.filters()) {
-            builder.appendKeyOperatorValue(item.key(), item.operator().sqlOperator, item.value() ?: "")
+            when (item.operator()) {
+                FilterItemOperator.NULL_OR_BLANK, FilterItemOperator.NOT_NULL_AND_NOT_BLANK ->
+                    builder.appendComplexQuery(item.operator().getSqlCondition(item.key()))
+
+                else -> builder.appendKeyOperatorValue(item.key(), item.operator().sqlOperator, item.value() ?: "")
+            }
         }
         for (item in scope.complexFilters()) {
             builder.appendComplexQuery(item.whereQuery())

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/WhereClauseFromScopeBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/WhereClauseFromScopeBuilder.kt
@@ -36,12 +36,7 @@ internal class WhereClauseFromScopeBuilder(private val builder: WhereClauseBuild
             return "1"
         }
         for (item in scope.filters()) {
-            when (item.operator()) {
-                FilterItemOperator.NULL_OR_BLANK, FilterItemOperator.NOT_NULL_AND_NOT_BLANK ->
-                    builder.appendComplexQuery(item.operator().getSqlCondition(item.key()))
-
-                else -> builder.appendKeyOperatorValue(item.key(), item.operator().sqlOperator, item.value() ?: "")
-            }
+            builder.appendComplexQuery(item.operator().getSqlCondition(item.key(), item.value() ?: ""))
         }
         for (item in scope.complexFilters()) {
             builder.appendComplexQuery(item.whereQuery())

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/WhereClauseFromScopeBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/WhereClauseFromScopeBuilder.kt
@@ -36,7 +36,7 @@ internal class WhereClauseFromScopeBuilder(private val builder: WhereClauseBuild
             return "1"
         }
         for (item in scope.filters()) {
-            builder.appendKeyOperatorValue(item.key(), item.operator().sqlOperator, item.value())
+            builder.appendKeyOperatorValue(item.key(), item.operator().sqlOperator, item.value() ?: "")
         }
         for (item in scope.complexFilters()) {
             builder.appendComplexQuery(item.whereQuery())

--- a/core/src/main/java/org/hisp/dhis/android/core/event/search/EventCollectionRepositoryAdapter.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/search/EventCollectionRepositoryAdapter.kt
@@ -130,6 +130,13 @@ internal class EventCollectionRepositoryAdapter(
                     filterRepo = filterRepo.byDataValue(deId).lt(DateUtils.DATE_FORMAT.format(date))
                 }
             }
+            filter.isEmpty?.let { empty ->
+                filterRepo = if (empty) {
+                    filterRepo.byDataValue(deId).isNullOrBlank()
+                } else {
+                    filterRepo.byDataValue(deId).isNotNullAndIsNotBlank()
+                }
+            }
         }
 
         return filterRepo

--- a/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/internal/AttributeValueFilterHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/programstageworkinglist/internal/AttributeValueFilterHelper.kt
@@ -47,6 +47,7 @@ object AttributeValueFilterHelper {
                 .`in`(it.`in`())
                 .like(it.like())
                 .dateFilter(it.dateFilter())
+                .isEmpty(it.isEmpty)
                 .build()
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/FilterOperatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/FilterOperatorHelper.kt
@@ -81,6 +81,13 @@ internal class FilterOperatorHelper(
                 filterItems.add(filterBuilder.operator(FilterItemOperator.LE).value(dateValue).build())
             }
         }
+        filter.isEmpty?.let {
+            if (it) {
+                filterItems.add(filterBuilder.operator(FilterItemOperator.NULL_OR_BLANK).build())
+            } else {
+                filterItems.add(filterBuilder.operator(FilterItemOperator.NOT_NULL_AND_NOT_BLANK).build())
+            }
+        }
 
         return filterItems
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -369,9 +369,12 @@ internal class TrackedEntityInstanceLocalQueryHelper(
         for (item in scope.filter()) {
             val sub = String.format(
                 "SELECT 1 FROM %s %s WHERE %s = %s AND %s = '%s' AND %s",
-                TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), teavAlias,
-                dot(teavAlias, trackedEntityInstance), dot(teiAlias, IdentifiableColumns.UID),
-                dot(teavAlias, trackedEntityAttribute), escapeQuotes(item.key()),
+                TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
+                teavAlias,
+                dot(teavAlias, trackedEntityInstance),
+                dot(teiAlias, IdentifiableColumns.UID),
+                dot(teavAlias, trackedEntityAttribute),
+                escapeQuotes(item.key()),
                 item.operator().getSqlCondition(
                     dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
                     getFilterItemValueStr(item),
@@ -575,7 +578,7 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                         "AND ${
                             item.operator().getSqlCondition(
                                 dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.VALUE),
-                                getFilterItemValueStr(item)
+                                getFilterItemValueStr(item),
                             )
                         } "
                     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -302,6 +302,7 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                     "%" + escapeQuotes(orgUnit) + "%",
                 )
             }
+
             OrganisationUnitMode.CHILDREN -> scope.orgUnits().forEach { orgUnit ->
                 inner.appendOrKeyStringValue(
                     dot(orgunitAlias, OrganisationUnitTableInfo.Columns.PARENT),
@@ -311,6 +312,7 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                 // TODO Include orgunit?
                 inner.appendOrKeyStringValue(dot(orgunitAlias, IdentifiableColumns.UID), escapeQuotes(orgUnit))
             }
+
             OrganisationUnitMode.CAPTURE ->
                 inner.appendComplexQuery(
                     String.format(
@@ -322,9 +324,11 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                         OrganisationUnit.Scope.SCOPE_DATA_CAPTURE.name,
                     ),
                 )
+
             OrganisationUnitMode.SELECTED -> scope.orgUnits().forEach { orgUnit ->
                 inner.appendOrKeyStringValue(dot(orgunitAlias, IdentifiableColumns.UID), escapeQuotes(orgUnit))
             }
+
             OrganisationUnitMode.ACCESSIBLE, OrganisationUnitMode.ALL -> {
             }
         }
@@ -335,11 +339,15 @@ internal class TrackedEntityInstanceLocalQueryHelper(
 
     private fun appendQueryWhere(where: WhereClauseBuilder, scope: TrackedEntityInstanceQueryRepositoryScope) {
         scope.query()?.let { query ->
-            val tokens = query.value().split(" ".toRegex()).toTypedArray()
+            val tokens = query.value()?.split(" ".toRegex())?.toTypedArray() ?: listOf("").toTypedArray()
             for (token in tokens) {
                 val valueStr =
                     if (query.operator() == FilterItemOperator.LIKE) {
                         "%${escapeQuotes(token)}%"
+                    } else if (query.operator() == FilterItemOperator.NULL_OR_BLANK ||
+                        query.operator() == FilterItemOperator.NOT_NULL_AND_NOT_BLANK
+                    ) {
+                        token
                     } else {
                         escapeQuotes(token)
                     }
@@ -452,9 +460,11 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                             listOf(EventStatus.ACTIVE, EventStatus.SCHEDULE, EventStatus.OVERDUE),
                         )
                     }
+
                     EventStatus.COMPLETED, EventStatus.VISITED -> {
                         statusWhere.appendKeyStringValue(dot(eventAlias, EventTableInfo.Columns.STATUS), eventStatus)
                     }
+
                     EventStatus.SCHEDULE -> {
                         statusWhere.appendIsNullValue(EventTableInfo.Columns.EVENT_DATE)
                         statusWhere.appendInKeyEnumValues(
@@ -466,6 +476,7 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                             nowStr,
                         )
                     }
+
                     EventStatus.OVERDUE -> {
                         statusWhere.appendIsNullValue(EventTableInfo.Columns.EVENT_DATE)
                         statusWhere.appendInKeyEnumValues(
@@ -477,6 +488,7 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                             nowStr,
                         )
                     }
+
                     EventStatus.SKIPPED -> {
                         statusWhere.appendKeyStringValue(dot(eventAlias, EventTableInfo.Columns.STATUS), eventStatus)
                     }
@@ -540,6 +552,7 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                 )
                 where.appendKeyOperatorValue(assignedUserColumn, "IN", subquery)
             }
+
             AssignedUserMode.ANY -> where.appendIsNotNullValue(assignedUserColumn)
             AssignedUserMode.NONE -> where.appendIsNullValue(assignedUserColumn)
             else -> {
@@ -575,10 +588,12 @@ internal class TrackedEntityInstanceLocalQueryHelper(
             FilterItemOperator.LIKE -> "'%${escapeQuotes(item.value())}%'"
             FilterItemOperator.SW -> "'${escapeQuotes(item.value())}%'"
             FilterItemOperator.EW -> "'%${escapeQuotes(item.value())}'"
+            FilterItemOperator.NULL_OR_BLANK, FilterItemOperator.NOT_NULL_AND_NOT_BLANK -> ""
             FilterItemOperator.IN, FilterItemOperator.NOT_IN -> {
-                val value = strToList(item.value()).joinToString(separator = ",") { "'${escapeQuotes(it)}'" }
+                val value = strToList(item.value()!!).joinToString(separator = ",") { "'${escapeQuotes(it)}'" }
                 "($value)"
             }
+
             else -> "'${escapeQuotes(item.value())}'"
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -343,24 +343,21 @@ internal class TrackedEntityInstanceLocalQueryHelper(
             for (token in tokens) {
                 val valueStr =
                     if (query.operator() == FilterItemOperator.LIKE) {
-                        "%${escapeQuotes(token)}%"
-                    } else if (query.operator() == FilterItemOperator.NULL_OR_BLANK ||
-                        query.operator() == FilterItemOperator.NOT_NULL_AND_NOT_BLANK
-                    ) {
-                        token
+                        "'%${escapeQuotes(token)}%'"
                     } else {
-                        escapeQuotes(token)
+                        "'${escapeQuotes(token)}'"
                     }
 
                 val sub = String.format(
-                    "SELECT 1 FROM %s %s WHERE %s = %s AND %s %s '%s'",
+                    "SELECT 1 FROM %s %s WHERE %s = %s AND %s",
                     TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
                     teavAlias,
                     dot(teavAlias, trackedEntityInstance),
                     dot(teiAlias, IdentifiableColumns.UID),
-                    dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
-                    query.operator().sqlOperator,
-                    valueStr,
+                    query.operator().getSqlCondition(
+                        dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
+                        valueStr,
+                    ),
                 )
 
                 where.appendExistsSubQuery(sub)
@@ -371,13 +368,14 @@ internal class TrackedEntityInstanceLocalQueryHelper(
     private fun appendFiltersWhere(where: WhereClauseBuilder, scope: TrackedEntityInstanceQueryRepositoryScope) {
         for (item in scope.filter()) {
             val sub = String.format(
-                "SELECT 1 FROM %s %s WHERE %s = %s AND %s = '%s' AND %s %s %s",
+                "SELECT 1 FROM %s %s WHERE %s = %s AND %s = '%s' AND %s",
                 TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(), teavAlias,
                 dot(teavAlias, trackedEntityInstance), dot(teiAlias, IdentifiableColumns.UID),
                 dot(teavAlias, trackedEntityAttribute), escapeQuotes(item.key()),
-                dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
-                item.operator().sqlOperator,
-                getFilterItemValueStr(item),
+                item.operator().getSqlCondition(
+                    dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
+                    getFilterItemValueStr(item),
+                ),
             )
 
             where.appendExistsSubQuery(sub)
@@ -574,9 +572,12 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                     "'${escapeQuotes(key)}' " +
 
                     items.joinToString("") { item ->
-                        "AND ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.VALUE)} " +
-                            "${item.operator().sqlOperator} " +
-                            "${getFilterItemValueStr(item)} "
+                        "AND ${
+                            item.operator().getSqlCondition(
+                                dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.VALUE),
+                                getFilterItemValueStr(item)
+                            )
+                        } "
                     }
 
                 where.appendExistsSubQuery(sub)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -150,25 +150,26 @@ internal class TrackedEntityInstanceQueryOnlineHelper(
                     val clause = items.map { item ->
                         val operator = if (upper) item.operator().apiUpperOperator else item.operator().apiOperator
 
-                        ":" + operator + ":" + getAPIValue(item)
+                        ":" + operator + (getAPIValue(item)?.let { ":$it" } ?: "")
                     }
 
                     key + clause.joinToString(separator = "")
                 }
         }
 
-        private fun getAPIValue(item: RepositoryScopeFilterItem): String {
+        private fun getAPIValue(item: RepositoryScopeFilterItem): String? {
+            val value = item.value() ?: return null
             return when (item.operator) {
                 FilterItemOperator.IN -> {
-                    val list = FilterOperatorsHelper.strToList(item.value()!!).map { escapeChars(it) }
+                    val list = FilterOperatorsHelper.strToList(value).map { escapeChars(it) }
                     list.joinToString(";")
                 }
 
                 FilterItemOperator.NOT_NULL_AND_NOT_BLANK,
                 FilterItemOperator.NULL_OR_BLANK,
-                -> ""
+                -> null
 
-                else -> escapeChars(item.value()!!)
+                else -> escapeChars(value)
             }
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -158,11 +158,17 @@ internal class TrackedEntityInstanceQueryOnlineHelper(
         }
 
         private fun getAPIValue(item: RepositoryScopeFilterItem): String {
-            return if (item.operator() == FilterItemOperator.IN) {
-                val list = FilterOperatorsHelper.strToList(item.value()).map { escapeChars(it) }
-                list.joinToString(";")
-            } else {
-                escapeChars(item.value())
+            return when (item.operator) {
+                FilterItemOperator.IN -> {
+                    val list = FilterOperatorsHelper.strToList(item.value()!!).map { escapeChars(it) }
+                    list.joinToString(";")
+                }
+
+                FilterItemOperator.NOT_NULL_AND_NOT_BLANK,
+                FilterItemOperator.NULL_OR_BLANK,
+                -> ""
+
+                else -> escapeChars(item.value()!!)
             }
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/WhereClauseBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/WhereClauseBuilder.kt
@@ -137,12 +137,12 @@ internal class WhereClauseBuilder {
         column: String,
         value: Any,
         logicGate: String,
-        eq: String,
+        operator: String,
         end: String,
     ): WhereClauseBuilder {
         val andOpt = if (addOperator) logicGate else ""
         addOperator = true
-        whereClause.append(andOpt).append(column).append(eq).append(value).append(end)
+        whereClause.append(andOpt).append(column).append(operator).append(value).append(end)
         return this
     }
 

--- a/core/src/sharedTest/java/org/hisp/dhis/android/core/data/event/EventDataFilterSamples.kt
+++ b/core/src/sharedTest/java/org/hisp/dhis/android/core/data/event/EventDataFilterSamples.kt
@@ -54,6 +54,7 @@ internal object EventDataFilterSamples {
                     .type(DatePeriodType.ABSOLUTE)
                     .build(),
             )
+            .isEmpty(false)
             .build()
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/collection/RepositoryPagingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/collection/RepositoryPagingShould.kt
@@ -161,7 +161,7 @@ class RepositoryPagingShould {
             RepositoryDataSource(store, updatedScope2, childrenAppenders)
         dataSource.loadAfter(PageKeyedDataSource.LoadParams(6, 3), loadCallback)
         verify(store).selectWhere(
-            "program = 'uid'",
+            "(program = 'uid')",
             "code DESC, name ASC",
             3,
             6,

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/WhereClauseFromScopeBuilderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/WhereClauseFromScopeBuilderShould.kt
@@ -50,6 +50,10 @@ class WhereClauseFromScopeBuilderShould {
         RepositoryScopeFilterItem.builder().key("k1").operator(FilterItemOperator.EQ).value("v1").build()
     private val likeItem =
         RepositoryScopeFilterItem.builder().key("k2").operator(FilterItemOperator.LIKE).value("v2").build()
+    private val nullOrBlankItem =
+        RepositoryScopeFilterItem.builder().key("k3").operator(FilterItemOperator.NULL_OR_BLANK).build()
+    private val notNullAndNotBlankItem =
+        RepositoryScopeFilterItem.builder().key("k4").operator(FilterItemOperator.NOT_NULL_AND_NOT_BLANK).build()
 
     @Test
     fun build_where_statement_for_equals_key_value() {
@@ -86,6 +90,28 @@ class WhereClauseFromScopeBuilderShould {
         verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value()!!)
         verify(builder)
             .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value()!!)
+        verify(builder).build()
+        verifyNoMoreInteractions(builder)
+    }
+
+    @Test
+    fun build_where_statement_for_null_or_blank_key() {
+        val scopeBuilder = WhereClauseFromScopeBuilder(builder)
+        whenever(builder.build()).doReturn("1")
+
+        scopeBuilder.getWhereClause(scopeForItems(listOf(nullOrBlankItem)))
+        verify(builder).appendComplexQuery("(k3 IS NULL OR k3 = '')")
+        verify(builder).build()
+        verifyNoMoreInteractions(builder)
+    }
+
+    @Test
+    fun build_where_statement_for_not_null_and_not_blank_key() {
+        val scopeBuilder = WhereClauseFromScopeBuilder(builder)
+        whenever(builder.build()).doReturn("1")
+
+        scopeBuilder.getWhereClause(scopeForItems(listOf(notNullAndNotBlankItem)))
+        verify(builder).appendComplexQuery("(k4 IS NOT NULL AND k4 != '')")
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/WhereClauseFromScopeBuilderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/WhereClauseFromScopeBuilderShould.kt
@@ -58,7 +58,7 @@ class WhereClauseFromScopeBuilderShould {
         whenever(builder.build()).doReturn("1")
 
         scopeBuilder.getWhereClause(scopeForItems(filterItems))
-        verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value())
+        verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value()!!)
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }
@@ -71,7 +71,7 @@ class WhereClauseFromScopeBuilderShould {
 
         scopeBuilder.getWhereClause(scopeForItems(filterItems))
         verify(builder)
-            .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value())
+            .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value()!!)
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }
@@ -83,9 +83,9 @@ class WhereClauseFromScopeBuilderShould {
         whenever(builder.build()).doReturn("1")
 
         scopeBuilder.getWhereClause(scopeForItems(filterItems))
-        verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value())
+        verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value()!!)
         verify(builder)
-            .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value())
+            .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value()!!)
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/WhereClauseFromScopeBuilderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/WhereClauseFromScopeBuilderShould.kt
@@ -62,7 +62,7 @@ class WhereClauseFromScopeBuilderShould {
         whenever(builder.build()).doReturn("1")
 
         scopeBuilder.getWhereClause(scopeForItems(filterItems))
-        verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value()!!)
+        verify(builder).appendComplexQuery("k1 = v1")
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }
@@ -74,8 +74,7 @@ class WhereClauseFromScopeBuilderShould {
         whenever(builder.build()).doReturn("1")
 
         scopeBuilder.getWhereClause(scopeForItems(filterItems))
-        verify(builder)
-            .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value()!!)
+        verify(builder).appendComplexQuery("k2 LIKE v2")
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }
@@ -87,9 +86,8 @@ class WhereClauseFromScopeBuilderShould {
         whenever(builder.build()).doReturn("1")
 
         scopeBuilder.getWhereClause(scopeForItems(filterItems))
-        verify(builder).appendKeyOperatorValue(eqItem.key(), eqItem.operator().sqlOperator, eqItem.value()!!)
-        verify(builder)
-            .appendKeyOperatorValue(likeItem.key(), likeItem.operator().sqlOperator, likeItem.value()!!)
+        verify(builder).appendComplexQuery("k1 = v1")
+        verify(builder).appendComplexQuery("k2 LIKE v2")
         verify(builder).build()
         verifyNoMoreInteractions(builder)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
@@ -230,4 +230,42 @@ class TrackedEntityInstanceLocalQueryHelperShould {
 
         assertThat(sqlQuery).contains("value IN ('element1','element2')")
     }
+
+    @Test
+    fun build_sql_query_with_null_or_blank_attribute_filter() {
+        val scope = queryBuilder
+            .program(programUid)
+            .filter(
+                listOf(
+                    RepositoryScopeFilterItem.builder()
+                        .key("key")
+                        .operator(FilterItemOperator.NULL_OR_BLANK)
+                        .build(),
+                ),
+            )
+            .build()
+
+        val sqlQuery = localQueryHelper.getSqlQuery(scope, emptySet(), 50)
+
+        assertThat(sqlQuery).contains("(teav.value IS NULL OR teav.value = '')")
+    }
+
+    @Test
+    fun build_sql_query_with_not_null_and_not_blank_data_value() {
+        val scope = queryBuilder
+            .program(programUid)
+            .dataValue(
+                listOf(
+                    RepositoryScopeFilterItem.builder()
+                        .key("dataElement")
+                        .operator(FilterItemOperator.NOT_NULL_AND_NOT_BLANK)
+                        .build(),
+                ),
+            )
+            .build()
+
+        val sqlQuery = localQueryHelper.getSqlQuery(scope, emptySet(), 50)
+
+        assertThat(sqlQuery).contains("(tedv.value IS NOT NULL AND tedv.value != '')")
+    }
 }


### PR DESCRIPTION
Tracker filters (eventFilters, trackedEntityInstanceFilters and programStageWorkingLists) support an isEmpty/isNotEmpty operator for text values that the SDK previously did not handle. This PR adds full support for the operator, exposing a new isEmpty property on filters and building the corresponding SQL condition so the operator is honored in both offline and online queries.

Related task: [ANDROSDK-2309](https://dhis2.atlassian.net/browse/ANDROSDK-2309)

[ANDROSDK-2309]: https://dhis2.atlassian.net/browse/ANDROSDK-2309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ