### PR TITLE
chore: [ANDROSDK-2372] Set proper authorization type from Credentials when creating a fresh db

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11290,6 +11290,7 @@ public final class org/hisp/dhis/android/core/maintenance/D2ErrorCode : java/lan
 	public static final field API_UNSUCCESSFUL_RESPONSE Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field APP_NAME_NOT_SET Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field APP_VERSION_NOT_SET Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
+	public static final field AUTHENTICATED_USER_MISMATCH Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field BAD_CREDENTIALS Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field BAD_CREDENTIALS_OFFLINE_CODE Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field CANT_ACCESS_KEYSTORE Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
@@ -23389,7 +23390,7 @@ public abstract interface class org/hisp/dhis/android/core/user/oauth2/OAuth2Han
 	public abstract fun blockingBuildLogoutUrl (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Config;)Ljava/lang/String;
 	public fun blockingChangePin (Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;
 	public abstract fun blockingHandleEnrollmentResponse (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun blockingHandleLogInResponse (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
+	public abstract fun blockingHandleLogInResponse (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/hisp/dhis/android/core/user/User;
 	public abstract fun blockingLogIn (Lorg/hisp/dhis/android/core/user/oauth2/OAuth2Config;)Ljava/lang/String;
 	public abstract fun blockingLogOut ()V
 	public fun blockingSetPin (Ljava/lang/String;)Lorg/hisp/dhis/android/core/arch/helpers/Result;

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManager.kt
@@ -97,9 +97,15 @@ internal interface MultiUserDatabaseManager {
      *
      * @param serverUrl The server URL associated with the database
      * @param username The username associated with the database
+     * @param authorizationType The type the caller has established for the account, which replaces
+     * the recorded one. Pass null to keep whatever the account already holds.
      * @return True if the database was loaded, false otherwise
      */
-    suspend fun loadExistingKeepingEncryption(serverUrl: String, username: String): Boolean
+    suspend fun loadExistingKeepingEncryption(
+        serverUrl: String,
+        username: String,
+        authorizationType: AuthorizationType?,
+    ): Boolean
 
     /**
      * Sets the maximum number of accounts that can be stored.

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManager.kt
@@ -98,13 +98,13 @@ internal interface MultiUserDatabaseManager {
      * @param serverUrl The server URL associated with the database
      * @param username The username associated with the database
      * @param authorizationType The type the caller has established for the account, which replaces
-     * the recorded one. Pass null to keep whatever the account already holds.
+     * the recorded one
      * @return True if the database was loaded, false otherwise
      */
     suspend fun loadExistingKeepingEncryption(
         serverUrl: String,
         username: String,
-        authorizationType: AuthorizationType?,
+        authorizationType: AuthorizationType,
     ): Boolean
 
     /**

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2ErrorCode.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2ErrorCode.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.maintenance
 
 enum class D2ErrorCode {
     ALREADY_AUTHENTICATED,
+    AUTHENTICATED_USER_MISMATCH,
 
     @Deprecated("")
     ALREADY_EXECUTED,

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -209,8 +209,7 @@ internal class LogInCall(
     @Throws(D2Error::class)
     @Suppress("ThrowsCount")
     private suspend fun tryLoginOffline(credentials: Credentials, originalError: D2Error? = null): User {
-        val existingDatabase =
-            loginDatabaseManager.loadExistingKeepingEncryption(credentials.serverUrl, credentials.username)
+        val existingDatabase = loginDatabaseManager.loadExistingKeepingEncryption(credentials)
         if (!existingDatabase) {
             throw originalError ?: exceptions.noUserOfflineError()
         }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInCall.kt
@@ -247,6 +247,7 @@ internal class LogInCall(
     @Throws(D2Error::class)
     suspend fun blockingLogInOpenIDConnect(serverUrl: String, openIDConnectState: AuthState): User {
         return logInWithToken(
+            existingUsername = null,
             serverUrl = serverUrl,
             token = openIDConnectState.idToken!!,
             openIDConnectState = openIDConnectState,
@@ -255,8 +256,9 @@ internal class LogInCall(
     }
 
     @Throws(D2Error::class)
-    suspend fun logInOAuth2(serverUrl: String, oauth2State: OAuth2State): User {
+    suspend fun logInOAuth2(existingUsername: String?, serverUrl: String, oauth2State: OAuth2State): User {
         return logInWithToken(
+            existingUsername = existingUsername,
             serverUrl = serverUrl,
             token = oauth2State.accessToken
                 ?: throw exceptions.oauth2NoValidTokenError("The OAuth2 response has no access token"),
@@ -267,6 +269,7 @@ internal class LogInCall(
 
     @Throws(D2Error::class)
     private suspend fun logInWithToken(
+        existingUsername: String?,
         serverUrl: String,
         token: String,
         openIDConnectState: AuthState?,
@@ -283,6 +286,9 @@ internal class LogInCall(
                 networkHandler.authenticate("Bearer $token")
             }.getOrThrow()
             val username = user.username()!!
+            if (existingUsername != null && username != existingUsername) {
+                throw exceptions.authenticatedUserMismatchError()
+            }
             credentials = Credentials(
                 username = username,
                 serverUrl = trimmedServerUrl!!,

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInDatabaseManager.kt
@@ -59,8 +59,12 @@ internal class LogInDatabaseManager(
         }
     }
 
-    suspend fun loadExistingKeepingEncryption(serverUrl: String, username: String): Boolean {
-        return multiUserDatabaseManager.loadExistingKeepingEncryption(serverUrl, username)
+    suspend fun loadExistingKeepingEncryption(credentials: Credentials): Boolean {
+        return multiUserDatabaseManager.loadExistingKeepingEncryption(
+            credentials.serverUrl,
+            credentials.username,
+            credentials.authorizationType,
+        )
     }
 
     fun isPendingToImportDB(serverUrl: String, username: String): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInExceptions.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/LogInExceptions.kt
@@ -177,6 +177,17 @@ internal class LogInExceptions internal constructor(
             .build()
     }
 
+    fun authenticatedUserMismatchError(): D2Error {
+        return D2Error.builder()
+            .errorCode(D2ErrorCode.AUTHENTICATED_USER_MISMATCH)
+            .errorDescription(
+                "The authorized user does not match the account being restored. " +
+                    "The user must authorize again with the expected account.",
+            )
+            .errorComponent(D2ErrorComponent.SDK)
+            .build()
+    }
+
     fun openIdConnectNoValidTokenError(detail: String): D2Error {
         return D2Error.builder()
             .errorCode(D2ErrorCode.OPEN_ID_CONNECT_NO_VALID_TOKEN)

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/OAuth2Handler.kt
@@ -44,7 +44,12 @@ interface OAuth2Handler {
 
     fun blockingLogIn(config: OAuth2Config): String
 
-    fun blockingHandleLogInResponse(serverUrl: String, authorizationCode: String, state: String): User
+    fun blockingHandleLogInResponse(
+        existingUsername: String?,
+        serverUrl: String,
+        authorizationCode: String,
+        state: String,
+    ): User
 
     fun isDeviceRegistered(): Boolean
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -173,6 +173,7 @@ internal class OAuth2HandlerImpl(
 
     @Suppress("ThrowsCount")
     private suspend fun handleLogInResponseInternal(
+        existingUsername: String?,
         serverUrl: String,
         authorizationCode: String,
         state: String,
@@ -215,7 +216,7 @@ internal class OAuth2HandlerImpl(
         return when (result) {
             is Result.Success -> {
                 val oauth2State = result.value.copy(keyId = keyId)
-                val user = logInCall.logInOAuth2(normalizedUrl, oauth2State)
+                val user = logInCall.logInOAuth2(existingUsername, normalizedUrl, oauth2State)
                 val username = user.username()
                     ?: throw logInExceptions.oauth2ResponseWithoutUsernameError()
                 oauth2StateSecureStore.set(normalizedUrl, username, oauth2State)
@@ -229,8 +230,15 @@ internal class OAuth2HandlerImpl(
         }
     }
 
-    override fun blockingHandleLogInResponse(serverUrl: String, authorizationCode: String, state: String): User {
-        return runBlocking { handleLogInResponseInternal(serverUrl, authorizationCode, state) }
+    override fun blockingHandleLogInResponse(
+        existingUsername: String?,
+        serverUrl: String,
+        authorizationCode: String,
+        state: String,
+    ): User {
+        return runBlocking {
+            handleLogInResponseInternal(existingUsername, serverUrl, authorizationCode, state)
+        }
     }
 
     override fun isDeviceRegistered(): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
@@ -137,7 +137,7 @@ internal class RoomMultiUserDatabaseManager(
     override suspend fun loadExistingKeepingEncryption(
         serverUrl: String,
         username: String,
-        authorizationType: AuthorizationType?,
+        authorizationType: AuthorizationType,
     ): Boolean {
         return loadExistingChangingEncryptionIfRequired(
             serverUrl,
@@ -198,7 +198,7 @@ internal class RoomMultiUserDatabaseManager(
         username: String,
         encryptionExtractor: (config: DatabaseAccount) -> Boolean,
         alsoOpenWhenEncryptionDoesntChange: Boolean,
-        authorizationType: AuthorizationType?,
+        authorizationType: AuthorizationType,
     ): Boolean {
         val existingAccount = getAccount(serverUrl, username) ?: return false
         val encrypt = encryptionExtractor(existingAccount)
@@ -209,9 +209,7 @@ internal class RoomMultiUserDatabaseManager(
                 username,
                 encrypt,
                 loginConfig = existingAccount.loginConfig(),
-                authorizationType = authorizationType
-                    ?: existingAccount.authorizationType
-                    ?: AuthorizationType.BASIC,
+                authorizationType = authorizationType,
             )
             openDatabase(updatedAccount)
         }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/db/access/RoomMultiUserDatabaseManager.kt
@@ -74,6 +74,7 @@ internal class RoomMultiUserDatabaseManager(
             username,
             { encrypt },
             true,
+            authorizationType,
         )
 
         if (!existing) {
@@ -92,6 +93,7 @@ internal class RoomMultiUserDatabaseManager(
             username,
             { obj: DatabaseAccount -> obj.encrypted() },
             true,
+            authorizationType,
         )
 
         if (!existing) {
@@ -128,15 +130,21 @@ internal class RoomMultiUserDatabaseManager(
             credentials.username,
             { encrypt },
             false,
+            credentials.authorizationType,
         )
     }
 
-    override suspend fun loadExistingKeepingEncryption(serverUrl: String, username: String): Boolean {
+    override suspend fun loadExistingKeepingEncryption(
+        serverUrl: String,
+        username: String,
+        authorizationType: AuthorizationType?,
+    ): Boolean {
         return loadExistingChangingEncryptionIfRequired(
             serverUrl,
             username,
             { obj: DatabaseAccount -> obj.encrypted() },
             true,
+            authorizationType,
         )
     }
 
@@ -190,6 +198,7 @@ internal class RoomMultiUserDatabaseManager(
         username: String,
         encryptionExtractor: (config: DatabaseAccount) -> Boolean,
         alsoOpenWhenEncryptionDoesntChange: Boolean,
+        authorizationType: AuthorizationType?,
     ): Boolean {
         val existingAccount = getAccount(serverUrl, username) ?: return false
         val encrypt = encryptionExtractor(existingAccount)
@@ -200,7 +209,9 @@ internal class RoomMultiUserDatabaseManager(
                 username,
                 encrypt,
                 loginConfig = existingAccount.loginConfig(),
-                authorizationType = existingAccount.authorizationType ?: AuthorizationType.BASIC,
+                authorizationType = authorizationType
+                    ?: existingAccount.authorizationType
+                    ?: AuthorizationType.BASIC,
             )
             openDatabase(updatedAccount)
         }

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
@@ -161,7 +161,7 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
 
     @Test
     fun not_create_database_when_non_existing_when_calling_loadExistingKeepingEncryption() = runTest {
-        manager.loadExistingKeepingEncryption(serverUrl, username)
+        manager.loadExistingKeepingEncryption(serverUrl, username, null)
         verifyNoMoreInteractions(databaseManager)
     }
 
@@ -180,9 +180,41 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
             ),
         ).doReturn(unencryptedConfiguration)
 
-        manager.loadExistingKeepingEncryption(serverUrl, username)
+        manager.loadExistingKeepingEncryption(serverUrl, username, null)
 
         verify(databaseManager).createOrOpenUnencryptedDatabase(unencryptedDbName)
+    }
+
+    @Test
+    fun replace_the_recorded_authorization_type_with_the_one_the_caller_established() = runTest {
+        // The stored account says BASIC, either because it predates the type or because an earlier
+        // login defaulted it. Opening it as OPEN_ID_CONNECT must correct the record: otherwise the
+        // account stays labelled as a password one and, once its tokens are gone, logging in would
+        // be routed to the password flow with no way out.
+        whenever(databaseConfigurationSecureStore.get()).doReturn(unencryptedConfiguration)
+        whenever(
+            configurationHelper.addOrUpdateAccount(
+                unencryptedConfiguration,
+                serverUrl,
+                username,
+                false,
+                null,
+                null,
+                AuthorizationType.OPEN_ID_CONNECT,
+            ),
+        ).doReturn(unencryptedConfiguration)
+
+        manager.loadExistingKeepingEncryption(serverUrl, username, AuthorizationType.OPEN_ID_CONNECT)
+
+        verify(configurationHelper).addOrUpdateAccount(
+            unencryptedConfiguration,
+            serverUrl,
+            username,
+            false,
+            null,
+            null,
+            AuthorizationType.OPEN_ID_CONNECT,
+        )
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/configuration/internal/MultiUserDatabaseManagerUnitShould.kt
@@ -161,7 +161,7 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
 
     @Test
     fun not_create_database_when_non_existing_when_calling_loadExistingKeepingEncryption() = runTest {
-        manager.loadExistingKeepingEncryption(serverUrl, username, null)
+        manager.loadExistingKeepingEncryption(serverUrl, username, AuthorizationType.BASIC)
         verifyNoMoreInteractions(databaseManager)
     }
 
@@ -180,7 +180,7 @@ class MultiUserDatabaseManagerUnitShould : BaseCallShould() {
             ),
         ).doReturn(unencryptedConfiguration)
 
-        manager.loadExistingKeepingEncryption(serverUrl, username, null)
+        manager.loadExistingKeepingEncryption(serverUrl, username, AuthorizationType.BASIC)
 
         verify(databaseManager).createOrOpenUnencryptedDatabase(unencryptedDbName)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -646,7 +646,7 @@ class LogInCallUnitShould : BaseCallShould() {
     }
 
     private suspend fun reLogInWithOAuth2Token(state: OAuth2State): User =
-        logInCall().logInOAuth2(SERVER_URL, state)
+        logInCall().logInOAuth2(null, SERVER_URL, state)
 
     private fun oauth2State(accessToken: String): OAuth2State =
         OAuth2State(

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/LogInCallUnitShould.kt
@@ -54,7 +54,6 @@ import org.hisp.dhis.android.core.user.User
 import org.hisp.dhis.android.core.user.oauth2.OAuth2State
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2StateSecureStore
 import org.hisp.dhis.android.core.user.openid.OpenIDConnectStateSecureStore
-import org.hisp.dhis.android.core.user.openid.OpenIDConnectTokenRefresher
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -90,7 +89,6 @@ class LogInCallUnitShould : BaseCallShould() {
     private val accountManager: AccountManagerImpl = mock()
     private val oauth2StateSecureStore: OAuth2StateSecureStore = mock()
     private val openIDConnectStateSecureStore: OpenIDConnectStateSecureStore = mock()
-    private val openIDConnectTokenRefresher: OpenIDConnectTokenRefresher = mock()
     private val databasesConfigurationStore: DatabaseConfigurationInsecureStore = mock()
     private val openIdAuthState: AuthState = mock()
 
@@ -143,6 +141,13 @@ class LogInCallUnitShould : BaseCallShould() {
         }
     }
 
+    /** The authorization type is matched loosely; the tests that care about it assert it explicitly. */
+    private fun givenExistingDatabase(exists: Boolean = true) = runTest {
+        whenever(
+            multiUserDatabaseManager.loadExistingKeepingEncryption(eq(SERVER_URL), eq(USERNAME), anyOrNull()),
+        ).thenReturn(exists)
+    }
+
     @Test
     fun throw_d2_error_for_null_username() = runTest {
         assertD2Error(D2ErrorCode.LOGIN_USERNAME_NULL) { instantiateCall(null, PASSWORD, SERVER_URL) }
@@ -190,7 +195,7 @@ class LogInCallUnitShould : BaseCallShould() {
     @Throws(D2Error::class)
     fun not_invoke_stores_on_exception_on_call() = runTest {
         whenAPICall { throw d2Error }
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(false)
+        givenExistingDatabase(exists = false)
         whenever(d2Error.errorCode()).thenReturn(D2ErrorCode.UNEXPECTED)
 
         assertD2Error { login() }
@@ -224,7 +229,7 @@ class LogInCallUnitShould : BaseCallShould() {
     @Test
     fun succeed_for_login_offline_if_database_exists_and_authenticated_user_too() = runTest {
         whenAPICall { throw d2Error }
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
         login()
         verifySuccessOffline()
@@ -234,7 +239,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun succeed_for_login_offline_if_server_has_a_trailing_slash() = runTest {
         whenAPICall { throw d2Error }
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         login()
         verifySuccessOffline()
     }
@@ -242,7 +247,7 @@ class LogInCallUnitShould : BaseCallShould() {
     @Test
     fun throw_original_d2_error_if_no_previous_database_offline() = runTest {
         whenAPICall { throw d2Error }
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(false)
+        givenExistingDatabase(exists = false)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(null)
         assertD2Error(d2Error.errorCode()) { login() }
     }
@@ -250,7 +255,7 @@ class LogInCallUnitShould : BaseCallShould() {
     @Test
     fun throw_d2_error_if_no_previous_authenticated_user_offline() = runTest {
         whenAPICall { throw d2Error }
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUserStore.selectFirst()).thenReturn(null)
         assertD2Error(D2ErrorCode.NO_AUTHENTICATED_USER_OFFLINE) { login() }
     }
@@ -259,7 +264,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun throw_d2_error_if_logging_offline_with_bad_credentials() = runTest {
         whenAPICall { throw d2Error }
         whenever(authenticatedUser.hash()).thenReturn("different_hash")
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
         assertD2Error(D2ErrorCode.BAD_CREDENTIALS) { login() }
     }
@@ -286,7 +291,7 @@ class LogInCallUnitShould : BaseCallShould() {
         // still open for offline work.
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(null)
         whenever(databasesConfigurationStore.get()).thenReturn(oauth2Configuration())
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -300,7 +305,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun keep_the_oauth2_authorization_type_when_the_account_has_no_stored_state() = runTest {
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(null)
         whenever(databasesConfigurationStore.get()).thenReturn(oauth2Configuration())
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -317,7 +322,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun reject_a_wrong_offline_code_when_the_oauth2_account_has_no_stored_state() = runTest {
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(null)
         whenever(databasesConfigurationStore.get()).thenReturn(oauth2Configuration())
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, "correct"))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -362,7 +367,7 @@ class LogInCallUnitShould : BaseCallShould() {
         whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(null)
         whenever(databasesConfigurationStore.get())
             .thenReturn(configurationWith(AuthorizationType.OPEN_ID_CONNECT))
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -378,7 +383,7 @@ class LogInCallUnitShould : BaseCallShould() {
         // The stored state must win, or these users would be pushed to the password flow.
         whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
         whenever(databasesConfigurationStore.get()).thenReturn(configurationWith(null))
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -394,8 +399,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun log_in_offline_when_the_stored_oauth2_tokens_are_already_discarded() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN).copy(accessToken = null, refreshToken = null)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(null)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -409,8 +413,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun log_in_offline_without_contacting_server_when_oauth2_state_exists_for_account() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(null)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -425,8 +428,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun persist_credentials_with_oauth2_state_and_null_password_after_oauth2_login() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
+        givenExistingDatabase()
         // The PIN is set right after the first login, so it is still null when re-logging in.
         whenever(authenticatedUser.hash()).thenReturn(null)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
@@ -442,8 +444,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun persist_credentials_with_pin_when_oauth2_login_pin_matches_stored_hash() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -458,8 +459,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun reject_oauth2_login_with_offline_code_error_when_pin_does_not_match_stored_hash() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
+        givenExistingDatabase()
         // Stored hash corresponds to a different PIN.
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, "correct"))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
@@ -474,8 +474,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun reject_oauth2_login_with_offline_code_error_when_account_has_no_stored_hash_but_pin_is_given() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(true)
+        givenExistingDatabase()
         // The account has no PIN configured, so any offline code supplied by the user must be rejected.
         whenever(authenticatedUser.hash()).thenReturn(null)
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
@@ -490,8 +489,7 @@ class LogInCallUnitShould : BaseCallShould() {
     fun throw_no_authenticated_user_error_for_oauth2_login_when_no_local_database_exists() = runTest {
         val state = oauth2State(accessToken = ACCESS_TOKEN)
         whenever(oauth2StateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(state)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME))
-            .thenReturn(false)
+        givenExistingDatabase(exists = false)
 
         assertD2Error(D2ErrorCode.NO_AUTHENTICATED_USER_OFFLINE) {
             instantiateCall(USERNAME, null, SERVER_URL)
@@ -503,9 +501,27 @@ class LogInCallUnitShould : BaseCallShould() {
     // authorizing again in the browser, so it behaves exactly like the OAuth2 one.
 
     @Test
+    fun correct_a_stale_recorded_account_type_when_opening_the_database_offline() = runTest {
+        // The account was created before the type existed, so it reads as BASIC. The stored state is
+        // what proves it is an OpenID one, and opening the database must carry that down so the
+        // record stops lying.
+        whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
+        whenever(databasesConfigurationStore.get()).thenReturn(configurationWith(null))
+        givenExistingDatabase()
+        whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
+        whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
+
+        instantiateCall(USERNAME, PIN, SERVER_URL)
+
+        verifyBlocking(multiUserDatabaseManager) {
+            loadExistingKeepingEncryption(SERVER_URL, USERNAME, AuthorizationType.OPEN_ID_CONNECT)
+        }
+    }
+
+    @Test
     fun log_in_offline_without_contacting_server_when_openid_state_exists_for_account() = runTest {
         whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -518,7 +534,7 @@ class LogInCallUnitShould : BaseCallShould() {
     @Test
     fun persist_credentials_with_openid_state_and_pin_after_openid_login() = runTest {
         whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, PIN))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)
 
@@ -540,7 +556,7 @@ class LogInCallUnitShould : BaseCallShould() {
     @Test
     fun reject_openid_login_with_offline_code_error_when_pin_does_not_match_stored_hash() = runTest {
         whenever(openIDConnectStateSecureStore.get(SERVER_URL, USERNAME)).thenReturn(openIdAuthState)
-        whenever(multiUserDatabaseManager.loadExistingKeepingEncryption(SERVER_URL, USERNAME)).thenReturn(true)
+        givenExistingDatabase()
         // Stored hash corresponds to a different PIN.
         whenever(authenticatedUser.hash()).thenReturn(UserHelper.md5(USERNAME, "correct"))
         whenever(authenticatedUserStore.selectFirst()).thenReturn(authenticatedUser)

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -53,6 +53,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -240,7 +241,7 @@ class OAuth2HandlerImplShould {
     fun blockingHandleLogInResponse_throws_when_state_does_not_match() {
         seedSuccessfulLogInPrerequisites()
 
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, "forged-state")
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, "forged-state")
     }
 
     @Test(expected = D2Error::class)
@@ -249,21 +250,21 @@ class OAuth2HandlerImplShould {
         oauth2SecureStore.clientId = CLIENT_ID
         oauth2SecureStore.keyId = KEY_ID
 
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
     }
 
     @Test(expected = D2Error::class)
     fun blockingHandleLogInResponse_throws_when_temp_code_verifier_missing() {
         oauth2SecureStore.tempState = STATE
 
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
     }
 
     @Test(expected = D2Error::class)
     fun blockingHandleLogInResponse_throws_when_client_id_missing() {
         oauth2SecureStore.tempState = STATE
         oauth2SecureStore.tempCodeVerifier = "verifier"
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
     }
 
     @Test(expected = D2Error::class)
@@ -271,14 +272,14 @@ class OAuth2HandlerImplShould {
         oauth2SecureStore.tempState = STATE
         oauth2SecureStore.tempCodeVerifier = "verifier"
         oauth2SecureStore.clientId = CLIENT_ID
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
     }
 
     @Test(expected = D2Error::class)
     fun blockingHandleLogInResponse_throws_when_private_key_missing() {
         seedSuccessfulLogInPrerequisites()
         whenever(keyStoreManager.getPrivateKey(KEY_ID)).thenReturn(null)
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
     }
 
     @Test
@@ -290,7 +291,7 @@ class OAuth2HandlerImplShould {
                 .doReturn(Result.Failure(serverError()))
         }
 
-        runCatching { handler.blockingHandleLogInResponse("HTTPS://Server.com/", AUTH_CODE, STATE) }
+        runCatching { handler.blockingHandleLogInResponse(null, "HTTPS://Server.com/", AUTH_CODE, STATE) }
             .also { assertThat(it.isFailure).isTrue() }
 
         assertThat(oauth2SecureStore.tempCodeVerifier).isNull()
@@ -311,7 +312,7 @@ class OAuth2HandlerImplShould {
                 .doReturn(Result.Failure(serverError()))
         }
 
-        runCatching { handler.blockingHandleLogInResponse("HTTPS://Server.com/", AUTH_CODE, STATE) }
+        runCatching { handler.blockingHandleLogInResponse(null, "HTTPS://Server.com/", AUTH_CODE, STATE) }
 
         val endpointCaptor = argumentCaptor<String>()
         val assertionCaptor = argumentCaptor<String>()
@@ -342,16 +343,16 @@ class OAuth2HandlerImplShould {
         val expectedUser: User = mock()
         whenever(expectedUser.username()).thenReturn(USERNAME)
         logInCall.stub {
-            onBlocking { logInOAuth2(any(), any()) }.doReturn(expectedUser)
+            onBlocking { logInOAuth2(anyOrNull(), any(), any()) }.doReturn(expectedUser)
         }
 
-        val user = handler.blockingHandleLogInResponse("HTTPS://Server.com/", AUTH_CODE, STATE)
+        val user = handler.blockingHandleLogInResponse(null, "HTTPS://Server.com/", AUTH_CODE, STATE)
 
         assertThat(user).isSameInstanceAs(expectedUser)
         // logInOAuth2 called with normalized server url and the state with our keyId
         val urlCaptor = argumentCaptor<String>()
         val stateCaptor = argumentCaptor<OAuth2State>()
-        verifyBlocking(logInCall) { logInOAuth2(urlCaptor.capture(), stateCaptor.capture()) }
+        verifyBlocking(logInCall) { logInOAuth2(anyOrNull(), urlCaptor.capture(), stateCaptor.capture()) }
         assertThat(urlCaptor.firstValue).isEqualTo(NORMALIZED_URL)
         assertThat(stateCaptor.firstValue.keyId).isEqualTo(KEY_ID)
         assertThat(stateCaptor.firstValue.accessToken).isEqualTo(exchangedState.accessToken)
@@ -372,10 +373,10 @@ class OAuth2HandlerImplShould {
         val expectedUser: User = mock()
         whenever(expectedUser.username()).thenReturn(USERNAME)
         logInCall.stub {
-            onBlocking { logInOAuth2(any(), any()) }.doReturn(expectedUser)
+            onBlocking { logInOAuth2(anyOrNull(), any(), any()) }.doReturn(expectedUser)
         }
 
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
 
         // Tokens expire; the DCR registration must not. Otherwise the user cannot start a new
         // authorization round after the refresh token is rejected without enrolling from scratch.
@@ -400,10 +401,10 @@ class OAuth2HandlerImplShould {
         val userWithoutUsername: User = mock()
         whenever(userWithoutUsername.username()).thenReturn(null)
         logInCall.stub {
-            onBlocking { logInOAuth2(any(), any()) }.doReturn(userWithoutUsername)
+            onBlocking { logInOAuth2(anyOrNull(), any(), any()) }.doReturn(userWithoutUsername)
         }
 
-        handler.blockingHandleLogInResponse("https://server.com", AUTH_CODE, STATE)
+        handler.blockingHandleLogInResponse(null, "https://server.com", AUTH_CODE, STATE)
     }
 
     // endregion


### PR DESCRIPTION
 Opening the database of an existing account no longer overwrites its authorization type with BASIC. `loadExistingChangingEncryptionIfRequired` now receives the type the login has just established and gives it precedence over the recorded one, so `MultiUserDatabaseManager.loadExistingKeepingEncryption` takes it as a parameter and `LogInDatabaseManager` receives the credentials it comes from.                      
                                                                                                                                                                                                                                                                                                                                                                                                                                 
Accounts created before the authorization type existed have it null, and defaulting them to BASIC labelled a token-based account as a password one for good. It went unnoticed because a stored OAuth2 or OpenID state takes precedence when the type is resolved at login; but once that state is discarded — after the provider rejects the refresh token — the login was routed to the password flow with no way out. The type is now corrected on the first login after upgrading, which also covers accounts opened offline.

Related task: [ANDROSDK-2372](https://dhis2.atlassian.net/browse/ANDROSDK-2372)

[ANDROSDK-2372]: https://dhis2.atlassian.net/browse/ANDROSDK-2372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ