### PR TITLE
fix: [ANDROSDK-2342] download files of program attributes

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9095,6 +9095,7 @@ public final class org/hisp/dhis/android/core/event/EventDownloader : org/hisp/d
 	public final fun byProgramUid (Ljava/lang/String;)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun downloadFileResources (Z)Lorg/hisp/dhis/android/core/event/EventDownloader;
 	public final fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getEventFilterCollectionRepository ()Lorg/hisp/dhis/android/core/event/EventFilterCollectionRepository;
 	public final fun limit (I)Lorg/hisp/dhis/android/core/event/EventDownloader;
@@ -21608,6 +21609,7 @@ public final class org/hisp/dhis/android/core/trackedentity/internal/TrackedEnti
 	public final fun byTrackedEntityInstanceFilter ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun byUid ()Lorg/hisp/dhis/android/core/arch/repositories/filters/internal/ListFilterConnector;
 	public final fun download ()Lio/reactivex/Observable;
+	public final fun downloadFileResources (Z)Lorg/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader;
 	public final fun flowDownload ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getProgramStageWorkingListObjectRepository ()Lorg/hisp/dhis/android/core/programstageworkinglist/ProgramStageWorkingListCollectionRepository;
 	public final fun getTrackedEntityInstanceFilterCollectionRepository ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceFilterCollectionRepository;

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperIntegrationShould.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceRoutineSamples.dataset
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceRoutineSamples.event1
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceRoutineSamples.program
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceRoutineSamples.trackedEntityAttribute
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceRoutineSamples.trackedEntityInstance
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
 import org.junit.Test
@@ -72,6 +73,32 @@ internal class FileResourceDownloadCallHelperIntegrationShould : BaseFileResourc
             ),
             TestConfig(
                 params = FileResourceDownloadParams(programUids = listOf("non-existing-program")),
+                expectedSize = 0,
+            ),
+        )
+
+        configs.forEach { config ->
+            fileResourceCallHelper.getMissingTrackerAttributeValues(config.params, emptyList()).let { files ->
+                assertThat(files.size).isEqualTo(config.expectedSize)
+            }
+        }
+    }
+
+    @Test
+    fun get_missing_attributes_scoped_by_attribute() = runTest {
+        val configs = listOf(
+            TestConfig(
+                params = FileResourceDownloadParams(
+                    trackedEntityUids = listOf(trackedEntityInstance.uid()),
+                    trackedEntityAttributeUids = listOf(trackedEntityAttribute.uid()),
+                ),
+                expectedSize = 1,
+            ),
+            TestConfig(
+                params = FileResourceDownloadParams(
+                    trackedEntityUids = listOf(trackedEntityInstance.uid()),
+                    trackedEntityAttributeUids = listOf("non-existing-attribute"),
+                ),
                 expectedSize = 0,
             ),
         )

--- a/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/EventDownloader.kt
@@ -115,4 +115,22 @@ class EventDownloader internal constructor(
         connectorFactory.listConnector { eventFilters ->
             params.copy(eventFilters = eventFilters)
         }
+
+    /**
+     * If true, the file resources (files and images) linked to the data values of the downloaded events are
+     * downloaded as part of this call, right after each batch of events is persisted. Only the files that have not
+     * been previously downloaded are requested, and a file that fails to be downloaded is ignored.
+     *
+     * This is the recommended way of downloading tracker file resources, as it keeps data and files in sync instead
+     * of relying on a separate call once the data download has finished.
+     *
+     * The maximum file size is taken from the synchronization settings.
+     *
+     * @param downloadFileResources True to download the file resources
+     * @return the new repository
+     */
+    fun downloadFileResources(downloadFileResources: Boolean): EventDownloader =
+        connectorFactory.eqConnector<Boolean> { value ->
+            params.copy(downloadFileResources = value ?: false)
+        }.eq(downloadFileResources)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -114,7 +114,7 @@ internal class EventDownloadCall internal constructor(
             dataDomainTypes = listOf(FileResourceDataDomainType.TRACKER),
             elementTypes = listOf(FileResourceElementType.DATA_ELEMENT),
             eventUids = items.map { it.uid },
-            contextProgramUid = program,
+            programUids = listOfNotNull(program),
         )
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -34,6 +34,11 @@ import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandler
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.search.EventQueryCollectionRepository
+import org.hisp.dhis.android.core.fileresource.FileResourceDataDomainType
+import org.hisp.dhis.android.core.fileresource.FileResourceDomainType
+import org.hisp.dhis.android.core.fileresource.FileResourceElementType
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadCall
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadParams
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
@@ -57,6 +62,7 @@ internal class EventDownloadCall internal constructor(
     organisationUnitStore: OrganisationUnitStore,
     organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
     databaseAdapter: DatabaseAdapter,
+    fileResourceDownloadCall: FileResourceDownloadCall,
     private val eventQueryBundleFactory: EventQueryBundleFactory,
     private val trackerParentCallFactory: TrackerParentCallFactory,
     private val persistenceCallFactory: EventPersistenceCallFactory,
@@ -70,6 +76,7 @@ internal class EventDownloadCall internal constructor(
     organisationUnitStore,
     organisationUnitNetworkHandler,
     databaseAdapter,
+    fileResourceDownloadCall,
 ) {
 
     override suspend fun getBundles(params: ProgramDataDownloadParams): List<EventQueryBundle> {
@@ -94,9 +101,27 @@ internal class EventDownloadCall internal constructor(
         lastUpdatedManager.update(bundle)
     }
 
+    /**
+     * Events only carry data values, so the tracked entity attributes are left out: filtering by event uid does not
+     * restrict the attribute values and every pending attribute in the database would be downloaded.
+     */
+    override fun getFileResourceDownloadParams(
+        items: List<Event>,
+        program: String?,
+    ): FileResourceDownloadParams {
+        return FileResourceDownloadParams(
+            domainTypes = listOf(FileResourceDomainType.DATA_VALUE),
+            dataDomainTypes = listOf(FileResourceDataDomainType.TRACKER),
+            elementTypes = listOf(FileResourceElementType.DATA_ELEMENT),
+            eventUids = items.map { it.uid },
+            contextProgramUid = program,
+        )
+    }
+
     override suspend fun queryByUids(
         bundle: EventQueryBundle,
         overwrite: Boolean,
+        downloadFileResources: Boolean,
         relatives: RelationshipItemRelatives,
     ): ItemsWithPagingResult {
         val result = ItemsWithPagingResult(0, true, null, false)
@@ -121,6 +146,12 @@ internal class EventDownloadCall internal constructor(
             )
 
             persistItems(items, params = persistParams, relatives)
+
+            downloadFileResourcesIfEnabled(
+                enabled = downloadFileResources,
+                items = items,
+                program = eventQuery.commonParams.program,
+            )
 
             result.count += items.size
         } catch (d2Error: D2Error) {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceDownloader.kt
@@ -75,14 +75,17 @@ class FileResourceDownloader internal constructor(
         flowDownload().collectAndWrapException()
     }
 
+    @Deprecated(message = TRACKER_DEPRECATION_MESSAGE)
     fun byTrackedEntityUid(): ListFilterConnector<FileResourceDownloader, String> {
         return connectorFactory.listConnector { list -> params.copy(trackedEntityUids = list) }
     }
 
+    @Deprecated(message = TRACKER_DEPRECATION_MESSAGE)
     fun byEventUid(): ListFilterConnector<FileResourceDownloader, String> {
         return connectorFactory.listConnector { list -> params.copy(eventUids = list) }
     }
 
+    @Deprecated(message = TRACKER_DEPRECATION_MESSAGE)
     fun byProgramUid(): ListFilterConnector<FileResourceDownloader, String> {
         return connectorFactory.listConnector { list -> params.copy(programUids = list) }
     }
@@ -111,3 +114,10 @@ class FileResourceDownloader internal constructor(
         return connectorFactory.eqConnector { value -> params.copy(maxContentLength = value) }
     }
 }
+
+private const val TRACKER_DEPRECATION_MESSAGE =
+    "Download the tracker file resources along with the data, using " +
+        "TrackedEntityInstanceDownloader.downloadFileResources() or EventDownloader.downloadFileResources(). " +
+        "Downloading them separately, once the data download has already finished, loses the program each tracked " +
+        "entity was downloaded for. The server requires it to resolve the files of attributes assigned to a " +
+        "program, so the SDK has to infer it from the local metadata and might pick the wrong one, or none at all."

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
@@ -53,7 +53,7 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.settings.internal.SynchronizationSettingStore
 import org.koin.core.annotation.Singleton
 
-@SuppressWarnings("LongParameterList", "MagicNumber")
+@SuppressWarnings("LongParameterList", "MagicNumber", "TooManyFunctions")
 @Singleton
 internal class FileResourceDownloadCall(
     private val fileResourceStore: FileResourceStore,
@@ -66,15 +66,30 @@ internal class FileResourceDownloadCall(
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
 ) {
 
+    /**
+     * Downloads the file resources linked to a set of tracker items that have just been downloaded and persisted.
+     *
+     * Unlike [download], it is scoped to the items in [params] and knows the program they were downloaded for
+     * ([FileResourceDownloadParams.contextProgramUid]), which is required to build the tracked entity attribute
+     * endpoints. It does not delete outdated file resources: that is a global routine and would be too expensive to
+     * run once per page.
+     *
+     * File resources are best effort: a failure here must never abort the tracker data download.
+     */
+    suspend fun downloadTrackerFileResources(params: FileResourceDownloadParams) {
+        try {
+            val existingFileResources = fileResourceStore.selectUids()
+            downloadTrackerValues(withResolvedMaxContentLength(params), existingFileResources)
+        } catch (d2Error: D2Error) {
+            Log.v(FileResourceDownloadCall::class.java.canonicalName, d2Error.errorDescription())
+        }
+    }
+
     fun download(params: FileResourceDownloadParams): Flow<D2Progress> = flow {
         val progressManager = D2ProgressManager(4)
         val existingFileResources = fileResourceStore.selectUids()
 
-        val paramsWithCorrectedMaxContentLength = params.copy(
-            maxContentLength = params.maxContentLength
-                ?: synchronizationSettingsStore.selectFirst()?.fileMaxLengthBytes()
-                ?: defaultDownloadMaxContentLength,
-        )
+        val paramsWithCorrectedMaxContentLength = withResolvedMaxContentLength(params)
 
         downloadAggregatedValues(paramsWithCorrectedMaxContentLength, existingFileResources)
         emit(progressManager.increaseProgress(FileResource::class.java, isComplete = false))
@@ -87,6 +102,14 @@ internal class FileResourceDownloadCall(
 
         fileResourceRoutine.internalDeleteOutdatedFileResources()
         emit(progressManager.increaseProgress(FileResource::class.java, isComplete = true))
+    }
+
+    private suspend fun withResolvedMaxContentLength(params: FileResourceDownloadParams): FileResourceDownloadParams {
+        return params.copy(
+            maxContentLength = params.maxContentLength
+                ?: synchronizationSettingsStore.selectFirst()?.fileMaxLengthBytes()
+                ?: defaultDownloadMaxContentLength,
+        )
     }
 
     private suspend fun downloadAggregatedValues(

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
@@ -103,7 +103,7 @@ internal class FileResourceDownloadCallHelper(
         }
 
         val attributeValues = trackedEntityAttributeValueStore.selectWhere(attributeValuesWhereClauseBuilder.build())
-        val resolveProgram = buildAttributeProgramResolver(attributeValues, params.contextProgramUid)
+        val resolveProgram = buildAttributeProgramResolver(attributeValues, params.contextProgram())
 
         return attributeValues.map { av ->
             val type = trackedEntityAttributes.find { it.uid() == av.trackedEntityAttribute() }!!.valueType()!!
@@ -112,13 +112,10 @@ internal class FileResourceDownloadCallHelper(
     }
 
     /**
-     * Builds a function that resolves the program to use when downloading the file of an attribute value. The tracker
-     * API requires the program uid for attributes assigned to a program: without it the file is not resolved.
+     * Builds a function that resolves the program to send when downloading the file of an attribute value. The
+     * tracker API requires it for attributes assigned to a program: without it the file is not resolved.
      *
-     * When the file resources are downloaded along with the tracker data, the program is known and is preferred. In
-     * any other case it is inferred from the local metadata: the programs the attribute is assigned to, intersected
-     * with the programs the tracked entity is enrolled in. Attributes that are not assigned to any program resolve to
-     * null, as the endpoint works without the parameter for tracked entity type attributes.
+     * The metadata both decisions are based on is read once for the whole batch, not once per value.
      */
     private suspend fun buildAttributeProgramResolver(
         attributeValues: List<TrackedEntityAttributeValue>,
@@ -128,39 +125,72 @@ internal class FileResourceDownloadCallHelper(
             return { null }
         }
 
-        val programAttributesWhereClause = WhereClauseBuilder()
+        val programsByAttribute = getProgramsByAttribute(attributeValues)
+        val programsByTrackedEntity = getProgramsByTrackedEntity(attributeValues)
+
+        return { value ->
+            resolveAttributeProgram(
+                programsWithAttribute = programsByAttribute[value.trackedEntityAttribute()].orEmpty(),
+                programsOfTrackedEntity = programsByTrackedEntity[value.trackedEntityInstance()].orEmpty(),
+                contextProgramUid = contextProgramUid,
+            )
+        }
+    }
+
+    /**
+     * Picks the program to send for a single attribute value. [contextProgramUid] is the program the data was
+     * downloaded for, when the download happened along with the tracker data.
+     *
+     * - The attribute is not assigned to any program: no program is sent. The endpoint resolves tracked entity type
+     *   attributes without it.
+     * - The attribute is assigned to the program the data was downloaded for: that one. It is the only candidate
+     *   known to be right, so it takes precedence over any inference.
+     * - Otherwise the download context does not apply to this attribute, which happens when the value was stored by
+     *   a previous download of a different program. The program is then inferred: one the attribute is assigned to
+     *   and the tracked entity is enrolled in. Falling back to the first assigned program is a guess, kept because
+     *   sending a program the attribute belongs to still resolves more often than sending none.
+     */
+    private fun resolveAttributeProgram(
+        programsWithAttribute: List<String>,
+        programsOfTrackedEntity: Set<String>,
+        contextProgramUid: String?,
+    ): String? {
+        return when {
+            programsWithAttribute.isEmpty() -> null
+            contextProgramUid in programsWithAttribute -> contextProgramUid
+            else -> programsWithAttribute.firstOrNull { it in programsOfTrackedEntity }
+                ?: programsWithAttribute.first()
+        }
+    }
+
+    private suspend fun getProgramsByAttribute(
+        attributeValues: List<TrackedEntityAttributeValue>,
+    ): Map<String?, List<String>> {
+        val whereClause = WhereClauseBuilder()
             .appendInKeyStringValues(
                 ProgramTrackedEntityAttributeTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE,
                 attributeValues.map { it.trackedEntityAttribute() }.distinct(),
             )
             .build()
 
-        val programsByAttribute = programTrackedEntityAttributeStore.selectWhere(programAttributesWhereClause)
+        return programTrackedEntityAttributeStore.selectWhere(whereClause)
             .groupBy({ it.trackedEntityAttribute()?.uid() }, { it.program()?.uid() })
             .mapValues { (_, programs) -> programs.filterNotNull().distinct().sorted() }
+    }
 
-        val enrollmentsWhereClause = WhereClauseBuilder()
+    private suspend fun getProgramsByTrackedEntity(
+        attributeValues: List<TrackedEntityAttributeValue>,
+    ): Map<String?, Set<String>> {
+        val whereClause = WhereClauseBuilder()
             .appendInKeyStringValues(
                 EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE,
                 attributeValues.map { it.trackedEntityInstance() }.distinct(),
             )
             .build()
 
-        val programsByTrackedEntity = enrollmentStore.selectWhere(enrollmentsWhereClause)
+        return enrollmentStore.selectWhere(whereClause)
             .groupBy({ it.trackedEntityInstance() }, { it.program() })
             .mapValues { (_, programs) -> programs.filterNotNull().toSet() }
-
-        return { value ->
-            val candidates = programsByAttribute[value.trackedEntityAttribute()].orEmpty()
-            when {
-                candidates.isEmpty() -> null
-                contextProgramUid != null && candidates.contains(contextProgramUid) -> contextProgramUid
-                else -> {
-                    val enrolledPrograms = programsByTrackedEntity[value.trackedEntityInstance()].orEmpty()
-                    candidates.firstOrNull { enrolledPrograms.contains(it) } ?: candidates.first()
-                }
-            }
-        }
     }
 
     suspend fun getMissingTrackerDataValues(

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
@@ -31,12 +31,15 @@ import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.core.dataset.internal.DataSetElementStore
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.event.internal.EventStore
 import org.hisp.dhis.android.core.fileresource.FileResourceValueType
 import org.hisp.dhis.android.core.icon.CustomIcon
 import org.hisp.dhis.android.core.icon.internal.CustomIconStore
+import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
 import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
@@ -48,6 +51,7 @@ import org.hisp.dhis.android.persistence.datavalue.DataValueTableInfo
 import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
 import org.hisp.dhis.android.persistence.event.EventTableInfo
 import org.hisp.dhis.android.persistence.icon.CustomIconTableInfo
+import org.hisp.dhis.android.persistence.program.ProgramTrackedEntityAttributeTableInfo
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeTableInfo
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeValueTableInfo
 import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityDataValueTableInfo
@@ -62,6 +66,8 @@ internal class FileResourceDownloadCallHelper(
     private val trackedEntityAttributeStore: TrackedEntityAttributeStore,
     private val trackedEntityDataValueStore: TrackedEntityDataValueStore,
     private val trackedEntityInstanceStore: TrackedEntityInstanceStore,
+    private val programTrackedEntityAttributeStore: ProgramTrackedEntityAttributeStore,
+    private val enrollmentStore: EnrollmentStore,
     private val eventStore: EventStore,
     private val dataSetElementStore: DataSetElementStore,
     private val dataValueStore: DataValueStore,
@@ -96,11 +102,65 @@ internal class FileResourceDownloadCallHelper(
             }
         }
 
-        return trackedEntityAttributeValueStore.selectWhere(attributeValuesWhereClauseBuilder.build())
-            .map { av ->
-                val type = trackedEntityAttributes.find { it.uid() == av.trackedEntityAttribute() }!!.valueType()!!
-                MissingTrackerAttributeValue(av, type)
+        val attributeValues = trackedEntityAttributeValueStore.selectWhere(attributeValuesWhereClauseBuilder.build())
+        val resolveProgram = buildAttributeProgramResolver(attributeValues, params.contextProgramUid)
+
+        return attributeValues.map { av ->
+            val type = trackedEntityAttributes.find { it.uid() == av.trackedEntityAttribute() }!!.valueType()!!
+            MissingTrackerAttributeValue(av, type, resolveProgram(av))
+        }
+    }
+
+    /**
+     * Builds a function that resolves the program to use when downloading the file of an attribute value. The tracker
+     * API requires the program uid for attributes assigned to a program: without it the file is not resolved.
+     *
+     * When the file resources are downloaded along with the tracker data, the program is known and is preferred. In
+     * any other case it is inferred from the local metadata: the programs the attribute is assigned to, intersected
+     * with the programs the tracked entity is enrolled in. Attributes that are not assigned to any program resolve to
+     * null, as the endpoint works without the parameter for tracked entity type attributes.
+     */
+    private suspend fun buildAttributeProgramResolver(
+        attributeValues: List<TrackedEntityAttributeValue>,
+        contextProgramUid: String?,
+    ): (TrackedEntityAttributeValue) -> String? {
+        if (attributeValues.isEmpty()) {
+            return { null }
+        }
+
+        val programAttributesWhereClause = WhereClauseBuilder()
+            .appendInKeyStringValues(
+                ProgramTrackedEntityAttributeTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE,
+                attributeValues.map { it.trackedEntityAttribute() }.distinct(),
+            )
+            .build()
+
+        val programsByAttribute = programTrackedEntityAttributeStore.selectWhere(programAttributesWhereClause)
+            .groupBy({ it.trackedEntityAttribute()?.uid() }, { it.program()?.uid() })
+            .mapValues { (_, programs) -> programs.filterNotNull().distinct().sorted() }
+
+        val enrollmentsWhereClause = WhereClauseBuilder()
+            .appendInKeyStringValues(
+                EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE,
+                attributeValues.map { it.trackedEntityInstance() }.distinct(),
+            )
+            .build()
+
+        val programsByTrackedEntity = enrollmentStore.selectWhere(enrollmentsWhereClause)
+            .groupBy({ it.trackedEntityInstance() }, { it.program() })
+            .mapValues { (_, programs) -> programs.filterNotNull().toSet() }
+
+        return { value ->
+            val candidates = programsByAttribute[value.trackedEntityAttribute()].orEmpty()
+            when {
+                candidates.isEmpty() -> null
+                contextProgramUid != null && candidates.contains(contextProgramUid) -> contextProgramUid
+                else -> {
+                    val enrolledPrograms = programsByTrackedEntity[value.trackedEntityInstance()].orEmpty()
+                    candidates.firstOrNull { enrolledPrograms.contains(it) } ?: candidates.first()
+                }
             }
+        }
     }
 
     suspend fun getMissingTrackerDataValues(

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
@@ -94,6 +94,13 @@ internal class FileResourceDownloadCallHelper(
             appendInKeyStringValues(TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE, attributes)
             appendNotInKeyStringValues(TrackedEntityAttributeValueTableInfo.Columns.VALUE, existingFileResources)
 
+            if (params.trackedEntityAttributeUids.isNotEmpty()) {
+                appendInKeyStringValues(
+                    TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_ATTRIBUTE,
+                    params.trackedEntityAttributeUids,
+                )
+            }
+
             val teiParamsClause = getTrackedEntityWhereClauseFromParams(params)
 
             if (teiParamsClause.isEmpty.not()) {
@@ -103,7 +110,7 @@ internal class FileResourceDownloadCallHelper(
         }
 
         val attributeValues = trackedEntityAttributeValueStore.selectWhere(attributeValuesWhereClauseBuilder.build())
-        val resolveProgram = buildAttributeProgramResolver(attributeValues, params.contextProgram())
+        val resolveProgram = buildAttributeProgramResolver(attributeValues, params.programUids.singleOrNull())
 
         return attributeValues.map { av ->
             val type = trackedEntityAttributes.find { it.uid() == av.trackedEntityAttribute() }!!.valueType()!!
@@ -138,17 +145,8 @@ internal class FileResourceDownloadCallHelper(
     }
 
     /**
-     * Picks the program to send for a single attribute value. [contextProgramUid] is the program the data was
-     * downloaded for, when the download happened along with the tracker data.
-     *
-     * - The attribute is not assigned to any program: no program is sent. The endpoint resolves tracked entity type
-     *   attributes without it.
-     * - The attribute is assigned to the program the data was downloaded for: that one. It is the only candidate
-     *   known to be right, so it takes precedence over any inference.
-     * - Otherwise the download context does not apply to this attribute, which happens when the value was stored by
-     *   a previous download of a different program. The program is then inferred: one the attribute is assigned to
-     *   and the tracked entity is enrolled in. Falling back to the first assigned program is a guess, kept because
-     *   sending a program the attribute belongs to still resolves more often than sending none.
+     * The program the download is scoped to when the attribute belongs to it, otherwise a program the attribute is
+     * assigned to and the tracked entity is enrolled in. Null for attributes not assigned to any program.
      */
     private fun resolveAttributeProgram(
         programsWithAttribute: List<String>,

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadParams.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadParams.kt
@@ -39,17 +39,12 @@ internal data class FileResourceDownloadParams(
     val dataDomainTypes: List<FileResourceDataDomainType> = FileResourceDataDomainType.entries,
     val domainTypes: List<FileResourceDomainType> = FileResourceDomainType.entries,
     val trackedEntityUids: List<String> = emptyList(),
+    val trackedEntityAttributeUids: List<String> = emptyList(),
     val eventUids: List<String> = emptyList(),
     val programUids: List<String> = emptyList(),
     val dataSetUids: List<String> = emptyList(),
     val maxContentLength: Int? = null,
-    val contextProgramUid: String? = null,
 ) : BaseScope {
-
-    /**
-     * Program to send to endpoints with fallback to [programUids] if there is a single program.
-     */
-    fun contextProgram(): String? = contextProgramUid ?: programUids.singleOrNull()
 
     fun hasAnyTrackerData(): Boolean {
         return trackedEntityUids.isNotEmpty() || eventUids.isNotEmpty() || programUids.isNotEmpty()

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadParams.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadParams.kt
@@ -43,16 +43,13 @@ internal data class FileResourceDownloadParams(
     val programUids: List<String> = emptyList(),
     val dataSetUids: List<String> = emptyList(),
     val maxContentLength: Int? = null,
-    /**
-     * Program the file resources are being downloaded for. Unlike [programUids], it is not a filter: it is the
-     * program used to build the tracked entity attribute file / image endpoints, which the tracker API requires for
-     * attributes assigned to a program.
-     *
-     * It is only known when the file resources are downloaded as part of a tracker data download. Otherwise it is
-     * null and the program is inferred from the local metadata, which might be ambiguous.
-     */
     val contextProgramUid: String? = null,
 ) : BaseScope {
+
+    /**
+     * Program to send to endpoints with fallback to [programUids] if there is a single program.
+     */
+    fun contextProgram(): String? = contextProgramUid ?: programUids.singleOrNull()
 
     fun hasAnyTrackerData(): Boolean {
         return trackedEntityUids.isNotEmpty() || eventUids.isNotEmpty() || programUids.isNotEmpty()

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadParams.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadParams.kt
@@ -43,6 +43,15 @@ internal data class FileResourceDownloadParams(
     val programUids: List<String> = emptyList(),
     val dataSetUids: List<String> = emptyList(),
     val maxContentLength: Int? = null,
+    /**
+     * Program the file resources are being downloaded for. Unlike [programUids], it is not a filter: it is the
+     * program used to build the tracked entity attribute file / image endpoints, which the tracker API requires for
+     * attributes assigned to a program.
+     *
+     * It is only known when the file resources are downloaded as part of a tracker data download. Otherwise it is
+     * null and the program is inferred from the local metadata, which might be ambiguous.
+     */
+    val contextProgramUid: String? = null,
 ) : BaseScope {
 
     fun hasAnyTrackerData(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/MissingTrackerAttributeValue.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/MissingTrackerAttributeValue.kt
@@ -31,7 +31,15 @@ package org.hisp.dhis.android.core.fileresource.internal
 import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 
+/**
+ * A tracked entity attribute value whose file resource has not been downloaded yet.
+ *
+ * @param program program that must be used to build the file / image endpoint. The tracker API requires it for
+ * attributes assigned to a program: without it the server is not able to resolve the file. It is null when the
+ * attribute is not assigned to any program, in which case the endpoint works without it.
+ */
 internal data class MissingTrackerAttributeValue(
     val value: TrackedEntityAttributeValue,
     val valueType: ValueType,
+    val program: String? = null,
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramDataDownloadParams.kt
@@ -52,6 +52,7 @@ internal data class ProgramDataDownloadParams(
     val trackedEntityInstanceFilters: List<TrackedEntityInstanceFilter>? = null,
     val programStageWorkingLists: List<ProgramStageWorkingList>? = null,
     val eventFilters: List<EventFilter>? = null,
+    val downloadFileResources: Boolean = false,
 ) : BaseScope {
 
     fun hasProgramOrFilters(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -112,7 +112,11 @@ internal class TrackedEntityInstanceDownloadCall(
             domainTypes = listOf(FileResourceDomainType.DATA_VALUE),
             dataDomainTypes = listOf(FileResourceDataDomainType.TRACKER),
             trackedEntityUids = items.map { it.uid },
-            contextProgramUid = program,
+            trackedEntityAttributeUids = items
+                .flatMap { it.trackedEntityAttributeValues().orEmpty() }
+                .map { it.trackedEntityAttribute() }
+                .distinct(),
+            programUids = listOfNotNull(program),
         )
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -33,6 +33,10 @@ import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.fileresource.FileResourceDataDomainType
+import org.hisp.dhis.android.core.fileresource.FileResourceDomainType
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadCall
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadParams
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
@@ -50,7 +54,7 @@ import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.koin.core.annotation.Singleton
 
 @Singleton
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 internal class TrackedEntityInstanceDownloadCall(
     userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
     systemInfoModuleDownloader: SystemInfoModuleDownloader,
@@ -59,6 +63,7 @@ internal class TrackedEntityInstanceDownloadCall(
     organisationUnitStore: OrganisationUnitStore,
     organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
     databaseAdapter: DatabaseAdapter,
+    fileResourceDownloadCall: FileResourceDownloadCall,
     private val queryFactory: TrackerQueryBundleFactory,
     private val trackerCallFactory: TrackerParentCallFactory,
     private val persistenceCallFactory: TrackedEntityInstancePersistenceCallFactory,
@@ -73,6 +78,7 @@ internal class TrackedEntityInstanceDownloadCall(
     organisationUnitStore,
     organisationUnitNetworkHandler,
     databaseAdapter,
+    fileResourceDownloadCall,
 ) {
     override suspend fun getBundles(params: ProgramDataDownloadParams): List<TrackerQueryBundle> {
         return queryFactory.getQueries(params)
@@ -98,9 +104,22 @@ internal class TrackedEntityInstanceDownloadCall(
         lastUpdatedManager.update(bundle)
     }
 
+    override fun getFileResourceDownloadParams(
+        items: List<TrackedEntityInstance>,
+        program: String?,
+    ): FileResourceDownloadParams {
+        return FileResourceDownloadParams(
+            domainTypes = listOf(FileResourceDomainType.DATA_VALUE),
+            dataDomainTypes = listOf(FileResourceDataDomainType.TRACKER),
+            trackedEntityUids = items.map { it.uid },
+            contextProgramUid = program,
+        )
+    }
+
     override suspend fun queryByUids(
         bundle: TrackerQueryBundle,
         overwrite: Boolean,
+        downloadFileResources: Boolean,
         relatives: RelationshipItemRelatives,
     ): ItemsWithPagingResult {
         val result = ItemsWithPagingResult(0, true, null, false)
@@ -133,6 +152,12 @@ internal class TrackedEntityInstanceDownloadCall(
                 )
 
                 persistItems(teisList, persistParams, relatives)
+
+                downloadFileResourcesIfEnabled(
+                    enabled = downloadFileResources,
+                    items = teisList,
+                    program = teiQuery.commonParams.program,
+                )
             }
         } catch (d2Error: D2Error) {
             result.successfulSync = false

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloader.kt
@@ -165,4 +165,23 @@ class TrackedEntityInstanceDownloader internal constructor(
         connectorFactory.listConnector { programStageWorkingLists ->
             params.copy(programStageWorkingLists = programStageWorkingLists)
         }
+
+    /**
+     * If true, the file resources (files and images) linked to the downloaded tracked entity instances are downloaded
+     * as part of this call, right after each batch of instances is persisted. Only the files that have not been
+     * previously downloaded are requested, and a file that fails to be downloaded is ignored.
+     *
+     * This is the recommended way of downloading tracker file resources. Downloading them here, instead of in a
+     * separate call once the data download has finished, is what allows the SDK to know the program each tracked
+     * entity was downloaded for, which the server requires to resolve the files of attributes assigned to a program.
+     *
+     * The maximum file size is taken from the synchronization settings.
+     *
+     * @param downloadFileResources True to download the file resources
+     * @return the new repository
+     */
+    fun downloadFileResources(downloadFileResources: Boolean): TrackedEntityInstanceDownloader =
+        connectorFactory.eqConnector<Boolean> { value ->
+            params.copy(downloadFileResources = value ?: false)
+        }.eq(downloadFileResources)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -39,6 +39,8 @@ import org.hisp.dhis.android.core.arch.call.D2ProgressSyncStatus
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.handlers.internal.IdentifiableDataHandlerParams
 import org.hisp.dhis.android.core.arch.helpers.Result
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadCall
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadParams
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
@@ -66,6 +68,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     private val organisationUnitStore: OrganisationUnitStore,
     private val organisationUnitNetworkHandler: OrganisationUnitNetworkHandler,
     private val databaseAdapter: DatabaseAdapter,
+    private val fileResourceDownloadCall: FileResourceDownloadCall,
 ) {
     fun download(params: ProgramDataDownloadParams): Flow<TrackerD2Progress> = channelFlow {
         val progressManager = TrackerD2ProgressManager(null)
@@ -98,7 +101,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
         for (bundle in bundles) {
             if (bundle.commonParams.uids.isNotEmpty()) {
-                val result = queryByUids(bundle, params.overwrite, relatives)
+                val result = queryByUids(bundle, params.overwrite, params.downloadFileResources, relatives)
 
                 result.d2Error?.let {
                     throw it
@@ -209,6 +212,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                             limit,
                             bundleProgram.itemCount,
                             params.overwrite,
+                            params.downloadFileResources,
                             relatives,
                         )
                     } else {
@@ -272,15 +276,24 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         }
     }
 
+    @Suppress("LongParameterList")
     private suspend fun getItemsForOrgUnitProgramCombination(
         trackerQueryBuilder: TrackerAPIQuery,
         combinationLimit: Int,
         downloadedCount: Int,
         overwrite: Boolean,
+        downloadFileResources: Boolean,
         relatives: RelationshipItemRelatives,
     ): ItemsWithPagingResult {
         return try {
-            getItemsWithPaging(trackerQueryBuilder, combinationLimit, downloadedCount, overwrite, relatives)
+            getItemsWithPaging(
+                trackerQueryBuilder,
+                combinationLimit,
+                downloadedCount,
+                overwrite,
+                downloadFileResources,
+                relatives,
+            )
         } catch (ignored: D2Error) {
             // TODO Build result
             ItemsWithPagingResult(0, false, null, false)
@@ -288,11 +301,13 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     }
 
     @Throws(D2Error::class)
+    @Suppress("LongParameterList")
     private suspend fun getItemsWithPaging(
         query: TrackerAPIQuery,
         combinationLimit: Int,
         downloadedCount: Int,
         overwrite: Boolean,
+        downloadFileResources: Boolean,
         relatives: RelationshipItemRelatives,
     ): ItemsWithPagingResult {
         var downloadedItemsForCombination = 0
@@ -339,6 +354,12 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
             persistItems(itemsToPersist, persistParams, relatives)
 
+            downloadFileResourcesIfEnabled(
+                enabled = downloadFileResources,
+                items = itemsToPersist,
+                program = callPage.query.commonParams.program,
+            )
+
             downloadedItemsForCombination += itemsToPersist.size
 
             if (items.size < callPage.query.pageSize) {
@@ -352,6 +373,23 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         }
 
         return ItemsWithPagingResult(downloadedItemsForCombination, true, null, exhaustedProgram)
+    }
+
+    /**
+     * Downloads the file resources linked to the items that have just been persisted, within the same download
+     * iteration. Downloading them here, and not once the whole data download has finished, is what makes the program
+     * of each item known: the tracker API needs it to resolve the files of attributes assigned to a program.
+     */
+    protected suspend fun downloadFileResourcesIfEnabled(
+        enabled: Boolean,
+        items: List<T>,
+        program: String?,
+    ) {
+        if (enabled && items.isNotEmpty()) {
+            fileResourceDownloadCall.downloadTrackerFileResources(
+                getFileResourceDownloadParams(items, program),
+            )
+        }
     }
 
     private fun getItemsToPersist(paging: Paging, pageItems: List<T>): List<T> {
@@ -434,8 +472,18 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     protected abstract suspend fun queryByUids(
         bundle: Q,
         overwrite: Boolean,
+        downloadFileResources: Boolean,
         relatives: RelationshipItemRelatives,
     ): ItemsWithPagingResult
+
+    /**
+     * Builds the params to download the file resources of [items], scoped to them and to the [program] they have been
+     * downloaded for.
+     */
+    protected abstract fun getFileResourceDownloadParams(
+        items: List<T>,
+        program: String?,
+    ): FileResourceDownloadParams
 
     protected abstract suspend fun getQuery(
         bundle: Q,

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -78,6 +78,7 @@ internal class FileResourceNetworkHandlerImpl(
             service.getImageFromTrackedEntityAttribute(
                 v.value.trackedEntityInstance(),
                 v.value.trackedEntityAttribute(),
+                v.program,
                 dimension,
             )
         } else {
@@ -96,6 +97,7 @@ internal class FileResourceNetworkHandlerImpl(
             service.getFileFromTrackedEntityAttribute(
                 v.value.trackedEntityInstance(),
                 v.value.trackedEntityAttribute(),
+                v.program,
             )
         } else {
             service.getFileFromTrackedEntityAttribute41(

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
@@ -90,11 +90,13 @@ internal class FileResourceService(private val client: HttpServiceClient) {
     suspend fun getImageFromTrackedEntityAttribute(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUid: String,
+        programUid: String?,
         dimension: String,
     ): ByteArray {
         return client.get {
             url("$TRACKER/$TRACKED_ENTIES/$trackedEntityInstanceUid/$ATTRIBUTES/$trackedEntityAttributeUid/image")
             parameters {
+                attribute(PROGRAM, programUid)
                 dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }
@@ -103,9 +105,13 @@ internal class FileResourceService(private val client: HttpServiceClient) {
     suspend fun getFileFromTrackedEntityAttribute(
         trackedEntityInstanceUid: String,
         trackedEntityAttributeUid: String,
+        programUid: String?,
     ): ByteArray {
         return client.get {
             url("$TRACKER/$TRACKED_ENTIES/$trackedEntityInstanceUid/$ATTRIBUTES/$trackedEntityAttributeUid/file")
+            parameters {
+                attribute(PROGRAM, programUid)
+            }
         }
     }
 
@@ -184,5 +190,6 @@ internal class FileResourceService(private val client: HttpServiceClient) {
         const val EVENTS = "events"
         const val TRACKER = "tracker"
         const val DATA_VALUES = "dataValues"
+        const val PROGRAM = "program"
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventDownloaderShould.kt
@@ -131,4 +131,34 @@ class EventDownloaderShould {
 
         assertThat(params.eventFilters).isEqualTo(listOf(eventFilter))
     }
+
+    @Test
+    fun should_not_download_file_resources_by_default() {
+        downloader.download()
+
+        verify(call).download(paramsCapture.capture())
+        val params = paramsCapture.firstValue
+
+        assertThat(params.downloadFileResources).isFalse()
+    }
+
+    @Test
+    fun should_parse_download_file_resources_params() {
+        downloader.downloadFileResources(true).download()
+
+        verify(call).download(paramsCapture.capture())
+        val params = paramsCapture.firstValue
+
+        assertThat(params.downloadFileResources).isTrue()
+    }
+
+    @Test
+    fun should_parse_download_file_resources_params_when_disabled() {
+        downloader.downloadFileResources(false).download()
+
+        verify(call).download(paramsCapture.capture())
+        val params = paramsCapture.firstValue
+
+        assertThat(params.downloadFileResources).isFalse()
+    }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
@@ -138,6 +138,29 @@ internal class FileResourceDownloadCallHelperShould {
     }
 
     @Test
+    fun use_a_single_program_filter_as_the_context_program() = runTest {
+        givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
+        givenEnrolledPrograms(PROGRAM_1, PROGRAM_2)
+
+        // The enrollment inference would pick PROGRAM_1, so this only passes if the filter acts as the context.
+        val params = FileResourceDownloadParams(programUids = listOf(PROGRAM_2))
+        val values = helper.getMissingTrackerAttributeValues(params, emptyList())
+
+        assertThat(values.single().program).isEqualTo(PROGRAM_2)
+    }
+
+    @Test
+    fun not_use_the_program_filter_as_the_context_program_when_it_holds_several_programs() = runTest {
+        givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
+        givenEnrolledPrograms(PROGRAM_2)
+
+        val params = FileResourceDownloadParams(programUids = listOf(PROGRAM_1, PROGRAM_2))
+        val values = helper.getMissingTrackerAttributeValues(params, emptyList())
+
+        assertThat(values.single().program).isEqualTo(PROGRAM_2)
+    }
+
+    @Test
     fun fall_back_to_any_program_with_the_attribute_when_the_tracked_entity_is_not_enrolled() = runTest {
         givenProgramsForAttribute(PROGRAM_2)
         givenEnrolledPrograms()

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
@@ -102,17 +102,18 @@ internal class FileResourceDownloadCallHelperShould {
         givenProgramsForAttribute()
         givenEnrolledPrograms(PROGRAM_1)
 
-        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = PROGRAM_1), emptyList())
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(programUid = PROGRAM_1), emptyList())
 
         assertThat(values.single().program).isNull()
     }
 
     @Test
-    fun prefer_the_context_program_when_the_attribute_is_assigned_to_it() = runTest {
+    fun use_the_program_the_download_is_scoped_to_when_the_attribute_is_assigned_to_it() = runTest {
         givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
         givenEnrolledPrograms(PROGRAM_1, PROGRAM_2)
 
-        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = PROGRAM_2), emptyList())
+        // The enrollment inference would pick PROGRAM_1, so this only passes if the single program acts as context.
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(programUid = PROGRAM_2), emptyList())
 
         assertThat(values.single().program).isEqualTo(PROGRAM_2)
     }
@@ -122,7 +123,7 @@ internal class FileResourceDownloadCallHelperShould {
         givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
         givenEnrolledPrograms(PROGRAM_2)
 
-        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = null), emptyList())
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(programUid = null), emptyList())
 
         assertThat(values.single().program).isEqualTo(PROGRAM_2)
     }
@@ -132,25 +133,13 @@ internal class FileResourceDownloadCallHelperShould {
         givenProgramsForAttribute(PROGRAM_2)
         givenEnrolledPrograms(PROGRAM_1, PROGRAM_2)
 
-        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = PROGRAM_1), emptyList())
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(programUid = PROGRAM_1), emptyList())
 
         assertThat(values.single().program).isEqualTo(PROGRAM_2)
     }
 
     @Test
-    fun use_a_single_program_filter_as_the_context_program() = runTest {
-        givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
-        givenEnrolledPrograms(PROGRAM_1, PROGRAM_2)
-
-        // The enrollment inference would pick PROGRAM_1, so this only passes if the filter acts as the context.
-        val params = FileResourceDownloadParams(programUids = listOf(PROGRAM_2))
-        val values = helper.getMissingTrackerAttributeValues(params, emptyList())
-
-        assertThat(values.single().program).isEqualTo(PROGRAM_2)
-    }
-
-    @Test
-    fun not_use_the_program_filter_as_the_context_program_when_it_holds_several_programs() = runTest {
+    fun not_use_several_programs_as_the_context_program() = runTest {
         givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
         givenEnrolledPrograms(PROGRAM_2)
 
@@ -165,7 +154,7 @@ internal class FileResourceDownloadCallHelperShould {
         givenProgramsForAttribute(PROGRAM_2)
         givenEnrolledPrograms()
 
-        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = null), emptyList())
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(programUid = null), emptyList())
 
         assertThat(values.single().program).isEqualTo(PROGRAM_2)
     }
@@ -191,9 +180,9 @@ internal class FileResourceDownloadCallHelperShould {
         whenever(enrollmentStore.selectWhere(any())).doReturn(enrollments)
     }
 
-    private fun paramsFor(contextProgramUid: String?) = FileResourceDownloadParams(
+    private fun paramsFor(programUid: String?) = FileResourceDownloadParams(
         trackedEntityUids = listOf(TEI_UID),
-        contextProgramUid = contextProgramUid,
+        programUids = listOfNotNull(programUid),
     )
 
     private val imageAttribute = TrackedEntityAttribute.builder()

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
@@ -1,0 +1,193 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.fileresource.internal
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.common.ObjectWithUid
+import org.hisp.dhis.android.core.common.ValueType
+import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
+import org.hisp.dhis.android.core.dataset.internal.DataSetElementStore
+import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
+import org.hisp.dhis.android.core.enrollment.Enrollment
+import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
+import org.hisp.dhis.android.core.event.internal.EventStore
+import org.hisp.dhis.android.core.icon.internal.CustomIconStore
+import org.hisp.dhis.android.core.program.ProgramTrackedEntityAttribute
+import org.hisp.dhis.android.core.program.internal.ProgramTrackedEntityAttributeStore
+import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttribute
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityAttributeValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityDataValueStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(JUnit4::class)
+internal class FileResourceDownloadCallHelperShould {
+
+    private val dataElementStore: DataElementStore = mock()
+    private val trackedEntityAttributeValueStore: TrackedEntityAttributeValueStore = mock()
+    private val trackedEntityAttributeStore: TrackedEntityAttributeStore = mock()
+    private val trackedEntityDataValueStore: TrackedEntityDataValueStore = mock()
+    private val trackedEntityInstanceStore: TrackedEntityInstanceStore = mock()
+    private val programTrackedEntityAttributeStore: ProgramTrackedEntityAttributeStore = mock()
+    private val enrollmentStore: EnrollmentStore = mock()
+    private val eventStore: EventStore = mock()
+    private val dataSetElementStore: DataSetElementStore = mock()
+    private val dataValueStore: DataValueStore = mock()
+    private val customIconStore: CustomIconStore = mock()
+    private val dhisVersionManager: DHISVersionManagerImpl = mock()
+
+    private lateinit var helper: FileResourceDownloadCallHelper
+
+    @Before
+    fun setUp() = runTest {
+        whenever(dhisVersionManager.isGreaterOrEqualThanInternal(any())).doReturn(true)
+        whenever(trackedEntityAttributeStore.selectWhere(any())).doReturn(listOf(imageAttribute))
+        whenever(trackedEntityInstanceStore.selectUidsWhere(any())).doReturn(listOf(TEI_UID))
+        whenever(trackedEntityAttributeValueStore.selectWhere(any())).doReturn(listOf(attributeValue))
+
+        helper = FileResourceDownloadCallHelper(
+            dataElementStore,
+            trackedEntityAttributeValueStore,
+            trackedEntityAttributeStore,
+            trackedEntityDataValueStore,
+            trackedEntityInstanceStore,
+            programTrackedEntityAttributeStore,
+            enrollmentStore,
+            eventStore,
+            dataSetElementStore,
+            dataValueStore,
+            customIconStore,
+            dhisVersionManager,
+        )
+    }
+
+    @Test
+    fun not_resolve_a_program_for_tracked_entity_type_attributes() = runTest {
+        givenProgramsForAttribute()
+        givenEnrolledPrograms(PROGRAM_1)
+
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = PROGRAM_1), emptyList())
+
+        assertThat(values.single().program).isNull()
+    }
+
+    @Test
+    fun prefer_the_context_program_when_the_attribute_is_assigned_to_it() = runTest {
+        givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
+        givenEnrolledPrograms(PROGRAM_1, PROGRAM_2)
+
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = PROGRAM_2), emptyList())
+
+        assertThat(values.single().program).isEqualTo(PROGRAM_2)
+    }
+
+    @Test
+    fun fall_back_to_an_enrolled_program_when_there_is_no_context_program() = runTest {
+        givenProgramsForAttribute(PROGRAM_1, PROGRAM_2)
+        givenEnrolledPrograms(PROGRAM_2)
+
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = null), emptyList())
+
+        assertThat(values.single().program).isEqualTo(PROGRAM_2)
+    }
+
+    @Test
+    fun fall_back_to_an_enrolled_program_when_the_context_program_does_not_have_the_attribute() = runTest {
+        givenProgramsForAttribute(PROGRAM_2)
+        givenEnrolledPrograms(PROGRAM_1, PROGRAM_2)
+
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = PROGRAM_1), emptyList())
+
+        assertThat(values.single().program).isEqualTo(PROGRAM_2)
+    }
+
+    @Test
+    fun fall_back_to_any_program_with_the_attribute_when_the_tracked_entity_is_not_enrolled() = runTest {
+        givenProgramsForAttribute(PROGRAM_2)
+        givenEnrolledPrograms()
+
+        val values = helper.getMissingTrackerAttributeValues(paramsFor(contextProgramUid = null), emptyList())
+
+        assertThat(values.single().program).isEqualTo(PROGRAM_2)
+    }
+
+    private suspend fun givenProgramsForAttribute(vararg programUids: String) {
+        val links = programUids.map { programUid ->
+            ProgramTrackedEntityAttribute.builder()
+                .uid("$programUid-$ATTRIBUTE_UID")
+                .program(ObjectWithUid.create(programUid))
+                .trackedEntityAttribute(ObjectWithUid.create(ATTRIBUTE_UID))
+                .build()
+        }
+        whenever(programTrackedEntityAttributeStore.selectWhere(any())).doReturn(links)
+    }
+
+    private suspend fun givenEnrolledPrograms(vararg programUids: String) {
+        val enrollments = programUids.map { programUid ->
+            mock<Enrollment> {
+                on { trackedEntityInstance() } doReturn TEI_UID
+                on { program() } doReturn programUid
+            }
+        }
+        whenever(enrollmentStore.selectWhere(any())).doReturn(enrollments)
+    }
+
+    private fun paramsFor(contextProgramUid: String?) = FileResourceDownloadParams(
+        trackedEntityUids = listOf(TEI_UID),
+        contextProgramUid = contextProgramUid,
+    )
+
+    private val imageAttribute = TrackedEntityAttribute.builder()
+        .uid(ATTRIBUTE_UID)
+        .valueType(ValueType.IMAGE)
+        .build()
+
+    private val attributeValue = TrackedEntityAttributeValue.builder()
+        .trackedEntityAttribute(ATTRIBUTE_UID)
+        .trackedEntityInstance(TEI_UID)
+        .value("fileResourceUid")
+        .build()
+
+    companion object {
+        private const val ATTRIBUTE_UID = "attributeUid"
+        private const val TEI_UID = "teiUid"
+        private const val PROGRAM_1 = "program1"
+        private const val PROGRAM_2 = "program2"
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloaderShould.kt
@@ -202,4 +202,34 @@ class TrackedEntityInstanceDownloaderShould {
         assertThat(params.programStageWorkingLists)
             .isEqualTo(listOf(programStageWorkingList1, programStageWorkingList2))
     }
+
+    @Test
+    fun should_not_download_file_resources_by_default() {
+        downloader.download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.downloadFileResources).isFalse()
+    }
+
+    @Test
+    fun should_parse_download_file_resources_params() {
+        downloader.downloadFileResources(true).download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.downloadFileResources).isTrue()
+    }
+
+    @Test
+    fun should_parse_download_file_resources_params_when_disabled() {
+        downloader.downloadFileResources(false).download()
+
+        verify(call).download(paramsCapture.capture())
+
+        val params = paramsCapture.firstValue
+        assertThat(params.downloadFileResources).isFalse()
+    }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -36,6 +36,8 @@ import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallEx
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.arch.db.access.internal.AppDatabase
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadCall
+import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadParams
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
@@ -82,6 +84,7 @@ class TrackerDownloadCallShould {
     private val databaseAdapter: DatabaseAdapter = mock()
     private val appDatabase: AppDatabase = mock()
     private val d2Dao: D2Dao = mock()
+    private val fileResourceDownloadCall: FileResourceDownloadCall = mock()
     private val queryFactory: TrackerQueryBundleFactory = mock()
     private val trackerCallFactory: TrackerParentCallFactory = mock()
     private val persistenceCallFactory: TrackedEntityInstancePersistenceCallFactory = mock()
@@ -106,6 +109,7 @@ class TrackerDownloadCallShould {
             organisationUnitStore,
             organisationUnitNetworkHandler,
             databaseAdapter,
+            fileResourceDownloadCall,
             queryFactory,
             trackerCallFactory,
             persistenceCallFactory,
@@ -175,6 +179,58 @@ class TrackerDownloadCallShould {
 
         assertThat(progressList).isNotEmpty()
         assertThat(progressList.last().isComplete).isTrue()
+    }
+
+    @Test
+    fun download_file_resources_of_each_page_scoped_to_its_program_when_enabled() = runTest {
+        val teiUids = givenASinglePageOfTeis(program = "program1")
+
+        call.download(ProgramDataDownloadParams(downloadFileResources = true)).toList()
+
+        val captor = argumentCaptor<FileResourceDownloadParams>()
+        verify(fileResourceDownloadCall).downloadTrackerFileResources(captor.capture())
+
+        val params = captor.firstValue
+        assertThat(params.trackedEntityUids).containsExactlyElementsIn(teiUids)
+        assertThat(params.contextProgramUid).isEqualTo("program1")
+    }
+
+    @Test
+    fun not_download_file_resources_when_disabled() = runTest {
+        givenASinglePageOfTeis(program = "program1")
+
+        call.download(ProgramDataDownloadParams()).toList()
+
+        verify(fileResourceDownloadCall, never()).downloadTrackerFileResources(any())
+    }
+
+    private suspend fun givenASinglePageOfTeis(program: String): List<String> {
+        val orgUnitUid = "orgUnit1"
+        val commonParams = TrackerQueryCommonParams(
+            uids = emptyList(),
+            programs = listOf(program),
+            program = null,
+            startDate = null,
+            hasLimitByOrgUnit = false,
+            ouMode = OrganisationUnitMode.DESCENDANTS,
+            orgUnitsBeforeDivision = listOf(orgUnitUid),
+            limit = ProgramDataDownloadParams.DEFAULT_LIMIT,
+        )
+        val bundle = TrackerQueryBundle(commonParams, listOf(orgUnitUid), null, null, null)
+
+        whenever(queryFactory.getQueries(any())).doReturn(listOf(bundle))
+        whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>())).doReturn(emptyList())
+
+        val endpointCallFactory: TrackedEntityEndpointCallFactory = mock()
+        whenever(trackerCallFactory.getTrackedEntityCall()).doReturn(endpointCallFactory)
+
+        val teiUids = listOf("tei1", "tei2")
+        val teis = teiUids.map { TrackedEntityInstance.builder().uid(it).build() }
+        val payload: Payload<TrackedEntityInstance> = mock()
+        whenever(payload.items).doReturn(teis)
+        whenever(endpointCallFactory.getCollectionCall(any())).doReturn(payload)
+
+        return teiUids
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -45,6 +45,7 @@ import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStor
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndPersistCallFactory
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityEndpointCallFactory
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceDownloadCall
@@ -192,7 +193,9 @@ class TrackerDownloadCallShould {
 
         val params = captor.firstValue
         assertThat(params.trackedEntityUids).containsExactlyElementsIn(teiUids)
-        assertThat(params.contextProgramUid).isEqualTo("program1")
+        assertThat(params.programUids).containsExactly("program1")
+        // Scoped to the attributes of the payload, so the files of other programs are left to their own sync.
+        assertThat(params.trackedEntityAttributeUids).containsExactly("attribute1", "attribute2")
     }
 
     @Test
@@ -225,7 +228,24 @@ class TrackerDownloadCallShould {
         whenever(trackerCallFactory.getTrackedEntityCall()).doReturn(endpointCallFactory)
 
         val teiUids = listOf("tei1", "tei2")
-        val teis = teiUids.map { TrackedEntityInstance.builder().uid(it).build() }
+        val attributesByTei = mapOf(
+            "tei1" to listOf("attribute1"),
+            "tei2" to listOf("attribute1", "attribute2"),
+        )
+        val teis = teiUids.map { teiUid ->
+            TrackedEntityInstance.builder()
+                .uid(teiUid)
+                .trackedEntityAttributeValues(
+                    attributesByTei.getValue(teiUid).map { attributeUid ->
+                        TrackedEntityAttributeValue.builder()
+                            .trackedEntityAttribute(attributeUid)
+                            .trackedEntityInstance(teiUid)
+                            .value("fileResource-$teiUid-$attributeUid")
+                            .build()
+                    },
+                )
+                .build()
+        }
         val payload: Payload<TrackedEntityInstance> = mock()
         whenever(payload.items).doReturn(teis)
         whenever(endpointCallFactory.getCollectionCall(any())).doReturn(payload)


### PR DESCRIPTION
The tracker API needs the program uid to resolve the file of a tracked entity attribute that is assigned to a program. The SDK was not sending it, so images and files of program attributes were never downloaded, while the ones assigned to the tracked entity type worked fine. File resources can now be downloaded atomically with the tracker data, through `TrackedEntityInstanceDownloader.downloadFileResources()` and `EventDownloader.downloadFileResources()`: downloading them in the same iteration that persists each batch is what keeps the program of every item known.

When there is no download context, which is the case of the standalone `FileResourceDownloader`, the program is inferred from the local metadata: the programs the attribute is assigned to, intersected with the enrollments of the tracked entity. That covers the usual case but can pick the wrong program when an attribute belongs to several, so the tracker filters of that downloader are now deprecated with that caveat. Only tracked entities and events are atomised here; aggregated data values and custom icons still download separately.

Related task: [ANDROSDK-2342](https://dhis2.atlassian.net/browse/ANDROSDK-2342)

[ANDROSDK-2342]: https://dhis2.atlassian.net/browse/ANDROSDK-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ