### PR TITLE
feature: [ANDROSDK-2366] persist image settings and add resource context

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2025,6 +2025,61 @@ public final class org/hisp/dhis/android/core/arch/helpers/GeometryHelper {
 	public final fun validateGeometry (Lorg/hisp/dhis/android/core/common/Geometry;)V
 }
 
+public abstract class org/hisp/dhis/android/core/arch/helpers/ResourceContext {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPath ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilePath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFilePath ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Ljava/lang/String;
+	public final fun getDatasetUid ()Ljava/lang/String;
+	public final fun getImagePath ()Ljava/lang/String;
+	public final fun getResourceUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttribute ()Ljava/lang/String;
+	public final fun getImagePath ()Ljava/lang/String;
+	public final fun getProgramUid ()Ljava/lang/String;
+	public final fun getResourceUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class org/hisp/dhis/android/core/arch/helpers/Result {
 	public final fun flatMap (Lkotlin/jvm/functions/Function1;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public final fun fold (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
@@ -10070,6 +10125,7 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceBuilder$C
 }
 
 public final class org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository {
+	public static final field DEFAULT_QUALITY Ljava/lang/String;
 	public final fun blockingUpload ()V
 	public final fun byContentLength ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/LongFilterConnector;
 	public final fun byContentType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
@@ -10082,6 +10138,7 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceCollectio
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
 	public fun suspendAdd (Ljava/io/File;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun suspendAdd (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun suspendProcessAndAdd (Ljava/io/File;Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/repositories/object/ReadOnlyObjectRepository;
 	public fun uid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/fileresource/FileResourceObjectRepository;
 	public final fun upload ()Lio/reactivex/Observable;
@@ -10171,6 +10228,14 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceValueType
 
 public final class org/hisp/dhis/android/core/fileresource/OrgHispDhisAndroidCoreFileresourceFileResourceDIModuleModuleKt {
 	public static final fun module (Lorg/hisp/dhis/android/core/fileresource/FileResourceDIModule;)Lorg/koin/core/module/Module;
+}
+
+public final class org/hisp/dhis/android/core/fileresource/internal/UploadQuality : java/lang/Enum {
+	public static final field DEFAULT Lorg/hisp/dhis/android/core/fileresource/internal/UploadQuality;
+	public static final field ORIGINAL Lorg/hisp/dhis/android/core/fileresource/internal/UploadQuality;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/fileresource/internal/UploadQuality;
+	public static fun values ()[Lorg/hisp/dhis/android/core/fileresource/internal/UploadQuality;
 }
 
 public final class org/hisp/dhis/android/core/icon/CustomIcon : org/hisp/dhis/android/core/common/CoreObject {
@@ -18335,22 +18400,25 @@ public final class org/hisp/dhis/android/core/settings/DataSetFiltersBuilder$Com
 
 public final class org/hisp/dhis/android/core/settings/DataSetSetting : org/hisp/dhis/android/core/common/CoreObject {
 	public static final field Companion Lorg/hisp/dhis/android/core/settings/DataSetSetting$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;)V
 	public static final fun builder ()Lorg/hisp/dhis/android/core/settings/DataSetSetting$Builder;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/Date;
-	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/util/Map;
 	public final fun component5 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/settings/DataSetSetting;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/settings/DataSetSetting;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/settings/DataSetSetting;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/settings/DataSetSetting;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/settings/DataSetSetting;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/settings/DataSetSetting;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImageSettings ()Ljava/util/Map;
 	public final fun getLastUpdated ()Ljava/util/Date;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getPeriodDSDBTrimming ()Ljava/lang/Integer;
 	public final fun getPeriodDSDownload ()Ljava/lang/Integer;
 	public final fun getUid ()Ljava/lang/String;
 	public fun hashCode ()I
+	public final fun imageSettings ()Ljava/util/Map;
 	public final fun lastUpdated ()Ljava/util/Date;
 	public final fun name ()Ljava/lang/String;
 	public final fun periodDSDBTrimming ()Ljava/lang/Integer;
@@ -18372,15 +18440,18 @@ public class org/hisp/dhis/android/core/settings/DataSetSettingBuilder {
 	public static final field Companion Lorg/hisp/dhis/android/core/settings/DataSetSettingBuilder$Companion;
 	public fun <init> ()V
 	public fun build ()Lorg/hisp/dhis/android/core/settings/DataSetSetting;
+	protected final fun getImageSettings ()Ljava/util/Map;
 	protected final fun getLastUpdated ()Ljava/util/Date;
 	protected final fun getName ()Ljava/lang/String;
 	protected final fun getPeriodDSDBTrimming ()Ljava/lang/Integer;
 	protected final fun getPeriodDSDownload ()Ljava/lang/Integer;
 	protected final fun getUid ()Ljava/lang/String;
+	public final fun imageSettings (Ljava/util/Map;)Lorg/hisp/dhis/android/core/settings/DataSetSetting$Builder;
 	public final fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/settings/DataSetSetting$Builder;
 	public final fun name (Ljava/lang/String;)Lorg/hisp/dhis/android/core/settings/DataSetSetting$Builder;
 	public final fun periodDSDBTrimming (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/settings/DataSetSetting$Builder;
 	public final fun periodDSDownload (Ljava/lang/Integer;)Lorg/hisp/dhis/android/core/settings/DataSetSetting$Builder;
+	protected final fun setImageSettings (Ljava/util/Map;)V
 	protected final fun setLastUpdated (Ljava/util/Date;)V
 	protected final fun setName (Ljava/lang/String;)V
 	protected final fun setPeriodDSDBTrimming (Ljava/lang/Integer;)V
@@ -18438,6 +18509,7 @@ public final class org/hisp/dhis/android/core/settings/DataSetSettingsBuilder$Co
 }
 
 public final class org/hisp/dhis/android/core/settings/DataSetSettingsObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
+	public final fun getImageQualityFromDataSetSetting (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/settings/DataSyncPeriod : java/lang/Enum {
@@ -19040,7 +19112,7 @@ public final class org/hisp/dhis/android/core/settings/ProgramItemHeaderBuilder$
 
 public final class org/hisp/dhis/android/core/settings/ProgramSetting : org/hisp/dhis/android/core/common/CoreObject {
 	public static final field Companion Lorg/hisp/dhis/android/core/settings/ProgramSetting$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Ljava/util/Map;)V
 	public static final fun builder ()Lorg/hisp/dhis/android/core/settings/ProgramSetting$Builder;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
@@ -19052,6 +19124,7 @@ public final class org/hisp/dhis/android/core/settings/ProgramSetting : org/hisp
 	public final fun component16 ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
 	public final fun component17 ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
 	public final fun component18 ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
+	public final fun component19 ()Ljava/util/Map;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/Date;
@@ -19060,8 +19133,8 @@ public final class org/hisp/dhis/android/core/settings/ProgramSetting : org/hisp
 	public final fun component7 ()Ljava/lang/Integer;
 	public final fun component8 ()Ljava/lang/Integer;
 	public final fun component9 ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;)Lorg/hisp/dhis/android/core/settings/ProgramSetting;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/settings/ProgramSetting;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/settings/ProgramSetting;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Ljava/util/Map;)Lorg/hisp/dhis/android/core/settings/ProgramSetting;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/settings/ProgramSetting;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/LimitScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/EnrollmentScope;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Lorg/hisp/dhis/android/core/settings/DownloadPeriod;Ljava/util/Map;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/settings/ProgramSetting;
 	public final fun enrollmentDBTrimming ()Lorg/hisp/dhis/android/core/settings/EnrollmentScope;
 	public final fun enrollmentDateDBTrimming ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
 	public final fun enrollmentDateDownload ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
@@ -19081,6 +19154,7 @@ public final class org/hisp/dhis/android/core/settings/ProgramSetting : org/hisp
 	public final fun getEventsDBTrimming ()Ljava/lang/Integer;
 	public final fun getEventsDownload ()Ljava/lang/Integer;
 	public final fun getFilters ()Ljava/util/List;
+	public final fun getImageSettings ()Ljava/util/Map;
 	public final fun getLastUpdated ()Ljava/util/Date;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSettingDBTrimming ()Lorg/hisp/dhis/android/core/settings/LimitScope;
@@ -19091,6 +19165,7 @@ public final class org/hisp/dhis/android/core/settings/ProgramSetting : org/hisp
 	public final fun getUpdateDBTrimming ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
 	public final fun getUpdateDownload ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
 	public fun hashCode ()I
+	public final fun imageSettings ()Ljava/util/Map;
 	public final fun lastUpdated ()Ljava/util/Date;
 	public final fun name ()Ljava/lang/String;
 	public final fun settingDBTrimming ()Lorg/hisp/dhis/android/core/settings/LimitScope;
@@ -19134,6 +19209,7 @@ public class org/hisp/dhis/android/core/settings/ProgramSettingBuilder {
 	protected final fun getEventsDBTrimming ()Ljava/lang/Integer;
 	protected final fun getEventsDownload ()Ljava/lang/Integer;
 	protected final fun getFilters ()Ljava/util/List;
+	protected final fun getImageSettings ()Ljava/util/Map;
 	protected final fun getLastUpdated ()Ljava/util/Date;
 	protected final fun getName ()Ljava/lang/String;
 	protected final fun getSettingDBTrimming ()Lorg/hisp/dhis/android/core/settings/LimitScope;
@@ -19143,6 +19219,7 @@ public class org/hisp/dhis/android/core/settings/ProgramSettingBuilder {
 	protected final fun getUid ()Ljava/lang/String;
 	protected final fun getUpdateDBTrimming ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
 	protected final fun getUpdateDownload ()Lorg/hisp/dhis/android/core/settings/DownloadPeriod;
+	public final fun imageSettings (Ljava/util/Map;)Lorg/hisp/dhis/android/core/settings/ProgramSetting$Builder;
 	public final fun lastUpdated (Ljava/util/Date;)Lorg/hisp/dhis/android/core/settings/ProgramSetting$Builder;
 	public final fun name (Ljava/lang/String;)Lorg/hisp/dhis/android/core/settings/ProgramSetting$Builder;
 	protected final fun setEnrollmentDBTrimming (Lorg/hisp/dhis/android/core/settings/EnrollmentScope;)V
@@ -19154,6 +19231,7 @@ public class org/hisp/dhis/android/core/settings/ProgramSettingBuilder {
 	protected final fun setEventsDBTrimming (Ljava/lang/Integer;)V
 	protected final fun setEventsDownload (Ljava/lang/Integer;)V
 	protected final fun setFilters (Ljava/util/List;)V
+	protected final fun setImageSettings (Ljava/util/Map;)V
 	protected final fun setLastUpdated (Ljava/util/Date;)V
 	protected final fun setName (Ljava/lang/String;)V
 	protected final fun setSettingDBTrimming (Lorg/hisp/dhis/android/core/settings/LimitScope;)V
@@ -19221,6 +19299,7 @@ public final class org/hisp/dhis/android/core/settings/ProgramSettingsBuilder$Co
 }
 
 public final class org/hisp/dhis/android/core/settings/ProgramSettingsObjectRepository : org/hisp/dhis/android/core/arch/repositories/object/internal/ReadOnlyAnyObjectWithDownloadRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithDownloadObjectRepository {
+	public final fun getImageQualityFromProgramSettings (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/hisp/dhis/android/core/settings/QuickAction {
@@ -27338,6 +27417,7 @@ public final class org/hisp/dhis/android/persistence/settings/DataSetSettingTabl
 
 public final class org/hisp/dhis/android/persistence/settings/DataSetSettingTableInfo$Columns : org/hisp/dhis/android/core/common/CoreColumns {
 	public static final field Companion Lorg/hisp/dhis/android/persistence/settings/DataSetSettingTableInfo$Columns$Companion;
+	public static final field IMAGE_SETTINGS Ljava/lang/String;
 	public static final field LAST_UPDATED Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;
 	public static final field PERIOD_D_S_DOWNLOAD Ljava/lang/String;
@@ -27457,6 +27537,7 @@ public final class org/hisp/dhis/android/persistence/settings/ProgramSettingTabl
 	public static final field EVENT_DATE_DOWNLOAD Ljava/lang/String;
 	public static final field EVENT_DATE_D_B_TRIMMING Ljava/lang/String;
 	public static final field FILTERS Ljava/lang/String;
+	public static final field IMAGE_SETTINGS Ljava/lang/String;
 	public static final field LAST_UPDATED Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;
 	public static final field SETTING_DOWNLOAD Ljava/lang/String;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2026,56 +2026,42 @@ public final class org/hisp/dhis/android/core/arch/helpers/GeometryHelper {
 }
 
 public abstract class org/hisp/dhis/android/core/arch/helpers/ResourceContext {
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getPath ()Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$FileContext;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getFilePath ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getFilePath ()Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getResourceUid ()Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$DatasetImageContext;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAttribute ()Ljava/lang/String;
 	public final fun getDatasetUid ()Ljava/lang/String;
-	public final fun getImagePath ()Ljava/lang/String;
-	public final fun getResourceUid ()Ljava/lang/String;
+	public fun getResourceUid ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext : org/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext$ImageContext$ProgramImageContext;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAttribute ()Ljava/lang/String;
-	public final fun getImagePath ()Ljava/lang/String;
 	public final fun getProgramUid ()Ljava/lang/String;
-	public final fun getResourceUid ()Ljava/lang/String;
+	public fun getResourceUid ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -10112,6 +10112,7 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceBuilder$C
 
 public final class org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository : org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl, org/hisp/dhis/android/core/arch/repositories/collection/ReadWriteWithUidCollectionRepository {
 	public static final field DEFAULT_QUALITY Ljava/lang/String;
+	public final fun blockingProcessAndAdd (Ljava/io/File;Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext;)Ljava/lang/String;
 	public final fun blockingUpload ()V
 	public final fun byContentLength ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/LongFilterConnector;
 	public final fun byContentType ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
@@ -10122,6 +10123,7 @@ public final class org/hisp/dhis/android/core/fileresource/FileResourceCollectio
 	public final fun byState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun bySyncState ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/EnumFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/StringFilterConnector;
+	public final fun rxProcessAndAdd (Ljava/io/File;Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext;)Lio/reactivex/Single;
 	public fun suspendAdd (Ljava/io/File;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun suspendAdd (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun suspendProcessAndAdd (Ljava/io/File;Lorg/hisp/dhis/android/core/arch/helpers/ResourceContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
@@ -114,7 +114,7 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestFullDispatch
     fun add_file_untouched_for_a_plain_file_context() = fileResourceTest {
         val file = storeImageFile("plain-file.png")
 
-        val fileResource = processAndAdd(file, ResourceContext.FileContext(file.absolutePath))
+        val fileResource = processAndAdd(file, ResourceContext.FileContext)
 
         assertThat(fileResource.contentLength()).isEqualTo(file.length())
     }
@@ -173,8 +173,6 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestFullDispatch
             ResourceContext.ImageContext.ProgramImageContext(
                 programUid = "unconfiguredPr",
                 resourceUid = ITEM_A_UID,
-                attribute = ITEM_A_UID,
-                imagePath = file.absolutePath,
             ),
         )
 
@@ -200,16 +198,12 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestFullDispatch
         ResourceContext.ImageContext.ProgramImageContext(
             programUid = PROGRAM_UID,
             resourceUid = itemUid,
-            attribute = itemUid,
-            imagePath = file.absolutePath,
         )
 
     private fun dataSetImageContext(file: File, itemUid: String) =
         ResourceContext.ImageContext.DatasetImageContext(
             datasetUid = DATA_SET_UID,
             resourceUid = itemUid,
-            attribute = itemUid,
-            imagePath = file.absolutePath,
         )
 
     private fun storeFile(): File {

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
@@ -27,23 +27,64 @@
  */
 package org.hisp.dhis.android.testapp.fileresource
 
+import android.graphics.Bitmap
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
+import org.hisp.dhis.android.core.arch.helpers.FileCompressionHelper
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper.getFileResourceDirectory
+import org.hisp.dhis.android.core.arch.helpers.ResourceContext
 import org.hisp.dhis.android.core.data.fileresource.RandomGeneratedInputStream
+import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceStore
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil.writeInputStream
-import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestEmptyDispatcher
+import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
+import java.util.Random
 
+/**
+ * The image settings driving these tests come from the downloaded `settings/synchronization_settings.json`, so
+ * nothing is written to the settings tables. Inserting a setting row for a synthetic program/dataSet uid violates
+ * its foreign key, and the failed transaction poisons the shared Room connection for the rest of the class.
+ */
 @RunWith(D2JunitRunner::class)
-class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestEmptyDispatcher() {
+class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+
+    private val addedFileResources = mutableListOf<FileResource>()
+    private val addedSourceFiles = mutableListOf<File>()
+
+    /**
+     * Runs the test body and its clean up inside a single coroutine, going through the stores. Room binds the
+     * connection, and the transaction open on it, to the coroutine context, so cleaning up from a separate
+     * coroutine (an `@After` with its own `runTest`) fails with "cannot start a transaction within a transaction".
+     */
+    private fun fileResourceTest(block: suspend () -> Unit) = runTest {
+        try {
+            block()
+        } finally {
+            removeAddedFileResources()
+        }
+    }
+
+    private suspend fun removeAddedFileResources() {
+        addedFileResources.forEach { fileResource ->
+            File(fileResource.path()).delete()
+            koin.get<FileResourceStore>().delete(fileResource.uid())
+        }
+        addedFileResources.clear()
+
+        addedSourceFiles.forEach { sourceFile ->
+            File(sourceFile.parent, "compressed-${sourceFile.name}").delete()
+            sourceFile.delete()
+        }
+        addedSourceFiles.clear()
+    }
 
     @Test
     fun add_fileResources_to_the_repository() = runTest {
@@ -66,13 +107,153 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestEmptyDispatc
         assertThat(savedFile.exists()).isTrue()
 
         savedFile.delete()
-        koin.get<FileResourceStore>().delete(fileResource.uid()!!)
+        koin.get<FileResourceStore>().delete(fileResource.uid())
     }
+
+    @Test
+    fun add_file_untouched_for_a_plain_file_context() = fileResourceTest {
+        val file = storeImageFile("plain-file.png")
+
+        val fileResource = processAndAdd(file, ResourceContext.FileContext(file.absolutePath))
+
+        assertThat(fileResource.contentLength()).isEqualTo(file.length())
+    }
+
+    @Test
+    fun compress_image_when_program_setting_quality_is_default() = fileResourceTest {
+        val file = storeImageFile("program-default.png")
+
+        val fileResource = processAndAdd(file, programImageContext(file, ITEM_B_UID))
+
+        assertCompressed(fileResource, file)
+    }
+
+    @Test
+    fun keep_original_image_when_program_setting_quality_is_original() = fileResourceTest {
+        val file = storeImageFile("program-original.png")
+
+        val fileResource = processAndAdd(file, programImageContext(file, ITEM_A_UID))
+
+        assertThat(fileResource.contentLength()).isEqualTo(file.length())
+    }
+
+    @Test
+    fun compress_image_when_dataset_setting_quality_is_default() = fileResourceTest {
+        val file = storeImageFile("dataset-default.png")
+
+        val fileResource = processAndAdd(file, dataSetImageContext(file, ITEM_A_UID))
+
+        assertCompressed(fileResource, file)
+    }
+
+    @Test
+    fun keep_original_image_when_dataset_setting_quality_is_original() = fileResourceTest {
+        val file = storeImageFile("dataset-original.png")
+
+        val fileResource = processAndAdd(file, dataSetImageContext(file, ITEM_B_UID))
+
+        assertThat(fileResource.contentLength()).isEqualTo(file.length())
+    }
+
+    @Test
+    fun compress_image_when_the_item_has_no_configured_quality() = fileResourceTest {
+        val file = storeImageFile("program-unconfigured-item.png")
+
+        val fileResource = processAndAdd(file, programImageContext(file, "unconfiguredIt"))
+
+        assertCompressed(fileResource, file)
+    }
+
+    @Test
+    fun compress_image_when_the_program_has_no_settings_at_all() = fileResourceTest {
+        val file = storeImageFile("program-unconfigured.png")
+
+        val fileResource = processAndAdd(
+            file,
+            ResourceContext.ImageContext.ProgramImageContext(
+                programUid = "unconfiguredPr",
+                resourceUid = ITEM_A_UID,
+                attribute = ITEM_A_UID,
+                imagePath = file.absolutePath,
+            ),
+        )
+
+        assertCompressed(fileResource, file)
+    }
+
+    private fun assertCompressed(fileResource: FileResource, sourceFile: File) {
+        assertThat(fileResource.contentLength()).isLessThan(sourceFile.length())
+        assertThat(fileResource.contentLength()).isAtMost(FileCompressionHelper.TARGET_SIZE_BYTES)
+    }
+
+    private suspend fun processAndAdd(file: File, resourceContext: ResourceContext): FileResource {
+        val uid = d2.fileResourceModule().fileResources().suspendProcessAndAdd(file, resourceContext)
+
+        val fileResource = d2.fileResourceModule().fileResources().uid(uid).blockingGet()!!
+        addedFileResources.add(fileResource)
+
+        assertThat(File(fileResource.path()).exists()).isTrue()
+        return fileResource
+    }
+
+    private fun programImageContext(file: File, itemUid: String) =
+        ResourceContext.ImageContext.ProgramImageContext(
+            programUid = PROGRAM_UID,
+            resourceUid = itemUid,
+            attribute = itemUid,
+            imagePath = file.absolutePath,
+        )
+
+    private fun dataSetImageContext(file: File, itemUid: String) =
+        ResourceContext.ImageContext.DatasetImageContext(
+            datasetUid = DATA_SET_UID,
+            resourceUid = itemUid,
+            attribute = itemUid,
+            imagePath = file.absolutePath,
+        )
 
     private fun storeFile(): File {
         val inputStream: InputStream = RandomGeneratedInputStream(1024)
         val context = InstrumentationRegistry.getInstrumentation().context
         val destinationFile = File(getFileResourceDirectory(context), "file1.png")
         return writeInputStream(inputStream, destinationFile, 1024)
+    }
+
+    /**
+     * Stores a decodable PNG of random pixels, large enough that the default compression has to shrink it. Random
+     * noise barely compresses, so the encoded size stays well above [FileCompressionHelper.TARGET_SIZE_BYTES].
+     */
+    private fun storeImageFile(name: String): File {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val destinationFile = File(getFileResourceDirectory(context), name)
+
+        val random = Random(SEED)
+        val pixels = IntArray(IMAGE_SIDE_PX * IMAGE_SIDE_PX) { OPAQUE or random.nextInt(RGB_RANGE) }
+        val bitmap = Bitmap.createBitmap(IMAGE_SIDE_PX, IMAGE_SIDE_PX, Bitmap.Config.ARGB_8888)
+        try {
+            bitmap.setPixels(pixels, 0, IMAGE_SIDE_PX, 0, 0, IMAGE_SIDE_PX, IMAGE_SIDE_PX)
+            FileOutputStream(destinationFile).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        } finally {
+            bitmap.recycle()
+        }
+
+        assertThat(destinationFile.length()).isGreaterThan(FileCompressionHelper.TARGET_SIZE_BYTES)
+        addedSourceFiles.add(destinationFile)
+        return destinationFile
+    }
+
+    companion object {
+        // Configured in settings/synchronization_settings.json. Each item is given the opposite quality by the
+        // program and by the dataSet setting, so a single uid covers both branches depending on the context:
+        // item A -> ORIGINAL for the program, DEFAULT for the dataSet; item B -> the other way around.
+        private const val PROGRAM_UID = "IpHINAT79UW"
+        private const val DATA_SET_UID = "BfMAe6Itzgt"
+        private const val ITEM_A_UID = "aJK3Dfn45Ol"
+        private const val ITEM_B_UID = "bJK3Dfn45Ol"
+
+        private const val IMAGE_SIDE_PX = 1000
+        private const val OPAQUE = 0xFF000000.toInt()
+        private const val RGB_RANGE = 0xFFFFFF
+        private const val SEED = 42L
     }
 }

--- a/core/src/main/assets/migrations/181.sql
+++ b/core/src/main/assets/migrations/181.sql
@@ -190,3 +190,7 @@ ALTER TABLE Program ADD COLUMN displayProgramStagesLabel TEXT;
 ALTER TABLE Program ADD COLUMN displayEventsLabel TEXT;
 ALTER TABLE ProgramStage ADD COLUMN displayEventsLabel TEXT;
 ALTER TABLE TrackedEntityType ADD COLUMN displayTrackedEntityTypesLabel TEXT;
+
+# Add image upload quality settings to program and dataSet settings (ANDROSDK-2348)
+ALTER TABLE ProgramSetting ADD COLUMN imageSettings TEXT;
+ALTER TABLE DataSetSetting ADD COLUMN imageSettings TEXT;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
@@ -47,7 +47,7 @@ import kotlin.math.sqrt
 object FileCompressionHelper {
 
     private const val JPEG_QUALITY = 80
-    private const val TARGET_SIZE_BYTES = 600 * 1024L // 600 KB
+    internal const val TARGET_SIZE_BYTES = 600 * 1024L // 600 KB
     private const val SCALE_STEP = 0.8f // reduce dimensions by 20% on each retry
     private const val MAX_ITERATIONS = 10
     private const val FULL_SIZE = 1f

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/ResourceContext.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/ResourceContext.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.helpers
+
+sealed class ResourceContext(val path: String) {
+    sealed class ImageContext(val filePath: String, resourceUid: String) : ResourceContext(filePath) {
+        data class ProgramImageContext(
+            val programUid: String,
+            val resourceUid: String,
+            val attribute: String,
+            val imagePath: String,
+        ) : ImageContext(imagePath, resourceUid)
+
+        data class DatasetImageContext(
+            val datasetUid: String,
+            val resourceUid: String,
+            val attribute: String,
+            val imagePath: String,
+        ) : ImageContext(imagePath, resourceUid)
+    }
+
+    data class FileContext(val filePath: String) : ResourceContext(filePath)
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/ResourceContext.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/ResourceContext.kt
@@ -28,22 +28,18 @@
 
 package org.hisp.dhis.android.core.arch.helpers
 
-sealed class ResourceContext(val path: String) {
-    sealed class ImageContext(val filePath: String, resourceUid: String) : ResourceContext(filePath) {
+sealed class ResourceContext {
+    sealed class ImageContext(open val resourceUid: String) : ResourceContext() {
         data class ProgramImageContext(
             val programUid: String,
-            val resourceUid: String,
-            val attribute: String,
-            val imagePath: String,
-        ) : ImageContext(imagePath, resourceUid)
+            override val resourceUid: String,
+        ) : ImageContext(resourceUid)
 
         data class DatasetImageContext(
             val datasetUid: String,
-            val resourceUid: String,
-            val attribute: String,
-            val imagePath: String,
-        ) : ImageContext(imagePath, resourceUid)
+            override val resourceUid: String,
+        ) : ImageContext(resourceUid)
     }
 
-    data class FileContext(val filePath: String) : ResourceContext(filePath)
+    data object FileContext : ResourceContext()
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -128,9 +128,8 @@ class FileResourceCollectionRepository internal constructor(
 
     suspend fun suspendProcessAndAdd(o: File, resourceContext: ResourceContext): String = withContext(dispatcher) {
         val processedFile = when (resourceContext) {
-            is ResourceContext.ImageContext.ProgramImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
-            is ResourceContext.ImageContext.DatasetImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
-            is ResourceContext.FileContext -> o
+            is ResourceContext.ImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
+            ResourceContext.FileContext -> o
         }
         suspendAdd(processedFile)
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -29,8 +29,11 @@ package org.hisp.dhis.android.core.fileresource
 
 import android.content.Context
 import io.reactivex.Observable
+import io.reactivex.Single
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.rx2.rxSingle
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.helpers.FileCompressionHelper
@@ -133,6 +136,12 @@ class FileResourceCollectionRepository internal constructor(
         }
         suspendAdd(processedFile)
     }
+
+    fun rxProcessAndAdd(o: File, resourceContext: ResourceContext): Single<String> =
+        rxSingle { suspendProcessAndAdd(o, resourceContext) }
+
+    fun blockingProcessAndAdd(o: File, resourceContext: ResourceContext): String =
+        runBlocking { suspendProcessAndAdd(o, resourceContext) }
 
     private fun compressImageIfNeeded(file: File, quality: UploadQuality): File {
         return if (quality == UploadQuality.DEFAULT) {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.arch.call.D2Progress
+import org.hisp.dhis.android.core.arch.helpers.FileCompressionHelper
+import org.hisp.dhis.android.core.arch.helpers.ResourceContext
 import org.hisp.dhis.android.core.arch.helpers.UidGeneratorImpl
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadWriteWithUidCollectionRepository
@@ -49,9 +51,12 @@ import org.hisp.dhis.android.core.common.internal.DataStatePropagator
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceProjectionTransformer
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceStore
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil.saveFile
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.settings.DataSetSettingsObjectRepository
+import org.hisp.dhis.android.core.settings.ProgramSettingsObjectRepository
 import org.hisp.dhis.android.persistence.fileresource.FileResourceTableInfo
 import org.koin.core.annotation.Singleton
 import java.io.File
@@ -64,6 +69,8 @@ class FileResourceCollectionRepository internal constructor(
     transformer: FileResourceProjectionTransformer,
     dataStatePropagator: DataStatePropagator,
     private val context: Context,
+    private val programSettingsRepository: Lazy<ProgramSettingsObjectRepository>,
+    private val dataSetSettingsRepository: Lazy<DataSetSettingsObjectRepository>,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ReadWriteWithUidCollectionRepositoryImpl<FileResource, File, FileResourceCollectionRepository>(
     fileResourceStore,
@@ -77,6 +84,8 @@ class FileResourceCollectionRepository internal constructor(
             transformer,
             dataStatePropagator,
             context,
+            programSettingsRepository,
+            dataSetSettingsRepository,
             dispatcher,
         )
     },
@@ -114,6 +123,35 @@ class FileResourceCollectionRepository internal constructor(
                 .errorDescription("Unexpected exception adding file")
                 .originalException(e)
                 .build()
+        }
+    }
+
+    suspend fun suspendProcessAndAdd(o: File, resourceContext: ResourceContext): String = withContext(dispatcher) {
+        val processedFile = when (resourceContext) {
+            is ResourceContext.ImageContext.ProgramImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
+            is ResourceContext.ImageContext.DatasetImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
+            is ResourceContext.FileContext -> o
+        }
+        suspendAdd(processedFile)
+    }
+
+    private fun compressImageIfNeeded(file: File, quality: UploadQuality): File {
+        return if (quality == UploadQuality.DEFAULT) {
+            FileCompressionHelper.compressFile(file)
+        } else {
+            file
+        }
+    }
+
+    private suspend fun getQuality(resourceContext: ResourceContext.ImageContext): UploadQuality {
+        return when (resourceContext) {
+            is ResourceContext.ImageContext.ProgramImageContext ->
+                programSettingsRepository.value
+                    .getImageQualityFromProgramSettings(resourceContext.programUid, resourceContext.resourceUid)
+
+            is ResourceContext.ImageContext.DatasetImageContext ->
+                dataSetSettingsRepository.value
+                    .getImageQualityFromDataSetSetting(resourceContext.datasetUid, resourceContext.resourceUid)
         }
     }
 
@@ -164,5 +202,6 @@ class FileResourceCollectionRepository internal constructor(
 
     internal companion object {
         val childrenAppenders: ChildrenAppenderGetter<FileResource> = emptyMap()
+        const val DEFAULT_QUALITY = "default"
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/UploadQuality.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/UploadQuality.kt
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.fileresource.internal
+
+enum class UploadQuality {
+    DEFAULT,
+    ORIGINAL,
+}
+
+/**
+ * Key holding the [UploadQuality] within the per-item map of the imageSettings configuration, as sent by the
+ * Android Settings web app: `{"itemUid": {"uploadQuality": "ORIGINAL"}}`.
+ */
+internal const val UPLOAD_QUALITY_KEY = "uploadQuality"
+
+/**
+ * Parses [value] into an [UploadQuality], falling back to [UploadQuality.DEFAULT] for any value this SDK version
+ * does not know about. The Settings web app may introduce new qualities before the SDK supports them, and an
+ * unknown value must not prevent the rest of the settings from being read.
+ */
+internal fun uploadQualityOf(value: String): UploadQuality {
+    return UploadQuality.entries.find { it.name == value } ?: UploadQuality.DEFAULT
+}
+
+/**
+ * Converts a raw imageSettings map, where the quality is still the string sent by the server or stored in the
+ * database, into its domain representation. See [uploadQualityOf] for the handling of unknown qualities.
+ */
+internal fun Map<String, Map<String, String>>.toUploadQualityMap(): Map<String, Map<String, UploadQuality>> {
+    return mapValues { (_, itemSettings) ->
+        itemSettings.mapValues { (_, quality) -> uploadQualityOf(quality) }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/DataSetSetting.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/DataSetSetting.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.settings
 
 import org.hisp.dhis.android.annotations.ModelBuilder
 import org.hisp.dhis.android.core.common.CoreObject
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import java.util.Date
 
 @ModelBuilder
@@ -37,12 +38,14 @@ data class DataSetSetting(
     val uid: String?,
     val name: String?,
     val lastUpdated: Date?,
+    val imageSettings: Map<String, Map<String, UploadQuality>>?,
     val periodDSDownload: Int?,
     val periodDSDBTrimming: Int?,
 ) : CoreObject {
     fun uid(): String? = uid
     fun name(): String? = name
     fun lastUpdated(): Date? = lastUpdated
+    fun imageSettings(): Map<String, Map<String, UploadQuality>>? = imageSettings
     fun periodDSDownload(): Int? = periodDSDownload
     fun periodDSDBTrimming(): Int? = periodDSDBTrimming
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/DataSetSettingsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/DataSetSettingsObjectRepository.kt
@@ -29,8 +29,12 @@ package org.hisp.dhis.android.core.settings
 
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyAnyObjectWithDownloadRepositoryImpl
+import org.hisp.dhis.android.core.fileresource.internal.UPLOAD_QUALITY_KEY
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import org.hisp.dhis.android.core.settings.internal.DataSetSettingCall
 import org.hisp.dhis.android.core.settings.internal.DataSetSettingStore
+import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
+import org.hisp.dhis.android.persistence.settings.DataSetSettingTableInfo
 import org.koin.core.annotation.Singleton
 
 @Singleton(binds = [DataSetSettingsObjectRepository::class])
@@ -53,5 +57,17 @@ class DataSetSettingsObjectRepository internal constructor(
                 .specificSettings(specifics)
                 .build()
         }
+    }
+
+    suspend fun getImageQualityFromDataSetSetting(dataSetUid: String, resourceUid: String): UploadQuality {
+        val specificClause = WhereClauseBuilder()
+            .appendKeyStringValue(DataSetSettingTableInfo.Columns.UID, dataSetUid)
+            .build()
+
+        return store.selectOneWhere(specificClause)
+            ?.imageSettings()
+            ?.get(resourceUid)
+            ?.get(UPLOAD_QUALITY_KEY)
+            ?: UploadQuality.DEFAULT
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/ProgramSetting.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/ProgramSetting.kt
@@ -31,6 +31,7 @@ package org.hisp.dhis.android.core.settings
 import org.hisp.dhis.android.annotations.ModelBuilder
 import org.hisp.dhis.android.core.common.CoreObject
 import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import java.util.Date
 
 @ModelBuilder
@@ -54,6 +55,7 @@ data class ProgramSetting(
     val eventDateDBTrimming: DownloadPeriod?,
     val enrollmentDateDownload: DownloadPeriod?,
     val enrollmentDateDBTrimming: DownloadPeriod?,
+    val imageSettings: Map<String, Map<String, UploadQuality>>?,
 ) : CoreObject {
     fun uid(): String? = uid
     fun name(): String? = name
@@ -73,6 +75,7 @@ data class ProgramSetting(
     fun eventDateDBTrimming(): DownloadPeriod? = eventDateDBTrimming
     fun enrollmentDateDownload(): DownloadPeriod? = enrollmentDateDownload
     fun enrollmentDateDBTrimming(): DownloadPeriod? = enrollmentDateDBTrimming
+    fun imageSettings(): Map<String, Map<String, UploadQuality>>? = imageSettings
 
     fun toBuilder(): Builder = ProgramSettingBuilder.from(this)
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/ProgramSettingsObjectRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/ProgramSettingsObjectRepository.kt
@@ -29,8 +29,12 @@ package org.hisp.dhis.android.core.settings
 
 import org.hisp.dhis.android.core.arch.repositories.collection.ReadOnlyWithDownloadObjectRepository
 import org.hisp.dhis.android.core.arch.repositories.`object`.internal.ReadOnlyAnyObjectWithDownloadRepositoryImpl
+import org.hisp.dhis.android.core.fileresource.internal.UPLOAD_QUALITY_KEY
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import org.hisp.dhis.android.core.settings.internal.ProgramSettingCall
 import org.hisp.dhis.android.core.settings.internal.ProgramSettingStore
+import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
+import org.hisp.dhis.android.persistence.settings.ProgramSettingTableInfo
 import org.koin.core.annotation.Singleton
 
 @Singleton(binds = [ProgramSettingsObjectRepository::class])
@@ -53,5 +57,17 @@ class ProgramSettingsObjectRepository internal constructor(
                 .specificSettings(specifics)
                 .build()
         }
+    }
+
+    suspend fun getImageQualityFromProgramSettings(programUid: String, resourceUid: String): UploadQuality {
+        val specificClause = WhereClauseBuilder()
+            .appendKeyStringValue(ProgramSettingTableInfo.Columns.UID, programUid)
+            .build()
+
+        return store.selectOneWhere(specificClause)
+            ?.imageSettings()
+            ?.get(resourceUid)
+            ?.get(UPLOAD_QUALITY_KEY)
+            ?: UploadQuality.DEFAULT
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/settings/DataSetSettingDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/settings/DataSetSettingDTO.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.network.settings
 
 import kotlinx.serialization.Serializable
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.fileresource.internal.toUploadQualityMap
 import org.hisp.dhis.android.core.settings.DataSetSetting
 
 @Serializable
@@ -39,6 +40,7 @@ internal data class DataSetSettingDTO(
     val lastUpdated: String?,
     val periodDSDownload: Int?,
     val periodDSDBTrimming: Int?,
+    val imageSettings: Map<String, Map<String, String>>?,
 ) {
     fun toDomain(): DataSetSetting {
         return DataSetSetting.builder()
@@ -47,6 +49,7 @@ internal data class DataSetSettingDTO(
             .lastUpdated(lastUpdated?.let { DateUtils.DATE_FORMAT.parse(it) })
             .periodDSDownload(periodDSDownload)
             .periodDSDBTrimming(periodDSDBTrimming)
+            .imageSettings(imageSettings?.toUploadQualityMap())
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/settings/ProgramSettingDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/settings/ProgramSettingDTO.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.network.settings
 
 import kotlinx.serialization.Serializable
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
+import org.hisp.dhis.android.core.fileresource.internal.toUploadQualityMap
 import org.hisp.dhis.android.core.settings.DownloadPeriod
 import org.hisp.dhis.android.core.settings.EnrollmentScope
 import org.hisp.dhis.android.core.settings.LimitScope
@@ -56,6 +57,7 @@ internal data class ProgramSettingDTO(
     val eventDateDBTrimming: String?,
     val enrollmentDateDownload: String?,
     val enrollmentDateDBTrimming: String?,
+    val imageSettings: Map<String, Map<String, String>>?,
 ) {
     fun toDomain(): ProgramSetting {
         return ProgramSetting.builder()
@@ -77,6 +79,7 @@ internal data class ProgramSettingDTO(
             .eventDateDBTrimming(eventDateDBTrimming?.let { DownloadPeriod.valueOf(it) })
             .enrollmentDateDownload(enrollmentDateDownload?.let { DownloadPeriod.valueOf(it) })
             .enrollmentDateDBTrimming(enrollmentDateDBTrimming?.let { DownloadPeriod.valueOf(it) })
+            .imageSettings(imageSettings?.toUploadQualityMap())
             .build()
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/DataSetSettingDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/DataSetSettingDB.kt
@@ -39,6 +39,7 @@ internal data class DataSetSettingDB(
     val lastUpdated: String?,
     val periodDSDownload: Int?,
     val periodDSDBTrimming: Int?,
+    val imageSettings: ImageSettingsDB?,
 ) : EntityDB<DataSetSetting> {
 
     override fun toDomain(): DataSetSetting {
@@ -48,6 +49,7 @@ internal data class DataSetSettingDB(
             .lastUpdated(lastUpdated.toJavaDate())
             .periodDSDownload(periodDSDownload)
             .periodDSDBTrimming(periodDSDBTrimming)
+            .imageSettings(imageSettings?.toDomain())
             .build()
     }
 }
@@ -59,5 +61,6 @@ internal fun DataSetSetting.toDB(): DataSetSettingDB {
         lastUpdated = lastUpdated().dateFormat(),
         periodDSDownload = periodDSDownload(),
         periodDSDBTrimming = periodDSDBTrimming(),
+        imageSettings = imageSettings()?.toImageSettingsDB(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/ImageSettingsDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/ImageSettingsDB.kt
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.settings
+
+import kotlinx.serialization.SerializationException
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
+import org.hisp.dhis.android.core.fileresource.internal.toUploadQualityMap
+
+/**
+ * Persists the imageSettings map of a program or dataSet setting as a JSON string. The outer key is the item uid
+ * (dataElement or trackedEntityAttribute) and the inner map holds the settings for that item, e.g.
+ * `{"deId":{"uploadQuality":"ORIGINAL"}}`.
+ */
+@JvmInline
+internal value class ImageSettingsDB(
+    val value: String,
+) {
+    fun toDomain(): Map<String, Map<String, UploadQuality>> {
+        return try {
+            KotlinxJsonParser.instance
+                .decodeFromString<Map<String, Map<String, String>>>(value)
+                .toUploadQualityMap()
+        } catch (e: SerializationException) {
+            emptyMap()
+        }
+    }
+}
+
+internal fun Map<String, Map<String, UploadQuality>>.toImageSettingsDB(): ImageSettingsDB {
+    return try {
+        val rawSettings = mapValues { (_, itemSettings) ->
+            itemSettings.mapValues { (_, quality) -> quality.name }
+        }
+        ImageSettingsDB(KotlinxJsonParser.instance.encodeToString(rawSettings))
+    } catch (e: SerializationException) {
+        ImageSettingsDB("{}")
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/persistence/settings/ProgramSettingDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/settings/ProgramSettingDB.kt
@@ -57,6 +57,7 @@ internal data class ProgramSettingDB(
     val eventDateDBTrimming: String?,
     val enrollmentDateDownload: String?,
     val enrollmentDateDBTrimming: String?,
+    val imageSettings: ImageSettingsDB?,
 ) : EntityDB<ProgramSetting> {
 
     override fun toDomain(): ProgramSetting {
@@ -79,6 +80,7 @@ internal data class ProgramSettingDB(
             eventDateDBTrimming?.let { eventDateDBTrimming(DownloadPeriod.valueOf(it)) }
             enrollmentDateDownload?.let { enrollmentDateDownload(DownloadPeriod.valueOf(it)) }
             enrollmentDateDBTrimming?.let { enrollmentDateDBTrimming(DownloadPeriod.valueOf(it)) }
+            imageSettings(imageSettings?.toDomain())
         }.build()
     }
 }
@@ -103,5 +105,6 @@ internal fun ProgramSetting.toDB(): ProgramSettingDB {
         eventDateDBTrimming = eventDateDBTrimming()?.name,
         enrollmentDateDownload = enrollmentDateDownload()?.name,
         enrollmentDateDBTrimming = enrollmentDateDBTrimming()?.name,
+        imageSettings = imageSettings()?.toImageSettingsDB(),
     )
 }

--- a/core/src/sharedTest/resources/settings/dataset_settings.json
+++ b/core/src/sharedTest/resources/settings/dataset_settings.json
@@ -10,7 +10,15 @@
       "name": "Child Health",
       "lastUpdated": "2020-01-31T22:38:20.210Z",
       "periodDSDownload": 10,
-      "periodDSDBTrimming": 15
+      "periodDSDBTrimming": 15,
+      "imageSettings": {
+        "aJK3Dfn45Ol": {
+          "uploadQuality": "DEFAULT"
+        },
+        "bJK3Dfn45Ol": {
+          "uploadQuality": "ORIGINAL"
+        }
+      }
     },
     "EKWVBc5C0ms": {
       "id": "lyLU2wR22tC",

--- a/core/src/sharedTest/resources/settings/program_settings.json
+++ b/core/src/sharedTest/resources/settings/program_settings.json
@@ -42,7 +42,15 @@
       "enrollmentDBTrimming": "ONLY_ACTIVE",
       "eventDateDBTrimming": "LAST_MONTH",
       "enrollmentDateDownload": "ANY",
-      "enrollmentDateDBTrimming": "LAST_MONTH"
+      "enrollmentDateDBTrimming": "LAST_MONTH",
+      "imageSettings": {
+        "aJK3Dfn45Ol": {
+          "uploadQuality": "ORIGINAL"
+        },
+        "bJK3Dfn45Ol": {
+          "uploadQuality": "DEFAULT"
+        }
+      }
     },
     "lxAQ7Zs9VYR": {
       "id": "lxAQ7Zs9VYR",

--- a/core/src/sharedTest/resources/settings/synchronization_settings.json
+++ b/core/src/sharedTest/resources/settings/synchronization_settings.json
@@ -16,7 +16,15 @@
         "name": "Child Health",
         "lastUpdated": "2020-01-31T22:38:20.210Z",
         "periodDSDownload": 10,
-        "periodDSDBTrimming": 15
+        "periodDSDBTrimming": 15,
+        "imageSettings": {
+          "aJK3Dfn45Ol": {
+            "uploadQuality": "DEFAULT"
+          },
+          "bJK3Dfn45Ol": {
+            "uploadQuality": "ORIGINAL"
+          }
+        }
       },
       "EKWVBc5C0ms": {
         "id": "lyLU2wR22tC",
@@ -63,7 +71,15 @@
         "enrollmentDBTrimming": "ONLY_ACTIVE",
         "eventDateDBTrimming": "LAST_MONTH",
         "enrollmentDateDownload": "ANY",
-        "enrollmentDateDBTrimming": "LAST_MONTH"
+        "enrollmentDateDBTrimming": "LAST_MONTH",
+        "imageSettings": {
+          "aJK3Dfn45Ol": {
+            "uploadQuality": "ORIGINAL"
+          },
+          "bJK3Dfn45Ol": {
+            "uploadQuality": "DEFAULT"
+          }
+        }
       },
       "lxAQ7Zs9VYR": {
         "id": "lxAQ7Zs9VYR",

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/DataSetSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/DataSetSettingsShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.settings
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.common.CoreObjectShould
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import org.hisp.dhis.android.network.settings.DataSetSettingsDTO
 import org.junit.Test
 
@@ -59,5 +60,11 @@ internal class DataSetSettingsShould : CoreObjectShould<DataSetSettingsDTO>(
             .isEqualTo(BaseIdentifiableObject.parseDate("2020-01-31T22:38:20.210Z"))
         assertThat(childHealth.periodDSDownload()).isEqualTo(10)
         assertThat(childHealth.periodDSDBTrimming()).isEqualTo(15)
+        assertThat(childHealth.imageSettings()).isEqualTo(
+            mapOf(
+                "aJK3Dfn45Ol" to mapOf("uploadQuality" to UploadQuality.DEFAULT),
+                "bJK3Dfn45Ol" to mapOf("uploadQuality" to UploadQuality.ORIGINAL),
+            ),
+        )
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.settings
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.common.BaseIdentifiableObject
 import org.hisp.dhis.android.core.common.CoreObjectShould
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
 import org.hisp.dhis.android.network.settings.ProgramSettingsDTO
 import org.junit.Test
 
@@ -87,5 +88,11 @@ internal class ProgramSettingsShould : CoreObjectShould<ProgramSettingsDTO>(
         assertThat(childProgramme.enrollmentDateDownload()).isEqualTo(DownloadPeriod.ANY)
         assertThat(childProgramme.enrollmentDateDBTrimming())
             .isEqualTo(DownloadPeriod.LAST_MONTH)
+        assertThat(childProgramme.imageSettings()).isEqualTo(
+            mapOf(
+                "aJK3Dfn45Ol" to mapOf("uploadQuality" to UploadQuality.ORIGINAL),
+                "bJK3Dfn45Ol" to mapOf("uploadQuality" to UploadQuality.DEFAULT),
+            ),
+        )
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/network/settings/ImageSettingsDTOShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/network/settings/ImageSettingsDTOShould.kt
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.network.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+import org.hisp.dhis.android.core.fileresource.internal.UPLOAD_QUALITY_KEY
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * The upload quality is deserialized as a plain String and only then mapped to [UploadQuality]. Deserializing it
+ * straight into the enum makes an unknown quality abort the whole settings payload, which silently leaves every
+ * program/dataSet setting unstored.
+ */
+@RunWith(JUnit4::class)
+internal class ImageSettingsDTOShould {
+
+    @Test
+    fun map_unknown_program_upload_quality_to_default_without_failing() {
+        val json = """
+            {
+              "globalSettings": {},
+              "specificSettings": {
+                "IpHINAT79UW": {
+                  "id": "IpHINAT79UW",
+                  "imageSettings": {
+                    "deId": { "uploadQuality": "AGGRESSIVE" },
+                    "attrId": { "uploadQuality": "ORIGINAL" }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val settings = KotlinxJsonParser.instance
+            .decodeFromString(ProgramSettingsDTO.serializer(), json)
+            .toDomain()
+
+        assertThat(settings.specificSettings()["IpHINAT79UW"]?.imageSettings()).isEqualTo(
+            mapOf(
+                "deId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.DEFAULT),
+                "attrId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.ORIGINAL),
+            ),
+        )
+    }
+
+    @Test
+    fun map_unknown_dataset_upload_quality_to_default_without_failing() {
+        val json = """
+            {
+              "globalSettings": {},
+              "specificSettings": {
+                "BfMAe6Itzgt": {
+                  "id": "BfMAe6Itzgt",
+                  "imageSettings": {
+                    "deId": { "uploadQuality": "AGGRESSIVE" }
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val settings = KotlinxJsonParser.instance
+            .decodeFromString(DataSetSettingsDTO.serializer(), json)
+            .toDomain()
+
+        assertThat(settings.specificSettings()["BfMAe6Itzgt"]?.imageSettings()).isEqualTo(
+            mapOf("deId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.DEFAULT)),
+        )
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/persistence/settings/ImageSettingsDBShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/persistence/settings/ImageSettingsDBShould.kt
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.persistence.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.fileresource.internal.UPLOAD_QUALITY_KEY
+import org.hisp.dhis.android.core.fileresource.internal.UploadQuality
+import org.hisp.dhis.android.core.settings.DataSetSetting
+import org.hisp.dhis.android.core.settings.ProgramSetting
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+internal class ImageSettingsDBShould {
+
+    @Test
+    fun serialize_image_settings_as_json() {
+        val db = IMAGE_SETTINGS.toImageSettingsDB()
+
+        assertThat(db.value).isEqualTo(
+            """{"deId":{"uploadQuality":"ORIGINAL"},"attrId":{"uploadQuality":"DEFAULT"}}""",
+        )
+    }
+
+    @Test
+    fun restore_image_settings_from_json() {
+        val db = ImageSettingsDB("""{"deId":{"uploadQuality":"ORIGINAL"}}""")
+
+        assertThat(db.toDomain()).isEqualTo(
+            mapOf("deId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.ORIGINAL)),
+        )
+    }
+
+    @Test
+    fun fall_back_to_empty_map_when_stored_value_is_not_valid_json() {
+        assertThat(ImageSettingsDB("not-json").toDomain()).isEmpty()
+    }
+
+    @Test
+    fun fall_back_to_default_quality_for_unknown_stored_quality_keeping_the_other_items() {
+        val db = ImageSettingsDB(
+            """{"deId":{"uploadQuality":"AGGRESSIVE"},"attrId":{"uploadQuality":"ORIGINAL"}}""",
+        )
+
+        assertThat(db.toDomain()).isEqualTo(
+            mapOf(
+                "deId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.DEFAULT),
+                "attrId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.ORIGINAL),
+            ),
+        )
+    }
+
+    @Test
+    fun persist_image_settings_through_program_setting_db_round_trip() {
+        val programSetting = ProgramSetting.builder()
+            .uid("IpHINAT79UW")
+            .imageSettings(IMAGE_SETTINGS)
+            .build()
+
+        assertThat(programSetting.toDB().toDomain().imageSettings()).isEqualTo(IMAGE_SETTINGS)
+    }
+
+    @Test
+    fun persist_image_settings_through_dataset_setting_db_round_trip() {
+        val dataSetSetting = DataSetSetting.builder()
+            .uid("BfMAe6Itzgt")
+            .imageSettings(IMAGE_SETTINGS)
+            .build()
+
+        assertThat(dataSetSetting.toDB().toDomain().imageSettings()).isEqualTo(IMAGE_SETTINGS)
+    }
+
+    @Test
+    fun keep_image_settings_null_when_not_configured() {
+        val programSettingDB = ProgramSetting.builder().uid("IpHINAT79UW").build().toDB()
+        val dataSetSettingDB = DataSetSetting.builder().uid("BfMAe6Itzgt").build().toDB()
+
+        assertThat(programSettingDB.imageSettings).isNull()
+        assertThat(dataSetSettingDB.imageSettings).isNull()
+        assertThat(programSettingDB.toDomain().imageSettings()).isNull()
+        assertThat(dataSetSettingDB.toDomain().imageSettings()).isNull()
+    }
+
+    companion object {
+        private val IMAGE_SETTINGS = mapOf(
+            "deId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.ORIGINAL),
+            "attrId" to mapOf(UPLOAD_QUALITY_KEY to UploadQuality.DEFAULT),
+        )
+    }
+}

--- a/processor/src/main/java/org/hisp/dhis/android/processor/ModelBuilderProcessor.kt
+++ b/processor/src/main/java/org/hisp/dhis/android/processor/ModelBuilderProcessor.kt
@@ -110,11 +110,8 @@ class ModelBuilderProcessor(
                 }
 
             val typeImports = fields.flatMap { field ->
-                val arguments = field.type.arguments.mapNotNull {
-                    it.type?.resolve()?.declaration?.qualifiedName?.asString()
-                }
-                arguments + field.type.declaration.qualifiedName?.asString()
-            }.filterNotNull().distinct().sorted()
+                collectTypeImports(field.type)
+            }.distinct().sorted()
 
             file += """
             package $packageName
@@ -206,6 +203,18 @@ class ModelBuilderProcessor(
      */
     private fun renderType(type: KSType): String {
         return type.toString().replace(TYPEALIAS_REGEX) { it.groupValues[1] }
+    }
+
+    /**
+     * Collects the imports required to render [type], walking type arguments recursively so that types nested
+     * more than one level deep (e.g. the enum in `Map<String, Map<String, UploadQuality>>`) are imported too.
+     */
+    private fun collectTypeImports(type: KSType): List<String> {
+        val argumentImports = type.arguments.flatMap { argument ->
+            argument.type?.resolve()?.let { collectTypeImports(it) } ?: emptyList()
+        }
+
+        return argumentImports + listOfNotNull(type.declaration.qualifiedName?.asString())
     }
 
     private fun getPropertyName(name: String): String {


### PR DESCRIPTION
Program and dataSet specific settings now carry an `imageSettings` map, keyed by item uid, holding the `UploadQuality` configured for that item (`DEFAULT` or `ORIGINAL`). The map is downloaded from the Android Settings web app, serialized into a new `imageSettings` column on `ProgramSetting` and `DataSetSetting` through a value class, and read back from it. Unknown qualities degrade to `DEFAULT` instead of failing, so a Settings web app offering a quality this SDK version does not know about cannot abort the whole settings download. The `@ModelBuilder` processor also needed to collect imports from nested type arguments for the generated builders to compile. This part covers [ANDROSDK-2348](https://dhis2.atlassian.net/browse/ANDROSDK-2348).

On top of that, `FileResourceCollectionRepository.suspendProcessAndAdd` takes a `ResourceContext` sealed class describing the origin of the file — a program image, a dataSet image or a plain file. Image contexts resolve their configured quality from the corresponding settings and are compressed unless `ORIGINAL` is set, while plain files are stored untouched. Note this branch is based on ANDROSDK-2349, so its compression helper shows up in the diff until that PR is merged.

Related task: [ANDROSDK-2366](https://dhis2.atlassian.net/browse/ANDROSDK-2366)

[ANDROSDK-2348]: https://dhis2.atlassian.net/browse/ANDROSDK-2348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANDROSDK-2366]: https://dhis2.atlassian.net/browse/ANDROSDK-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ