### PR TITLE
feature: [ANDROSDK-2371] revisit image compression logic

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -184,6 +184,7 @@ kotlin {
 
 dependencies {
 
+    implementation(libs.androidx.exifinterface)
     coreLibraryDesugaring(libs.desugaring)
 
     ksp(project(":processor"))

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/helpers/FileCompressionHelperShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/arch/helpers/FileCompressionHelperShould.kt
@@ -31,27 +31,38 @@ import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat
 import android.graphics.BitmapFactory
 import android.graphics.Color
+import android.media.ExifInterface
+import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import org.hisp.dhis.android.core.arch.helpers.FileCompressionHelper
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
+import org.junit.After
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
-import java.util.Locale
 
 @RunWith(D2JunitRunner::class)
 class FileCompressionHelperShould {
 
+    private val createdFiles = mutableListOf<File>()
+
+    @After
+    fun tearDown() {
+        createdFiles.forEach { it.delete() }
+        createdFiles.clear()
+    }
+
     @Test
     fun compress_png_below_target_size() {
-        val target = 20 * 1024L
-        val file = getFile(CompressFormat.PNG, getNoisyBitmap(1024, 1024))
+        val target = 150 * 1024L
+        val file = writeImage("png-to-compress.png", CompressFormat.PNG, noisyBitmap(1500, 1500))
         assertThat(file.length()).isGreaterThan(target)
 
-        val compressedFile = FileCompressionHelper.compressFile(file, target)
+        val compressedFile = compress(file, target)
 
         assertThat(compressedFile.exists()).isTrue()
         assertThat(compressedFile.length()).isAtMost(target)
@@ -59,22 +70,37 @@ class FileCompressionHelperShould {
 
     @Test
     fun compress_jpeg_below_target_size() {
-        val target = 20 * 1024L
-        val file = getFile(CompressFormat.JPEG, getNoisyBitmap(1024, 1024))
+        val target = 150 * 1024L
+        val file = writeImage("jpeg-to-compress.jpg", CompressFormat.JPEG, noisyBitmap(1500, 1500))
         assertThat(file.length()).isGreaterThan(target)
 
-        val compressedFile = FileCompressionHelper.compressFile(file, target)
+        val compressedFile = compress(file, target)
 
         assertThat(compressedFile.exists()).isTrue()
         assertThat(compressedFile.length()).isAtMost(target)
     }
 
+    /**
+     * The point of measuring every attempt instead of decaying a guessed scale: the result must use most of the
+     * budget, not just fit in it, so that as little quality as possible is thrown away.
+     */
+    @Test
+    fun land_close_to_the_target_size() {
+        val target = 150 * 1024L
+        val file = writeImage("png-close-to-target.png", CompressFormat.PNG, noisyBitmap(1500, 1500))
+
+        val compressedFile = compress(file, target)
+
+        assertThat(compressedFile.length()).isAtMost(target)
+        assertThat(compressedFile.length()).isGreaterThan((target * CLOSENESS_RATIO).toLong())
+    }
+
     @Test
     fun preserve_aspect_ratio_when_compressing() {
-        val target = 20 * 1024L
-        val file = getFile(CompressFormat.PNG, getNoisyBitmap(2048, 1024))
+        val target = 100 * 1024L
+        val file = writeImage("png-wide.png", CompressFormat.PNG, noisyBitmap(2048, 1024))
 
-        val compressedFile = FileCompressionHelper.compressFile(file, target)
+        val compressedFile = compress(file, target)
 
         val compressedBitmap = BitmapFactory.decodeFile(compressedFile.absolutePath)
         val ratio = compressedBitmap.width.toFloat() / compressedBitmap.height.toFloat()
@@ -82,54 +108,145 @@ class FileCompressionHelperShould {
     }
 
     @Test
-    fun do_not_upscale_when_file_is_already_below_target() {
-        val file = getFile(CompressFormat.PNG, getNoisyBitmap(100, 125))
+    fun return_the_original_file_when_it_is_already_below_target() {
+        val file = writeImage("jpeg-small.jpg", CompressFormat.JPEG, noisyBitmap(100, 125))
 
-        val compressedFile = FileCompressionHelper.compressFile(file, 600 * 1024L)
+        val compressedFile = compress(file, FileCompressionHelper.TARGET_SIZE_BYTES)
 
-        val compressedBitmap = BitmapFactory.decodeFile(compressedFile.absolutePath)
-        assertThat(compressedBitmap.width).isEqualTo(100)
-        assertThat(compressedBitmap.height).isEqualTo(125)
+        assertThat(compressedFile).isEqualTo(file)
     }
 
     @Test
     fun return_original_file_when_it_cannot_be_decoded() {
-        val notAnImage = File(
-            FileResourceDirectoryHelper.getRootFileResourceDirectory(context()),
-            "not-an-image.txt",
-        )
+        val notAnImage = File(directory(), "not-an-image.txt")
+        createdFiles.add(notAnImage)
         FileOutputStream(notAnImage).use { it.write("this is not an image".toByteArray()) }
 
-        val result = FileCompressionHelper.compressFile(notAnImage, 20 * 1024L)
+        val result = compress(notAnImage, 20 * 1024L)
 
         assertThat(result).isEqualTo(notAnImage)
     }
 
-    companion object {
-        private fun context() = InstrumentationRegistry.getInstrumentation().context
+    @Test
+    fun convert_an_opaque_png_to_jpeg() {
+        val file = writeImage("png-opaque.png", CompressFormat.PNG, noisyBitmap(1024, 1024))
 
-        private fun getFile(compressFormat: CompressFormat, bitmap: Bitmap): File {
-            val imageFile = File(
-                FileResourceDirectoryHelper.getRootFileResourceDirectory(context()),
-                "image-to-compress." + compressFormat.name.lowercase(Locale.getDefault()),
-            )
+        val compressedFile = compress(file, 100 * 1024L)
+
+        assertThat(compressedFile.extension).isEqualTo("jpg")
+        assertThat(mimeTypeOf(compressedFile)).isEqualTo("image/jpeg")
+    }
+
+    @Test
+    fun keep_png_when_the_image_has_transparent_pixels() {
+        val file = writeImage("png-translucent.png", CompressFormat.PNG, noisyBitmap(1024, 1024, opaque = false))
+
+        val compressedFile = compress(file, 300 * 1024L)
+
+        assertThat(compressedFile.extension).isEqualTo("png")
+        assertThat(mimeTypeOf(compressedFile)).isEqualTo("image/png")
+        assertThat(BitmapFactory.decodeFile(compressedFile.absolutePath).hasAlpha()).isTrue()
+    }
+
+    /**
+     * The server rejects webp, so it must be converted even when it is already small enough to be uploaded as it is.
+     */
+    @Test
+    @Suppress("DEPRECATION")
+    fun convert_webp_even_when_it_is_below_the_target() {
+        val file = writeImage("image-webp.webp", CompressFormat.WEBP, noisyBitmap(300, 300))
+        assertThat(file.length()).isLessThan(FileCompressionHelper.TARGET_SIZE_BYTES)
+
+        val compressedFile = compress(file, FileCompressionHelper.TARGET_SIZE_BYTES)
+
+        assertThat(compressedFile).isNotEqualTo(file)
+        assertThat(compressedFile.extension).isEqualTo("jpg")
+        assertThat(mimeTypeOf(compressedFile)).isEqualTo("image/jpeg")
+    }
+
+    /**
+     * Re-encoding drops the EXIF metadata, so the orientation has to be baked into the pixels: a landscape image
+     * flagged as rotated must come out as a portrait one.
+     */
+    @Test
+    @Suppress("DEPRECATION")
+    fun apply_the_exif_orientation() {
+        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        val file = writeImage("jpeg-rotated.jpg", CompressFormat.JPEG, noisyBitmap(600, 300))
+        ExifInterface(file.absolutePath).apply {
+            setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_ROTATE_90.toString())
+            saveAttributes()
+        }
+
+        val compressedFile = compress(file, 10 * 1024L)
+
+        val compressedBitmap = BitmapFactory.decodeFile(compressedFile.absolutePath)
+        assertThat(compressedBitmap.height).isGreaterThan(compressedBitmap.width)
+    }
+
+    /**
+     * An unreachable target must not degrade the image indefinitely: the largest side is kept at the minimum
+     * dimension and the resulting file is returned even though it exceeds the target.
+     */
+    @Test
+    fun stop_shrinking_at_the_minimum_dimension() {
+        val target = 1024L
+        val file = writeImage("png-unreachable.png", CompressFormat.PNG, noisyBitmap(1024, 1024))
+
+        val compressedFile = compress(file, target)
+
+        val compressedBitmap = BitmapFactory.decodeFile(compressedFile.absolutePath)
+        assertThat(maxOf(compressedBitmap.width, compressedBitmap.height)).isEqualTo(MIN_DIMENSION_PX)
+        assertThat(compressedFile.length()).isGreaterThan(target)
+    }
+
+    private fun compress(file: File, target: Long): File {
+        return FileCompressionHelper.compressFile(file, target).also { createdFiles.add(it) }
+    }
+
+    private fun writeImage(name: String, compressFormat: CompressFormat, bitmap: Bitmap): File {
+        val imageFile = File(directory(), name)
+        createdFiles.add(imageFile)
+        try {
             FileOutputStream(imageFile).use { os ->
-                bitmap.compress(compressFormat, 100, os)
+                bitmap.compress(compressFormat, LOSSLESS_QUALITY, os)
                 os.flush()
             }
-            return imageFile
+        } finally {
+            bitmap.recycle()
         }
+        return imageFile
+    }
+
+    private fun mimeTypeOf(file: File): String? {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, options)
+        return options.outMimeType
+    }
+
+    companion object {
+        private const val MIN_DIMENSION_PX = 256
+        private const val LOSSLESS_QUALITY = 100
+        private const val CLOSENESS_RATIO = 0.7
+
+        private fun directory() =
+            FileResourceDirectoryHelper.getRootFileResourceDirectory(
+                InstrumentationRegistry.getInstrumentation().context,
+            )
 
         /**
          * Builds a high-entropy bitmap whose pixels vary per position, so that the encoded file does not collapse to a
-         * trivial size and the compression loop is actually exercised.
+         * trivial size and the compression loop is actually exercised. When [opaque] is false, the alpha channel also
+         * varies, which is what makes the image worth keeping as a lossless PNG.
          */
-        private fun getNoisyBitmap(width: Int, height: Int): Bitmap {
+        private fun noisyBitmap(width: Int, height: Int, opaque: Boolean = true): Bitmap {
             val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             val pixels = IntArray(width * height) { i ->
                 val x = i % width
                 val y = i / width
-                Color.rgb(
+                val alpha = if (opaque) 0xFF else (x * 7 + y * 3) and 0xFF
+                Color.argb(
+                    alpha,
                     (x * 37 + y * 17) and 0xFF,
                     (x * 91 + y * 53) and 0xFF,
                     (x * 13 + y * 191) and 0xFF,

--- a/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/testapp/fileresource/FileResourceAddMockIntegrationShould.kt
@@ -33,6 +33,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.d2.internal.DhisAndroidSdkKoinContext.koin
 import org.hisp.dhis.android.core.arch.helpers.FileCompressionHelper
+import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper.getFileCacheResourceDirectory
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper.getFileResourceDirectory
 import org.hisp.dhis.android.core.arch.helpers.ResourceContext
 import org.hisp.dhis.android.core.data.fileresource.RandomGeneratedInputStream
@@ -79,10 +80,7 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestFullDispatch
         }
         addedFileResources.clear()
 
-        addedSourceFiles.forEach { sourceFile ->
-            File(sourceFile.parent, "compressed-${sourceFile.name}").delete()
-            sourceFile.delete()
-        }
+        addedSourceFiles.forEach { sourceFile -> sourceFile.delete() }
         addedSourceFiles.clear()
     }
 
@@ -182,6 +180,24 @@ class FileResourceAddMockIntegrationShould : BaseMockIntegrationTestFullDispatch
     private fun assertCompressed(fileResource: FileResource, sourceFile: File) {
         assertThat(fileResource.contentLength()).isLessThan(sourceFile.length())
         assertThat(fileResource.contentLength()).isAtMost(FileCompressionHelper.TARGET_SIZE_BYTES)
+
+        // The stored images are opaque, so they are converted to jpeg. The name exposed to the server keeps the
+        // original one, with the extension of the format actually uploaded, and the content type must agree with it.
+        assertThat(fileResource.name()).isEqualTo("${sourceFile.nameWithoutExtension}.jpg")
+        assertThat(fileResource.contentType()).isEqualTo("image/jpeg")
+        assertThat(File(fileResource.path()!!).extension).isEqualTo("jpg")
+
+        assertNoLeftOverTemporaryFiles()
+    }
+
+    /**
+     * The compressed image is a temporary file that must not survive the add: only the copy in the file resource
+     * directory is kept.
+     */
+    private fun assertNoLeftOverTemporaryFiles() {
+        val cacheDirectory = getFileCacheResourceDirectory(d2.context())
+        val temporaryFiles = cacheDirectory.listFiles()?.filter { it.name.startsWith("compressed-") }
+        assertThat(temporaryFiles ?: emptyList<File>()).isEmpty()
     }
 
     private suspend fun processAndAdd(file: File, resourceContext: ResourceContext): FileResource {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
@@ -30,77 +30,201 @@ package org.hisp.dhis.android.core.arch.helpers
 
 import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat
-import android.graphics.BitmapFactory
-import androidx.core.graphics.scale
-import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil
+import android.util.Log
+import org.hisp.dhis.android.core.arch.helpers.internal.ImageFileHelper
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import kotlin.math.sqrt
 
 /**
  * Compresses image files before uploading them to the server, keeping the quality loss to a minimum.
  *
- * The strategy is to iteratively downscale the image until the encoded file drops below a target size. JPEG images
- * are encoded with a fixed quality; PNG images are lossless, so for them the size reduction relies solely on the
- * scaling. The first scale factor is estimated from the size ratio so that, in most cases, a single pass is enough.
+ * Files that are already below the target size and in a format the server accepts are returned untouched. Otherwise
+ * the image is re-encoded at a fixed quality and the size is reduced by downscaling: every attempt is measured and
+ * the next scale is predicted from that measurement, so the result lands just below the target instead of well
+ * under it.
+ *
+ * Note that only JPEG and PNG are produced, because those are the only formats that the platform can encode and the
+ * server accepts. Anything else that can be decoded (webp, heif, bmp, gif...) is converted, and the caller is
+ * responsible for exposing the resulting file with the extension it now has: the content type is derived from the
+ * name, and it must agree with the actual bytes.
  */
 object FileCompressionHelper {
 
-    private const val JPEG_QUALITY = 80
+    private val TAG = FileCompressionHelper::class.java.simpleName
+
     internal const val TARGET_SIZE_BYTES = 600 * 1024L // 600 KB
-    private const val SCALE_STEP = 0.8f // reduce dimensions by 20% on each retry
-    private const val MAX_ITERATIONS = 10
-    private const val FULL_SIZE = 1f
-    private const val MIN_DIMENSION_PX = 1
 
     /**
-     * Compress an image file so that its encoded size does not exceed [targetSizeBytes]. The aspect ratio is always
-     * preserved. If the file cannot be decoded as an image, the original file is returned unchanged.
+     * Quality of the lossy encodings, never lowered to reach the target. Below this JPEG starts showing visible
+     * blocking, and since the artifacts survive every later downscaling while the resolution above the dimension the
+     * image is displayed at is not used, spending the budget on quality is worth more than spending it on pixels.
+     */
+    private const val JPEG_QUALITY = 85
+
+    /**
+     * Lossless formats ignore the quality, so the value is irrelevant for them.
+     */
+    private const val LOSSLESS_QUALITY = 100
+
+    private const val MAX_SCALE_REFINEMENTS = 4
+    private const val FULL_SIZE = 1f
+
+    /**
+     * Fraction of the target the prediction aims at. Without this margin an attempt landing barely above the target
+     * would predict a scale barely below the current one, converging to the boundary from above instead of crossing
+     * it within the allowed refinements.
+     */
+    private const val SAFETY_RATIO = 0.95f
+
+    /**
+     * Upper bound for the largest side of the working bitmap. A 50 MP picture would need 200 MB as an ARGB_8888
+     * bitmap, so it is subsampled by the decoder before being loaded.
+     */
+    private const val MAX_WORKING_DIMENSION_PX = 4096
+
+    /**
+     * Lower bound for the largest side of the result. Shrinking an image below this is not worth the loss, even if
+     * that means missing the target.
+     */
+    private const val MIN_DIMENSION_PX = 256
+
+    private const val COMPRESSED_PREFIX = "compressed-"
+    private const val JPEG_EXTENSION = "jpg"
+    private const val PNG_EXTENSION = "png"
+
+    /**
+     * Image mime types decodable by the platform that the server accepts as they are. Formats it cannot decode (tiff,
+     * raw, pcx, pnm, jpeg2000) never reach the compression, and are also accepted by the server. Note that webp,
+     * heif and avif are decodable but rejected by the server, so they are always converted.
+     */
+    private val SERVER_SUPPORTED_MIME_TYPES = setOf(
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/bmp",
+        "image/x-ms-bmp",
+        "image/vnd.wap.wbmp",
+    )
+
+    /**
+     * Compress an image file so that its encoded size does not exceed [targetSizeBytes]. The aspect ratio and the
+     * EXIF orientation are always preserved.
+     *
+     * The original file is returned unchanged when it cannot be decoded as an image, when it is already below the
+     * target in a format the server accepts, or when compressing it would not make it any smaller. Otherwise a new
+     * file is returned, written in the Sdk cache directory when available; the caller owns it and should delete it
+     * once consumed. Note that the returned file may be a JPEG or a PNG regardless of the input format, so its
+     * extension may differ from the one of [fileToCompress].
      *
      * @param fileToCompress  Image file to compress.
      * @param targetSizeBytes Maximum size, in bytes, the resulting file should have.
-     * @return A new [File] with the compressed image, or the original file if it could not be decoded.
+     * @return A [File] with the compressed image, or [fileToCompress] if it was not compressed.
      */
     @JvmStatic
     @JvmOverloads
+    @Suppress("ReturnCount")
     fun compressFile(fileToCompress: File, targetSizeBytes: Long = TARGET_SIZE_BYTES): File {
-        val source = BitmapFactory.decodeFile(fileToCompress.absolutePath) ?: return fileToCompress
-        val format = resolveCompressFormat(fileToCompress)
-        val outputFile = File(fileToCompress.parent, "compressed-${fileToCompress.name}")
+        val mimeType = ImageFileHelper.decodeMimeType(fileToCompress) ?: return fileToCompress
+        val isSupportedFormat = SERVER_SUPPORTED_MIME_TYPES.contains(mimeType)
+        if (isSupportedFormat && fileToCompress.length() <= targetSizeBytes) {
+            return fileToCompress
+        }
 
-        try {
-            compressUntilBelowTarget(source, format, outputFile, targetSizeBytes, fileToCompress.length())
+        val source = ImageFileHelper.decodeBitmap(fileToCompress, MAX_WORKING_DIMENSION_PX)
+        if (source == null) {
+            Log.w(TAG, "${fileToCompress.name} could not be decoded, it will be uploaded as it is")
+            return fileToCompress
+        }
+
+        val format = if (ImageFileHelper.usesTransparency(source)) CompressFormat.PNG else CompressFormat.JPEG
+        val compressed = try {
+            encodeBelowTarget(source, format, targetSizeBytes)
         } finally {
             source.recycle()
         }
-        return outputFile
+
+        return when {
+            compressed == null -> {
+                Log.w(TAG, "${fileToCompress.name} could not be encoded, it will be uploaded as it is")
+                fileToCompress
+            }
+
+            isSupportedFormat && compressed.size >= fileToCompress.length() -> {
+                Log.w(TAG, "Compressing ${fileToCompress.name} does not make it smaller, it is left as it is")
+                fileToCompress
+            }
+
+            else -> {
+                if (compressed.size > targetSizeBytes) {
+                    Log.w(TAG, "${fileToCompress.name} could not be compressed below $targetSizeBytes bytes")
+                }
+                writeOutput(fileToCompress, compressed, format) ?: fileToCompress
+            }
+        }
     }
 
-    private fun compressUntilBelowTarget(
+    /**
+     * Encode the bitmap trying to stay below the target: one encoding at full resolution, and a scale search when
+     * that is already too big.
+     *
+     * @return The smallest encoded image found, or null if the platform could not encode the bitmap at all.
+     */
+    private fun encodeBelowTarget(source: Bitmap, format: CompressFormat, targetSizeBytes: Long): ByteArray? {
+        val fullSize = encode(source, FULL_SIZE, qualityOf(format), format) ?: return null
+        return if (fullSize.size <= targetSizeBytes) {
+            fullSize
+        } else {
+            searchScale(source, format, targetSizeBytes, fullSize)
+        }
+    }
+
+    /**
+     * Look for the largest scale whose encoded size still fits in the target. Every attempt is measured and the next
+     * scale is predicted from that measurement, which converges in one or two attempts because the encoded size grows
+     * almost linearly with the pixel count. Gives up once the minimum dimension is reached, returning the smallest
+     * result found even though it exceeds the target.
+     */
+    @Suppress("ReturnCount")
+    private fun searchScale(
         source: Bitmap,
         format: CompressFormat,
-        outputFile: File,
         targetSizeBytes: Long,
-        originalSizeBytes: Long,
-    ) {
-        var scale = estimateInitialScale(originalSizeBytes, targetSizeBytes)
-        var iteration = 0
-        do {
-            writeScaledBitmap(source, scale, format, outputFile)
-            if (outputFile.length() <= targetSizeBytes) {
-                return
+        fullSize: ByteArray,
+    ): ByteArray {
+        val quality = qualityOf(format)
+        val minScale = minScale(source)
+        var smallest = fullSize
+        var scale = sizeRatio(fullSize.size, targetSizeBytes).coerceAtLeast(minScale)
+
+        repeat(MAX_SCALE_REFINEMENTS) {
+            val attempt = encode(source, scale, quality, format) ?: return smallest
+            if (attempt.size <= targetSizeBytes) {
+                return attempt
             }
-            scale *= SCALE_STEP
-            iteration++
-        } while (iteration < MAX_ITERATIONS)
+            if (attempt.size < smallest.size) {
+                smallest = attempt
+            }
+            if (scale <= minScale) {
+                return smallest
+            }
+            scale = (scale * sizeRatio(attempt.size, targetSizeBytes)).coerceAtLeast(minScale)
+        }
+        return smallest
     }
 
-    private fun writeScaledBitmap(source: Bitmap, scale: Float, format: CompressFormat, outputFile: File) {
-        val scaled = scaleBitmap(source, scale)
-        try {
-            FileOutputStream(outputFile).use { out ->
-                scaled.compress(format, JPEG_QUALITY, out)
-            }
+    /**
+     * Encode the bitmap in memory, so that only the accepted attempt is written to disk.
+     *
+     * @return The encoded bytes, or null if the platform refused to encode the bitmap in the given format.
+     */
+    private fun encode(source: Bitmap, scale: Float, quality: Int, format: CompressFormat): ByteArray? {
+        val scaled = ImageFileHelper.scaleBitmap(source, scale)
+        return try {
+            val out = ByteArrayOutputStream()
+            if (scaled.compress(format, quality, out)) out.toByteArray() else null
         } finally {
             if (scaled !== source) {
                 scaled.recycle()
@@ -108,31 +232,54 @@ object FileCompressionHelper {
         }
     }
 
-    private fun scaleBitmap(source: Bitmap, scale: Float): Bitmap {
-        if (scale >= FULL_SIZE) {
-            return source
+    private fun writeOutput(sourceFile: File, content: ByteArray, format: CompressFormat): File? {
+        var outputFile: File? = null
+        return try {
+            outputFile = createOutputFile(sourceFile, format)
+            FileOutputStream(outputFile).use { it.write(content) }
+            outputFile
+        } catch (e: IOException) {
+            Log.w(TAG, "Could not write the compressed image, ${sourceFile.name} will be uploaded as it is", e)
+            outputFile?.delete()
+            null
         }
-        val width = (source.width * scale).toInt().coerceAtLeast(MIN_DIMENSION_PX)
-        val height = (source.height * scale).toInt().coerceAtLeast(MIN_DIMENSION_PX)
-        return source.scale(width, height)
     }
 
     /**
-     * Estimate the first scale factor from the size ratio. Encoded size grows roughly with the pixel count (width x
-     * height), so scaling each dimension by the square root of the target ratio lands close to the target in one pass.
+     * The compressed image is a volatile file, so it goes to the cache directory. That directory is shared by every
+     * image being added, so the name cannot be derived from the source alone: two sources with the same name, or the
+     * same source being added twice concurrently, would write over each other. The prefix also keeps the source safe
+     * when the cache directory is not available and the extension has not changed.
      */
-    private fun estimateInitialScale(originalSizeBytes: Long, targetSizeBytes: Long): Float {
-        return if (originalSizeBytes > targetSizeBytes) {
-            sqrt(targetSizeBytes.toFloat() / originalSizeBytes)
-        } else {
-            FULL_SIZE
-        }
+    @Throws(IOException::class)
+    private fun createOutputFile(sourceFile: File, format: CompressFormat): File {
+        val directory = ImageFileHelper.getCacheDirectory() ?: sourceFile.absoluteFile.parentFile
+        val prefix = "$COMPRESSED_PREFIX${sourceFile.nameWithoutExtension}-"
+        return File.createTempFile(prefix, ".${extensionOf(format)}", directory)
     }
 
-    private fun resolveCompressFormat(file: File): CompressFormat {
-        return when (FileResourceUtil.getExtension(file.name)?.lowercase()) {
-            "png" -> CompressFormat.PNG
-            else -> CompressFormat.JPEG
-        }
+    private fun extensionOf(format: CompressFormat): String {
+        return if (format == CompressFormat.PNG) PNG_EXTENSION else JPEG_EXTENSION
+    }
+
+    private fun qualityOf(format: CompressFormat): Int {
+        return if (format == CompressFormat.PNG) LOSSLESS_QUALITY else JPEG_QUALITY
+    }
+
+    /**
+     * The encoded size grows roughly with the pixel count, so scaling both dimensions by the square root of the size
+     * ratio lands close to the target.
+     */
+    private fun sizeRatio(measuredSizeBytes: Int, targetSizeBytes: Long): Float {
+        return sqrt(targetSizeBytes * SAFETY_RATIO / measuredSizeBytes).coerceAtMost(FULL_SIZE)
+    }
+
+    /**
+     * Smallest scale allowed for this bitmap, which keeps its largest side at [MIN_DIMENSION_PX]. Images that are
+     * already smaller than that are never downscaled.
+     */
+    private fun minScale(source: Bitmap): Float {
+        val largestSide = maxOf(source.width, source.height)
+        return minOf(MIN_DIMENSION_PX, largestSide).toFloat() / largestSide
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileCompressionHelper.kt
@@ -240,7 +240,11 @@ object FileCompressionHelper {
             outputFile
         } catch (e: IOException) {
             Log.w(TAG, "Could not write the compressed image, ${sourceFile.name} will be uploaded as it is", e)
-            outputFile?.delete()
+            outputFile?.let {
+                if (!it.delete()) {
+                    Log.w(TAG, "Could not delete the partially written ${it.name}")
+                }
+            }
             null
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResizerHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/FileResizerHelper.kt
@@ -29,8 +29,8 @@ package org.hisp.dhis.android.core.arch.helpers
 
 import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat
-import android.graphics.BitmapFactory
-import org.hisp.dhis.android.core.D2Manager
+import androidx.core.graphics.scale
+import org.hisp.dhis.android.core.arch.helpers.internal.ImageFileHelper
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceUtil.getExtension
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
@@ -42,10 +42,21 @@ import java.io.IOException
 object FileResizerHelper {
 
     /**
+     * The image is decoded with some room above the requested dimension, so that the final downscaling is a filtered
+     * pass over a bitmap that still holds more detail than the result, instead of relying only on the power of two
+     * subsampling of the decoder, which can only land on the requested dimension by chance.
+     */
+    private const val DECODE_HEADROOM_FACTOR = 2
+
+    private const val LOSSLESS_QUALITY = 100
+
+    /**
      * Resize an image file to a given dimension. The possible dimensions are small (256px), medium (512px) and
      * large (1024px). The method will scale the largest between height and width to the given dimension
      * without change the relation between them. In case both height and width are smaller than the given dimension
      * the method will return the given file without modifications.
+     *
+     * The EXIF orientation is baked into the pixels of the resized image, since re-encoding it drops the metadata.
      *
      * @param fileToResize  Image file to resize.
      * @param dimension     The dimension to resize.
@@ -54,53 +65,61 @@ object FileResizerHelper {
     @JvmStatic
     @Throws(D2Error::class)
     fun resizeFile(fileToResize: File, dimension: Dimension): File {
-        val bitmap = BitmapFactory.decodeFile(fileToResize.absolutePath)
+        val bitmap = ImageFileHelper.decodeBitmap(fileToResize, dimension.dimension * DECODE_HEADROOM_FACTOR)
+            ?: throw buildD2Error("${fileToResize.name} could not be decoded as an image")
         val width = bitmap.width.toFloat()
         val height = bitmap.height.toFloat()
         val scaleFactor = width / height
-        return if (scaleFactor > 1) {
-            if (width < dimension.dimension) {
-                fileToResize
+        try {
+            return if (scaleFactor > 1) {
+                if (width < dimension.dimension) {
+                    fileToResize
+                } else {
+                    resize(
+                        fileToResize,
+                        bitmap,
+                        dimension.dimension,
+                        (dimension.dimension / scaleFactor).toInt(),
+                        dimension,
+                    )
+                }
             } else {
-                resize(
-                    fileToResize,
-                    bitmap,
-                    dimension.dimension,
-                    (dimension.dimension / scaleFactor).toInt(),
-                    dimension,
-                )
+                if (height < dimension.dimension) {
+                    fileToResize
+                } else {
+                    resize(
+                        fileToResize,
+                        bitmap,
+                        (scaleFactor * dimension.dimension).toInt(),
+                        dimension.dimension,
+                        dimension,
+                    )
+                }
             }
-        } else {
-            if (height < dimension.dimension) {
-                fileToResize
-            } else {
-                resize(
-                    fileToResize,
-                    bitmap,
-                    (scaleFactor * dimension.dimension).toInt(),
-                    dimension.dimension,
-                    dimension,
-                )
-            }
+        } finally {
+            bitmap.recycle()
         }
     }
 
     @Throws(D2Error::class)
-    @Suppress("MagicNumber")
     private fun resize(fileToResize: File, bitmap: Bitmap, dstWidth: Int, dstHeight: Int, dimension: Dimension): File {
-        val scaledBitmap = Bitmap.createScaledBitmap(bitmap, dstWidth, dstHeight, false)
-        val parentFile = getCacheDir() ?: fileToResize.parentFile
+        val scaledBitmap = bitmap.scale(dstWidth, dstHeight)
+        val parentFile = ImageFileHelper.getCacheDirectory() ?: fileToResize.absoluteFile.parentFile
         val resizedFile = File(parentFile.path, "resized-${dimension.name}-${fileToResize.name}")
         try {
-            FileOutputStream(resizedFile).use { fileOutputStream ->
-                scaledBitmap.compress(getCompressFormat(resizedFile), 100, fileOutputStream)
-                fileOutputStream.flush()
-                fileOutputStream.close()
-                bitmap.recycle()
-                scaledBitmap.recycle()
+            val format = getCompressFormat(resizedFile)
+            val encoded = FileOutputStream(resizedFile).use { fileOutputStream ->
+                scaledBitmap.compress(format, LOSSLESS_QUALITY, fileOutputStream)
+            }
+            if (!encoded) {
+                throw buildD2Error("${fileToResize.name} could not be encoded as $format")
             }
         } catch (e: IOException) {
-            throw buildD2Error(e)
+            throw buildD2Error(e.message)
+        } finally {
+            if (scaledBitmap !== bitmap) {
+                scaledBitmap.recycle()
+            }
         }
         return resizedFile
     }
@@ -111,27 +130,12 @@ object FileResizerHelper {
         return if (isJpeg) CompressFormat.JPEG else CompressFormat.PNG
     }
 
-    private fun buildD2Error(e: Exception): D2Error {
+    private fun buildD2Error(description: String?): D2Error {
         return D2Error.builder()
             .errorComponent(D2ErrorComponent.SDK)
             .errorCode(D2ErrorCode.FAIL_RESIZING_IMAGE)
-            .errorDescription(e.message ?: "Failed to resize image")
+            .errorDescription(description ?: "Failed to resize image")
             .build()
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun getCacheDir(): File? {
-        return if (D2Manager.isD2Instantiated()) {
-            D2Manager.getD2().context().let {
-                try {
-                    FileResourceDirectoryHelper.getFileCacheResourceDirectory(it)
-                } catch (e: RuntimeException) {
-                    FileResourceDirectoryHelper.getRootFileCacheResourceDirectory(it)
-                }
-            }
-        } else {
-            null
-        }
     }
 
     @Suppress("MagicNumber")

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/internal/ImageFileHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/helpers/internal/ImageFileHelper.kt
@@ -1,0 +1,211 @@
+/*
+ *  Copyright (c) 2004-2026, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.core.arch.helpers.internal
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.graphics.Matrix
+import android.util.Log
+import androidx.core.graphics.scale
+import androidx.exifinterface.media.ExifInterface
+import org.hisp.dhis.android.core.D2Manager
+import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
+import java.io.File
+import java.io.IOException
+
+/**
+ * Image decoding primitives shared by the helpers that transform image files before uploading them.
+ *
+ * Decoding is always subsampled and never trusts the file extension: the image header is read first, which gives both
+ * the real mime type and the dimensions needed to bound the memory used by the working bitmap.
+ */
+internal object ImageFileHelper {
+
+    private val TAG = ImageFileHelper::class.java.simpleName
+
+    private const val SAMPLE_SIZE_STEP = 2
+    private const val MAX_SAMPLE_SIZE = 32
+    private const val OPAQUE_ALPHA = 255
+    private const val FULL_SIZE = 1f
+    private const val MIN_DIMENSION_PX = 1
+    private const val ROTATION_90 = 90f
+    private const val ROTATION_180 = 180f
+    private const val ROTATION_270 = 270f
+    private const val NO_ROTATION = 0f
+
+    /**
+     * Read the mime type from the image header, ignoring the file extension.
+     *
+     * @return The mime type reported by the platform decoder, or null if the file is not an image this platform can
+     * decode.
+     */
+    fun decodeMimeType(file: File): String? {
+        return decodeBounds(file)?.outMimeType
+    }
+
+    /**
+     * Decode an image applying the EXIF orientation, subsampled so that its largest side is not much larger than
+     * [maxDimensionPx]. Subsampling happens inside the decoder, so the full sized bitmap is never allocated.
+     *
+     * @return The decoded bitmap, or null if the file is not a decodable image or there is not enough memory for it.
+     */
+    @Suppress("ReturnCount")
+    fun decodeBitmap(file: File, maxDimensionPx: Int): Bitmap? {
+        val bounds = decodeBounds(file) ?: return null
+        var sampleSize = computeSampleSize(bounds, maxDimensionPx)
+
+        while (sampleSize <= MAX_SAMPLE_SIZE) {
+            try {
+                val options = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+                val bitmap = BitmapFactory.decodeFile(file.absolutePath, options)
+                return bitmap?.let { applyExifRotation(file, it) }
+            } catch (e: OutOfMemoryError) {
+                Log.w(TAG, "Not enough memory to decode ${file.name} with sample size $sampleSize", e)
+                sampleSize *= SAMPLE_SIZE_STEP
+            }
+        }
+        return null
+    }
+
+    /**
+     * Whether the bitmap actually contains translucent pixels. [Bitmap.hasAlpha] only tells whether the bitmap has an
+     * alpha channel, which is the case for every image decoded from a PNG with an alpha channel even when all its
+     * pixels are opaque, so the pixels are scanned when the flag is set.
+     */
+    @Suppress("ReturnCount")
+    fun usesTransparency(bitmap: Bitmap): Boolean {
+        if (!bitmap.hasAlpha()) {
+            return false
+        }
+        val row = IntArray(bitmap.width)
+        for (y in 0 until bitmap.height) {
+            bitmap.getPixels(row, 0, bitmap.width, 0, y, bitmap.width, 1)
+            if (row.any { Color.alpha(it) < OPAQUE_ALPHA }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Scale both dimensions by [scale], preserving the aspect ratio. The source bitmap is returned as is when no
+     * downscaling is required, so callers must check the identity before recycling the result.
+     */
+    fun scaleBitmap(source: Bitmap, scale: Float): Bitmap {
+        if (scale >= FULL_SIZE) {
+            return source
+        }
+        val width = (source.width * scale).toInt().coerceAtLeast(MIN_DIMENSION_PX)
+        val height = (source.height * scale).toInt().coerceAtLeast(MIN_DIMENSION_PX)
+        return source.scale(width, height)
+    }
+
+    /**
+     * The directory where the volatile results of transforming an image should be written, or null if the Sdk is not
+     * initialized yet.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun getCacheDirectory(): File? {
+        return if (D2Manager.isD2Instantiated()) {
+            D2Manager.getD2().context().let {
+                try {
+                    FileResourceDirectoryHelper.getFileCacheResourceDirectory(it)
+                } catch (e: RuntimeException) {
+                    Log.w(TAG, "Could not resolve the account cache directory", e)
+                    FileResourceDirectoryHelper.getRootFileCacheResourceDirectory(it)
+                }
+            }
+        } else {
+            null
+        }
+    }
+
+    private fun decodeBounds(file: File): BitmapFactory.Options? {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, options)
+        return options.takeIf { it.outWidth > 0 && it.outHeight > 0 }
+    }
+
+    /**
+     * Largest power of two that keeps the decoded largest side greater than or equal to [maxDimensionPx]. Never
+     * upsamples: images smaller than the bound are decoded at their original size.
+     */
+    private fun computeSampleSize(bounds: BitmapFactory.Options, maxDimensionPx: Int): Int {
+        var sampleSize = 1
+        val largestSide = maxOf(bounds.outWidth, bounds.outHeight)
+        while (largestSide / (sampleSize * SAMPLE_SIZE_STEP) >= maxDimensionPx) {
+            sampleSize *= SAMPLE_SIZE_STEP
+        }
+        return sampleSize
+    }
+
+    /**
+     * Bake the EXIF orientation into the pixels. Re-encoding the bitmap drops the metadata, so an image that was only
+     * upright thanks to its EXIF tag would otherwise be uploaded rotated.
+     */
+    private fun applyExifRotation(file: File, bitmap: Bitmap): Bitmap {
+        val degrees = readExifRotation(file)
+        if (degrees == NO_ROTATION) {
+            return bitmap
+        }
+        val matrix = Matrix().apply { postRotate(degrees) }
+        val rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+        if (rotated !== bitmap) {
+            bitmap.recycle()
+        }
+        return rotated
+    }
+
+    /**
+     * The AndroidX [ExifInterface] is worth the dependency here because the platform one only parses the metadata of
+     * Jpeg files, and heif images are precisely one of the cases this reaches: the server rejects them, so they are
+     * always converted, and a camera writes the orientation of those as a tag rather than into the pixels. Reading
+     * them with the platform class would silently report them as not rotated.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun readExifRotation(file: File): Float {
+        return try {
+            val orientation = ExifInterface(file.absolutePath)
+                .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> ROTATION_90
+                ExifInterface.ORIENTATION_ROTATE_180 -> ROTATION_180
+                ExifInterface.ORIENTATION_ROTATE_270 -> ROTATION_270
+                else -> NO_ROTATION
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "Could not read the EXIF orientation of ${file.name}", e)
+            NO_ROTATION
+        } catch (e: RuntimeException) {
+            Log.w(TAG, "Could not read the EXIF orientation of ${file.name}", e)
+            NO_ROTATION
+        }
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -112,10 +112,28 @@ class FileResourceCollectionRepository internal constructor(
     fun blockingUpload() = Unit
 
     override suspend fun suspendAdd(o: File): String = withContext(dispatcher) {
+        addFile(o, o.name)
+    }
+
+    suspend fun suspendProcessAndAdd(o: File, resourceContext: ResourceContext): String = withContext(dispatcher) {
+        val processedFile = when (resourceContext) {
+            is ResourceContext.ImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
+            ResourceContext.FileContext -> o
+        }
         try {
+            addFile(processedFile, resourceName(o, processedFile))
+        } finally {
+            if (processedFile != o) {
+                processedFile.delete()
+            }
+        }
+    }
+
+    private suspend fun addFile(file: File, name: String): String {
+        return try {
             val generatedUid = UidGeneratorImpl().generate()
-            val dstFile = saveFile(o, generatedUid, context)
-            val fileResource = transformer.transform(dstFile).toBuilder().uid(generatedUid).name(o.name).build()
+            val dstFile = saveFile(file, generatedUid, context)
+            val fileResource = transformer.transform(dstFile).toBuilder().uid(generatedUid).name(name).build()
             store.insert(fileResource)
             fileResource.uid()
         } catch (e: Exception) {
@@ -129,12 +147,17 @@ class FileResourceCollectionRepository internal constructor(
         }
     }
 
-    suspend fun suspendProcessAndAdd(o: File, resourceContext: ResourceContext): String = withContext(dispatcher) {
-        val processedFile = when (resourceContext) {
-            is ResourceContext.ImageContext -> compressImageIfNeeded(o, getQuality(resourceContext))
-            ResourceContext.FileContext -> o
+    /**
+     * The name is taken from the original file, so that the temporary name of the processed one is not exposed to the
+     * server. The extension is taken from the processed file, because the compression may have changed the image
+     * format: the content type is derived from the name, so both must agree with the actual bytes.
+     */
+    private fun resourceName(originalFile: File, processedFile: File): String {
+        return if (processedFile.extension.equals(originalFile.extension, ignoreCase = true)) {
+            originalFile.name
+        } else {
+            "${originalFile.nameWithoutExtension}.${processedFile.extension}"
         }
-        suspendAdd(processedFile)
     }
 
     fun rxProcessAndAdd(o: File, resourceContext: ResourceContext): Single<String> =

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/FileResourceCollectionRepository.kt
@@ -28,6 +28,7 @@
 package org.hisp.dhis.android.core.fileresource
 
 import android.content.Context
+import android.util.Log
 import io.reactivex.Observable
 import io.reactivex.Single
 import kotlinx.coroutines.CoroutineDispatcher
@@ -111,9 +112,7 @@ class FileResourceCollectionRepository internal constructor(
     @Deprecated("Check {@link #upload()}.")
     fun blockingUpload() = Unit
 
-    override suspend fun suspendAdd(o: File): String = withContext(dispatcher) {
-        addFile(o, o.name)
-    }
+    override suspend fun suspendAdd(o: File): String = addFile(o, o.name)
 
     suspend fun suspendProcessAndAdd(o: File, resourceContext: ResourceContext): String = withContext(dispatcher) {
         val processedFile = when (resourceContext) {
@@ -123,14 +122,14 @@ class FileResourceCollectionRepository internal constructor(
         try {
             addFile(processedFile, resourceName(o, processedFile))
         } finally {
-            if (processedFile != o) {
-                processedFile.delete()
+            if (processedFile != o && !processedFile.delete()) {
+                Log.w(TAG, "Could not delete the temporary file ${processedFile.name}")
             }
         }
     }
 
-    private suspend fun addFile(file: File, name: String): String {
-        return try {
+    private suspend fun addFile(file: File, name: String): String = withContext(dispatcher) {
+        try {
             val generatedUid = UidGeneratorImpl().generate()
             val dstFile = saveFile(file, generatedUid, context)
             val fileResource = transformer.transform(dstFile).toBuilder().uid(generatedUid).name(name).build()
@@ -232,6 +231,7 @@ class FileResourceCollectionRepository internal constructor(
     }
 
     internal companion object {
+        private val TAG = FileResourceCollectionRepository::class.java.simpleName
         val childrenAppenders: ChildrenAppenderGetter<FileResource> = emptyMap()
         const val DEFAULT_QUALITY = "default"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ appauth = "0.11.1"
 
 # listenablefuture empty
 listenablefuture = "9999.0-empty-to-avoid-conflict-with-guava"
+exifinterface = "1.4.2"
 
 
 [libraries]
@@ -124,6 +125,7 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "testRules" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "coreTesting" }
 livedata-testing-ktx = { group = "com.jraska.livedata", name = "testing-ktx", version.ref = "liveDataTesting" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 [plugins]
 cyclonedx = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }


### PR DESCRIPTION
The image compression added earlier was based on a PoC. This reworks it to be production ready: it no longer trusts the file extension, supports a broader set of input formats, bounds the memory it uses, preserves the EXIF orientation, and converges on the target size by measuring instead of guessing.

**Format handling.** The format is now resolved from the image header rather than from the file name, so a JPEG named `.png` is no longer re-encoded as a PNG (which made it grow instead of shrink). The output format is chosen by scanning whether the bitmap actually contains translucent pixels — PNG when it does, JPEG otherwise — because `Bitmap.hasAlpha()` only reports the presence of an alpha channel, not its use. Formats the server rejects (webp, heif, avif) are always converted, even when they are already below the target size. Since the resulting extension may differ from the input, `FileResourceCollectionRepository` now builds the resource name from the original name with the extension actually produced, keeping `contentType` — which is derived from the name — in agreement with the bytes.

**Memory.** Decoding is subsampled through `inSampleSize` and bounded to 4096 px on the largest side, retrying with a larger sample size on `OutOfMemoryError`. Previously the full sized bitmap was decoded, which for a 50 MP picture means around 200 MB as ARGB_8888.

**EXIF orientation.** Re-encoding a bitmap drops the metadata, so an image that was only upright thanks to its orientation tag was being uploaded rotated. The rotation is now baked into the pixels. This uses the AndroidX `ExifInterface` rather than the platform one, because the latter only parses Jpeg metadata and heif images — which this path converts on purpose, as the server rejects them — would silently be reported as not rotated.

**Convergence.** The previous strategy estimated a single scale from the size ratio and then decayed it by 20% for up to 10 iterations, writing the file to disk on every attempt. Now the image is encoded once at full resolution and, if that does not fit, a scale search runs: every attempt is encoded in memory and the next scale is predicted from that measurement, using the square root of the size ratio since the encoded size grows roughly with the pixel count. The prediction aims at 95% of the target so that an attempt landing just above it still makes progress instead of converging on the boundary from above; it settles in one or two attempts and is capped at four. Only the accepted result is written to disk. The quality is fixed at 85 and never lowered to reach the target: JPEG artifacts below that survive every later downscaling, while resolution above the dimension the image is displayed at is not used, so the budget is better spent on quality than on pixels. A floor of 256 px on the largest side keeps an unreachable target from degrading the image indefinitely.

**No-ops.** The original file is now returned untouched when it cannot be decoded, when it is already below the target in a format the server accepts, or when compressing it would not make it any smaller. When a new file is produced it is written to the SDK cache directory with `File.createTempFile`, so that two images with the same name being added concurrently cannot overwrite each other, and the repository deletes it once the add completes.

**FileResizerHelper.** It shares the new decoding primitives, so it also gets subsampled decoding and EXIF orientation. It now raises a `D2Error` when the file is not a decodable image instead of throwing an NPE, and its final downscaling pass is filtered.

Tests cover the format conversion, the preservation of transparency, the conversion of a webp already below the target, the EXIF rotation, the minimum dimension floor, landing close to the target rather than well under it, and the absence of leftover temporary files after an add. There are no public API signature changes, so the API dump is unchanged.


Related task: [ANDROSDK-2371](https://dhis2.atlassian.net/browse/ANDROSDK-2371)


[ANDROSDK-2371]: https://dhis2.atlassian.net/browse/ANDROSDK-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ