### PR TITLE
fix: [ANDROSDK-2376] store the JSON value of a dataStore entry

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/migrations/DataBaseMigrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/data/database/migrations/DataBaseMigrationShould.kt
@@ -160,4 +160,62 @@ class DataBaseMigrationShould {
         val db = initDatabaseToVersion(2)
         assertThat(ifTableExists(TrackedEntityAttributeReservedValueTableInfo.TABLE_INFO.name(), db)).isTrue()
     }
+
+    /**
+     * ANDROSDK-2376: downloaded dataStore entries were persisted as the `toString()` of the
+     * internal `JsonWrapper` value class. Migration 181 unwraps them in place so existing
+     * installations are repaired without waiting for the app to trigger a dataStore download.
+     */
+    @Test
+    fun repair_data_store_values_wrapped_by_json_wrapper_to_string_in_migration_181() = runTest {
+        val db = initDatabaseToVersion(180)
+
+        insertDataStoreEntry(db, "settings", """JsonWrapper(json={"skipMigration":true})""", "SYNCED")
+        insertDataStoreEntry(db, "summary", """JsonWrapper(json=[{"id":"fKHBpN5v8Sj"}])""", "SYNCED")
+        insertDataStoreEntry(db, "explicitNull", "JsonWrapper(json=null)", "SYNCED")
+        insertDataStoreEntry(db, "absentValue", "null", "SYNCED")
+        // Only the download produces the corrupted values, so anything written locally and still
+        // pending upload must be left exactly as the app wrote it.
+        insertDataStoreEntry(db, "locallyEdited", "null", "TO_UPDATE")
+
+        applyMigrationEndingAt(db, 181)
+
+        assertThat(dataStoreValue(db, "settings")).isEqualTo("""{"skipMigration":true}""")
+        assertThat(dataStoreValue(db, "summary")).isEqualTo("""[{"id":"fKHBpN5v8Sj"}]""")
+        // A genuine JSON null keeps its JSON representation, an absent value becomes SQL NULL.
+        assertThat(dataStoreValue(db, "explicitNull")).isEqualTo("null")
+        assertThat(dataStoreValue(db, "absentValue")).isNull()
+        assertThat(dataStoreValue(db, "locallyEdited")).isEqualTo("null")
+    }
+
+    private fun applyMigrationEndingAt(db: SupportSQLiteDatabase, endVersion: Int) {
+        val migration = ALL_MIGRATIONS.first { it.endVersion == endVersion }
+        db.beginTransaction()
+        try {
+            migration.migrate(db)
+            db.execSQL("PRAGMA user_version = ${migration.endVersion};")
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    private fun insertDataStoreEntry(
+        db: SupportSQLiteDatabase,
+        key: String,
+        value: String,
+        syncState: String,
+    ) {
+        db.execSQL(
+            "INSERT INTO DataStore (namespace, key, value, syncState, deleted) VALUES (?, ?, ?, ?, 0)",
+            arrayOf("capture", key, value, syncState),
+        )
+    }
+
+    private fun dataStoreValue(db: SupportSQLiteDatabase, key: String): String? {
+        val cursor = db.query("SELECT value FROM DataStore WHERE namespace = ? AND key = ?", arrayOf("capture", key))
+        val value = if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getString(0) else null
+        cursor.close()
+        return value
+    }
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreCollectionRepositoryMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/datastore/DataStoreCollectionRepositoryMockIntegrationShould.kt
@@ -28,6 +28,10 @@
 package org.hisp.dhis.android.testapp.datastore
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
 import org.junit.Test
@@ -84,5 +88,46 @@ class DataStoreCollectionRepositoryMockIntegrationShould : BaseMockIntegrationTe
             .blockingGet()
 
         assertThat(dataStoreEntries.size).isEqualTo(3)
+    }
+
+    /**
+     * The tests above only count rows, which is why ANDROSDK-2376 stayed green for as long as it
+     * did: an entry stored as `JsonWrapper(json={...})` is still a row, and is still non-null. The
+     * tests below pin the downloaded value itself, end to end through the real download pipeline
+     * the full dispatcher runs — response deserialization, [
+     * org.hisp.dhis.android.network.datastore.DataStoreEntryDTO.toDomain] and the store.
+     */
+    @Test
+    fun download_the_json_object_value_of_an_entry() {
+        val value = d2.dataStoreModule().dataStore()
+            .value("capture", "settings")
+            .blockingGet()!!
+            .value()
+
+        assertThat(value).isEqualTo("""{"skipMigration":true}""")
+    }
+
+    @Test
+    fun download_a_json_array_value_that_parses_back_as_json() {
+        val value = d2.dataStoreModule().dataStore()
+            .value("capture", "summary")
+            .blockingGet()!!
+            .value()!!
+
+        assertThat(value).doesNotContain("JsonWrapper")
+
+        val parsed = KotlinxJsonParser.instance.parseToJsonElement(value).jsonArray
+        assertThat(parsed).hasSize(4)
+        assertThat(parsed[0].jsonObject["id"]!!.jsonPrimitive.content).isEqualTo("fKHBpN5v8Sj")
+    }
+
+    @Test
+    fun download_an_empty_json_object_value() {
+        val value = d2.dataStoreModule().dataStore()
+            .value("scorecard", "savedObjects")
+            .blockingGet()!!
+            .value()
+
+        assertThat(value).isEqualTo("{}")
     }
 }

--- a/core/src/main/assets/migrations/181.sql
+++ b/core/src/main/assets/migrations/181.sql
@@ -194,3 +194,7 @@ ALTER TABLE TrackedEntityType ADD COLUMN displayTrackedEntityTypesLabel TEXT;
 # Add image upload quality settings to program and dataSet settings (ANDROSDK-2348)
 ALTER TABLE ProgramSetting ADD COLUMN imageSettings TEXT;
 ALTER TABLE DataSetSetting ADD COLUMN imageSettings TEXT;
+
+# Repair dataStore values persisted as JsonWrapper.toString() (ANDROSDK-2376)
+UPDATE DataStore SET value = NULL WHERE syncState = 'SYNCED' AND value = 'null';
+UPDATE DataStore SET value = substr(value, 18, length(value) - 18) WHERE syncState = 'SYNCED' AND value LIKE 'JsonWrapper(json=%)';

--- a/core/src/main/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTO.kt
@@ -44,7 +44,10 @@ internal data class DataStoreEntryDTO(
         return DataStoreEntry.builder()
             .namespace(namespace)
             .key(key)
-            .value(value.toString())
+            // `value` is a JsonWrapper value class, so `toString()` on it renders
+            // "JsonWrapper(json=...)" rather than the payload, and renders a null wrapper as the
+            // literal string "null". Serialize the wrapped JsonElement instead, and preserve null.
+            .value(value?.json?.toString())
             .syncState(State.SYNCED)
             .deleted(false)
             .build()

--- a/core/src/main/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTO.kt
@@ -44,9 +44,6 @@ internal data class DataStoreEntryDTO(
         return DataStoreEntry.builder()
             .namespace(namespace)
             .key(key)
-            // `value` is a JsonWrapper value class, so `toString()` on it renders
-            // "JsonWrapper(json=...)" rather than the payload, and renders a null wrapper as the
-            // literal string "null". Serialize the wrapped JsonElement instead, and preserve null.
             .value(value?.json?.toString())
             .syncState(State.SYNCED)
             .deleted(false)

--- a/core/src/test/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTOMappingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTOMappingShould.kt
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2004-2023, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.network.datastore
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.hisp.dhis.android.network.common.JsonWrapper
+import org.junit.Test
+
+/**
+ * `DataStoreEntry.value` is the caller-visible JSON of a dataStore entry, so this mapping is the
+ * public contract of both dataStore read endpoints — `getNamespaceValues38` and
+ * `getNamespaceKeyValue` each route through [DataStoreEntryDTO.toDomain].
+ *
+ * These tests pin that the stored value is the JSON payload itself. It previously stored the
+ * `toString()` of the [org.hisp.dhis.android.network.common.JsonWrapper] value class, which
+ * produced `JsonWrapper(json={...})` and could not be parsed by any consumer.
+ */
+class DataStoreEntryDTOMappingShould {
+
+    private fun dtoOf(json: String) =
+        DataStoreEntryDTO(key = "config", value = JsonWrapper(Json.parseToJsonElement(json)))
+
+    @Test
+    fun store_the_json_payload_and_not_the_wrapper_to_string() {
+        val json = """{"plugins":[{"id":"org.myorg.my-plugin"}]}"""
+
+        val entry = dtoOf(json).toDomain("dhis2AndroidPlugins")
+
+        assertThat(entry.value()).isEqualTo(json)
+        assertThat(entry.value()).doesNotContain("JsonWrapper")
+    }
+
+    @Test
+    fun round_trip_a_json_object_unchanged() {
+        val json = """{"a":1,"b":"two","c":[1,2,3],"d":{"e":true},"f":null}"""
+
+        val entry = dtoOf(json).toDomain("ns")
+
+        assertThat(entry.value()).isEqualTo(json)
+    }
+
+    @Test
+    fun preserve_a_json_array_at_the_root() {
+        val json = """[{"k":"v"},{"k":"w"}]"""
+
+        assertThat(dtoOf(json).toDomain("ns").value()).isEqualTo(json)
+    }
+
+    @Test
+    fun preserve_a_scalar_value() {
+        assertThat(dtoOf("42").toDomain("ns").value()).isEqualTo("42")
+        assertThat(dtoOf("\"text\"").toDomain("ns").value()).isEqualTo("\"text\"")
+        assertThat(dtoOf("true").toDomain("ns").value()).isEqualTo("true")
+    }
+
+    @Test
+    fun map_a_null_value_to_null_rather_than_the_string_null() {
+        // The previous implementation called toString() on a nullable wrapper, storing the
+        // four-character string "null" and making a genuinely absent value indistinguishable
+        // from a JSON null.
+        val entry = DataStoreEntryDTO(key = "config", value = null).toDomain("ns")
+
+        assertThat(entry.value()).isNull()
+    }
+
+    @Test
+    fun keep_the_namespace_and_key_it_was_given() {
+        val entry = dtoOf("{}").toDomain("dhis2AndroidPlugins")
+
+        assertThat(entry.namespace()).isEqualTo("dhis2AndroidPlugins")
+        assertThat(entry.key()).isEqualTo("config")
+    }
+
+    @Test
+    fun produce_a_value_that_parses_back_as_json() {
+        // The whole point: a consumer must be able to deserialize what we stored.
+        val json = """{"plugins":[{"id":"org.a","version":"1"}]}"""
+
+        val stored = dtoOf(json).toDomain("ns").value()
+
+        // Would throw if the stored text were not valid JSON.
+        Json.parseToJsonElement(stored!!)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTOMappingShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/network/datastore/DataStoreEntryDTOMappingShould.kt
@@ -28,7 +28,9 @@
 package org.hisp.dhis.android.network.datastore
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.serialization.json.Json
+import org.hisp.dhis.android.core.arch.json.internal.KotlinxJsonParser
+import org.hisp.dhis.android.core.common.State
+import org.hisp.dhis.android.core.datastore.DataStoreEntry
 import org.hisp.dhis.android.network.common.JsonWrapper
 import org.junit.Test
 
@@ -43,8 +45,12 @@ import org.junit.Test
  */
 class DataStoreEntryDTOMappingShould {
 
+    // The same parser the network layer decodes responses with, so these tests exercise the
+    // production configuration (lenient, coerced input values, implicit nulls).
+    private val parser = KotlinxJsonParser.instance
+
     private fun dtoOf(json: String) =
-        DataStoreEntryDTO(key = "config", value = JsonWrapper(Json.parseToJsonElement(json)))
+        DataStoreEntryDTO(key = "config", value = JsonWrapper(parser.parseToJsonElement(json)))
 
     @Test
     fun store_the_json_payload_and_not_the_wrapper_to_string() {
@@ -104,7 +110,40 @@ class DataStoreEntryDTOMappingShould {
 
         val stored = dtoOf(json).toDomain("ns").value()
 
-        // Would throw if the stored text were not valid JSON.
-        Json.parseToJsonElement(stored!!)
+        // Parsing would throw if the stored text were not valid JSON, and the parsed tree must be
+        // the one the server sent rather than merely something well formed.
+        assertThat(parser.parseToJsonElement(stored!!)).isEqualTo(parser.parseToJsonElement(json))
+    }
+
+    @Test
+    fun round_trip_an_entry_through_to_dto_and_back() {
+        // A value that cannot be mapped back to a DTO cannot be posted either: `toDto` runs it
+        // through `JsonWrapper.fromString`, which swallows a parse failure and yields a null body.
+        val json = """{"plugins":[{"id":"org.a","version":"1"}],"enabled":true}"""
+        val entry = DataStoreEntry.builder()
+            .namespace("dhis2AndroidPlugins")
+            .key("config")
+            .value(json)
+            .syncState(State.SYNCED)
+            .deleted(false)
+            .build()
+
+        val roundTripped = entry.toDto().toDomain("dhis2AndroidPlugins")
+
+        assertThat(entry.toDto().value).isNotNull()
+        assertThat(roundTripped.value()).isEqualTo(json)
+    }
+
+    @Test
+    fun map_a_null_value_back_to_a_null_dto_value() {
+        val entry = DataStoreEntry.builder()
+            .namespace("ns")
+            .key("config")
+            .value(null)
+            .syncState(State.SYNCED)
+            .deleted(false)
+            .build()
+
+        assertThat(entry.toDto().value).isNull()
     }
 }


### PR DESCRIPTION
`DataStoreEntryDTO.toDomain` called `toString()` on `value`, a `JsonWrapper` value class, so every entry read from the server dataStore was persisted as `JsonWrapper(json={...})` and could not be deserialized by any consumer. The same call turned a null wrapper into the literal string `"null"`, making an absent value indistinguishable from a JSON null. Serializing the wrapped `JsonElement` and preserving null fixes both.

Both read paths — `getNamespaceValues38` and `getNamespaceKeyValue` — route through `toDomain`, so both were affected, and every namespace is: `ANDROID_SETTINGS_APP` is stored corrupted too, but the bug is masked there because `settingModule()` parses that namespace into its own typed tables rather than reading the generic dataStore. That is why it went unnoticed since ANDROSDK-2016 — no consumer read the server dataStore raw until now. The new mapping tests fail on 6 of 7 cases against the previous implementation, and the fix was verified end to end against a local DHIS2 instance with the Android Capture App plugin system reading `dhis2AndroidPlugins`.

### Migration 181: repairing installations that already downloaded corrupted values

Downloaded entries were stored as `JsonWrapper(json={...})` instead of the JSON payload, and an absent value was stored as the literal string `"null"`. Only downloaded rows are affected, so the repair is restricted to `SYNCED` entries and leaves anything written locally untouched.

The two statements are order-dependent:

1. `UPDATE DataStore SET value = NULL WHERE syncState = 'SYNCED' AND value = 'null';`

   Restores an absent value to `NULL`. This must run before the unwrapping below: a genuine JSON null was stored as `JsonWrapper(json=null)`, and unwrapping it first would leave the string `"null"`, which this statement would then wrongly turn into a `NULL`.

2. `UPDATE DataStore SET value = substr(value, 18, length(value) - 18) WHERE syncState = 'SYNCED' AND value LIKE 'JsonWrapper(json=%)';`

   Strips the 17-character `"JsonWrapper(json="` prefix and the trailing `")"` to recover the payload.

`DataBaseMigrationShould.repair_data_store_values_wrapped_by_json_wrapper_to_string_in_migration_181` pins both statements and their ordering against real SQLite: it migrates to 180, seeds a wrapped object, a wrapped array, a genuine JSON null, an absent value and a locally edited row, applies migration 181 and asserts each outcome.

Related task: [ANDROSDK-2376](https://dhis2.atlassian.net/browse/ANDROSDK-2376)

[ANDROSDK-2376]: https://dhis2.atlassian.net/browse/ANDROSDK-2376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
