### PR TITLE
fix: [ANDROSDK-2344] store cookies by host to avoid mixing sessions across servers

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
@@ -38,9 +38,13 @@ internal class CookieAuthenticatorHelper {
     companion object {
         private const val COOKIE_KEY = "Cookie"
         private const val SET_COOKIE_KEY = "set-cookie"
+        private const val PATH_ATTRIBUTE = "path"
+        private const val DEFAULT_PATH = "/"
     }
 
-    private val cookieMapByHost = mutableMapOf<String, MutableMap<String, String>>()
+    private data class StoredCookie(val nameValue: String, val path: String)
+
+    private val cookieMapByHost = mutableMapOf<String, MutableMap<String, StoredCookie>>()
 
     fun storeCookieIfSentByServer(res: HttpResponse) {
         val host = res.call.request.url.host
@@ -52,28 +56,67 @@ internal class CookieAuthenticatorHelper {
                 val nameValue = cookie.substringBefore(";")
                 val name = nameValue.substringBefore("=").trim()
                 if (name.isNotEmpty()) {
-                    hostCookies[name] = nameValue
+                    val path = extractPath(cookie)
+                    hostCookies[cookieId(name, path)] = StoredCookie(nameValue, path)
                 }
             }
         }
     }
 
-    fun isCookieDefined(host: String): Boolean {
-        return !cookieMapByHost[host].isNullOrEmpty()
+    fun isCookieDefined(requestBuilder: HttpRequestBuilder): Boolean {
+        return matchingCookies(requestBuilder).isNotEmpty()
     }
 
-    fun removeCookie(host: String) {
-        cookieMapByHost.remove(host)
-    }
-
-    fun addCookieHeader(requestBuilder: HttpRequestBuilder) {
+    fun removeCookie(requestBuilder: HttpRequestBuilder) {
         val host = requestBuilder.url.host
-        val hostCookies = cookieMapByHost[host]
-        if (!hostCookies.isNullOrEmpty()) {
-            requestBuilder.apply {
-                headers.remove(COOKIE_KEY)
-                header(COOKIE_KEY, hostCookies.values.joinToString("; "))
+        val requestPath = requestBuilder.url.build().encodedPath
+        cookieMapByHost[host]?.let { hostCookies ->
+            hostCookies.values.removeAll { pathMatches(it.path, requestPath) }
+            if (hostCookies.isEmpty()) {
+                cookieMapByHost.remove(host)
             }
         }
     }
+
+    fun addCookieHeader(requestBuilder: HttpRequestBuilder) {
+        val matching = matchingCookies(requestBuilder)
+        if (matching.isNotEmpty()) {
+            requestBuilder.apply {
+                headers.remove(COOKIE_KEY)
+                header(COOKIE_KEY, matching.joinToString("; ") { it.nameValue })
+            }
+        }
+    }
+
+    /**
+     * Cookies are stored per host, but a host can serve several DHIS2 instances under different
+     * paths (e.g. `.../stable-2-41-9` and `.../stable-2-43-0-1`). Each cookie carries its own
+     * `Path`, so a cookie is only attached to a request whose path matches that `Path`, avoiding
+     * that an instance receives another instance's cookie.
+     */
+    private fun matchingCookies(requestBuilder: HttpRequestBuilder): List<StoredCookie> {
+        val requestPath = requestBuilder.url.build().encodedPath
+        return cookieMapByHost[requestBuilder.url.host]
+            ?.values
+            ?.filter { pathMatches(it.path, requestPath) }
+            .orEmpty()
+    }
+
+    private fun extractPath(cookie: String): String {
+        return cookie.split(";")
+            .map { it.trim() }
+            .firstOrNull { it.substringBefore("=").trim().equals(PATH_ATTRIBUTE, ignoreCase = true) }
+            ?.substringAfter("=")
+            ?.trim()
+            ?.ifEmpty { DEFAULT_PATH }
+            ?: DEFAULT_PATH
+    }
+
+    private fun pathMatches(cookiePath: String, requestPath: String): Boolean {
+        if (cookiePath == requestPath) return true
+        if (!requestPath.startsWith(cookiePath)) return false
+        return cookiePath.endsWith("/") || requestPath.getOrNull(cookiePath.length) == '/'
+    }
+
+    private fun cookieId(name: String, path: String): String = "$name@$path"
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
@@ -113,9 +113,11 @@ internal class CookieAuthenticatorHelper {
     }
 
     private fun pathMatches(cookiePath: String, requestPath: String): Boolean {
-        if (cookiePath == requestPath) return true
-        if (!requestPath.startsWith(cookiePath)) return false
-        return cookiePath.endsWith("/") || requestPath.getOrNull(cookiePath.length) == '/'
+        return cookiePath == requestPath ||
+            (
+                requestPath.startsWith(cookiePath) &&
+                    (cookiePath.endsWith("/") || requestPath.getOrNull(cookiePath.length) == '/')
+                )
     }
 
     private fun cookieId(name: String, path: String): String = "$name@$path"

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorHelper.kt
@@ -40,34 +40,40 @@ internal class CookieAuthenticatorHelper {
         private const val SET_COOKIE_KEY = "set-cookie"
     }
 
-    private val cookieMap = mutableMapOf<String, String>()
+    private val cookieMapByHost = mutableMapOf<String, MutableMap<String, String>>()
 
     fun storeCookieIfSentByServer(res: HttpResponse) {
+        val host = res.call.request.url.host
         val cookies = res.headers.getAll(SET_COOKIE_KEY)
 
         if (!cookies.isNullOrEmpty()) {
+            val hostCookies = cookieMapByHost.getOrPut(host) { mutableMapOf() }
             cookies.forEach { cookie ->
                 val nameValue = cookie.substringBefore(";")
                 val name = nameValue.substringBefore("=").trim()
                 if (name.isNotEmpty()) {
-                    cookieMap[name] = nameValue
+                    hostCookies[name] = nameValue
                 }
             }
         }
     }
 
-    fun isCookieDefined(): Boolean {
-        return cookieMap.isNotEmpty()
+    fun isCookieDefined(host: String): Boolean {
+        return !cookieMapByHost[host].isNullOrEmpty()
     }
 
-    fun removeCookie() {
-        cookieMap.clear()
+    fun removeCookie(host: String) {
+        cookieMapByHost.remove(host)
     }
 
     fun addCookieHeader(requestBuilder: HttpRequestBuilder) {
-        requestBuilder.apply {
-            headers.remove(COOKIE_KEY)
-            header(COOKIE_KEY, cookieMap.values.joinToString("; "))
+        val host = requestBuilder.url.host
+        val hostCookies = cookieMapByHost[host]
+        if (!hostCookies.isNullOrEmpty()) {
+            requestBuilder.apply {
+                headers.remove(COOKIE_KEY)
+                header(COOKIE_KEY, hostCookies.values.joinToString("; "))
+            }
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPlugin.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPlugin.kt
@@ -46,7 +46,7 @@ internal class ParentAuthenticatorPlugin(
         on(Send) { request ->
             val isLoginCall = request.headers[AUTHORIZATION_KEY] != null
             if (isLoginCall) {
-                cookieHelper.removeCookie()
+                cookieHelper.removeCookie(request.url.host)
                 val call = proceed(request)
                 cookieHelper.storeCookieIfSentByServer(call.response)
                 call

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPlugin.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPlugin.kt
@@ -46,7 +46,7 @@ internal class ParentAuthenticatorPlugin(
         on(Send) { request ->
             val isLoginCall = request.headers[AUTHORIZATION_KEY] != null
             if (isLoginCall) {
-                cookieHelper.removeCookie(request.url.host)
+                cookieHelper.removeCookie(request)
                 val call = proceed(request)
                 cookieHelper.storeCookieIfSentByServer(call.response)
                 call

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
@@ -54,7 +54,8 @@ internal class PasswordAndCookieAuthenticator(
         credentials: Credentials,
     ): HttpClientCall {
         userIdHelper.builderWithUserId(requestBuilder)
-        val useCookie = cookieHelper.isCookieDefined()
+        val host = requestBuilder.url.host
+        val useCookie = cookieHelper.isCookieDefined(host)
         if (useCookie) {
             cookieHelper.addCookieHeader(requestBuilder)
         } else {
@@ -63,7 +64,7 @@ internal class PasswordAndCookieAuthenticator(
         val call = sender.proceed(requestBuilder)
 
         val finalCall = if (useCookie && hasAuthenticationFailed(call.response)) {
-            cookieHelper.removeCookie()
+            cookieHelper.removeCookie(host)
             val originalRequest: HttpRequestBuilder = HttpRequestBuilder().apply {
                 takeFrom(call.request)
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
@@ -54,8 +54,7 @@ internal class PasswordAndCookieAuthenticator(
         credentials: Credentials,
     ): HttpClientCall {
         userIdHelper.builderWithUserId(requestBuilder)
-        val host = requestBuilder.url.host
-        val useCookie = cookieHelper.isCookieDefined(host)
+        val useCookie = cookieHelper.isCookieDefined(requestBuilder)
         if (useCookie) {
             cookieHelper.addCookieHeader(requestBuilder)
         } else {
@@ -64,7 +63,7 @@ internal class PasswordAndCookieAuthenticator(
         val call = sender.proceed(requestBuilder)
 
         val finalCall = if (useCookie && hasAuthenticationFailed(call.response)) {
-            cookieHelper.removeCookie(host)
+            cookieHelper.removeCookie(requestBuilder)
             val originalRequest: HttpRequestBuilder = HttpRequestBuilder().apply {
                 takeFrom(call.request)
             }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorShould.kt
@@ -42,8 +42,10 @@ import org.junit.Test
 
 class CookieAuthenticatorShould {
 
-    private val hostA = "server-a.com"
-    private val hostB = "server-b.com"
+    private val host = "play.im.dhis2.org"
+    private val otherHost = "another.dhis2.org"
+    private val instanceAPath = "/stable-2-41-9"
+    private val instanceBPath = "/stable-2-43-0-1"
 
     private fun clientRespondingWithCookies(cookies: List<String>): HttpClient {
         return HttpClient(
@@ -58,24 +60,29 @@ class CookieAuthenticatorShould {
         )
     }
 
-    private suspend fun HttpClient.storeCookiesFrom(cookieHelper: CookieAuthenticatorHelper, url: String) {
-        val response: HttpResponse = get(url)
+    private suspend fun storeCookiesFrom(cookieHelper: CookieAuthenticatorHelper, host: String, cookies: List<String>) {
+        val response: HttpResponse = clientRespondingWithCookies(cookies).get("https://$host/api/me")
         cookieHelper.storeCookieIfSentByServer(response)
     }
 
+    private fun requestTo(host: String, instancePath: String): HttpRequestBuilder {
+        return HttpRequestBuilder().apply { url("https://$host$instancePath/api/metadata") }
+    }
+
     @Test
-    fun store_multiple_cookies() = runTest {
+    fun store_and_send_cookies_matching_the_request_path() = runTest {
         val cookieHelper = CookieAuthenticatorHelper()
-        val client = clientRespondingWithCookies(
+
+        storeCookiesFrom(
+            cookieHelper,
+            host,
             listOf(
-                "JSESSIONID=4DD96301F71D2F5EC41DFD1D3BC012AB; Path=/current; Secure; HttpOnly",
+                "JSESSIONID=4DD96301F71D2F5EC41DFD1D3BC012AB; Path=$instanceAPath; Secure; HttpOnly",
                 "_ga=34FJALK23LLFLF; Secure; HttpOnly",
             ),
         )
 
-        client.storeCookiesFrom(cookieHelper, "https://$hostA/api")
-
-        val requestBuilder = HttpRequestBuilder().apply { url("https://$hostA/api/me") }
+        val requestBuilder = requestTo(host, instanceAPath)
         cookieHelper.addCookieHeader(requestBuilder)
 
         assertThat(requestBuilder.headers["Cookie"])
@@ -83,32 +90,43 @@ class CookieAuthenticatorShould {
     }
 
     @Test
+    fun not_mix_cookies_between_instances_sharing_the_same_host() = runTest {
+        val cookieHelper = CookieAuthenticatorHelper()
+
+        storeCookiesFrom(cookieHelper, host, listOf("JSESSIONID=INSTANCE_A_SESSION; Path=$instanceAPath"))
+
+        assertThat(cookieHelper.isCookieDefined(requestTo(host, instanceAPath))).isTrue()
+        assertThat(cookieHelper.isCookieDefined(requestTo(host, instanceBPath))).isFalse()
+
+        val requestToOtherInstance = requestTo(host, instanceBPath)
+        cookieHelper.addCookieHeader(requestToOtherInstance)
+
+        assertThat(requestToOtherInstance.headers["Cookie"]).isNull()
+    }
+
+    @Test
     fun not_mix_cookies_between_hosts() = runTest {
         val cookieHelper = CookieAuthenticatorHelper()
-        val client = clientRespondingWithCookies(listOf("JSESSIONID=HOST_A_SESSION; Path=/"))
 
-        client.storeCookiesFrom(cookieHelper, "https://$hostA/api")
+        storeCookiesFrom(cookieHelper, host, listOf("JSESSIONID=INSTANCE_A_SESSION; Path=$instanceAPath"))
 
-        assertThat(cookieHelper.isCookieDefined(hostA)).isTrue()
-        assertThat(cookieHelper.isCookieDefined(hostB)).isFalse()
+        assertThat(cookieHelper.isCookieDefined(requestTo(otherHost, instanceAPath))).isFalse()
 
-        val requestToOtherHost = HttpRequestBuilder().apply { url("https://$hostB/api/me") }
+        val requestToOtherHost = requestTo(otherHost, instanceAPath)
         cookieHelper.addCookieHeader(requestToOtherHost)
 
         assertThat(requestToOtherHost.headers["Cookie"]).isNull()
     }
 
     @Test
-    fun remove_cookies_only_for_the_given_host() = runTest {
+    fun remove_cookies_only_for_the_matching_instance() = runTest {
         val cookieHelper = CookieAuthenticatorHelper()
-        clientRespondingWithCookies(listOf("JSESSIONID=HOST_A_SESSION; Path=/"))
-            .storeCookiesFrom(cookieHelper, "https://$hostA/api")
-        clientRespondingWithCookies(listOf("JSESSIONID=HOST_B_SESSION; Path=/"))
-            .storeCookiesFrom(cookieHelper, "https://$hostB/api")
+        storeCookiesFrom(cookieHelper, host, listOf("JSESSIONID=INSTANCE_A_SESSION; Path=$instanceAPath"))
+        storeCookiesFrom(cookieHelper, host, listOf("JSESSIONID=INSTANCE_B_SESSION; Path=$instanceBPath"))
 
-        cookieHelper.removeCookie(hostA)
+        cookieHelper.removeCookie(requestTo(host, instanceAPath))
 
-        assertThat(cookieHelper.isCookieDefined(hostA)).isFalse()
-        assertThat(cookieHelper.isCookieDefined(hostB)).isTrue()
+        assertThat(cookieHelper.isCookieDefined(requestTo(host, instanceAPath))).isFalse()
+        assertThat(cookieHelper.isCookieDefined(requestTo(host, instanceBPath))).isTrue()
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/CookieAuthenticatorShould.kt
@@ -29,51 +29,86 @@
 package org.hisp.dhis.android.core.arch.api.authentication.internal
 
 import com.google.common.truth.Truth.assertThat
-import io.ktor.client.call.HttpClientCall
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.url
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Headers
-import io.ktor.http.HeadersImpl
-import io.ktor.http.HttpProtocolVersion
-import io.ktor.http.HttpStatusCode
-import io.ktor.util.date.GMTDate
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.InternalAPI
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import org.mockito.kotlin.mock
-import kotlin.coroutines.CoroutineContext
 
 class CookieAuthenticatorShould {
 
-    @OptIn(InternalAPI::class)
-    @Test
-    fun store_multiple_cookies() {
-        val cookieHelper = CookieAuthenticatorHelper()
+    private val hostA = "server-a.com"
+    private val hostB = "server-b.com"
 
-        val response = object : HttpResponse() {
-            override val call: HttpClientCall = mock()
-            override val rawContent: ByteReadChannel = mock()
-            override val coroutineContext: CoroutineContext = mock()
-            override val requestTime: GMTDate = GMTDate.START
-            override val responseTime: GMTDate = GMTDate.START
-            override val status: HttpStatusCode = HttpStatusCode.OK
-            override val version: HttpProtocolVersion = HttpProtocolVersion.HTTP_2_0
-            override val headers: Headers = HeadersImpl(
-                mapOf(
-                    "set-cookie" to listOf(
-                        "JSESSIONID=4DD96301F71D2F5EC41DFD1D3BC012AB; Path=/current; Secure; HttpOnly",
-                        "_ga=34FJALK23LLFLF; Secure; HttpOnly",
-                    ),
-                ),
-            )
-        }
+    private fun clientRespondingWithCookies(cookies: List<String>): HttpClient {
+        return HttpClient(
+            MockEngine { _ ->
+                respond(
+                    content = "OK",
+                    headers = Headers.build {
+                        cookies.forEach { append("set-cookie", it) }
+                    },
+                )
+            },
+        )
+    }
 
+    private suspend fun HttpClient.storeCookiesFrom(cookieHelper: CookieAuthenticatorHelper, url: String) {
+        val response: HttpResponse = get(url)
         cookieHelper.storeCookieIfSentByServer(response)
+    }
 
-        val requestBuilder = HttpRequestBuilder()
+    @Test
+    fun store_multiple_cookies() = runTest {
+        val cookieHelper = CookieAuthenticatorHelper()
+        val client = clientRespondingWithCookies(
+            listOf(
+                "JSESSIONID=4DD96301F71D2F5EC41DFD1D3BC012AB; Path=/current; Secure; HttpOnly",
+                "_ga=34FJALK23LLFLF; Secure; HttpOnly",
+            ),
+        )
+
+        client.storeCookiesFrom(cookieHelper, "https://$hostA/api")
+
+        val requestBuilder = HttpRequestBuilder().apply { url("https://$hostA/api/me") }
         cookieHelper.addCookieHeader(requestBuilder)
 
         assertThat(requestBuilder.headers["Cookie"])
             .isEqualTo("JSESSIONID=4DD96301F71D2F5EC41DFD1D3BC012AB; _ga=34FJALK23LLFLF")
+    }
+
+    @Test
+    fun not_mix_cookies_between_hosts() = runTest {
+        val cookieHelper = CookieAuthenticatorHelper()
+        val client = clientRespondingWithCookies(listOf("JSESSIONID=HOST_A_SESSION; Path=/"))
+
+        client.storeCookiesFrom(cookieHelper, "https://$hostA/api")
+
+        assertThat(cookieHelper.isCookieDefined(hostA)).isTrue()
+        assertThat(cookieHelper.isCookieDefined(hostB)).isFalse()
+
+        val requestToOtherHost = HttpRequestBuilder().apply { url("https://$hostB/api/me") }
+        cookieHelper.addCookieHeader(requestToOtherHost)
+
+        assertThat(requestToOtherHost.headers["Cookie"]).isNull()
+    }
+
+    @Test
+    fun remove_cookies_only_for_the_given_host() = runTest {
+        val cookieHelper = CookieAuthenticatorHelper()
+        clientRespondingWithCookies(listOf("JSESSIONID=HOST_A_SESSION; Path=/"))
+            .storeCookiesFrom(cookieHelper, "https://$hostA/api")
+        clientRespondingWithCookies(listOf("JSESSIONID=HOST_B_SESSION; Path=/"))
+            .storeCookiesFrom(cookieHelper, "https://$hostB/api")
+
+        cookieHelper.removeCookie(hostA)
+
+        assertThat(cookieHelper.isCookieDefined(hostA)).isFalse()
+        assertThat(cookieHelper.isCookieDefined(hostB)).isTrue()
     }
 }


### PR DESCRIPTION
## Summary

Fixes [ANDROSDK-2344](https://dhis2.atlassian.net/browse/ANDROSDK-2344): cookies were not well managed when calling external URLs through the SDK's `httpServiceClient()`. The HTTP client kept a single global cookie store, so cookies captured from one host (e.g. the DHIS2 instance) leaked into requests to a different host, and vice versa, corrupting the active session.

## Root cause

`CookieAuthenticatorHelper` held a single, host-agnostic `cookieMap`. Combined with the login-call detection (any request carrying an `Authorization` header is treated as a login), an external request would:
- clear the current DHIS2 session cookie, and
- store the external server's `set-cookie` into the shared map,

so the next call to the DHIS2 instance sent the wrong host's cookie.

## Change

Scope the cookie store by host (Option 2):
- `CookieAuthenticatorHelper` now keys cookies by host (`Map<host, Map<name, value>>`). Cookies are stored under the responding host and only attached to requests going to that same host.
- `isCookieDefined(host)` / `removeCookie(host)` now operate per host; the login branch in `ParentAuthenticatorPlugin` only clears the destination host's cookies.
- `PasswordAndCookieAuthenticator` passes the request host through.

The DHIS2 session-expiry fallback (redirect to login → retry with password) is unchanged, now scoped per host.

## Tests

`CookieAuthenticatorShould` rewritten to use `MockEngine` (real responses with a host), plus new cases:
- `not_mix_cookies_between_hosts`
- `remove_cookies_only_for_the_given_host`

`./gradlew :core:testDebugUnitTest` for the affected classes → passing.

[ANDROSDK-2344]: https://dhis2.atlassian.net/browse/ANDROSDK-2344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ