### PR TITLE
chore: [ANDROSDK-2368] fix transifex language mapping in config file

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,6 +1,6 @@
 [main]
 host     = https://www.transifex.com
-lang_map = fa_AF: prs, uz@Cyrl: uz, uz@Latn: uz_Latn, zh_CN: zh-rCN
+lang_map = fa_AF: prs, uz@Cyrl: uz, uz@Latn: uz-rUZ, zh_CN: zh-rCN, pt_BR: pt-rBR, es_419: es-rES, ar_IQ: ar-rIQ, hi_IN: hi-rIN, ar_EG: ar-rEG, ar_SD: ar-rSD, ko_KR: ko-rKR, sw_TZ: sw-rTZ, zh_HK: zh-rHK, en_US: en-rUS, es_US: es-rUS
 
 [o:hisp-uio:p:dhis2-android-sdk:r:strings-xml]
 file_filter  = core/src/main/res/values-<lang>/strings.xml


### PR DESCRIPTION
Corrects and completes the `lang_map` entry in `.tx/config` so Transifex locale codes are mapped to valid Android resource qualifiers. `uz@Latn` was mapped to the non-existent `uz_Latn`, and the region-specific locales pulled from Transifex (`pt_BR`, `es_419`, `ar_IQ`, `hi_IN`, `ar_EG`, `ar_SD`, `ko_KR`, `sw_TZ`, `zh_HK`, `en_US`, `es_US`) had no mapping at all, so their translations were not landing in the expected `values-<qualifier>` directories.

Related task: [ANDROSDK-2368](https://dhis2.atlassian.net/browse/ANDROSDK-2368)

[ANDROSDK-2368]: https://dhis2.atlassian.net/browse/ANDROSDK-2368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ