### PR TITLE
fix: [ANDROSDK-2369] send bearer token for token accounts with a PIN

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsSecureStorageMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsSecureStorageMockIntegrationShould.kt
@@ -30,6 +30,7 @@ package org.hisp.dhis.android.core.arch.storage.internal
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import net.openid.appauth.AuthState
+import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -59,6 +60,22 @@ class CredentialsSecureStorageMockIntegrationShould {
         setAndVerify(Credentials("username", "serverUrl", null, null, authState))
     }
 
+    @Test
+    fun credentials_are_correctly_stored_for_open_id_connect_config_with_pin() {
+        val authState = AuthState()
+        setAndVerify(Credentials("username", "serverUrl", null, PIN, authState))
+    }
+
+    @Test
+    fun credentials_are_correctly_stored_for_oauth2_config_with_pin() {
+        setAndVerify(Credentials("username", "serverUrl", null, PIN, null, oauth2State()))
+    }
+
+    @Test
+    fun credentials_are_correctly_stored_for_password_and_pin() {
+        setAndVerify(Credentials("username", "serverUrl", "password", PIN, null))
+    }
+
     private fun setAndVerify(credentials: Credentials) {
         val store1 = instantiateStore()
         store1.set(credentials)
@@ -84,5 +101,19 @@ class CredentialsSecureStorageMockIntegrationShould {
         val store2 = instantiateStore()
         val retrievedCredentials2 = store2.get()
         assertThat(retrievedCredentials2).isNull()
+    }
+
+    private fun oauth2State() = OAuth2State(
+        clientId = "client",
+        keyId = "key",
+        accessToken = "token",
+        refreshToken = "refresh",
+        expiresAt = Long.MAX_VALUE,
+        scope = null,
+        tokenEndpoint = "https://dhis2.org/oauth2/token",
+    )
+
+    companion object {
+        private const val PIN = "1234"
     }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsSecureStorageMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsSecureStorageMockIntegrationShould.kt
@@ -44,19 +44,19 @@ class CredentialsSecureStorageMockIntegrationShould {
 
     @Test
     fun credentials_are_correctly_stored_for_regular_password() {
-        setAndVerify(Credentials("username", "serverUrl", "password", null))
+        setAndVerify(Credentials("username", "serverUrl", "password", null, null))
     }
 
     @Test
     fun credentials_are_correctly_stored_for_really_log_password() {
         val pw = (0 until 1000).joinToString { it.toString() }
-        setAndVerify(Credentials("username", "serverUrl", pw, null))
+        setAndVerify(Credentials("username", "serverUrl", pw, null, null))
     }
 
     @Test
     fun credentials_are_correctly_stored_for_open_id_connect_config() {
         val authState = AuthState()
-        setAndVerify(Credentials("username", "serverUrl", null, authState))
+        setAndVerify(Credentials("username", "serverUrl", null, null, authState))
     }
 
     private fun setAndVerify(credentials: Credentials) {
@@ -74,7 +74,7 @@ class CredentialsSecureStorageMockIntegrationShould {
     @Test
     fun credentials_are_correctly_removed() {
         val store1 = instantiateStore()
-        val credentials = Credentials("username", "serverUrl", "password", null)
+        val credentials = Credentials("username", "serverUrl", "password", null, null)
         store1.set(credentials)
         store1.remove()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2Manager.kt
@@ -207,7 +207,7 @@ object D2Manager {
         if (testingServerUrl.isNullOrEmpty()) {
             throw NoSuchFieldException("No testing Server Url")
         }
-        d2DIComponent.credentialsSecureStore.set(Credentials(username, testingServerUrl!!, password, null))
+        d2DIComponent.credentialsSecureStore.set(Credentials(username, testingServerUrl!!, password, null, null, null))
         d2DIComponent.userIdInMemoryStore.set(username)
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPlugin.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPlugin.kt
@@ -32,6 +32,7 @@ import io.ktor.client.plugins.api.createClientPlugin
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient.Companion.IS_EXTERNAL_REQUEST_ATTRIBUTE_KEY
 import org.hisp.dhis.android.core.arch.api.authentication.internal.UserIdAuthenticatorHelper.Companion.AUTHORIZATION_KEY
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
+import org.hisp.dhis.android.core.common.AuthorizationType
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -57,16 +58,16 @@ internal class ParentAuthenticatorPlugin(
                         proceed(request)
                     }
 
-                    credentials?.password != null -> {
-                        passwordAndCookieAuthenticator.handlePasswordCall(this, request, credentials)
-                    }
-
-                    credentials?.openIDConnectState != null -> {
+                    credentials?.authorizationType == AuthorizationType.OPEN_ID_CONNECT -> {
                         openIDConnectAuthenticator.handleTokenCall(this, request, credentials)
                     }
 
-                    credentials?.oauth2State != null -> {
+                    credentials?.authorizationType == AuthorizationType.OAUTH2 -> {
                         oauth2Authenticator.handleTokenCall(this, request, credentials)
+                    }
+
+                    credentials?.authorizationType == AuthorizationType.BASIC && credentials.password != null -> {
+                        passwordAndCookieAuthenticator.handlePasswordCall(this, request, credentials)
                     }
 
                     else -> {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseImportExportImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/access/internal/DatabaseImportExportImpl.kt
@@ -165,7 +165,7 @@ internal class DatabaseImportExportImpl(
         CipherUtil.createEncryptedZipFile(
             input = copiedDatabase,
             output = protectedDatabase,
-            password = credentials.password!!,
+            password = credentials.passwordOrPin!!,
         )
 
         val metadata = DatabaseExportMetadata(

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/Credentials.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/Credentials.kt
@@ -36,6 +36,7 @@ internal data class Credentials(
     val username: String,
     val serverUrl: String,
     val password: String?,
+    val pin: String?,
     val openIDConnectState: AuthState?,
     val oauth2State: OAuth2State? = null,
 ) {
@@ -46,13 +47,17 @@ internal data class Credentials(
         else -> AuthorizationType.BASIC
     }
 
+    val passwordOrPin: String?
+        get() = password ?: pin
+
     fun getHash(): String? {
-        return password?.let { UserHelper.md5(username, it) }
+        return passwordOrPin?.let { UserHelper.md5(username, it) }
     }
 
     override fun equals(other: Any?) =
         (other is Credentials) &&
             username == other.username &&
+            pin == other.pin &&
             password == other.password &&
             serverUrl == other.serverUrl &&
             openIDConnectState?.jsonSerializeString() == other.openIDConnectState?.jsonSerializeString() &&
@@ -62,6 +67,7 @@ internal data class Credentials(
         var result = username.hashCode()
         result = 31 * result + serverUrl.hashCode()
         result = 31 * result + (password?.hashCode() ?: 0)
+        result = 31 * result + (pin?.hashCode() ?: 0)
         result = 31 * result + (openIDConnectState?.jsonSerializeString()?.hashCode() ?: 0)
         result = 31 * result + (oauth2State?.jsonSerializeString()?.hashCode() ?: 0)
         return result

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsSecureStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsSecureStoreImpl.kt
@@ -42,6 +42,7 @@ internal class CredentialsSecureStoreImpl(private val secureStore: ChunkedSecure
         secureStore.setData(USERNAME_KEY, credentials.username)
         secureStore.setData(SERVER_URL_KEY, credentials.serverUrl)
         secureStore.setData(PASSWORD_KEY, credentials.password)
+        secureStore.setData(PIN_KEY, credentials.pin)
         secureStore.setData(OPEN_ID_CONNECT_STATE_KEY, credentials.openIDConnectState?.jsonSerializeString())
         secureStore.setData(OAUTH2_STATE_KEY, credentials.oauth2State?.jsonSerializeString())
     }
@@ -69,11 +70,12 @@ internal class CredentialsSecureStoreImpl(private val secureStore: ChunkedSecure
 
             if (username != null && serverUrl != null) {
                 val password = secureStore.getData(PASSWORD_KEY)
+                val pin = secureStore.getData(PIN_KEY)
                 val openIDConnectStateStr = secureStore.getData(OPEN_ID_CONNECT_STATE_KEY)
                 val openIDConnectState = openIDConnectStateStr?.let { AuthState.jsonDeserialize(it) }
                 val oauth2StateStr = secureStore.getData(OAUTH2_STATE_KEY)
                 val oauth2State = oauth2StateStr?.let { OAuth2State.jsonDeserialize(it) }
-                return Credentials(username, serverUrl, password, openIDConnectState, oauth2State)
+                return Credentials(username, serverUrl, password, pin, openIDConnectState, oauth2State)
             }
         } catch (e: RuntimeException) {
             remove()
@@ -86,6 +88,7 @@ internal class CredentialsSecureStoreImpl(private val secureStore: ChunkedSecure
         secureStore.removeData(USERNAME_KEY)
         secureStore.removeData(SERVER_URL_KEY)
         secureStore.removeData(PASSWORD_KEY)
+        secureStore.removeData(PIN_KEY)
         secureStore.removeData(OPEN_ID_CONNECT_STATE_KEY)
         secureStore.removeData(OAUTH2_STATE_KEY)
     }
@@ -94,6 +97,7 @@ internal class CredentialsSecureStoreImpl(private val secureStore: ChunkedSecure
         private const val USERNAME_KEY = "username"
         internal const val SERVER_URL_KEY = "serverUrl"
         private const val PASSWORD_KEY = "password"
+        private const val PIN_KEY = "pin"
         private const val OPEN_ID_CONNECT_STATE_KEY = "oicState"
         private const val OAUTH2_STATE_KEY = "oauth2State"
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -66,7 +66,7 @@ internal class LogInCall(
     private val openIDConnectTokenRefresher: Lazy<OpenIDConnectTokenRefresher>,
 ) {
     @Throws(D2Error::class)
-    suspend fun logIn(username: String?, password: String?, serverUrl: String?): User {
+    suspend fun logIn(username: String?, passwordOrPin: String?, serverUrl: String?): User {
         exceptions.throwExceptionIfUsernameNull(username)
         exceptions.throwExceptionIfAlreadyAuthenticated()
 
@@ -78,12 +78,12 @@ internal class LogInCall(
         val openIdState = openIDConnectStateSecureStore.get(trimmedServerUrl, username)
         return when {
             oauth2State != null ->
-                logInWithOAuth2State(trimmedServerUrl, username, password, oauth2State)
+                logInWithOAuth2State(trimmedServerUrl, username, passwordOrPin, oauth2State)
             openIdState != null ->
-                logInWithOpenIdState(trimmedServerUrl, username, password, openIdState)
+                logInWithOpenIdState(trimmedServerUrl, username, passwordOrPin, openIdState)
             else -> {
-                exceptions.throwExceptionIfPasswordNull(password)
-                logInWithPassword(trimmedServerUrl, username, password)
+                exceptions.throwExceptionIfPasswordNull(passwordOrPin)
+                logInWithPassword(trimmedServerUrl, username, passwordOrPin)
             }
         }
     }
@@ -94,19 +94,8 @@ internal class LogInCall(
         pin: String?,
         state: OAuth2State,
     ): User {
-        val credentials = Credentials(username, serverUrl, pin, null, state)
-        return try {
-            val user = coroutineAPICallExecutor.wrap(errorCatcher = apiCallErrorCatcher) {
-                networkHandler.authenticate("Bearer ${state.accessToken!!}")
-            }.getOrThrow()
-            loginOnline(user, credentials)
-        } catch (d2Error: D2Error) {
-            if (d2Error.isOffline) {
-                tryLoginOffline(credentials, d2Error)
-            } else {
-                throw handleOnlineException(d2Error, credentials)
-            }
-        }
+        val credentials = Credentials(username, serverUrl, null, pin, null, state)
+        return tryLoginOffline(credentials)
     }
 
     private suspend fun logInWithOpenIdState(
@@ -115,7 +104,7 @@ internal class LogInCall(
         pin: String?,
         state: AuthState,
     ): User {
-        val credentials = Credentials(username, serverUrl, pin, state, null)
+        val credentials = Credentials(username, serverUrl, null, pin, state, null)
         // Try to refresh the idToken first; if it fails (offline or invalid refresh token) fall
         // back to the stored idToken and let the network call decide between online and offline.
         val token = openIDConnectTokenRefresher.value.blockingGetFreshTokenOrNull(state) ?: state.idToken!!
@@ -139,7 +128,7 @@ internal class LogInCall(
         username: String,
         password: String?,
     ): User {
-        val credentials = Credentials(username, serverUrl, password, null)
+        val credentials = Credentials(username, serverUrl, password, null, null, null)
         return try {
             if (loginDatabaseManager.isPendingToImportDB(serverUrl, username)) {
                 importDB(serverUrl, credentials)
@@ -223,11 +212,11 @@ internal class LogInCall(
 
     @Throws(D2Error::class)
     @Suppress("ThrowsCount")
-    private suspend fun tryLoginOffline(credentials: Credentials, originalError: D2Error): User {
+    private suspend fun tryLoginOffline(credentials: Credentials, originalError: D2Error? = null): User {
         val existingDatabase =
             loginDatabaseManager.loadExistingKeepingEncryption(credentials.serverUrl, credentials.username)
         if (!existingDatabase) {
-            throw originalError
+            throw originalError ?: exceptions.noUserOfflineError()
         }
         val existingUser = authenticatedUserStore.selectFirst() ?: throw exceptions.noUserOfflineError()
 
@@ -293,6 +282,7 @@ internal class LogInCall(
                 username = user.username()!!,
                 serverUrl = trimmedServerUrl!!,
                 password = null,
+                pin = null,
                 openIDConnectState = openIDConnectState,
                 oauth2State = oauth2State,
             )

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInDatabaseManager.kt
@@ -70,6 +70,6 @@ internal class LogInDatabaseManager(
 
     suspend fun importDB(serverUrl: String, credentials: Credentials) {
         val existingAccount = multiUserDatabaseManager.getAccount(serverUrl, credentials.username)!!
-        multiUserDatabaseManager.importAndLoadDb(existingAccount, credentials.password!!)
+        multiUserDatabaseManager.importAndLoadDb(existingAccount, credentials.passwordOrPin!!)
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -211,7 +211,7 @@ internal class OAuth2HandlerImpl(
             credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
             credentials.oauth2State == null -> Result.Failure(logInExceptions.pinRequiresTokenBasedAccountError())
             else -> {
-                val updated = credentials.copy(password = pin)
+                val updated = credentials.copy(pin = pin)
                 credentialsSecureStore.set(updated)
                 val existing = authenticatedUserStore.selectFirst()
                 if (existing == null) {
@@ -230,7 +230,7 @@ internal class OAuth2HandlerImpl(
         val credentials = credentialsSecureStore.get()
         return when {
             credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
-            credentials.password != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
+            credentials.pin != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
             else -> suspendSetPin(newPin)
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImpl.kt
@@ -135,7 +135,7 @@ internal class OpenIDConnectHandlerImpl(
         val credentials = credentialsSecureStore.get()
         return when {
             credentials == null -> Result.Failure(logInExceptions.noActiveSessionError())
-            credentials.password != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
+            credentials.pin != currentPin -> Result.Failure(logInExceptions.incorrectPinError())
             else -> suspendSetPin(newPin)
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImpl.kt
@@ -116,7 +116,7 @@ internal class OpenIDConnectHandlerImpl(
             credentials.openIDConnectState == null ->
                 Result.Failure(logInExceptions.pinRequiresTokenBasedAccountError())
             else -> {
-                val updated = credentials.copy(password = pin)
+                val updated = credentials.copy(pin = pin)
                 credentialsSecureStore.set(updated)
                 val existing = authenticatedUserStore.selectFirst()
                 if (existing == null) {

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPluginShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/api/authentication/internal/ParentAuthenticatorPluginShould.kt
@@ -117,7 +117,7 @@ class ParentAuthenticatorPluginShould {
 
     @Test
     fun return_test_and_user_when_server_take_request() = runTest {
-        val credentials = Credentials("test_user", "test_server", "test_password", null)
+        val credentials = Credentials("test_user", "test_server", "test_password", null, null)
         Mockito.`when`(credentialsSecureStore.get()).thenReturn(credentials)
         Mockito.`when`(userIdStore.get()).thenReturn("user-id")
 

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsShould.kt
@@ -49,25 +49,25 @@ class CredentialsShould {
 
     @Test
     fun return_basic_when_no_sso_state() {
-        val credentials = Credentials("user", "https://dhis2.org", "password", null, null)
+        val credentials = Credentials("user", "https://dhis2.org", "password", null, null, null)
         assertThat(credentials.authorizationType).isEqualTo(AuthorizationType.BASIC)
     }
 
     @Test
     fun return_open_id_connect_when_open_id_connect_state() {
-        val credentials = Credentials("user", "https://dhis2.org", null, openIDConnectState, null)
+        val credentials = Credentials("user", "https://dhis2.org", null, null, openIDConnectState, null)
         assertThat(credentials.authorizationType).isEqualTo(AuthorizationType.OPEN_ID_CONNECT)
     }
 
     @Test
     fun return_oauth2_when_oauth2_state() {
-        val credentials = Credentials("user", "https://dhis2.org", null, null, oauth2State)
+        val credentials = Credentials("user", "https://dhis2.org", null, null, null, oauth2State)
         assertThat(credentials.authorizationType).isEqualTo(AuthorizationType.OAUTH2)
     }
 
     @Test
     fun return_open_id_connect_when_both_sso_states() {
-        val credentials = Credentials("user", "https://dhis2.org", null, openIDConnectState, oauth2State)
+        val credentials = Credentials("user", "https://dhis2.org", null, null, openIDConnectState, oauth2State)
         assertThat(credentials.authorizationType).isEqualTo(AuthorizationType.OPEN_ID_CONNECT)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/storage/internal/CredentialsShould.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.arch.storage.internal
 
 import com.google.common.truth.Truth.assertThat
 import net.openid.appauth.AuthState
+import org.hisp.dhis.android.core.arch.helpers.UserHelper
 import org.hisp.dhis.android.core.common.AuthorizationType
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.junit.Test
@@ -69,5 +70,69 @@ class CredentialsShould {
     fun return_open_id_connect_when_both_sso_states() {
         val credentials = Credentials("user", "https://dhis2.org", null, null, openIDConnectState, oauth2State)
         assertThat(credentials.authorizationType).isEqualTo(AuthorizationType.OPEN_ID_CONNECT)
+    }
+
+    @Test
+    fun return_password_as_password_or_pin_when_password_is_set() {
+        val credentials = Credentials("user", "https://dhis2.org", "password", PIN, null, null)
+        assertThat(credentials.passwordOrPin).isEqualTo("password")
+    }
+
+    @Test
+    fun return_pin_as_password_or_pin_when_there_is_no_password() {
+        val credentials = Credentials("user", "https://dhis2.org", null, PIN, null, oauth2State)
+        assertThat(credentials.passwordOrPin).isEqualTo(PIN)
+    }
+
+    @Test
+    fun return_null_password_or_pin_when_neither_password_nor_pin() {
+        val credentials = Credentials("user", "https://dhis2.org", null, null, null, oauth2State)
+        assertThat(credentials.passwordOrPin).isNull()
+    }
+
+    @Test
+    fun build_hash_from_pin_when_there_is_no_password() {
+        val credentials = Credentials("user", "https://dhis2.org", null, PIN, null, oauth2State)
+        assertThat(credentials.getHash()).isEqualTo(UserHelper.md5("user", PIN))
+    }
+
+    @Test
+    fun build_hash_from_password_when_password_is_set() {
+        val credentials = Credentials("user", "https://dhis2.org", "password", null, null, null)
+        assertThat(credentials.getHash()).isEqualTo(UserHelper.md5("user", "password"))
+    }
+
+    @Test
+    fun return_null_hash_when_neither_password_nor_pin() {
+        val credentials = Credentials("user", "https://dhis2.org", null, null, null, oauth2State)
+        assertThat(credentials.getHash()).isNull()
+    }
+
+    @Test
+    fun be_equal_when_all_fields_including_pin_are_equal() {
+        val credentials = Credentials("user", "https://dhis2.org", null, PIN, null, oauth2State)
+        val other = Credentials("user", "https://dhis2.org", null, PIN, null, oauth2State)
+        assertThat(credentials).isEqualTo(other)
+        assertThat(credentials.hashCode()).isEqualTo(other.hashCode())
+    }
+
+    @Test
+    fun not_be_equal_when_pin_differs() {
+        val credentials = Credentials("user", "https://dhis2.org", null, PIN, null, oauth2State)
+        val other = credentials.copy(pin = "5678")
+        assertThat(credentials).isNotEqualTo(other)
+        assertThat(credentials.hashCode()).isNotEqualTo(other.hashCode())
+    }
+
+    @Test
+    fun not_be_equal_when_pin_is_removed() {
+        val credentials = Credentials("user", "https://dhis2.org", null, PIN, null, oauth2State)
+        val other = credentials.copy(pin = null)
+        assertThat(credentials).isNotEqualTo(other)
+        assertThat(credentials.hashCode()).isNotEqualTo(other.hashCode())
+    }
+
+    companion object {
+        private const val PIN = "1234"
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2ManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerForD2ManagerUnitShould.kt
@@ -47,7 +47,7 @@ class MultiUserDatabaseManagerForD2ManagerUnitShould : BaseCallShould() {
 
     private val username = "username"
     private val serverUrl = "https://dhis2.org"
-    private val credentials = Credentials(username, serverUrl, "password", null)
+    private val credentials = Credentials(username, serverUrl, "password", null, null)
     private val unencryptedDbName = "un.db"
 
     private val accountUnencrypted = DatabaseAccount.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/AccountManagerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/AccountManagerImplShould.kt
@@ -133,7 +133,7 @@ class AccountManagerImplShould {
     }
 
     private fun activeCredentials(): Credentials =
-        Credentials(USERNAME, SERVER_URL, "pwd", null)
+        Credentials(USERNAME, SERVER_URL, "pwd", null, null)
 
     private fun mockDatabaseAccount(
         serverUrl: String,

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -267,25 +267,28 @@ class LogInCallUnitShould : BaseCallShould() {
     // OAuth2 dispatcher tests
 
     @Test
-    fun route_to_oauth2_path_with_bearer_when_state_exists_for_account() = runTest {
+    fun log_in_offline_without_contacting_server_when_oauth2_state_exists_for_account() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
+        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
+            .thenReturn(true)
         whenever(authenticatedUser.hash()).thenReturn(null)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
-        whenever(
-            userNetworkHandler.authenticate(credentialsCaptor.capture()),
-        ).thenReturn(apiUser)
 
         // password is null — must NOT throw because the OAuth2 path skips the null check
-        instantiateCall(USERNAME, null, SERVER_URL)
+        val user = instantiateCall(USERNAME, null, SERVER_URL)
 
-        assertThat(credentialsCaptor.firstValue).isEqualTo("Bearer $ACCESS_TOKEN")
+        assertThat(user).isEqualTo(dbUser)
+        verifyBlocking(userNetworkHandler, never()) { authenticate(any()) }
     }
 
     @Test
     fun persist_credentials_with_oauth2_state_and_null_password_after_oauth2_login() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
+        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
+            .thenReturn(true)
+        // The PIN is set right after the first login, so it is still null when re-logging in.
         whenever(authenticatedUser.hash()).thenReturn(null)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -293,6 +296,22 @@ class LogInCallUnitShould : BaseCallShould() {
 
         verify(credentialsSecureStore).set(
             Credentials(USERNAME, SERVER_URL, null, null, null, state),
+        )
+    }
+
+    @Test
+    fun persist_credentials_with_pin_when_oauth2_login_pin_matches_stored_hash() = runTest {
+        val state = oauth2State(accessToken = ACCESS_TOKEN)
+        whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
+        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
+            .thenReturn(true)
+        whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+
+        instantiateCall(USERNAME, PIN, SERVER_URL)
+
+        verify(credentialsSecureStore).set(
+            Credentials(USERNAME, SERVER_URL, null, PIN, null, state),
         )
     }
 
@@ -300,6 +319,8 @@ class LogInCallUnitShould : BaseCallShould() {
     fun reject_oauth2_login_when_pin_does_not_match_stored_hash() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
+        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
+            .thenReturn(true)
         // Stored hash corresponds to a different PIN.
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, "correct"))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
@@ -307,24 +328,20 @@ class LogInCallUnitShould : BaseCallShould() {
         assertD2Error(D2ErrorCode.BAD_CREDENTIALS) {
             instantiateCall(USERNAME, "wrong-pin", SERVER_URL)
         }
+        verify(credentialsSecureStore, never()).set(any())
     }
 
     @Test
-    fun fall_back_to_offline_login_for_oauth2_when_authenticate_throws_offline() = runTest {
+    fun throw_no_authenticated_user_error_for_oauth2_login_when_no_local_database_exists() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenAPICall { throw d2Error } // d2Error.isOffline = true (set in setUp)
         whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
-        // OAuth2 accounts have hash() == null because password is null on both sides.
-        whenever(authenticatedUser.hash()).thenReturn(null)
-        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+            .thenReturn(false)
 
-        instantiateCall(USERNAME, null, SERVER_URL)
-
-        verify(credentialsSecureStore).set(
-            Credentials(USERNAME, SERVER_URL, null, null, null, state),
-        )
+        assertD2Error(D2ErrorCode.NO_AUTHENTICATED_USER_OFFLINE) {
+            instantiateCall(USERNAME, null, SERVER_URL)
+        }
+        verify(credentialsSecureStore, never()).set(any())
     }
 
     // OpenID Connect dispatcher tests
@@ -430,6 +447,7 @@ class LogInCallUnitShould : BaseCallShould() {
         private const val PASSWORD = "test_password"
         private const val BASE_URL = "https://dhis-instance.org"
         private const val SERVER_URL = BASE_URL
+        private const val PIN = "1234"
         private const val ACCESS_TOKEN = "access-token-1"
         private const val ID_TOKEN = "id-token-1"
         private const val FRESH_ID_TOKEN = "fresh-id-token-1"

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -260,7 +260,7 @@ class LogInCallUnitShould : BaseCallShould() {
     }
 
     private fun verifySuccessOffline() {
-        verify(credentialsSecureStore).set(Credentials(USERNAME, SERVER_URL, PASSWORD, null))
+        verify(credentialsSecureStore).set(Credentials(USERNAME, SERVER_URL, PASSWORD, null, null))
         verify(userIdStore).set("test_uid")
     }
 
@@ -292,7 +292,7 @@ class LogInCallUnitShould : BaseCallShould() {
         instantiateCall(USERNAME, null, SERVER_URL)
 
         verify(credentialsSecureStore).set(
-            Credentials(USERNAME, SERVER_URL, null, null, state),
+            Credentials(USERNAME, SERVER_URL, null, null, null, state),
         )
     }
 
@@ -323,7 +323,7 @@ class LogInCallUnitShould : BaseCallShould() {
         instantiateCall(USERNAME, null, SERVER_URL)
 
         verify(credentialsSecureStore).set(
-            Credentials(USERNAME, SERVER_URL, null, null, state),
+            Credentials(USERNAME, SERVER_URL, null, null, null, state),
         )
     }
 
@@ -374,7 +374,7 @@ class LogInCallUnitShould : BaseCallShould() {
         instantiateCall(USERNAME, null, SERVER_URL)
 
         verify(credentialsSecureStore).set(
-            Credentials(USERNAME, SERVER_URL, null, openIdAuthState, null),
+            Credentials(USERNAME, SERVER_URL, null, null, openIdAuthState, null),
         )
         verify(openIDConnectStateSecureStore).set(SERVER_URL, USERNAME, openIdAuthState)
     }
@@ -409,7 +409,7 @@ class LogInCallUnitShould : BaseCallShould() {
         instantiateCall(USERNAME, null, SERVER_URL)
 
         verify(credentialsSecureStore).set(
-            Credentials(USERNAME, SERVER_URL, null, openIdAuthState, null),
+            Credentials(USERNAME, SERVER_URL, null, null, openIdAuthState, null),
         )
     }
 

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -34,6 +34,7 @@ import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.arch.helpers.UserHelper
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.InMemorySecureStore
@@ -354,8 +355,7 @@ class OAuth2HandlerImplShould {
         assertThat(credentialsCaptor.firstValue.oauth2State).isNotNull()
         val userCaptor = argumentCaptor<AuthenticatedUser>()
         verifyBlocking(authenticatedUserStore) { updateOrInsertWhere(userCaptor.capture()) }
-        assertThat(userCaptor.firstValue.hash())
-            .isEqualTo(Credentials(USERNAME, NORMALIZED_URL, null, PIN, null).getHash())
+        assertThat(userCaptor.firstValue.hash()).isEqualTo(UserHelper.md5(USERNAME, PIN))
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -337,7 +337,7 @@ class OAuth2HandlerImplShould {
     // region setPin / changePin
 
     @Test
-    fun setPin_persists_pin_as_credentials_password_and_updates_authenticated_user_hash() {
+    fun setPin_persists_pin_as_credentials_pin_and_updates_authenticated_user_hash() {
         val credentials = credentialsWithOAuth2(sampleOAuth2State())
         whenever(credentialsSecureStore.get()).thenReturn(credentials)
         val existing = AuthenticatedUser.builder().user("uid").hash(null).build()
@@ -350,12 +350,12 @@ class OAuth2HandlerImplShould {
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
         verify(credentialsSecureStore).set(credentialsCaptor.capture())
-        assertThat(credentialsCaptor.firstValue.password).isEqualTo(PIN)
+        assertThat(credentialsCaptor.firstValue.pin).isEqualTo(PIN)
         assertThat(credentialsCaptor.firstValue.oauth2State).isNotNull()
         val userCaptor = argumentCaptor<AuthenticatedUser>()
         verifyBlocking(authenticatedUserStore) { updateOrInsertWhere(userCaptor.capture()) }
         assertThat(userCaptor.firstValue.hash())
-            .isEqualTo(Credentials(USERNAME, NORMALIZED_URL, PIN, null).getHash())
+            .isEqualTo(Credentials(USERNAME, NORMALIZED_URL, null, PIN, null).getHash())
     }
 
     @Test
@@ -392,7 +392,7 @@ class OAuth2HandlerImplShould {
 
     @Test
     fun changePin_replaces_pin_when_current_matches() {
-        val current = credentialsWithOAuth2(sampleOAuth2State()).copy(password = PIN)
+        val current = credentialsWithOAuth2(sampleOAuth2State()).copy(pin = PIN)
         whenever(credentialsSecureStore.get()).thenReturn(current)
         val existing = AuthenticatedUser.builder().user("uid").hash(current.getHash()).build()
         authenticatedUserStore.stub {
@@ -404,12 +404,12 @@ class OAuth2HandlerImplShould {
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
         verify(credentialsSecureStore).set(credentialsCaptor.capture())
-        assertThat(credentialsCaptor.firstValue.password).isEqualTo(NEW_PIN)
+        assertThat(credentialsCaptor.firstValue.pin).isEqualTo(NEW_PIN)
     }
 
     @Test
     fun changePin_fails_when_current_pin_does_not_match() {
-        val current = credentialsWithOAuth2(sampleOAuth2State()).copy(password = PIN)
+        val current = credentialsWithOAuth2(sampleOAuth2State()).copy(pin = PIN)
         whenever(credentialsSecureStore.get()).thenReturn(current)
 
         val result = handler.blockingChangePin("wrong", NEW_PIN)
@@ -497,6 +497,7 @@ class OAuth2HandlerImplShould {
             username = USERNAME,
             serverUrl = NORMALIZED_URL,
             password = null,
+            pin = null,
             openIDConnectState = null,
             oauth2State = state,
         )

--- a/core/src/test/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImplShould.kt
@@ -31,6 +31,7 @@ import android.content.Context
 import com.google.common.truth.Truth.assertThat
 import net.openid.appauth.AuthState
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.arch.helpers.UserHelper
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
 import org.hisp.dhis.android.core.arch.storage.internal.CredentialsSecureStore
 import org.hisp.dhis.android.core.maintenance.D2Error
@@ -103,8 +104,7 @@ class OpenIDConnectHandlerImplShould {
         assertThat(credentialsCaptor.firstValue.openIDConnectState).isNotNull()
         val userCaptor = argumentCaptor<AuthenticatedUser>()
         verifyBlocking(authenticatedUserStore) { updateOrInsertWhere(userCaptor.capture()) }
-        assertThat(userCaptor.firstValue.hash())
-            .isEqualTo(Credentials(USERNAME, SERVER_URL, null, PIN, null).getHash())
+        assertThat(userCaptor.firstValue.hash()).isEqualTo(UserHelper.md5(USERNAME, PIN))
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/openid/OpenIDConnectHandlerImplShould.kt
@@ -87,7 +87,7 @@ class OpenIDConnectHandlerImplShould {
     }
 
     @Test
-    fun setPin_persists_pin_as_credentials_password_and_updates_authenticated_user_hash() {
+    fun setPin_persists_pin_as_credentials_pin_and_updates_authenticated_user_hash() {
         whenever(credentialsSecureStore.get()).thenReturn(credentialsWithOpenId(authState))
         val existing = AuthenticatedUser.builder().user("uid").hash(null).build()
         authenticatedUserStore.stub {
@@ -99,12 +99,12 @@ class OpenIDConnectHandlerImplShould {
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
         verify(credentialsSecureStore).set(credentialsCaptor.capture())
-        assertThat(credentialsCaptor.firstValue.password).isEqualTo(PIN)
+        assertThat(credentialsCaptor.firstValue.pin).isEqualTo(PIN)
         assertThat(credentialsCaptor.firstValue.openIDConnectState).isNotNull()
         val userCaptor = argumentCaptor<AuthenticatedUser>()
         verifyBlocking(authenticatedUserStore) { updateOrInsertWhere(userCaptor.capture()) }
         assertThat(userCaptor.firstValue.hash())
-            .isEqualTo(Credentials(USERNAME, SERVER_URL, PIN, null).getHash())
+            .isEqualTo(Credentials(USERNAME, SERVER_URL, null, PIN, null).getHash())
     }
 
     @Test
@@ -141,7 +141,7 @@ class OpenIDConnectHandlerImplShould {
 
     @Test
     fun changePin_replaces_pin_when_current_matches() {
-        val current = credentialsWithOpenId(authState).copy(password = PIN)
+        val current = credentialsWithOpenId(authState).copy(pin = PIN)
         whenever(credentialsSecureStore.get()).thenReturn(current)
         val existing = AuthenticatedUser.builder().user("uid").hash(current.getHash()).build()
         authenticatedUserStore.stub {
@@ -153,12 +153,12 @@ class OpenIDConnectHandlerImplShould {
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val credentialsCaptor = argumentCaptor<Credentials>()
         verify(credentialsSecureStore).set(credentialsCaptor.capture())
-        assertThat(credentialsCaptor.firstValue.password).isEqualTo(NEW_PIN)
+        assertThat(credentialsCaptor.firstValue.pin).isEqualTo(NEW_PIN)
     }
 
     @Test
     fun changePin_fails_when_current_pin_does_not_match() {
-        val current = credentialsWithOpenId(authState).copy(password = PIN)
+        val current = credentialsWithOpenId(authState).copy(pin = PIN)
         whenever(credentialsSecureStore.get()).thenReturn(current)
 
         val result = handler.blockingChangePin("wrong", NEW_PIN)
@@ -172,6 +172,7 @@ class OpenIDConnectHandlerImplShould {
             username = USERNAME,
             serverUrl = SERVER_URL,
             password = null,
+            pin = null,
             openIDConnectState = state,
             oauth2State = null,
         )


### PR DESCRIPTION
When an offline PIN was set on an OAuth2/OpenID account, the PIN was stored in `Credentials.password` (it doubles as the offline database passphrase). Because `ParentAuthenticatorPlugin` checked `password != null` before the token branches, every subsequent online request for that account went out with `Authorization: Basic base64(username:PIN)` instead of the Bearer token, so the server answered with the HTML login page and metadata/data sync failed. The PIN now has its own `pin` field in `Credentials`, and the plugin dispatches on `Credentials.authorizationType` (OpenID Connect → OAuth2 → Basic), with the Basic branch additionally requiring a non-null password.

Splitting the PIN out of `password` touches everything that used to rely on that field: the PIN is persisted under its own secure store key, `getHash()` now derives from `passwordOrPin` so offline login and PIN verification keep working, and database export switched to `passwordOrPin` to stay symmetric with the import side, which already used it. OAuth2 re-login with a stored state now goes straight to the offline path — the first login is the one that authenticates online through the OAuth2 handler.

Related task: [ANDROSDK-2369](https://dhis2.atlassian.net/browse/ANDROSDK-2369)

[ANDROSDK-2369]: https://dhis2.atlassian.net/browse/ANDROSDK-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ