### PR TITLE
feature: [ANDROSDK-2349] implement default image compression

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1980,6 +1980,13 @@ public final class org/hisp/dhis/android/core/arch/helpers/DateUtils {
 	public static final fun getStartDate (Ljava/util/List;)Ljava/util/Date;
 }
 
+public final class org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper {
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/arch/helpers/FileCompressionHelper;
+	public static final fun compressFile (Ljava/io/File;)Ljava/io/File;
+	public static final fun compressFile (Ljava/io/File;J)Ljava/io/File;
+	public static synthetic fun compressFile$default (Ljava/io/File;JILjava/lang/Object;)Ljava/io/File;
+}
+
 public final class org/hisp/dhis/android/core/arch/helpers/FileResizerHelper {
 	public static final field INSTANCE Lorg/hisp/dhis/android/core/arch/helpers/FileResizerHelper;
 	public static final fun resizeFile (Ljava/io/File;Lorg/hisp/dhis/android/core/arch/helpers/FileResizerHelper$Dimension;)Ljava/io/File;

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/helpers/FileCompressionHelperShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/helpers/FileCompressionHelperShould.kt
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.testapp.arch.helpers
+
+import android.graphics.Bitmap
+import android.graphics.Bitmap.CompressFormat
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.helpers.FileCompressionHelper
+import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
+import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.FileOutputStream
+import java.util.Locale
+
+@RunWith(D2JunitRunner::class)
+class FileCompressionHelperShould {
+
+    @Test
+    fun compress_png_below_target_size() {
+        val target = 20 * 1024L
+        val file = getFile(CompressFormat.PNG, getNoisyBitmap(1024, 1024))
+        assertThat(file.length()).isGreaterThan(target)
+
+        val compressedFile = FileCompressionHelper.compressFile(file, target)
+
+        assertThat(compressedFile.exists()).isTrue()
+        assertThat(compressedFile.length()).isAtMost(target)
+    }
+
+    @Test
+    fun compress_jpeg_below_target_size() {
+        val target = 20 * 1024L
+        val file = getFile(CompressFormat.JPEG, getNoisyBitmap(1024, 1024))
+        assertThat(file.length()).isGreaterThan(target)
+
+        val compressedFile = FileCompressionHelper.compressFile(file, target)
+
+        assertThat(compressedFile.exists()).isTrue()
+        assertThat(compressedFile.length()).isAtMost(target)
+    }
+
+    @Test
+    fun preserve_aspect_ratio_when_compressing() {
+        val target = 20 * 1024L
+        val file = getFile(CompressFormat.PNG, getNoisyBitmap(2048, 1024))
+
+        val compressedFile = FileCompressionHelper.compressFile(file, target)
+
+        val compressedBitmap = BitmapFactory.decodeFile(compressedFile.absolutePath)
+        val ratio = compressedBitmap.width.toFloat() / compressedBitmap.height.toFloat()
+        assertThat(ratio).isWithin(0.05f).of(2.0f)
+    }
+
+    @Test
+    fun do_not_upscale_when_file_is_already_below_target() {
+        val file = getFile(CompressFormat.PNG, getNoisyBitmap(100, 125))
+
+        val compressedFile = FileCompressionHelper.compressFile(file, 600 * 1024L)
+
+        val compressedBitmap = BitmapFactory.decodeFile(compressedFile.absolutePath)
+        assertThat(compressedBitmap.width).isEqualTo(100)
+        assertThat(compressedBitmap.height).isEqualTo(125)
+    }
+
+    @Test
+    fun return_original_file_when_it_cannot_be_decoded() {
+        val notAnImage = File(
+            FileResourceDirectoryHelper.getRootFileResourceDirectory(context()),
+            "not-an-image.txt",
+        )
+        FileOutputStream(notAnImage).use { it.write("this is not an image".toByteArray()) }
+
+        val result = FileCompressionHelper.compressFile(notAnImage, 20 * 1024L)
+
+        assertThat(result).isEqualTo(notAnImage)
+    }
+
+    companion object {
+        private fun context() = InstrumentationRegistry.getInstrumentation().context
+
+        private fun getFile(compressFormat: CompressFormat, bitmap: Bitmap): File {
+            val imageFile = File(
+                FileResourceDirectoryHelper.getRootFileResourceDirectory(context()),
+                "image-to-compress." + compressFormat.name.lowercase(Locale.getDefault()),
+            )
+            FileOutputStream(imageFile).use { os ->
+                bitmap.compress(compressFormat, 100, os)
+                os.flush()
+            }
+            return imageFile
+        }
+
+        /**
+         * Builds a high-entropy bitmap whose pixels vary per position, so that the encoded file does not collapse to a
+         * trivial size and the compression loop is actually exercised.
+         */
+        private fun getNoisyBitmap(width: Int, height: Int): Bitmap {
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            val pixels = IntArray(width * height) { i ->
+                val x = i % width
+                val y = i / width
+                Color.rgb(
+                    (x * 37 + y * 17) and 0xFF,
+                    (x * 91 + y * 53) and 0xFF,
+                    (x * 13 + y * 191) and 0xFF,
+                )
+            }
+            bitmap.setPixels(pixels, 0, width, 0, 0, width, height)
+            return bitmap
+        }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.helpers
+
+import android.graphics.Bitmap
+import android.graphics.Bitmap.CompressFormat
+import android.graphics.BitmapFactory
+import androidx.core.graphics.scale
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil
+import java.io.File
+import java.io.FileOutputStream
+import kotlin.math.sqrt
+
+/**
+ * Compresses image files before uploading them to the server, keeping the quality loss to a minimum.
+ *
+ * The strategy is to iteratively downscale the image until the encoded file drops below a target size. JPEG images
+ * are encoded with a fixed quality; PNG images are lossless, so for them the size reduction relies solely on the
+ * scaling. The first scale factor is estimated from the size ratio so that, in most cases, a single pass is enough.
+ */
+object FileCompressionHelper {
+
+    private const val JPEG_QUALITY = 80
+    private const val TARGET_SIZE_BYTES = 600 * 1024L // 600 KB
+    private const val SCALE_STEP = 0.8f // reduce dimensions by 20% on each retry
+    private const val MAX_ITERATIONS = 10
+    private const val FULL_SIZE = 1f
+    private const val MIN_DIMENSION_PX = 1
+
+    /**
+     * Compress an image file so that its encoded size does not exceed [targetSizeBytes]. The aspect ratio is always
+     * preserved. If the file cannot be decoded as an image, the original file is returned unchanged.
+     *
+     * @param fileToCompress  Image file to compress.
+     * @param targetSizeBytes Maximum size, in bytes, the resulting file should have.
+     * @return A new [File] with the compressed image, or the original file if it could not be decoded.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun compressFile(fileToCompress: File, targetSizeBytes: Long = TARGET_SIZE_BYTES): File {
+        val source = BitmapFactory.decodeFile(fileToCompress.absolutePath) ?: return fileToCompress
+        val format = resolveCompressFormat(fileToCompress)
+        val outputFile = File(fileToCompress.parent, "compressed-${fileToCompress.name}")
+
+        try {
+            compressUntilBelowTarget(source, format, outputFile, targetSizeBytes, fileToCompress.length())
+        } finally {
+            source.recycle()
+        }
+        return outputFile
+    }
+
+    private fun compressUntilBelowTarget(
+        source: Bitmap,
+        format: CompressFormat,
+        outputFile: File,
+        targetSizeBytes: Long,
+        originalSizeBytes: Long,
+    ) {
+        var scale = estimateInitialScale(originalSizeBytes, targetSizeBytes)
+        var iteration = 0
+        do {
+            writeScaledBitmap(source, scale, format, outputFile)
+            if (outputFile.length() <= targetSizeBytes) {
+                return
+            }
+            scale *= SCALE_STEP
+            iteration++
+        } while (iteration < MAX_ITERATIONS)
+    }
+
+    private fun writeScaledBitmap(source: Bitmap, scale: Float, format: CompressFormat, outputFile: File) {
+        val scaled = scaleBitmap(source, scale)
+        try {
+            FileOutputStream(outputFile).use { out ->
+                scaled.compress(format, JPEG_QUALITY, out)
+            }
+        } finally {
+            if (scaled !== source) {
+                scaled.recycle()
+            }
+        }
+    }
+
+    private fun scaleBitmap(source: Bitmap, scale: Float): Bitmap {
+        if (scale >= FULL_SIZE) {
+            return source
+        }
+        val width = (source.width * scale).toInt().coerceAtLeast(MIN_DIMENSION_PX)
+        val height = (source.height * scale).toInt().coerceAtLeast(MIN_DIMENSION_PX)
+        return source.scale(width, height)
+    }
+
+    /**
+     * Estimate the first scale factor from the size ratio. Encoded size grows roughly with the pixel count (width x
+     * height), so scaling each dimension by the square root of the target ratio lands close to the target in one pass.
+     */
+    private fun estimateInitialScale(originalSizeBytes: Long, targetSizeBytes: Long): Float {
+        return if (originalSizeBytes > targetSizeBytes) {
+            sqrt(targetSizeBytes.toFloat() / originalSizeBytes)
+        } else {
+            FULL_SIZE
+        }
+    }
+
+    private fun resolveCompressFormat(file: File): CompressFormat {
+        return when (FileResourceUtil.getExtension(file.name)?.lowercase()) {
+            "png" -> CompressFormat.PNG
+            else -> CompressFormat.JPEG
+        }
+    }
+}


### PR DESCRIPTION
Introduces `FileCompressionHelper`, the default image compression that is meant to replace the MEDIUM resolution used so far. Instead of targeting a fixed pixel dimension, it works against a size threshold in kB: it downscales the image preserving the aspect ratio until the encoded file drops below the threshold, estimating the initial scale factor from the size ratio so a single pass is usually enough. The threshold is hardcoded to 600 kB by default but exposed as a parameter so it can be adjusted easily.

The helper is not wired into the upload flow yet; this PR only adds the helper and its instrumented tests. JPEG is encoded at a fixed quality while PNG relies on scaling only (lossless), and a file that cannot be decoded as an image is returned unchanged. The public API dump was regenerated for the new helper.

Related task: [ANDROSDK-2349](https://dhis2.atlassian.net/browse/ANDROSDK-2349)

[ANDROSDK-2349]: https://dhis2.atlassian.net/browse/ANDROSDK-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ