### PR TITLE
fix: [ANDROSDK-2329] use SELECTED mode for leaf orgunits on download

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1861,6 +1861,7 @@ public final class org/hisp/dhis/android/core/arch/db/stores/OrgHispDhisAndroidC
 public abstract interface class org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStore {
 	public abstract fun count (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun countWhere (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun exists (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun groupAndGetCountBy (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectFirst (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/db/stores/internal/ReadableStore.kt
@@ -43,4 +43,5 @@ interface ReadableStore<O> {
     suspend fun count(): Int
     suspend fun countWhere(whereClause: String): Int
     suspend fun groupAndGetCountBy(column: String): Map<String, Int>
+    suspend fun exists(whereClause: String): Boolean
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -40,6 +40,7 @@ import org.hisp.dhis.android.core.fileresource.FileResourceElementType
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadCall
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadParams
 import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
@@ -47,6 +48,7 @@ import org.hisp.dhis.android.core.relationship.internal.RelationshipDownloadAndP
 import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelatives
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 import org.hisp.dhis.android.core.tracker.exporter.TrackerAPIQuery
 import org.hisp.dhis.android.core.tracker.exporter.TrackerDownloadCall
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
@@ -168,11 +170,13 @@ internal class EventDownloadCall internal constructor(
     override suspend fun getQuery(
         bundle: EventQueryBundle,
         program: String?,
-        orgunitUid: String?,
+        orgunit: DownloadOrgunit?,
         limit: Int,
     ): TrackerAPIQuery? {
+        val ouMode = orgunit?.resolveOuMode(bundle.commonParams.ouMode) ?: bundle.commonParams.ouMode
+
         val eventUids = if (bundle.eventFilters != null) {
-            val filteredUids = getEventUidsByFilters(bundle, orgunitUid)
+            val filteredUids = getEventUidsByFilters(bundle, orgunit?.uid, ouMode)
 
             filteredUids.takeIf { it.isNotEmpty() }
         } else {
@@ -184,9 +188,10 @@ internal class EventDownloadCall internal constructor(
                 commonParams = bundle.commonParams.copy(
                     program = program,
                     limit = limit,
+                    ouMode = ouMode,
                 ),
                 lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams),
-                orgUnit = orgunitUid,
+                orgUnit = orgunit?.uid,
                 uids = eventUids.distinct(),
             )
         }
@@ -195,11 +200,12 @@ internal class EventDownloadCall internal constructor(
     private suspend fun getEventUidsByFilters(
         bundle: EventQueryBundle,
         orgunitUid: String?,
+        ouMode: OrganisationUnitMode,
     ): List<String> {
         return bundle.eventFilters?.flatMap {
             eventQueryCollectionRepository
                 .byOrgUnits().eq(orgunitUid)
-                .byOrgUnitMode().eq(bundle.commonParams.ouMode)
+                .byOrgUnitMode().eq(ouMode)
                 .byEventFilterObject().eq(it)
                 .onlineOnly().getDataFetcher().getUids()
         } ?: emptyList()

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -173,7 +173,7 @@ internal class EventDownloadCall internal constructor(
         orgunit: DownloadOrgunit?,
         limit: Int,
     ): TrackerAPIQuery? {
-        val ouMode = orgunit?.resolveOuMode(bundle.commonParams.ouMode) ?: bundle.commonParams.ouMode
+        val ouMode = orgunit?.resolvedOuMode ?: bundle.commonParams.ouMode
 
         val eventUids = if (bundle.eventFilters != null) {
             val filteredUids = getEventUidsByFilters(bundle, orgunit?.uid, ouMode)

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventDownloadCall.kt
@@ -190,7 +190,7 @@ internal class EventDownloadCall internal constructor(
                     limit = limit,
                     ouMode = ouMode,
                 ),
-                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams),
+                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle),
                 orgUnit = orgunit?.uid,
                 uids = eventUids.distinct(),
             )

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventLastUpdatedManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventLastUpdatedManager.kt
@@ -39,7 +39,7 @@ internal class EventLastUpdatedManager(
     suspend fun update(bundle: EventQueryBundle, syncDate: Date) {
         val sync = EventSync.builder()
             .program(bundle.commonParams.program)
-            .organisationUnitIdsHash(bundle.orgUnits.toSet().hashCode())
+            .organisationUnitIdsHash(bundle.orgUnitUids.toSet().hashCode())
             .downloadLimit(bundle.commonParams.limit)
             .workingListsHash(bundle.commonParams.workingListsHash)
             .lastUpdated(syncDate)

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundle.kt
@@ -30,9 +30,10 @@ package org.hisp.dhis.android.core.event.internal
 import org.hisp.dhis.android.core.event.EventFilter
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParams
 import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 
 internal data class EventQueryBundle(
     override val commonParams: TrackerQueryCommonParams,
-    override val orgUnits: List<String>,
+    override val orgUnits: List<DownloadOrgunit>,
     val eventFilters: List<EventFilter>?,
 ) : BaseTrackerQueryBundle

--- a/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleInternalFactory.kt
@@ -83,6 +83,8 @@ internal class EventQueryBundleInternalFactory(
         val orgUnitBundles = commonHelper.divideByOrgUnits(
             commonParams.orgUnitsBeforeDivision,
             commonParams.hasLimitByOrgUnit,
+            commonParams.ouMode,
+            leafCache,
         )
 
         return orgUnitBundles.map { orgUnits ->

--- a/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStore.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/organisationunit/internal/OrganisationUnitStore.kt
@@ -31,4 +31,6 @@ package org.hisp.dhis.android.core.organisationunit.internal
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableObjectStore
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 
-internal interface OrganisationUnitStore : IdentifiableObjectStore<OrganisationUnit>
+internal interface OrganisationUnitStore : IdentifiableObjectStore<OrganisationUnit> {
+    suspend fun isLeaf(organisationUnitId: String): Boolean
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -244,7 +244,7 @@ internal class TrackedEntityInstanceDownloadCall(
         orgunit: DownloadOrgunit?,
         limit: Int,
     ): TrackerAPIQuery? {
-        val ouMode = orgunit?.resolveOuMode(bundle.commonParams.ouMode) ?: bundle.commonParams.ouMode
+        val ouMode = orgunit?.resolvedOuMode ?: bundle.commonParams.ouMode
 
         val teiUids = if (
             bundle.trackedEntityInstanceFilters != null ||

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -39,6 +39,7 @@ import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadCall
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceDownloadParams
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitNetworkHandler
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
@@ -47,6 +48,7 @@ import org.hisp.dhis.android.core.relationship.internal.RelationshipItemRelative
 import org.hisp.dhis.android.core.systeminfo.internal.SystemInfoModuleDownloader
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryCollectionRepository
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 import org.hisp.dhis.android.core.tracker.exporter.TrackerAPIQuery
 import org.hisp.dhis.android.core.tracker.exporter.TrackerDownloadCall
 import org.hisp.dhis.android.core.tracker.importer.internal.TrackerImporterBreakTheGlassHelper
@@ -239,15 +241,17 @@ internal class TrackedEntityInstanceDownloadCall(
     override suspend fun getQuery(
         bundle: TrackerQueryBundle,
         program: String?,
-        orgunitUid: String?,
+        orgunit: DownloadOrgunit?,
         limit: Int,
     ): TrackerAPIQuery? {
+        val ouMode = orgunit?.resolveOuMode(bundle.commonParams.ouMode) ?: bundle.commonParams.ouMode
+
         val teiUids = if (
             bundle.trackedEntityInstanceFilters != null ||
             bundle.programStageWorkingLists != null
         ) {
-            val filteredUids = getTeiUidsByFilter(bundle, orgunitUid) +
-                getTeiUidsByWorkingList(bundle, orgunitUid)
+            val filteredUids = getTeiUidsByFilter(bundle, orgunit?.uid, ouMode) +
+                getTeiUidsByWorkingList(bundle, orgunit?.uid, ouMode)
 
             filteredUids.takeIf { it.isNotEmpty() }
         } else {
@@ -259,31 +263,40 @@ internal class TrackedEntityInstanceDownloadCall(
                 commonParams = bundle.commonParams.copy(
                     program = program,
                     limit = limit,
+                    ouMode = ouMode,
                 ),
                 programStatus = bundle.programStatus,
                 lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams),
-                orgUnit = orgunitUid,
+                orgUnit = orgunit?.uid,
                 uids = teiUids.distinct(),
             )
         }
     }
 
-    private suspend fun getTeiUidsByFilter(bundle: TrackerQueryBundle, orgunitUid: String?): List<String> {
+    private suspend fun getTeiUidsByFilter(
+        bundle: TrackerQueryBundle,
+        orgunitUid: String?,
+        ouMode: OrganisationUnitMode,
+    ): List<String> {
         return bundle.trackedEntityInstanceFilters?.flatMap {
             teiQueryCollectionRepository
                 .byTrackedEntityInstanceFilterObject().eq(it)
                 .byOrgUnits().eq(orgunitUid)
-                .byOrgUnitMode().eq(bundle.commonParams.ouMode)
+                .byOrgUnitMode().eq(ouMode)
                 .onlineOnly().suspendGetUids()
         } ?: emptyList()
     }
 
-    private suspend fun getTeiUidsByWorkingList(bundle: TrackerQueryBundle, orgunitUid: String?): List<String> {
+    private suspend fun getTeiUidsByWorkingList(
+        bundle: TrackerQueryBundle,
+        orgunitUid: String?,
+        ouMode: OrganisationUnitMode,
+    ): List<String> {
         return bundle.programStageWorkingLists?.flatMap {
             teiQueryCollectionRepository
                 .byProgramStageWorkingListObject().eq(it)
                 .byOrgUnits().eq(orgunitUid)
-                .byOrgUnitMode().eq(bundle.commonParams.ouMode)
+                .byOrgUnitMode().eq(ouMode)
                 .onlineOnly().suspendGetUids()
         } ?: emptyList()
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceDownloadCall.kt
@@ -266,7 +266,7 @@ internal class TrackedEntityInstanceDownloadCall(
                     ouMode = ouMode,
                 ),
                 programStatus = bundle.programStatus,
-                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle.commonParams),
+                lastUpdatedStr = lastUpdatedManager.getLastUpdatedStr(bundle),
                 orgUnit = orgunit?.uid,
                 uids = teiUids.distinct(),
             )

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceLastUpdatedManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceLastUpdatedManager.kt
@@ -38,7 +38,7 @@ internal class TrackedEntityInstanceLastUpdatedManager(
     suspend fun update(trackerQuery: TrackerQueryBundle, syncDate: Date) {
         val sync = TrackedEntityInstanceSync.builder()
             .program(trackerQuery.commonParams.program)
-            .organisationUnitIdsHash(trackerQuery.orgUnits.toSet().hashCode())
+            .organisationUnitIdsHash(trackerQuery.orgUnitUids.toSet().hashCode())
             .downloadLimit(trackerQuery.commonParams.limit)
             .workingListsHash(trackerQuery.commonParams.workingListsHash)
             .lastUpdated(syncDate)

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundle.kt
@@ -31,10 +31,11 @@ import org.hisp.dhis.android.core.enrollment.EnrollmentStatus
 import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 
 internal data class TrackerQueryBundle(
     override val commonParams: TrackerQueryCommonParams,
-    override val orgUnits: List<String>,
+    override val orgUnits: List<DownloadOrgunit>,
     val programStatus: EnrollmentStatus?,
     val trackedEntityInstanceFilters: List<TrackedEntityInstanceFilter>?,
     val programStageWorkingLists: List<ProgramStageWorkingList>?,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryBundleInternalFactory.kt
@@ -101,6 +101,8 @@ internal class TrackerQueryBundleInternalFactory(
         val orgUnitBundles = commonHelper.divideByOrgUnits(
             commonParams.orgUnitsBeforeDivision,
             commonParams.hasLimitByOrgUnit,
+            commonParams.ouMode,
+            leafCache,
         )
 
         return orgUnitBundles.map { orgUnits ->

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
@@ -207,10 +207,16 @@ internal class TrackerQueryFactoryCommonHelper(
     suspend fun divideByOrgUnits(
         orgUnits: List<String>,
         hasLimitByOrgUnit: Boolean,
+        ouMode: OrganisationUnitMode,
+        leafCache: MutableMap<String, Boolean>,
     ): List<List<DownloadOrgunit>> {
         val downloadOrgunits = orgUnits.map { uid ->
-            val isLeaf = organisationUnitStore.isLeaf(uid)
-            DownloadOrgunit(uid, isLeaf)
+            val isLeaf = if (DownloadOrgunit.isOverridable(ouMode)) {
+                leafCache.getOrPut(uid) { organisationUnitStore.isLeaf(uid) }
+            } else {
+                false
+            }
+            DownloadOrgunit.resolve(uid, ouMode, isLeaf)
         }
 
         return if (hasLimitByOrgUnit && downloadOrgunits.isNotEmpty()) {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryFactoryCommonHelper.kt
@@ -31,11 +31,13 @@ import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.settings.DownloadPeriod
 import org.hisp.dhis.android.core.settings.LimitScope
 import org.hisp.dhis.android.core.settings.ProgramSetting
 import org.hisp.dhis.android.core.settings.ProgramSettings
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.organisationunit.OrganisationUnitProgramLinkTableInfo
@@ -45,6 +47,7 @@ import java.util.Date
 @Suppress("TooManyFunctions")
 @Singleton
 internal class TrackerQueryFactoryCommonHelper(
+    private val organisationUnitStore: OrganisationUnitStore,
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore,
     private val organisationUnitProgramLinkStore: OrganisationUnitProgramLinkStore,
 ) {
@@ -201,14 +204,19 @@ internal class TrackerQueryFactoryCommonHelper(
         return false
     }
 
-    fun divideByOrgUnits(
+    suspend fun divideByOrgUnits(
         orgUnits: List<String>,
         hasLimitByOrgUnit: Boolean,
-    ): List<List<String>> {
-        return if (hasLimitByOrgUnit && orgUnits.isNotEmpty()) {
-            orgUnits.map { listOf(it) }
+    ): List<List<DownloadOrgunit>> {
+        val downloadOrgunits = orgUnits.map { uid ->
+            val isLeaf = organisationUnitStore.isLeaf(uid)
+            DownloadOrgunit(uid, isLeaf)
+        }
+
+        return if (hasLimitByOrgUnit && downloadOrgunits.isNotEmpty()) {
+            downloadOrgunits.map { listOf(it) }
         } else {
-            listOf(orgUnits)
+            listOf(downloadOrgunits)
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryInternalFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerQueryInternalFactory.kt
@@ -35,6 +35,11 @@ internal abstract class TrackerQueryInternalFactory<T>(
     protected val params: ProgramDataDownloadParams,
     protected val programSettings: ProgramSettings?,
 ) {
+    /**
+     * Shared across all programs queried through this factory instance so that an org unit's
+     * leaf status is only looked up once per sync pass, instead of once per program.
+     */
+    protected val leafCache = mutableMapOf<String, Boolean>()
 
     suspend fun queryGlobal(
         programs: List<String>,

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManager.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.settings.DownloadPeriod
 import org.hisp.dhis.android.core.settings.ProgramSetting
 import org.hisp.dhis.android.core.settings.ProgramSettings
+import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle
 import java.util.Date
 
 internal open class TrackerSyncLastUpdatedManager<S : TrackerBaseSync>(private val store: TrackerBaseSyncStore<S>) {
@@ -49,16 +50,16 @@ internal open class TrackerSyncLastUpdatedManager<S : TrackerBaseSync>(private v
         }
     }
 
-    fun getLastUpdatedStr(commonParams: TrackerQueryCommonParams): String? {
-        return getLastUpdated(commonParams)?.let { BaseIdentifiableObject.dateToDateStr(it) }
+    fun getLastUpdatedStr(bundle: BaseTrackerQueryBundle): String? {
+        return getLastUpdated(bundle)?.let { BaseIdentifiableObject.dateToDateStr(it) }
     }
 
-    private fun getLastUpdated(commonParams: TrackerQueryCommonParams): Date? {
+    private fun getLastUpdated(bundle: BaseTrackerQueryBundle): Date? {
         return getLastUpdated(
-            commonParams.program,
-            commonParams.orgUnitsBeforeDivision.toSet(),
-            commonParams.limit,
-            commonParams.workingListsHash,
+            bundle.commonParams.program,
+            bundle.orgUnitUids.toSet(),
+            bundle.commonParams.limit,
+            bundle.commonParams.workingListsHash,
         )
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParam
 internal interface BaseTrackerQueryBundle {
     val commonParams: TrackerQueryCommonParams
     val orgUnits: List<DownloadOrgunit>
+    val orgUnitUids: List<String>
+        get() = orgUnits.map { it.uid }
 }
 
 internal data class DownloadOrgunit(

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.android.core.tracker.exporter
 
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParams
 
 internal interface BaseTrackerQueryBundle {
@@ -37,4 +38,20 @@ internal interface BaseTrackerQueryBundle {
 internal data class DownloadOrgunit(
     val uid: String,
     val isLeaf: Boolean,
-)
+) {
+    /**
+     * A leaf org unit has no children, so requesting its descendants/children returns exactly
+     * itself: querying by SELECTED is equivalent but cheaper for the server to resolve.
+     */
+    fun resolveOuMode(baseMode: OrganisationUnitMode): OrganisationUnitMode {
+        return if (isLeaf && baseMode in LEAF_OVERRIDABLE_MODES) {
+            OrganisationUnitMode.SELECTED
+        } else {
+            baseMode
+        }
+    }
+
+    companion object {
+        private val LEAF_OVERRIDABLE_MODES = setOf(OrganisationUnitMode.DESCENDANTS, OrganisationUnitMode.CHILDREN)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
@@ -31,5 +31,10 @@ import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryCommonParam
 
 internal interface BaseTrackerQueryBundle {
     val commonParams: TrackerQueryCommonParams
-    val orgUnits: List<String>
+    val orgUnits: List<DownloadOrgunit>
 }
+
+internal data class DownloadOrgunit(
+    val uid: String,
+    val isLeaf: Boolean,
+)

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/BaseTrackerQueryBundle.kt
@@ -39,21 +39,20 @@ internal interface BaseTrackerQueryBundle {
 
 internal data class DownloadOrgunit(
     val uid: String,
-    val isLeaf: Boolean,
+    val resolvedOuMode: OrganisationUnitMode,
 ) {
-    /**
-     * A leaf org unit has no children, so requesting its descendants/children returns exactly
-     * itself: querying by SELECTED is equivalent but cheaper for the server to resolve.
-     */
-    fun resolveOuMode(baseMode: OrganisationUnitMode): OrganisationUnitMode {
-        return if (isLeaf && baseMode in LEAF_OVERRIDABLE_MODES) {
-            OrganisationUnitMode.SELECTED
-        } else {
-            baseMode
-        }
-    }
-
     companion object {
         private val LEAF_OVERRIDABLE_MODES = setOf(OrganisationUnitMode.DESCENDANTS, OrganisationUnitMode.CHILDREN)
+
+        fun isOverridable(mode: OrganisationUnitMode) = mode in LEAF_OVERRIDABLE_MODES
+
+        /**
+         * A leaf org unit has no children, so requesting its descendants/children returns exactly
+         * itself: querying by SELECTED is equivalent but cheaper for the server to resolve.
+         */
+        fun resolve(uid: String, baseMode: OrganisationUnitMode, isLeaf: Boolean): DownloadOrgunit {
+            val mode = if (isLeaf && isOverridable(baseMode)) OrganisationUnitMode.SELECTED else baseMode
+            return DownloadOrgunit(uid, mode)
+        }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCall.kt
@@ -167,17 +167,17 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
         val iterationResult = IterationResult()
         val limitPerCombo = getBundleLimit(bundle, params, bundleResult)
 
-        for ((orgUnitUid, orgunitPrograms) in bundleResult.bundleOrgUnitPrograms.entries) {
+        for ((downloadOrgunit, orgunitPrograms) in bundleResult.bundleOrgUnitPrograms.entries) {
             val pendingTeis = bundle.commonParams.limit - bundleResult.bundleCount
             val bundleLimit = min(limitPerCombo, pendingTeis)
 
             if (bundleLimit <= 0 || orgunitPrograms.isEmpty()) {
-                bundleResult.bundleOrgUnitsToDownload -= orgUnitUid
+                bundleResult.bundleOrgUnitsToDownload -= downloadOrgunit
                 continue
             }
 
             val result = iterateBundleOrgunit(
-                orgUnitUid,
+                downloadOrgunit,
                 bundle,
                 params,
                 bundleResult,
@@ -194,7 +194,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
     @Suppress("LongParameterList", "NestedBlockDepth")
     private suspend fun iterateBundleOrgunit(
-        orgUnitUid: String,
+        downloadOrgunit: DownloadOrgunit,
         bundle: Q,
         params: ProgramDataDownloadParams,
         bundleResult: BundleResult,
@@ -204,11 +204,11 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     ): IterationResult {
         val iterationResult = IterationResult()
 
-        bundleResult.bundleOrgUnitPrograms[orgUnitUid]?.let { bundlePrograms ->
+        bundleResult.bundleOrgUnitPrograms[downloadOrgunit]?.let { bundlePrograms ->
             var remainingPrograms = bundlePrograms
             for (bundleProgram in bundlePrograms) {
                 if (bundleResult.bundleCount < bundle.commonParams.limit) {
-                    val trackerQuery = getQuery(bundle, bundleProgram.program, orgUnitUid, limit)
+                    val trackerQuery = getQuery(bundle, bundleProgram.program, downloadOrgunit, limit)
 
                     val result = if (trackerQuery != null) {
                         getItemsForOrgUnitProgramCombination(
@@ -241,7 +241,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
                         remainingPrograms = remainingPrograms
                             .filter { it.program != bundleProgram.program }
                             .toMutableList()
-                        bundleResult.bundleOrgUnitPrograms[orgUnitUid] = remainingPrograms
+                        bundleResult.bundleOrgUnitPrograms[downloadOrgunit] = remainingPrograms
 
                         val hasOtherOrgunits = bundleResult.bundleOrgUnitPrograms.values.any { list ->
                             list.any { it.program == bundleProgram.program }
@@ -447,8 +447,8 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
 
     protected class BundleResult(
         var bundleCount: Int,
-        var bundleOrgUnitPrograms: MutableMap<String, MutableList<ItemsByProgramCount>>,
-        var bundleOrgUnitsToDownload: MutableList<String?>,
+        var bundleOrgUnitPrograms: MutableMap<DownloadOrgunit, MutableList<ItemsByProgramCount>>,
+        var bundleOrgUnitsToDownload: MutableList<DownloadOrgunit?>,
     )
 
     protected class IterationResult(
@@ -492,7 +492,7 @@ internal abstract class TrackerDownloadCall<T, Q : BaseTrackerQueryBundle>(
     protected abstract suspend fun getQuery(
         bundle: Q,
         program: String?,
-        orgunitUid: String?,
+        orgunit: DownloadOrgunit?,
         limit: Int,
     ): TrackerAPIQuery?
 

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/DataSetInstanceSQLStatementBuilderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/DataSetInstanceSQLStatementBuilderImpl.kt
@@ -77,6 +77,10 @@ internal open class DataSetInstanceSQLStatementBuilderImpl : ReadOnlySQLStatemen
         return RoomRawQuery("SELECT $column , COUNT(*) FROM (${selectAll()}) GROUP BY $column;")
     }
 
+    override fun existsWhere(whereClause: String): RoomRawQuery {
+        return RoomRawQuery("SELECT EXISTS(SELECT 1 FROM (${selectWhere(whereClause).sql + getLimit(1)}))")
+    }
+
     override fun deleteTable(): RoomRawQuery {
         return RoomRawQuery("DELETE FROM $SELECT_CLAUSE")
     }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilder.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilder.kt
@@ -44,6 +44,7 @@ internal interface ReadOnlySQLStatementBuilder {
     fun count(): RoomRawQuery
     fun countWhere(whereClause: String): RoomRawQuery
     fun countAndGroupBy(column: String): RoomRawQuery
+    fun existsWhere(whereClause: String): RoomRawQuery
     fun deleteTable(): RoomRawQuery
     fun deleteWhere(whereClause: String): RoomRawQuery
     fun updateWhere(updates: Map<String, Any>, whereClause: String): RoomRawQuery

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilderImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/querybuilders/ReadOnlySQLStatementBuilderImpl.kt
@@ -102,6 +102,10 @@ internal open class ReadOnlySQLStatementBuilderImpl(
         )
     }
 
+    override fun existsWhere(whereClause: String): RoomRawQuery {
+        return RoomRawQuery("SELECT EXISTS(SELECT 1 FROM $tableName WHERE $whereClause LIMIT 1)")
+    }
+
     override fun deleteTable(): RoomRawQuery {
         return RoomRawQuery("DELETE FROM $tableName;")
     }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/common/stores/ReadableStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/common/stores/ReadableStoreImpl.kt
@@ -129,4 +129,10 @@ internal open class ReadableStoreImpl<D, P : EntityDB<D>>(
         val groupCountList = readableDao.groupCountListRawQuery(query)
         return groupCountList.associate { it.key to it.count }
     }
+
+    override suspend fun exists(whereClause: String): Boolean {
+        val readableDao = daoProvider()
+        val query = builder.existsWhere(whereClause)
+        return readableDao.intRawQuery(query) == 1
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/organisationunit/OrganisationUnitStoreImpl.kt
@@ -32,6 +32,7 @@ import org.hisp.dhis.android.core.arch.db.access.DatabaseAdapter
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.persistence.common.querybuilders.SQLStatementBuilderImpl
+import org.hisp.dhis.android.persistence.common.querybuilders.WhereClauseBuilder
 import org.hisp.dhis.android.persistence.common.stores.IdentifiableObjectStoreImpl
 import org.koin.core.annotation.Singleton
 
@@ -42,4 +43,14 @@ internal class OrganisationUnitStoreImpl(
     { databaseAdapter.getCurrentDatabase().organisationUnitDao() },
     OrganisationUnit::toDB,
     SQLStatementBuilderImpl(OrganisationUnitTableInfo.TABLE_INFO),
-)
+) {
+    override suspend fun isLeaf(organisationUnitId: String): Boolean {
+        val whereClause = WhereClauseBuilder()
+            .appendKeyStringValue(
+                OrganisationUnitTableInfo.Columns.PARENT,
+                organisationUnitId,
+            )
+            .build()
+        return !exists(whereClause)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
@@ -35,6 +35,7 @@ import org.hisp.dhis.android.core.event.EventFilterCollectionRepository
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.resource.internal.ResourceHandler
@@ -44,6 +45,7 @@ import org.hisp.dhis.android.core.settings.ProgramSetting
 import org.hisp.dhis.android.core.settings.ProgramSettings
 import org.hisp.dhis.android.core.settings.ProgramSettingsObjectRepository
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerQueryFactoryCommonHelper
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.junit.Assert.fail
 import org.junit.Before
@@ -64,6 +66,7 @@ class EventQueryBundleFactoryShould {
     private val lastUpdatedManager: EventLastUpdatedManager = mock()
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
     private val organisationUnitProgramLinkLinkStore: OrganisationUnitProgramLinkStore = mock()
+    private val organisationUnitStore: OrganisationUnitStore = mock()
     private val eventFilterCollectionRepository: EventFilterCollectionRepository = mock()
     private val connectorEvent: StringFilterConnector<EventFilterCollectionRepository> = mock()
 
@@ -95,6 +98,7 @@ class EventQueryBundleFactoryShould {
         whenever(userOrganisationUnitLinkStore.queryRootCaptureOrganisationUnitUids()).thenReturn(rootOrgUnits)
         whenever(userOrganisationUnitLinkStore.queryOrganisationUnitUidsByScope(any()))
             .thenReturn(captureOrgUnits)
+        whenever(organisationUnitStore.isLeaf(any())).thenReturn(false)
 
         whenever(programSettingsObjectRepository.getInternal()).thenReturn(programSettings)
 
@@ -103,6 +107,7 @@ class EventQueryBundleFactoryShould {
         whenever(eventFilterCollectionRepository.blockingGet()).thenReturn(emptyList())
 
         val commonHelper = TrackerQueryFactoryCommonHelper(
+            organisationUnitStore,
             userOrganisationUnitLinkStore,
             organisationUnitProgramLinkLinkStore,
         )
@@ -120,7 +125,7 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
         assertThat(bundles.size).isEqualTo(1)
         val bundle = bundles[0]
-        assertThat(bundle.orgUnits).isEqualTo(rootOrgUnits)
+        assertThat(bundle.orgUnits).isEqualTo(rootOrgUnits.map { DownloadOrgunit(it, isLeaf = false) })
         assertThat(bundle.commonParams.programs).isEqualTo(programList)
         assertThat(bundle.commonParams.ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/internal/EventQueryBundleFactoryShould.kt
@@ -125,7 +125,8 @@ class EventQueryBundleFactoryShould {
         val bundles = bundleFactory.getQueries(params)
         assertThat(bundles.size).isEqualTo(1)
         val bundle = bundles[0]
-        assertThat(bundle.orgUnits).isEqualTo(rootOrgUnits.map { DownloadOrgunit(it, isLeaf = false) })
+        assertThat(bundle.orgUnits)
+            .isEqualTo(rootOrgUnits.map { DownloadOrgunit(it, resolvedOuMode = OrganisationUnitMode.DESCENDANTS) })
         assertThat(bundle.commonParams.programs).isEqualTo(programList)
         assertThat(bundle.commonParams.ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitProgramLink
 import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitProgramLinkStore
+import org.hisp.dhis.android.core.organisationunit.internal.OrganisationUnitStore
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
 import org.hisp.dhis.android.core.program.internal.ProgramStore
 import org.hisp.dhis.android.core.programstageworkinglist.ProgramStageWorkingList
@@ -44,6 +45,7 @@ import org.hisp.dhis.android.core.settings.ProgramSettings
 import org.hisp.dhis.android.core.settings.ProgramSettingsObjectRepository
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilter
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilterCollectionRepository
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 import org.hisp.dhis.android.core.user.internal.UserOrganisationUnitLinkStore
 import org.junit.Before
 import org.junit.Test
@@ -58,6 +60,7 @@ class TrackedEntityInstanceQueryFactoryShould {
 
     private val userOrganisationUnitLinkStore: UserOrganisationUnitLinkStore = mock()
     private val organisationUnitProgramLinkLinkStore: OrganisationUnitProgramLinkStore = mock()
+    private val organisationUnitStore: OrganisationUnitStore = mock()
     private val programStore: ProgramStore = mock()
     private val programSettingsObjectRepository: ProgramSettingsObjectRepository = mock()
     private val programSettings: ProgramSettings = mock()
@@ -103,6 +106,7 @@ class TrackedEntityInstanceQueryFactoryShould {
         whenever(userOrganisationUnitLinkStore.queryRootCaptureOrganisationUnitUids()).thenReturn(rootOrgUnits)
         whenever(userOrganisationUnitLinkStore.queryOrganisationUnitUidsByScope(any()))
             .thenReturn(captureOrgUnits)
+        whenever(organisationUnitStore.isLeaf(any())).thenReturn(false)
         whenever(organisationUnitProgramLinkLinkStore.selectWhere(any()))
             .thenReturn(links)
         whenever(programStore.getUidsByProgramType(any())).thenReturn(
@@ -119,6 +123,7 @@ class TrackedEntityInstanceQueryFactoryShould {
         whenever(teiFilterCollectionRepository.blockingGet()).thenReturn(emptyList())
 
         val commonHelper = TrackerQueryFactoryCommonHelper(
+            organisationUnitStore,
             userOrganisationUnitLinkStore,
             organisationUnitProgramLinkLinkStore,
         )
@@ -138,7 +143,7 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         val query = queries[0]
-        assertThat(query.orgUnits).isEqualTo(rootOrgUnits)
+        assertThat(query.orgUnits).isEqualTo(rootOrgUnits.map { DownloadOrgunit(it, isLeaf = false) })
         assertThat(query.commonParams.ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
         assertThat(query.commonParams.program).isNull()
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryFactoryShould.kt
@@ -143,7 +143,8 @@ class TrackedEntityInstanceQueryFactoryShould {
         val queries = queryFactory.getQueries(params)
         assertThat(queries.size).isEqualTo(1)
         val query = queries[0]
-        assertThat(query.orgUnits).isEqualTo(rootOrgUnits.map { DownloadOrgunit(it, isLeaf = false) })
+        assertThat(query.orgUnits)
+            .isEqualTo(rootOrgUnits.map { DownloadOrgunit(it, resolvedOuMode = OrganisationUnitMode.DESCENDANTS) })
         assertThat(query.commonParams.ouMode).isEqualTo(OrganisationUnitMode.DESCENDANTS)
         assertThat(query.commonParams.program).isNull()
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManagerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManagerShould.kt
@@ -33,6 +33,8 @@ import org.hisp.dhis.android.core.arch.db.stores.internal.TrackerBaseSyncStore
 import org.hisp.dhis.android.core.arch.helpers.DateUtils
 import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.program.internal.ProgramDataDownloadParams
+import org.hisp.dhis.android.core.tracker.exporter.BaseTrackerQueryBundle
+import org.hisp.dhis.android.core.tracker.exporter.DownloadOrgunit
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,9 +49,10 @@ class TrackerSyncLastUpdatedManagerShould {
     private val params: ProgramDataDownloadParams = mock()
 
     private val program = "program_uid"
-    private val orgUnits = listOf("org_unit_1", "org_unit_2")
-    private val orgUnitsHash = orgUnits.toSet().hashCode()
-    private val limit = 500
+    private val orgUnitsBeforeDivision = listOf("org_unit_1", "org_unit_2", "org_unit_3")
+    private val ouUids = listOf("org_unit_1", "org_unit_2")
+    private val orgUnitsHash = ouUids.toSet().hashCode()
+    private val defaultLimit = 500
     private val workingListsHash = 12345
     private val lastUpdated = DateUtils.DATE_FORMAT.parse("2017-11-29T11:27:46.935")
 
@@ -65,7 +68,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_last_updated_when_working_lists_hash_matches() = runTest {
         prepareWithSync(storedHash = workingListsHash)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(workingListsHash))
+        val result = manager.getLastUpdatedStr(createBundle(workingListsHash))
 
         assertThat(result).isNotNull()
     }
@@ -74,7 +77,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_null_when_working_lists_hash_changes() = runTest {
         prepareWithSync(storedHash = workingListsHash)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(99999))
+        val result = manager.getLastUpdatedStr(createBundle(99999))
 
         assertThat(result).isNull()
     }
@@ -83,7 +86,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_null_when_stored_hash_is_null_but_current_is_not() = runTest {
         prepareWithSync(storedHash = null)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(workingListsHash))
+        val result = manager.getLastUpdatedStr(createBundle(workingListsHash))
 
         assertThat(result).isNull()
     }
@@ -92,7 +95,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_null_when_current_hash_is_null_but_stored_is_not() = runTest {
         prepareWithSync(storedHash = workingListsHash)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(null))
+        val result = manager.getLastUpdatedStr(createBundle(null))
 
         assertThat(result).isNull()
     }
@@ -101,7 +104,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_last_updated_when_both_hashes_are_null() = runTest {
         prepareWithSync(storedHash = null)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(null))
+        val result = manager.getLastUpdatedStr(createBundle(null))
 
         assertThat(result).isNotNull()
     }
@@ -110,7 +113,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_null_when_no_sync_record_exists() = runTest {
         prepareWithSync(sync = null)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(workingListsHash))
+        val result = manager.getLastUpdatedStr(createBundle(workingListsHash))
 
         assertThat(result).isNull()
     }
@@ -119,7 +122,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_null_when_download_limit_increased() = runTest {
         prepareWithSync(storedHash = workingListsHash)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(workingListsHash).copy(limit = limit + 100))
+        val result = manager.getLastUpdatedStr(createBundle(workingListsHash, limit = defaultLimit + 100))
 
         assertThat(result).isNull()
     }
@@ -128,7 +131,7 @@ class TrackerSyncLastUpdatedManagerShould {
     fun return_last_updated_when_download_limit_decreased() = runTest {
         prepareWithSync(storedHash = workingListsHash)
 
-        val result = manager.getLastUpdatedStr(createCommonParams(workingListsHash).copy(limit = limit - 100))
+        val result = manager.getLastUpdatedStr(createBundle(workingListsHash, limit = defaultLimit - 100))
 
         assertThat(result).isNotNull()
     }
@@ -147,23 +150,30 @@ class TrackerSyncLastUpdatedManagerShould {
         return TrackedEntityInstanceSync.builder()
             .program(program)
             .organisationUnitIdsHash(orgUnitsHash)
-            .downloadLimit(limit)
+            .downloadLimit(defaultLimit)
             .workingListsHash(hash)
             .lastUpdated(lastUpdated)
             .build()
     }
 
-    private fun createCommonParams(hash: Int?): TrackerQueryCommonParams {
-        return TrackerQueryCommonParams(
+    private fun createBundle(hash: Int? = null, limit: Int? = null): BaseTrackerQueryBundle {
+        val commonParams = TrackerQueryCommonParams(
             uids = emptyList(),
             programs = listOf(program),
             program = program,
             startDate = null,
             hasLimitByOrgUnit = false,
             ouMode = OrganisationUnitMode.SELECTED,
-            orgUnitsBeforeDivision = orgUnits,
-            limit = limit,
+            orgUnitsBeforeDivision = orgUnitsBeforeDivision,
+            limit = limit ?: defaultLimit,
             workingListsHash = hash,
         )
+
+        return object : BaseTrackerQueryBundle {
+            override val commonParams: TrackerQueryCommonParams
+                get() = commonParams
+            override val orgUnits: List<DownloadOrgunit>
+                get() = ouUids.map { DownloadOrgunit(it, false) }
+        }
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManagerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManagerShould.kt
@@ -173,7 +173,7 @@ class TrackerSyncLastUpdatedManagerShould {
             override val commonParams: TrackerQueryCommonParams
                 get() = commonParams
             override val orgUnits: List<DownloadOrgunit>
-                get() = ouUids.map { DownloadOrgunit(it, false) }
+                get() = ouUids.map { DownloadOrgunit(it, OrganisationUnitMode.SELECTED) }
         }
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -224,7 +224,13 @@ class TrackerDownloadCallShould {
             orgUnitsBeforeDivision = listOf(orgUnitUid),
             limit = ProgramDataDownloadParams.DEFAULT_LIMIT,
         )
-        val bundle = TrackerQueryBundle(commonParams, listOf(orgUnitUid), null, null, null)
+        val bundle = TrackerQueryBundle(
+            commonParams,
+            listOf(DownloadOrgunit(orgUnitUid, isLeaf = false)),
+            null,
+            null,
+            null,
+        )
 
         whenever(queryFactory.getQueries(any())).doReturn(listOf(bundle))
         whenever(d2Dao.stringListRawQuery(any<SupportSQLiteQuery>())).doReturn(emptyList())
@@ -275,7 +281,7 @@ class TrackerDownloadCallShould {
         )
         val bundle = TrackerQueryBundle(
             commonParams = commonParams,
-            orgUnits = listOf(orgUnitUid),
+            orgUnits = listOf(DownloadOrgunit(orgUnitUid, isLeaf = false)),
             null,
             null,
             null,

--- a/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/tracker/exporter/TrackerDownloadCallShould.kt
@@ -226,7 +226,7 @@ class TrackerDownloadCallShould {
         )
         val bundle = TrackerQueryBundle(
             commonParams,
-            listOf(DownloadOrgunit(orgUnitUid, isLeaf = false)),
+            listOf(DownloadOrgunit(orgUnitUid, resolvedOuMode = OrganisationUnitMode.DESCENDANTS)),
             null,
             null,
             null,
@@ -281,7 +281,7 @@ class TrackerDownloadCallShould {
         )
         val bundle = TrackerQueryBundle(
             commonParams = commonParams,
-            orgUnits = listOf(DownloadOrgunit(orgUnitUid, isLeaf = false)),
+            orgUnits = listOf(DownloadOrgunit(orgUnitUid, resolvedOuMode = OrganisationUnitMode.DESCENDANTS)),
             null,
             null,
             null,


### PR DESCRIPTION
The tracker download flow (shared by events and tracked entity instances) queries the DHIS2 API per org unit using an org unit mode such as DESCENDANTS or SELECTED, chosen once for the whole download bundle. For org units known to have no children (leaves), requesting DESCENDANTS or CHILDREN returns the same result as SELECTED, but forces the server to resolve the sub-hierarchy unnecessarily. This PR threads the `DownloadOrgunit.isLeaf` flag — already computed when dividing a bundle by org unit — through `TrackerDownloadCall`, `EventDownloadCall`, and `TrackedEntityInstanceDownloadCall`, and uses it to override the org unit mode of each per-org-unit request to SELECTED whenever the target org unit is a leaf.

The override is scoped to the single API request via a `TrackerQueryCommonParams` copy, so it doesn't leak into the bundle-level `ouMode` used elsewhere. Only DESCENDANTS and CHILDREN are eligible for the SELECTED substitution; ACCESSIBLE and other modes are left untouched since they don't depend on the org unit's position in the hierarchy.

Related task: [ANDROSDK-2329](https://dhis2.atlassian.net/browse/ANDROSDK-2329)

[ANDROSDK-2329]: https://dhis2.atlassian.net/browse/ANDROSDK-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ