### PR TITLE
[ANDROSDK-2362] add login redirection to accommodate to v43 change

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/PasswordAndCookieAuthenticator.kt
@@ -44,7 +44,7 @@ internal class PasswordAndCookieAuthenticator(
 ) {
 
     companion object {
-        private val LOGIN_KEY_LIST = listOf("login.action", "dhis-web-login")
+        private val LOGIN_KEY_LIST = listOf("login.action", "dhis-web-login", "login")
         const val LOCATION_KEY = "Location"
     }
 


### PR DESCRIPTION
## [ANDROSDK-2362](https://dhis2.atlassian.net/browse/ANDROSDK-2362) Redirection to login page when cookies expired not properly handled on v43

### Problem

On DHIS2 v43 the redirection performed when a request is made with expired cookies is not being captured correctly by the SDK. As a result, the failed-authentication scenario is not detected and the user gets blocked in the App instead of transparently re-authenticating with password credentials.

### Cause

When a cookie-authenticated request fails, the server responds with a redirection (`3xx`) whose `Location` header points to the login page. `PasswordAndCookieAuthenticator` detects this by matching the `Location` value against a list of known login path fragments (`LOGIN_KEY_LIST`). In v43 the login redirect uses a new `login` path that was not present in that list, so the redirection was not recognized as an authentication failure and the fallback to password authentication never triggered.

### Change

Add `"login"` to `LOGIN_KEY_LIST` in `PasswordAndCookieAuthenticator` so the v43 login redirection is correctly identified as an expired-session redirect, alongside the existing `login.action` and `dhis-web-login` fragments.

```diff
- private val LOGIN_KEY_LIST = listOf("login.action", "dhis-web-login")
+ private val LOGIN_KEY_LIST = listOf("login.action", "dhis-web-login", "login")
```

This allows the authenticator to fall back to password authentication and retry the request, keeping the user logged in.


[ANDROSDK-2362]: https://dhis2.atlassian.net/browse/ANDROSDK-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ