### PR TITLE
fix: [ANDROSDK-2300] Make mock category combo explicit

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/program/trackerheaderengine/internal/TrackerHeaderEngine.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/trackerheaderengine/internal/TrackerHeaderEngine.kt
@@ -55,8 +55,8 @@ internal class TrackerHeaderEngine(
         val programIndicator: ProgramIndicator = ProgramIndicator.builder()
             .uid("mock_program_indicator")
             .expression(expression)
-            .categoryCombo(ObjectWithUid.create("bjDvmb4bfuf"))
-            .attributeCombo(ObjectWithUid.create("bjDvmb4bfuf"))
+            .categoryCombo(ObjectWithUid.create("mock_category_combo"))
+            .attributeCombo(ObjectWithUid.create("mock_category_combo"))
             .build()
 
         val attributeValueMap = attributeValues


### PR DESCRIPTION
The hardcoded category combos were not a problem because this program indicator is just used as an auxiliary PI to calculate the tracked entity header. The values for Category Combo or Attribute Combo are never used.
Anyway, the value has been changed to make it explicit and avoid confusion.

https://dhis2.atlassian.net/browse/ANDROSDK-2300 