### PR TITLE
fix: [ANDROSDK-2360] fix isEmpty filter for working lists

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/FilterItemOperator.kt
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.android.core.arch.repositories.scope.internal
 
+import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
+
 enum class FilterItemOperator(val sqlOperator: String, val apiOperator: String, val apiUpperOperator: String) {
     LIKE("LIKE", "like", "LIKE"),
     EQ("=", "eq", "EQ"),
@@ -53,6 +55,25 @@ enum class FilterItemOperator(val sqlOperator: String, val apiOperator: String, 
             NULL_OR_BLANK -> "($column IS NULL OR $column = '')"
             NOT_NULL_AND_NOT_BLANK -> "($column IS NOT NULL AND $column != '')"
             else -> "$column $sqlOperator $valueStr"
+        }
+    }
+
+    /**
+     * Appends this operator as an EXISTS/NOT EXISTS subquery over a link table. [sub] must be the
+     * "SELECT 1 FROM ... WHERE <fixed conditions>" prefix without a trailing AND; the value condition is appended
+     * here. NULL_OR_BLANK is expressed as the negation of NOT_NULL_AND_NOT_BLANK so that it also matches rows that
+     * are absent from the link table, not only rows present with a null or blank value.
+     */
+    internal fun getSqlLinkTable(
+        where: WhereClauseBuilder,
+        sub: String,
+        column: String,
+        valueStr: String? = null,
+    ): WhereClauseBuilder {
+        return when (this) {
+            NULL_OR_BLANK -> where.appendNotExistsSubQuery("$sub AND ($column IS NOT NULL AND $column != '')")
+            NOT_NULL_AND_NOT_BLANK -> where.appendExistsSubQuery("$sub AND ($column IS NOT NULL AND $column != '')")
+            else -> where.appendExistsSubQuery("$sub AND $column $sqlOperator $valueStr")
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -367,6 +367,11 @@ internal class TrackedEntityInstanceLocalQueryHelper(
 
     private fun appendFiltersWhere(where: WhereClauseBuilder, scope: TrackedEntityInstanceQueryRepositoryScope) {
         for (item in scope.filter()) {
+            // NULL_OR_BLANK must also match TEIs without a row for the attribute, so it is expressed as the
+            // negation of NOT_NULL_AND_NOT_BLANK instead of looking for existing rows with a blank value.
+            val isNullOrBlank = item.operator() == FilterItemOperator.NULL_OR_BLANK
+            val operator = if (isNullOrBlank) FilterItemOperator.NOT_NULL_AND_NOT_BLANK else item.operator()
+
             val sub = String.format(
                 "SELECT 1 FROM %s %s WHERE %s = %s AND %s = '%s' AND %s",
                 TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
@@ -375,13 +380,17 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                 dot(teiAlias, IdentifiableColumns.UID),
                 dot(teavAlias, trackedEntityAttribute),
                 escapeQuotes(item.key()),
-                item.operator().getSqlCondition(
+                operator.getSqlCondition(
                     dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
                     getFilterItemValueStr(item),
                 ),
             )
 
-            where.appendExistsSubQuery(sub)
+            if (isNullOrBlank) {
+                where.appendNotExistsSubQuery(sub)
+            } else {
+                where.appendExistsSubQuery(sub)
+            }
         }
     }
 
@@ -565,26 +574,38 @@ internal class TrackedEntityInstanceLocalQueryHelper(
         where: WhereClauseBuilder,
         dataValues: List<RepositoryScopeFilterItem>,
     ) {
+        val valueColumn = dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.VALUE)
         dataValues
             .groupBy { it.key() }
             .forEach { (key, items) ->
-                val sub = "SELECT 1 FROM ${TrackedEntityDataValueTableInfo.TABLE_INFO.name()} $tedvAlias " +
-                    "WHERE ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.EVENT)} = " +
-                    "${dot(eventAlias, IdentifiableColumns.UID)} " +
-                    "AND ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.DATA_ELEMENT)} = " +
-                    "'${escapeQuotes(key)}' " +
+                // NULL_OR_BLANK must also match events without a row for the data element, so it is expressed as
+                // the negation of NOT_NULL_AND_NOT_BLANK instead of looking for existing rows with a blank value.
+                val (nullOrBlankItems, otherItems) = items.partition {
+                    it.operator() == FilterItemOperator.NULL_OR_BLANK
+                }
 
-                    items.joinToString("") { item ->
-                        "AND ${
-                            item.operator().getSqlCondition(
-                                dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.VALUE),
-                                getFilterItemValueStr(item),
-                            )
-                        } "
+                if (nullOrBlankItems.isNotEmpty()) {
+                    val condition =
+                        "AND ${FilterItemOperator.NOT_NULL_AND_NOT_BLANK.getSqlCondition(valueColumn)} "
+                    where.appendNotExistsSubQuery(getDataValueSubQuery(key, condition))
+                }
+
+                if (otherItems.isNotEmpty()) {
+                    val conditions = otherItems.joinToString("") { item ->
+                        "AND ${item.operator().getSqlCondition(valueColumn, getFilterItemValueStr(item))} "
                     }
-
-                where.appendExistsSubQuery(sub)
+                    where.appendExistsSubQuery(getDataValueSubQuery(key, conditions))
+                }
             }
+    }
+
+    private fun getDataValueSubQuery(key: String, conditions: String): String {
+        return "SELECT 1 FROM ${TrackedEntityDataValueTableInfo.TABLE_INFO.name()} $tedvAlias " +
+            "WHERE ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.EVENT)} = " +
+            "${dot(eventAlias, IdentifiableColumns.UID)} " +
+            "AND ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.DATA_ELEMENT)} = " +
+            "'${escapeQuotes(key)}' " +
+            conditions
     }
 
     private fun getFilterItemValueStr(item: RepositoryScopeFilterItem): String {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -349,48 +349,41 @@ internal class TrackedEntityInstanceLocalQueryHelper(
                     }
 
                 val sub = String.format(
-                    "SELECT 1 FROM %s %s WHERE %s = %s AND %s",
+                    "SELECT 1 FROM %s %s WHERE %s = %s",
                     TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
                     teavAlias,
                     dot(teavAlias, trackedEntityInstance),
                     dot(teiAlias, IdentifiableColumns.UID),
-                    query.operator().getSqlCondition(
-                        dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
-                        valueStr,
-                    ),
                 )
 
-                where.appendExistsSubQuery(sub)
+                query.operator().getSqlLinkTable(
+                    where = where,
+                    sub = sub,
+                    column = dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
+                    valueStr = valueStr,
+                )
             }
         }
     }
 
     private fun appendFiltersWhere(where: WhereClauseBuilder, scope: TrackedEntityInstanceQueryRepositoryScope) {
         for (item in scope.filter()) {
-            // NULL_OR_BLANK must also match TEIs without a row for the attribute, so it is expressed as the
-            // negation of NOT_NULL_AND_NOT_BLANK instead of looking for existing rows with a blank value.
-            val isNullOrBlank = item.operator() == FilterItemOperator.NULL_OR_BLANK
-            val operator = if (isNullOrBlank) FilterItemOperator.NOT_NULL_AND_NOT_BLANK else item.operator()
-
             val sub = String.format(
-                "SELECT 1 FROM %s %s WHERE %s = %s AND %s = '%s' AND %s",
+                "SELECT 1 FROM %s %s WHERE %s = %s AND %s = '%s'",
                 TrackedEntityAttributeValueTableInfo.TABLE_INFO.name(),
                 teavAlias,
                 dot(teavAlias, trackedEntityInstance),
                 dot(teiAlias, IdentifiableColumns.UID),
                 dot(teavAlias, trackedEntityAttribute),
                 escapeQuotes(item.key()),
-                operator.getSqlCondition(
-                    dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
-                    getFilterItemValueStr(item),
-                ),
             )
 
-            if (isNullOrBlank) {
-                where.appendNotExistsSubQuery(sub)
-            } else {
-                where.appendExistsSubQuery(sub)
-            }
+            item.operator().getSqlLinkTable(
+                where = where,
+                sub = sub,
+                column = dot(teavAlias, TrackedEntityAttributeValueTableInfo.Columns.VALUE),
+                valueStr = getFilterItemValueStr(item),
+            )
         }
     }
 
@@ -578,34 +571,24 @@ internal class TrackedEntityInstanceLocalQueryHelper(
         dataValues
             .groupBy { it.key() }
             .forEach { (key, items) ->
-                // NULL_OR_BLANK must also match events without a row for the data element, so it is expressed as
-                // the negation of NOT_NULL_AND_NOT_BLANK instead of looking for existing rows with a blank value.
-                val (nullOrBlankItems, otherItems) = items.partition {
-                    it.operator() == FilterItemOperator.NULL_OR_BLANK
-                }
-
-                if (nullOrBlankItems.isNotEmpty()) {
-                    val condition =
-                        "AND ${FilterItemOperator.NOT_NULL_AND_NOT_BLANK.getSqlCondition(valueColumn)} "
-                    where.appendNotExistsSubQuery(getDataValueSubQuery(key, condition))
-                }
-
-                if (otherItems.isNotEmpty()) {
-                    val conditions = otherItems.joinToString("") { item ->
-                        "AND ${item.operator().getSqlCondition(valueColumn, getFilterItemValueStr(item))} "
-                    }
-                    where.appendExistsSubQuery(getDataValueSubQuery(key, conditions))
+                val sub = getDataValueSubQuery(key)
+                items.forEach { item ->
+                    item.operator().getSqlLinkTable(
+                        where = where,
+                        sub = sub,
+                        column = valueColumn,
+                        valueStr = getFilterItemValueStr(item),
+                    )
                 }
             }
     }
 
-    private fun getDataValueSubQuery(key: String, conditions: String): String {
+    private fun getDataValueSubQuery(key: String): String {
         return "SELECT 1 FROM ${TrackedEntityDataValueTableInfo.TABLE_INFO.name()} $tedvAlias " +
             "WHERE ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.EVENT)} = " +
             "${dot(eventAlias, IdentifiableColumns.UID)} " +
             "AND ${dot(tedvAlias, TrackedEntityDataValueTableInfo.Columns.DATA_ELEMENT)} = " +
-            "'${escapeQuotes(key)}' " +
-            conditions
+            "'${escapeQuotes(key)}'"
     }
 
     private fun getFilterItemValueStr(item: RepositoryScopeFilterItem): String {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/WhereClauseBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/WhereClauseBuilder.kt
@@ -168,6 +168,14 @@ internal class WhereClauseBuilder {
         return this
     }
 
+    fun appendNotExistsSubQuery(subQuery: String?): WhereClauseBuilder {
+        val andOpt = if (addOperator) AND else ""
+        addOperator = true
+        whereClause.append(andOpt).append(NOT_EXISTS).append(PARENTHESES_START).append(subQuery)
+            .append(PARENTHESES_END)
+        return this
+    }
+
     fun appendOperator(operator: String?): WhereClauseBuilder {
         whereClause.append(operator)
         addOperator = false
@@ -193,6 +201,7 @@ internal class WhereClauseBuilder {
         private const val PARENTHESES_START = "("
         private const val PARENTHESES_END = ")"
         private const val EXISTS = " EXISTS "
+        private const val NOT_EXISTS = " NOT EXISTS "
         private const val EQ_NUMBER = " = "
         private const val AND = " AND "
         private const val OR = " OR "

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
@@ -247,7 +247,8 @@ class TrackedEntityInstanceLocalQueryHelperShould {
 
         val sqlQuery = localQueryHelper.getSqlQuery(scope, emptySet(), 50)
 
-        assertThat(sqlQuery).contains("(teav.value IS NULL OR teav.value = '')")
+        assertThat(sqlQuery).contains("NOT EXISTS (")
+        assertThat(sqlQuery).contains("(teav.value IS NOT NULL AND teav.value != '')")
     }
 
     @Test


### PR DESCRIPTION
The `isEmpty` (NULL_OR_BLANK) filter for working lists was not returning the expected TEIs. The filter was translated into an `EXISTS` subquery over `TrackedEntityAttributeValue` that only matched instances having a row for the attribute with a null or empty value. In practice the most common "no value" case is that the row does not exist at all (the attribute was never filled in), so those TEIs were silently excluded. The same flaw affected the data value filter over `TrackedEntityDataValue`.

The fix reframes `NULL_OR_BLANK` as the logical negation of `NOT_NULL_AND_NOT_BLANK`: instead of `EXISTS(... value IS NULL OR value = '')`, it now emits `NOT EXISTS(... value IS NOT NULL AND value != '')`. This single correlated subquery covers all three cases — no row, row with NULL, and row with an empty string — and mirrors the server behavior of the API `null` operator. A `NOT EXISTS` helper was added to `WhereClauseBuilder`, and for data values the grouped conditions are partitioned so any `NULL_OR_BLANK` item is emitted as its own `NOT EXISTS` while the remaining operators keep the existing `EXISTS` path. `FilterItemOperator` itself is unchanged, since its condition is still correct for direct-column filters where the row always exists.

Related task: [ANDROSDK-2360](https://dhis2.atlassian.net/browse/ANDROSDK-2360)

[ANDROSDK-2360]: https://dhis2.atlassian.net/browse/ANDROSDK-2360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ