### PR TITLE
chore: [ANDROSDK-2341] tidy up code after model migration

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepositoryEvaluatorShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/analytics/trackerlinelist/TrackerLineListRepositoryEvaluatorShould.kt
@@ -174,7 +174,7 @@ internal class TrackerLineListRepositoryEvaluatorShould : BaseEvaluatorIntegrati
             .withEventOutput(programStage1.uid())
             .withColumn(TrackerLineListItem.OrganisationUnitItem())
             .withColumn(
-                TrackerLineListItem.Category(attribute.uid(), listOf(DataFilter.In(listOf(attributeOption.uid()!!)))),
+                TrackerLineListItem.Category(attribute.uid(), listOf(DataFilter.In(listOf(attributeOption.uid())))),
             )
             .blockingEvaluate()
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboLinkStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/category/internal/CategoryCategoryComboLinkStoreIntegrationShould.kt
@@ -46,7 +46,7 @@ class CategoryCategoryComboLinkStoreIntegrationShould : LinkStoreAbstractIntegra
     TestDatabaseAdapterFactory.get(),
 ) {
     override fun addMasterUid(): String {
-        return CategoryCategoryComboLinkSamples.getCategoryCategoryComboLink().categoryCombo()!!
+        return CategoryCategoryComboLinkSamples.getCategoryCategoryComboLink().categoryCombo()
     }
 
     override fun buildObject(): CategoryCategoryComboLink {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetElementStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetElementStoreIntegrationShould.kt
@@ -45,7 +45,7 @@ class DataSetElementStoreIntegrationShould : LinkStoreAbstractIntegrationShould<
     TestDatabaseAdapterFactory.get(),
 ) {
     override fun addMasterUid(): String {
-        return DataSetElementSamples.getDataSetElement().dataSet()!!.uid()
+        return DataSetElementSamples.getDataSetElement().dataSet().uid()
     }
 
     override fun buildObject(): DataSetElement {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceStoreIntegrationShould.kt
@@ -98,11 +98,11 @@ class DataSetInstanceStoreIntegrationShould : BaseMockIntegrationTestMetadataDis
         val period = d2.periodModule().periodHelper().blockingGetPeriodForPeriodId("202208")
 
         val categoryOption1 = d2.categoryModule().categoryOptionCombos()
-            .byCategoryComboUid().eq(dataElements[0]?.categoryCombo()?.uid())
+            .byCategoryComboUid().eq(dataElements[0].categoryCombo()?.uid())
             .one().blockingGet()!!
 
         val categoryOption2 = d2.categoryModule().categoryOptionCombos()
-            .byCategoryComboUid().eq(dataElements[1]?.categoryCombo()?.uid())
+            .byCategoryComboUid().eq(dataElements[1].categoryCombo()?.uid())
             .one().blockingGet()!!
 
         val attributeOption = d2.categoryModule().categoryOptionCombos()
@@ -117,7 +117,7 @@ class DataSetInstanceStoreIntegrationShould : BaseMockIntegrationTestMetadataDis
 
         dataValueStore.updateOrInsertWhere(
             baseBuilder
-                .dataElement(dataElements[0]?.dataElement()?.uid()!!)
+                .dataElement(dataElements[0].dataElement().uid())
                 .categoryOptionCombo(categoryOption1.uid())
                 .syncState(state1)
                 .build(),
@@ -125,7 +125,7 @@ class DataSetInstanceStoreIntegrationShould : BaseMockIntegrationTestMetadataDis
 
         dataValueStore.updateOrInsertWhere(
             baseBuilder
-                .dataElement(dataElements[1]?.dataElement()?.uid()!!)
+                .dataElement(dataElements[1].dataElement().uid())
                 .categoryOptionCombo(categoryOption2.uid())
                 .syncState(state2)
                 .build(),

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventAPIRealShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventAPIRealShould.kt
@@ -72,7 +72,7 @@ abstract class EventAPIRealShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validEvent1.uid() == importSummary.reference) {
                 EventUtils.assertEvent(importSummary, ImportStatus.SUCCESS)
             } else if (validEvent2.uid() == importSummary.reference) {
@@ -105,7 +105,7 @@ abstract class EventAPIRealShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.ERROR)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validEvent.uid() == importSummary.reference) {
                 EventUtils.assertEvent(importSummary, ImportStatus.SUCCESS)
             } else if (invalidEvent.uid() == importSummary.reference) {
@@ -142,7 +142,7 @@ abstract class EventAPIRealShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.ERROR)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validEvent.uid() == importSummary.reference) {
                 EventUtils.assertEvent(importSummary, ImportStatus.SUCCESS)
             } else if (invalidEvent.uid() == importSummary.reference) {
@@ -179,7 +179,7 @@ abstract class EventAPIRealShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validEvent1.uid() == importSummary.reference) {
                 EventUtils.assertEvent(importSummary, ImportStatus.SUCCESS)
             } else if (validEvent2.uid() == importSummary.reference) {
@@ -212,7 +212,7 @@ abstract class EventAPIRealShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.ERROR)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validEvent.uid() == importSummary.reference) {
                 EventUtils.assertEvent(importSummary, ImportStatus.SUCCESS)
             } else if (invalidEvent.uid() == importSummary.reference) {
@@ -249,7 +249,7 @@ abstract class EventAPIRealShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.WARNING)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validEvent.uid() == importSummary.reference) {
                 EventUtils.assertEvent(importSummary, ImportStatus.SUCCESS)
             } else if (invalidEvent.uid() == importSummary.reference) {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/event/internal/EventPostCallRealIntegrationShould.kt
@@ -193,7 +193,7 @@ class EventPostCallRealIntegrationShould : BaseRealIntegrationTest() {
             .one().blockingGet()!!
             .uid()
         programUid = d2.programModule().programs()
-            .byOrganisationUnitUid(orgUnitUid!!)
+            .byOrganisationUnitUid(orgUnitUid)
             .byProgramType().eq(ProgramType.WITHOUT_REGISTRATION)
             .one().blockingGet()!!
             .uid()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/BaseFileResourceRoutineIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/BaseFileResourceRoutineIntegrationShould.kt
@@ -122,9 +122,9 @@ internal open class BaseFileResourceRoutineIntegrationShould : BaseMockIntegrati
             trackedEntityTypeStore.delete(FileResourceRoutineSamples.trackedEntityType.uid())
             dataElementStore.delete(FileResourceRoutineSamples.dataElement1.uid())
             categoryComboStore.delete(FileResourceRoutineSamples.categoryCombo.uid())
-            fileResourceStore.deleteIfExists(FileResourceRoutineSamples.fileResource3.uid()!!)
-            fileResourceStore.deleteIfExists(FileResourceRoutineSamples.fileResource2.uid()!!)
-            fileResourceStore.deleteIfExists(FileResourceRoutineSamples.fileResource1.uid()!!)
+            fileResourceStore.deleteIfExists(FileResourceRoutineSamples.fileResource3.uid())
+            fileResourceStore.deleteIfExists(FileResourceRoutineSamples.fileResource2.uid())
+            fileResourceStore.deleteIfExists(FileResourceRoutineSamples.fileResource1.uid())
             organisationUnitStore.delete(FileResourceRoutineSamples.orgUnit1.uid())
         }
     }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceCallRealIntegrationShould.kt
@@ -148,7 +148,7 @@ class FileResourceCallRealIntegrationShould : BaseRealIntegrationTest() {
         d2.eventModule().events().uid(newEventUid).setEventDate(Date())
 
         val newValueUid = d2.fileResourceModule().fileResources().blockingAdd(file)
-        d2.trackedEntityModule().trackedEntityDataValues().value(newEventUid, existingValue.dataElement()!!)
+        d2.trackedEntityModule().trackedEntityDataValues().value(newEventUid, existingValue.dataElement())
             .blockingSet(newValueUid)
 
         d2.eventModule().events().blockingUpload()

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/DataElementLegendSetLinkStoreIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/legendset/DataElementLegendSetLinkStoreIntegrationShould.kt
@@ -43,7 +43,7 @@ class DataElementLegendSetLinkStoreIntegrationShould :
         TestDatabaseAdapterFactory.get(),
     ) {
     override fun addMasterUid(): String {
-        return DataElementLegendSetLinkSamples.getDataElementLegendSetLink().dataElement()!!
+        return DataElementLegendSetLinkSamples.getDataElementLegendSetLink().dataElement()
     }
 
     override fun buildObject(): DataElementLegendSetLink {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/option/OptionCallShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/option/OptionCallShould.kt
@@ -85,7 +85,7 @@ class OptionCallShould : BaseMockIntegrationTestEmptyEnqueable() {
         assertThat(option.displayName()).isEqualTo("0-14 years")
         assertThat(option.created()).isEqualTo("2014-08-18T12:39:16.000".toJavaDate())
         assertThat(option.lastUpdated()).isEqualTo("2014-08-18T12:39:16.000".toJavaDate())
-        assertThat(option.optionSet()!!.uid()).isEqualTo("VQ2lai3OfVG")
+        assertThat(option.optionSet().uid()).isEqualTo("VQ2lai3OfVG")
         assertThat(option.sortOrder()).isEqualTo(1)
     }
 

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/api/BreakTheGlassAPIShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/api/BreakTheGlassAPIShould.kt
@@ -96,7 +96,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
             val response = postTrackedEntities(tei)
             assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
 
-            for (importSummary in response.response!!.importSummaries!!) {
+            for (importSummary in response.response.importSummaries!!) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEvents(importSummary, ImportStatus.SUCCESS)
@@ -112,7 +112,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
 
         val response = postTrackedEntities(tei)
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEvents(importSummary, ImportStatus.SUCCESS)
@@ -120,7 +120,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
 
         val response2 = postTrackedEntities(tei)
         assertThat(response2.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response2.response!!.importSummaries!!) {
+        for (importSummary in response2.response.importSummaries!!) {
             TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEvents(importSummary, ImportStatus.SUCCESS)
@@ -134,7 +134,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
         val tei = teiWithEnrollmentInSearchScope()
         val response = postTrackedEntities(tei)
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEnrollments(
                 importSummary,
@@ -145,7 +145,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
 
         val response2 = postTrackedEntities(tei)
         assertThat(response2.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response2.response!!.importSummaries!!) {
+        for (importSummary in response2.response.importSummaries!!) {
             TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEnrollments(
                 importSummary,
@@ -161,7 +161,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
         val tei = teiWithEnrollmentInSearchScope()
         val response = postTrackedEntities(tei)
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEnrollments(
                 importSummary,
@@ -181,7 +181,7 @@ class BreakTheGlassAPIShould : BaseRealIntegrationTest() {
 
         val response2 = postTrackedEntities(tei)
         assertThat(response2.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response2.response!!.importSummaries!!) {
+        for (importSummary in response2.response.importSummaries!!) {
             TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
             TrackedEntityInstanceUtils.assertEvents(importSummary, ImportStatus.SUCCESS)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/api/TrackedEntityInstanceAPIShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/api/TrackedEntityInstanceAPIShould.kt
@@ -76,7 +76,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.ERROR)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             } else if (invalidTEI.uid() == importSummary.reference) {
@@ -105,7 +105,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
 
         assertThat(response.response!!.status).isEqualTo(ImportStatus.ERROR)
 
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             } else if (invalidTEI.uid() == importSummary.reference) {
@@ -132,7 +132,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val invalidTEI = TrackedEntityInstanceUtils.createValidTrackedEntityInstanceAndEnrollment()
         val response = executePostCall(listOf(validTEI, invalidTEI))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
             } else if (invalidTEI.uid() == importSummary.reference) {
@@ -153,7 +153,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val invalidTEI = TrackedEntityInstanceUtils.createValidTrackedEntityInstanceWithFutureEnrollment()
         val response = executePostCall(listOf(validTEI, invalidTEI))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -176,7 +176,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val invalidTEI = TrackedEntityInstanceUtils.createTrackedEntityInstanceAndTwoActiveEnrollment()
         val response = executePostCall(listOf(validTEI, invalidTEI))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -184,7 +184,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.ERROR)
                 assertThat(importSummary.enrollments!!.imported).isEqualTo(1)
-                assertThat(importSummary.enrollments!!.ignored).isEqualTo(1)
+                assertThat(importSummary.enrollments.ignored).isEqualTo(1)
             }
         }
         val serverValidTEI = getTrackedEntity(validTEI.uid())
@@ -201,7 +201,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val validTEI2 = TrackedEntityInstanceUtils.createValidTrackedEntityInstanceWithEnrollmentAndEvent()
         val response = executePostCall(listOf(validTEI1, validTEI2))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI1.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -227,7 +227,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val validTEI2 = TrackedEntityInstanceUtils.createValidTrackedEntityInstanceWithEnrollmentAndEvent()
         val response = executePostCall(listOf(validTEI1, validTEI2))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI1.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -253,7 +253,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val invalidTEI = TrackedEntityInstanceUtils.createTrackedEntityInstanceWithEnrollmentAndFutureEvent()
         val response = executePostCall(listOf(validTEI, invalidTEI))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -280,7 +280,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val invalidTEI = TrackedEntityInstanceUtils.createTrackedEntityInstanceWithInvalidDataElement()
         val response = executePostCall(listOf(validTEI, invalidTEI))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -315,7 +315,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val invalidTEI = TrackedEntityInstanceUtils.createTrackedEntityInstanceWithValidAndInvalidDataValue()
         val response = executePostCall(listOf(validTEI, invalidTEI))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (validTEI.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -351,7 +351,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
             TrackedEntityInstanceUtils.createTrackedEntityInstanceWithCompletedEnrollmentAndEvent()
         val response = executePostCall(listOf(completedEnrollment))
         assertThat(response.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (importSummary in response.response!!.importSummaries!!) {
+        for (importSummary in response.response.importSummaries!!) {
             if (completedEnrollment.uid() == importSummary.reference) {
                 TrackedEntityInstanceUtils.assertTei(importSummary, ImportStatus.SUCCESS)
                 TrackedEntityInstanceUtils.assertEnrollments(importSummary, ImportStatus.SUCCESS)
@@ -386,7 +386,7 @@ abstract class TrackedEntityInstanceAPIShould internal constructor(
         val deletedEvents = setEventsToDelete(instance)
         val deletedEventsResponse = executePostCall(listOf(deletedEvents))
         assertThat(deletedEventsResponse.response!!.status).isEqualTo(ImportStatus.SUCCESS)
-        for (teiImportSummaries in deletedEventsResponse.response!!.importSummaries!!) {
+        for (teiImportSummaries in deletedEventsResponse.response.importSummaries!!) {
             assertThat(teiImportSummaries.importCount.updated).isEqualTo(1)
             for (
             enrollmentImportSummary in teiImportSummaries.enrollments!!

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackerImporterPayloadGeneratorMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/NewTrackerImporterPayloadGeneratorMockIntegrationShould.kt
@@ -99,12 +99,12 @@ class NewTrackerImporterPayloadGeneratorMockIntegrationShould : BasePayloadGener
         // Get type attributes
         val typeAttributes = trackedEntityTypeAttributeStore
             .getForTrackedEntityType(trackedEntity.trackedEntityType()!!)
-            .mapNotNull { it.trackedEntityAttribute()?.uid() }
+            .mapNotNull { it.trackedEntityAttribute().uid() }
 
         // Get initial attribute values before sync
         val attributeValuesBefore = teiAttributeValueStore.queryByTrackedEntityInstance(teiId)
         val initialStates = attributeValuesBefore.associate {
-            it.trackedEntityAttribute()!! to it.syncState()
+            it.trackedEntityAttribute() to it.syncState()
         }
 
         // Simulate TE success: mark only type attributes as SYNCED
@@ -115,7 +115,7 @@ class NewTrackerImporterPayloadGeneratorMockIntegrationShould : BasePayloadGener
         val allAttributeValues = teiAttributeValueStore.queryByTrackedEntityInstance(teiId)
 
         allAttributeValues.forEach { attrValue ->
-            val attrUid = attrValue.trackedEntityAttribute()!!
+            val attrUid = attrValue.trackedEntityAttribute()
             if (typeAttributes.contains(attrUid)) {
                 // Type attributes should be SYNCED
                 assertThat(attrValue.syncState()).isEqualTo(State.SYNCED)
@@ -150,7 +150,7 @@ class NewTrackerImporterPayloadGeneratorMockIntegrationShould : BasePayloadGener
         // Get initial attribute values before sync
         val attributeValuesBefore = teiAttributeValueStore.queryByTrackedEntityInstance(teiUid)
         val initialStates = attributeValuesBefore.associate {
-            it.trackedEntityAttribute()!! to it.syncState()
+            it.trackedEntityAttribute() to it.syncState()
         }
 
         // Simulate enrollment success: mark only program attributes as SYNCED
@@ -161,7 +161,7 @@ class NewTrackerImporterPayloadGeneratorMockIntegrationShould : BasePayloadGener
         val allAttributeValues = teiAttributeValueStore.queryByTrackedEntityInstance(teiUid)
 
         allAttributeValues.forEach { attrValue ->
-            val attrUid = attrValue.trackedEntityAttribute()!!
+            val attrUid = attrValue.trackedEntityAttribute()
             if (programAttributes.contains(attrUid)) {
                 assertThat(attrValue.syncState()).isEqualTo(State.SYNCED)
             } else {
@@ -180,7 +180,7 @@ class NewTrackerImporterPayloadGeneratorMockIntegrationShould : BasePayloadGener
         val trackedEntityTypeAttributeStore: TrackedEntityTypeAttributeStore = koin.get()
         val typeAttributeUids = trackedEntityTypeAttributeStore
             .getForTrackedEntityType(trackedEntity.trackedEntityType()!!)
-            .mapNotNull { it.trackedEntityAttribute()?.uid() }
+            .mapNotNull { it.trackedEntityAttribute().uid() }
 
         // Create a program-only attribute (not in type attributes)
         val programOnlyAttrUid = "programOnlyAttr123"

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostCallRealIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstancePostCallRealIntegrationShould.kt
@@ -167,8 +167,8 @@ class TrackedEntityInstancePostCallRealIntegrationShould : BaseRealIntegrationTe
         // Enrollment module -> enroll the tracked entity instance to the program
         d2.enrollmentModule().enrollments().blockingAdd(
             EnrollmentCreateProjection.builder()
-                .organisationUnit(organisationUnit!!.uid())
-                .program(program!!.uid())
+                .organisationUnit(organisationUnit.uid())
+                .program(program.uid())
                 .trackedEntityInstance(teiUid)
                 .attributeOptionCombo(null)
                 .build(),

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/mock/BaseMockIntegrationTestLocalAnalyticsSuperLargeDispatcher.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/utils/integration/mock/BaseMockIntegrationTestLocalAnalyticsSuperLargeDispatcher.kt
@@ -48,7 +48,7 @@ abstract class BaseMockIntegrationTestLocalAnalyticsSuperLargeDispatcher : BaseM
             freshLogin(
                 RealServerMother.username,
                 RealServerMother.password,
-                dhis2MockServer.baseEndpoint!!,
+                dhis2MockServer.baseEndpoint,
             )
 
             objects.d2.let {

--- a/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/analytics/linelist/EventLineListServiceImpl.kt
@@ -190,7 +190,7 @@ internal class EventLineListServiceImpl(
             dataElementRepository
                 .byUid().`in`(dataElements.map { it.uid })
                 .suspendGet()
-                .map { it.uid()!! to it.displayName()!! }.toMap()
+                .map { it.uid() to it.displayName()!! }.toMap()
         } else {
             mapOf()
         }
@@ -199,7 +199,7 @@ internal class EventLineListServiceImpl(
             programIndicatorRepository
                 .byUid().`in`(programIndicators.map { it.uid })
                 .suspendGet()
-                .map { it.uid()!! to it.displayName()!! }.toMap()
+                .map { it.uid() to it.displayName()!! }.toMap()
         } else {
             mapOf()
         }
@@ -207,7 +207,7 @@ internal class EventLineListServiceImpl(
         val organisationUnitNameMap = organisationUnitRepository
             .byUid().`in`(organisationUnitUids)
             .suspendGet()
-            .map { it.uid()!! to it.displayName()!! }.toMap()
+            .map { it.uid() to it.displayName()!! }.toMap()
 
         return dataElementNameMap + programIndicatorNameMap + organisationUnitNameMap
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/IdentifiableDataHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/handlers/internal/IdentifiableDataHandlerImpl.kt
@@ -154,12 +154,12 @@ internal abstract class IdentifiableDataHandlerImpl<O>(
             relationship.toBuilder()
                 .syncState(State.SYNCED)
                 .deleted(false)
-                .build()!!
+                .build()
         }
     }
 
     private suspend fun deleteLinkedRelationships(o: O) {
-        o.uid()?.let { relationshipHandler.deleteLinkedRelationships(it) }
+        relationshipHandler.deleteLinkedRelationships(o.uid())
     }
 
     protected abstract fun addRelationshipState(o: O): O

--- a/core/src/main/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/common/internal/DataStatePropagatorImpl.kt
@@ -139,9 +139,7 @@ internal class DataStatePropagatorImpl(
     }
 
     override suspend fun propagateOwnershipUpdate(programOwner: ProgramOwner) {
-        programOwner.trackedEntityInstance()?.let {
-            setTeiSyncState(it, getStateForUpdate)
-        }
+        setTeiSyncState(programOwner.trackedEntityInstance(), getStateForUpdate)
     }
 
     private suspend fun propagateRelationshipUpdate(item: RelationshipItem?) {

--- a/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataelement/internal/DataElementAttributeChildrenAppender.kt
@@ -43,7 +43,7 @@ internal class DataElementAttributeChildrenAppender private constructor(
         val attributeValues = linkStore.getLinksForDataElement(m.uid())
             .map {
                 AttributeValue.builder()
-                    .attribute(ObjectWithUid.create(it.attribute()!!))
+                    .attribute(ObjectWithUid.create(it.attribute()))
                     .value(it.value()!!)
                     .build()
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/dataset/internal/DataSetInstanceServiceImpl.kt
@@ -163,7 +163,7 @@ internal class DataSetInstanceServiceImpl(
 
     override suspend fun suspendHasDataWriteAccess(dataSetUid: String): Boolean {
         val dataSet = dataSetCollectionRepository.uid(dataSetUid).suspendGet() ?: return false
-        return dataSet.access().write() ?: false
+        return dataSet.access().write()
     }
 
     @Deprecated(

--- a/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/enrollment/internal/EnrollmentServiceImpl.kt
@@ -107,7 +107,7 @@ internal class EnrollmentServiceImpl(
         val program = programRepository.uid(programUid).suspendGet() ?: return EnrollmentAccess.NO_ACCESS
 
         val dataAccess =
-            if (program.access().data()?.write() == true) {
+            if (program.access().data().write()) {
                 EnrollmentAccess.WRITE_ACCESS
             } else {
                 EnrollmentAccess.READ_ACCESS

--- a/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/Dhis2MockServer.kt
@@ -415,7 +415,7 @@ class Dhis2MockServer(private val fileReader: IFileReader, port: Int) {
             val body = fileReader.getStringFromFile(fileName)
             val response = MockResponse()
             response.setResponseCode(code)
-            response.setBody(body!!)
+            response.setBody(body)
             response.setHeader(CONTENT_TYPE, CONTENT_TYPE_JSON)
             return response
         } catch (_: IOException) {

--- a/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/ResponseController.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/mockwebserver/ResponseController.kt
@@ -28,14 +28,14 @@
 package org.hisp.dhis.android.core.mockwebserver
 
 class ResponseController internal constructor() {
-    private var methodsMap: MutableMap<String, LinkedHashMap<String?, String>> = mutableMapOf(
+    private val methodsMap: MutableMap<String, LinkedHashMap<String?, String>> = mutableMapOf(
         GET to LinkedHashMap(),
         POST to LinkedHashMap(),
         PUT to LinkedHashMap(),
         DELETE to LinkedHashMap(),
     )
-    private var codeResponses: MutableMap<String, Int> = mutableMapOf()
-    private var contentTypeMap: MutableMap<String, String> = mutableMapOf()
+    private val codeResponses: MutableMap<String, Int> = mutableMapOf()
+    private val contentTypeMap: MutableMap<String, String> = mutableMapOf()
 
     fun populateInternalResponses() {
         // move sdk dispatcher here
@@ -48,14 +48,14 @@ class ResponseController internal constructor() {
         responseCode: Int,
         contentType: String,
     ) {
-        var resourcesMap = methodsMap[method]
+        val resourcesMap = methodsMap[method]
         resourcesMap?.put(path, responseName)
         codeResponses.put(responseName, responseCode)
         contentTypeMap.put(responseName, contentType)
     }
 
     fun getBody(method: String, currentPath: String?): String? {
-        var resourcesMap: Map<String?, String> = methodsMap[method] ?: return null
+        val resourcesMap: Map<String?, String> = methodsMap[method] ?: return null
         var filename: String? = ""
 
         val paths: List<String?> = resourcesMap.keys.toList().asReversed()

--- a/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionSubCollectionCleaner.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/option/internal/OptionSubCollectionCleaner.kt
@@ -41,5 +41,5 @@ internal class OptionSubCollectionCleaner(
     tableName = OptionTableInfo.TABLE_INFO.name(),
     parentColumn = OptionTableInfo.Columns.OPTION_SET,
     databaseAdapter = databaseAdapter,
-    keyExtractor = Transformer { o -> o.optionSet()!!.uid() },
+    keyExtractor = Transformer { o -> o.optionSet().uid() },
 )

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramAttributeChildrenAppender.kt
@@ -43,7 +43,7 @@ internal class ProgramAttributeChildrenAppender private constructor(
         val attributeValues = linkStore.getLinksForProgram(m.uid())
             .map {
                 AttributeValue.builder()
-                    .attribute(ObjectWithUid.create(it.attribute()!!))
+                    .attribute(ObjectWithUid.create(it.attribute()))
                     .value(it.value()!!)
                     .build()
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramParentUidsHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramParentUidsHelper.kt
@@ -82,7 +82,7 @@ internal object ProgramParentUidsHelper {
         }
         for (type in types) {
             type.trackedEntityTypeAttributes()?.forEach { attribute ->
-                attribute.trackedEntityAttribute()?.uid()?.let { attributeUids.add(it) }
+                attributeUids.add(attribute.trackedEntityAttribute().uid())
             }
         }
         return attributeUids

--- a/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageAttributeChildrenAppender.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/internal/ProgramStageAttributeChildrenAppender.kt
@@ -43,7 +43,7 @@ internal class ProgramStageAttributeChildrenAppender private constructor(
         val attributeValues = linkStore.getLinksForProgramStage(m.uid())
             .map {
                 AttributeValue.builder()
-                    .attribute(ObjectWithUid.create(it.attribute()!!))
+                    .attribute(ObjectWithUid.create(it.attribute()))
                     .value(it.value()!!)
                     .build()
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipServiceImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/RelationshipServiceImpl.kt
@@ -109,7 +109,7 @@ internal class RelationshipServiceImpl(
     ): Boolean = when (constraint.relationshipEntity()) {
         RelationshipEntityType.PROGRAM_INSTANCE -> {
             val programUid = constraint.program()?.uid()
-            programRepository.uid(programUid).blockingGet()!!.access().data().write()!!
+            programRepository.uid(programUid).blockingGet()!!.access().data().write()
         }
 
         RelationshipEntityType.PROGRAM_STAGE_INSTANCE -> {
@@ -118,13 +118,13 @@ internal class RelationshipServiceImpl(
                 programStageRepository.uid(programStageUid).blockingGet()?.access()!!.data().write()
             } else {
                 val programUid = constraint.program()?.uid()
-                programRepository.uid(programUid).blockingGet()!!.access().data().write()!!
+                programRepository.uid(programUid).blockingGet()!!.access().data().write()
             }
         }
 
         RelationshipEntityType.TRACKED_ENTITY_INSTANCE -> {
             val teTypeUid = constraint.trackedEntityType()?.uid()
-            trackedEntityTypeRepository.uid(teTypeUid).blockingGet()!!.access().data().write()!!
+            trackedEntityTypeRepository.uid(teTypeUid).blockingGet()!!.access().data().write()
         }
 
         else -> false

--- a/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipDownloadAndPersistCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/relationship/internal/RelationshipDownloadAndPersistCallFactory.kt
@@ -169,7 +169,7 @@ internal class RelationshipDownloadAndPersistCallFactory(
             corruptedRelationships.addAll(relationshipStore.getRelationshipsByItem(builder.build()))
         }
         for (r in corruptedRelationships) {
-            r.uid()?.let { relationshipStore.deleteIfExists(it) }
+            relationshipStore.deleteIfExists(r.uid())
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionComparator.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/settings/internal/LatestAppVersionComparator.kt
@@ -33,8 +33,8 @@ import org.koin.core.annotation.Singleton
 @Singleton
 internal class LatestAppVersionComparator {
     val comparator: Comparator<in ApkDistributionVersion> = Comparator { v1, v2 ->
-        val partsV1 = v1.version?.split(".")?.map { it.toIntOrNull() ?: 0 } ?: emptyList()
-        val partsV2 = v2.version?.split(".")?.map { it.toIntOrNull() ?: 0 } ?: emptyList()
+        val partsV1 = v1.version.split(".").map { it.toIntOrNull() ?: 0 }
+        val partsV2 = v2.version.split(".").map { it.toIntOrNull() ?: 0 }
         var result = 0
         val maxLength = maxOf(partsV1.size, partsV2.size)
         for (i in 0 until maxLength) {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackerSyncLastUpdatedManager.kt
@@ -98,7 +98,7 @@ internal open class TrackerSyncLastUpdatedManager<S : TrackerBaseSync>(private v
             if (hasUpdateDownload(specificSetting)) {
                 period = specificSetting!!.updateDownload()
             } else if (hasUpdateDownload(globalSetting)) {
-                period = globalSetting!!.updateDownload()
+                period = globalSetting.updateDownload()
             }
         }
         return if (period == null || period == DownloadPeriod.ANY) {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScopeHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScopeHelper.kt
@@ -127,8 +127,8 @@ internal class TrackedEntityInstanceQueryRepositoryScopeHelper(
     ): TrackedEntityInstanceQueryRepositoryScope {
         val builder = scope.toBuilder()
 
-        workingList.program()?.uid()?.let { builder.program(it) }
-        workingList.programStage()?.uid()?.let { builder.programStage(it) }
+        builder.program(workingList.program().uid())
+        builder.programStage(workingList.programStage().uid())
 
         workingList.programStageQueryCriteria()?.let { criteria ->
             criteria.eventStatus()?.let { builder.eventStatus(listOf(it)) }

--- a/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/tracker/importer/internal/TrackerImporterBreakTheGlassHelper.kt
@@ -138,8 +138,8 @@ internal class TrackerImporterBreakTheGlassHelper(
     suspend fun fakeBreakGlass(instances: List<TrackedEntityInstance>) {
         instances.forEach { instance ->
             instance.enrollments.orEmpty().forEach { enrollment ->
-                if (instance.uid() != null && enrollment.program() != null) {
-                    ownershipManagerImpl.fakeBreakGlass(instance.uid()!!, enrollment.program()!!)
+                if (enrollment.program() != null) {
+                    ownershipManagerImpl.fakeBreakGlass(instance.uid(), enrollment.program()!!)
                 }
             }
         }

--- a/core/src/main/java/org/hisp/dhis/android/network/trackedentitytype/TrackedEntityTypeAttributeDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/trackedentitytype/TrackedEntityTypeAttributeDTO.kt
@@ -42,16 +42,14 @@ internal data class TrackedEntityTypeAttributeDTO(
 
 ) {
     fun toDomain(trackedEntityType: String): TrackedEntityTypeAttribute? {
-        return if (trackedEntityAttribute != null) {
+        return trackedEntityAttribute?.let {
             TrackedEntityTypeAttribute.builder()
                 .trackedEntityType(ObjectWithUid.create(trackedEntityType))
-                .trackedEntityAttribute(trackedEntityAttribute.toDomain())
+                .trackedEntityAttribute(it.toDomain())
                 .displayInList(displayInList)
                 .mandatory(mandatory)
                 .searchable(searchable)
                 .build()
-        } else {
-            null
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/network/trackervisualization/TrackerVisualizationDimensionDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/trackervisualization/TrackerVisualizationDimensionDTO.kt
@@ -44,11 +44,11 @@ internal data class TrackerVisualizationDimensionDTO(
     val repetition: TrackerVisualizationDimensionRepetitionDTO?,
 ) {
     fun toDomain(visualization: String, position: LayoutPosition): TrackerVisualizationDimension? {
-        return if (dimension != null) {
+        return dimension?.let {
             TrackerVisualizationDimension.builder()
                 .trackerVisualization(visualization)
                 .position(position)
-                .dimension(dimension)
+                .dimension(it)
                 .dimensionType(dimensionType)
                 .program(program?.toDomain())
                 .programStage(programStage?.toDomain())
@@ -56,8 +56,6 @@ internal data class TrackerVisualizationDimensionDTO(
                 .filter(filter)
                 .repetition(repetition?.toDomain())
                 .build()
-        } else {
-            null
         }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/dataset/DataSetOrganisationUnitLinkStoreImpl.kt
@@ -53,6 +53,6 @@ internal class DataSetOrganisationUnitLinkStoreImpl(
             .appendKeyStringValue(DataSetOrganisationUnitLinkTableInfo.Columns.ORGANISATION_UNIT, orgUnitUid)
             .build()
         val selectStatement = builder.selectWhere(whereClause)
-        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.dataSet()!!) }
+        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.dataSet()) }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/datastore/LocalDataStoreDB.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/datastore/LocalDataStoreDB.kt
@@ -22,7 +22,7 @@ internal data class LocalDataStoreDB(
 
 internal fun KeyValuePair.toDB(): LocalDataStoreDB {
     return LocalDataStoreDB(
-        key = key()!!,
+        key = key(),
         value = value(),
     )
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/legendset/DataElementLegendSetLinkStoreImpl.kt
@@ -53,6 +53,6 @@ internal class DataElementLegendSetLinkStoreImpl(
             .appendKeyStringValue(DataElementLegendSetLinkTableInfo.Columns.DATA_ELEMENT, dataElementUid)
             .build()
         val selectStatement = builder.selectWhere(whereClause)
-        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.legendSet()!!) }
+        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.legendSet()) }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/option/OptionGroupOptionLinkStoreImpl.kt
@@ -56,6 +56,6 @@ internal class OptionGroupOptionLinkStoreImpl(
             )
             .build()
         val selectStatement = builder.selectWhere(whereClause)
-        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.option()!!) }
+        return selectRawQuery(selectStatement).map { ObjectWithUid.create(it.option()) }
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueStoreImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/persistence/trackedentity/TrackedEntityAttributeValueStoreImpl.kt
@@ -58,7 +58,7 @@ internal class TrackedEntityAttributeValueStoreImpl(
             "WHERE " + teiInUploadableState() + ";"
         val valueList = selectRawQuery(toPostQuery)
 
-        return valueList.filter { it.trackedEntityInstance() != null }.groupBy { it.trackedEntityInstance()!! }
+        return valueList.groupBy { it.trackedEntityInstance() }
     }
 
     private fun teiInUploadableState(): String {

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/api/paging/internal/ApiPagingEngineShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/api/paging/internal/ApiPagingEngineShould.kt
@@ -40,13 +40,13 @@ class ApiPagingEngineShould {
     @Test
     @Throws(IllegalArgumentException::class, IllegalStateException::class)
     fun calculate_a_paging_list() {
-        var calculatedPagingList: List<Paging?> = getPaginationList(50, 179, 0)
-        var paging1 = Paging(1, 50, 0, 0, false)
-        var paging2 = Paging(2, 50, 0, 0, false)
-        var paging3 = Paging(3, 50, 0, 0, false)
-        var lastPaging = Paging(6, 30, 0, 1, true)
+        val calculatedPagingList: List<Paging?> = getPaginationList(50, 179, 0)
+        val paging1 = Paging(1, 50, 0, 0, false)
+        val paging2 = Paging(2, 50, 0, 0, false)
+        val paging3 = Paging(3, 50, 0, 0, false)
+        val lastPaging = Paging(6, 30, 0, 1, true)
 
-        var expectedPagingList: List<Paging?> =
+        val expectedPagingList: List<Paging?> =
             listOf(paging1, paging2, paging3, lastPaging)
 
         Truth.assertThat(expectedPagingList).isEqualTo(calculatedPagingList)
@@ -55,9 +55,9 @@ class ApiPagingEngineShould {
     @Test
     @Throws(IllegalArgumentException::class, IllegalStateException::class)
     fun calculate_a_paging_list_if_only_one_page() {
-        var calculatedPagingList: List<Paging?> = getPaginationList(50, 33, 0)
-        var paging = Paging(1, 33, 0, 0, true)
-        var expectedPagingList: List<Paging?> = ArrayList(listOf(paging))
+        val calculatedPagingList: List<Paging?> = getPaginationList(50, 33, 0)
+        val paging = Paging(1, 33, 0, 0, true)
+        val expectedPagingList: List<Paging?> = ArrayList(listOf(paging))
 
         Truth.assertThat(expectedPagingList).isEqualTo(calculatedPagingList)
     }
@@ -67,8 +67,8 @@ class ApiPagingEngineShould {
     fun calculate_a_paging_list_with_previously_downloaded() {
         var calculatedPagingList: List<Paging?> = getPaginationList(50, 85, 94)
         var paging1 = Paging(10, 10, 4, 0, false)
-        var paging2 = Paging(3, 50, 0, 0, false)
-        var lastPaging = Paging(6, 30, 0, 1, true)
+        val paging2 = Paging(3, 50, 0, 0, false)
+        val lastPaging = Paging(6, 30, 0, 1, true)
 
         var expectedPagingList: List<Paging?> =
             listOf(paging1, paging2, lastPaging)

--- a/core/src/test/java/org/hisp/dhis/android/core/event/EventFilterShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/event/EventFilterShould.kt
@@ -93,7 +93,7 @@ internal class EventFilterShould : CoreObjectShould<EventFilterDTO>(
         )
         assertThat(eventFilter.eventQueryCriteria()!!.events()).isEqualTo(listOf("event1Uid", "event2Uid"))
 
-        val dateFilter1 = eventFilter.eventQueryCriteria()!!.dataFilters()!![0]!!
+        val dateFilter1 = eventFilter.eventQueryCriteria()!!.dataFilters()!![0]
         assertThat(dateFilter1.dataItem()).isEqualTo("abcDataElementUid")
         assertThat(dateFilter1.le()).isEqualTo("20")
         assertThat(dateFilter1.ge()).isEqualTo("10")
@@ -102,19 +102,19 @@ internal class EventFilterShould : CoreObjectShould<EventFilterDTO>(
         assertThat(dateFilter1.`in`()).isEqualTo(setOf("India", "Norway"))
         assertThat(dateFilter1.like()).isEqualTo("abc")
 
-        val dateFilter2 = eventFilter.eventQueryCriteria()!!.dataFilters()!![1]!!
+        val dateFilter2 = eventFilter.eventQueryCriteria()!!.dataFilters()!![1]
         assertThat(dateFilter2.dataItem()).isEqualTo("dateDataElementUid")
         assertThat(dateFilter2.dateFilter()!!.startDate()).isEqualTo(DateUtils.SIMPLE_DATE_FORMAT.parse("2014-05-01"))
         assertThat(dateFilter2.dateFilter()!!.endDate()).isEqualTo(DateUtils.SIMPLE_DATE_FORMAT.parse("2019-03-20"))
         assertThat(dateFilter2.dateFilter()!!.type()).isEqualTo(DatePeriodType.ABSOLUTE)
 
-        val dateFilter3 = eventFilter.eventQueryCriteria()!!.dataFilters()!![2]!!
+        val dateFilter3 = eventFilter.eventQueryCriteria()!!.dataFilters()!![2]
         assertThat(dateFilter3.dataItem()).isEqualTo("anotherDateDataElementUid")
         assertThat(dateFilter3.dateFilter()!!.startBuffer()).isEqualTo(-5)
         assertThat(dateFilter3.dateFilter()!!.endBuffer()).isEqualTo(5)
         assertThat(dateFilter3.dateFilter()!!.type()).isEqualTo(DatePeriodType.RELATIVE)
 
-        val dateFilter4 = eventFilter.eventQueryCriteria()!!.dataFilters()!![3]!!
+        val dateFilter4 = eventFilter.eventQueryCriteria()!!.dataFilters()!![3]
         assertThat(dateFilter4.dataItem()).isEqualTo("yetAnotherDateDataElementUid")
         assertThat(dateFilter4.dateFilter()!!.period()).isEqualTo(RelativePeriod.LAST_WEEK)
         assertThat(dateFilter4.dateFilter()!!.type()).isEqualTo(DatePeriodType.RELATIVE)

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EnrollmentImportEnrollmentShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EnrollmentImportEnrollmentShould.kt
@@ -57,7 +57,7 @@ internal class EnrollmentImportEnrollmentShould : CoreObjectShould<EnrollmentImp
 
         assertThat(importEnrollment.importSummaries!!.size).isEqualTo(1)
 
-        val importSummary = importEnrollment.importSummaries!![0]
+        val importSummary = importEnrollment.importSummaries[0]
 
         assertThat(importSummary).isNotNull()
         assertThat(importSummary.events).isNotNull()

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EventImportEventShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/EventImportEventShould.kt
@@ -56,7 +56,7 @@ internal class EventImportEventShould : CoreObjectShould<EventImportSummariesDTO
         assertThat(importEvent.importSummaries).isNotNull()
         assertThat(importEvent.importSummaries!!.size).isEqualTo(2)
 
-        val importSummary = importEvent.importSummaries!![0]
+        val importSummary = importEvent.importSummaries[0]
         assertThat(importSummary).isNotNull()
         assertThat(importSummary.reference).isEqualTo("xqpUvfxT4PZ")
         assertThat(importSummary.responseType).isEqualTo("ImportSummary")

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportConflictShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/ImportConflictShould.kt
@@ -51,6 +51,6 @@ internal class ImportConflictShould : CoreObjectShould<ImportConflictDTO>(
         assertThat(importConflict.errorCode).isEqualTo("E7619")
         assertThat(importConflict.property).isEqualTo("value")
         assertThat(importConflict.indexes!![0]).isEqualTo(2)
-        assertThat(importConflict.indexes!![1]).isEqualTo(7)
+        assertThat(importConflict.indexes[1]).isEqualTo(7)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithTeiConflicts.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/imports/internal/TEIImportSummaryShouldwithTeiConflicts.kt
@@ -57,7 +57,7 @@ internal class TEIImportSummaryShouldwithTeiConflicts : CoreObjectShould<TEIImpo
         assertThat(importSummary.conflicts).isNotNull()
         assertThat(importSummary.conflicts!!.size).isEqualTo(1)
 
-        val importConflict = importSummary.conflicts!![0]
+        val importConflict = importSummary.conflicts[0]
 
         assertThat(importConflict).isNotNull()
         assertThat(importConflict.value)

--- a/core/src/test/java/org/hisp/dhis/android/core/map/layer/internal/MapLayerHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/map/layer/internal/MapLayerHandlerShould.kt
@@ -52,7 +52,7 @@ class MapLayerHandlerShould {
 
     private lateinit var mapLayerHandler: Handler<MapLayer>
 
-    private var mapLayers = listOf(mapLayer)
+    private val mapLayers = listOf(mapLayer)
 
     @Before
     fun setUp() = runTest {

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionGroupShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionGroupShould.kt
@@ -52,7 +52,7 @@ internal class OptionGroupShould : CoreObjectShould<OptionGroupDTO>(
         assertThat(optionGroup.lastUpdated()).isEqualTo(
             BaseIdentifiableObject.DATE_FORMAT.parse("2019-02-15T13:55:55.665"),
         )
-        assertThat(optionGroup.optionSet()!!.uid()).isEqualTo("VQ2lai3OfVG")
+        assertThat(optionGroup.optionSet().uid()).isEqualTo("VQ2lai3OfVG")
         assertThat(optionGroup.options()!![0].uid()).isEqualTo("Y1ILwhy5VDY")
         assertThat(optionGroup.options()!![1].uid()).isEqualTo("egT1YqFWsVk")
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/option/OptionShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/option/OptionShould.kt
@@ -49,7 +49,7 @@ internal class OptionShould : CoreObjectShould<OptionDTO>("option/option.json", 
         assertThat(option.name()).isEqualTo("0-14 years")
         assertThat(option.displayName()).isEqualTo("0-14 years")
         assertThat(option.sortOrder()).isEqualTo(1)
-        assertThat(option.optionSet()?.uid()).isEqualTo("VQ2lai3OfVG")
+        assertThat(option.optionSet().uid()).isEqualTo("VQ2lai3OfVG")
         assertThat(option.style().color()).isEqualTo("#000")
         assertThat(option.style().icon()).isEqualTo("my-icon-name")
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/program/internal/ProgramHandlerShould.kt
@@ -74,7 +74,7 @@ class ProgramHandlerShould {
 
     private val attributeValues: MutableList<AttributeValue> = ArrayList()
     private var programRuleVariables: List<ProgramRuleVariable> = mock()
-    private var attributeValue: ObjectWithUid = ObjectWithUid.create("Att_Uid")
+    private val attributeValue: ObjectWithUid = ObjectWithUid.create("Att_Uid")
 
     // object to test
     private lateinit var programHandler: ProgramHandler

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType30Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType30Should.kt
@@ -63,19 +63,19 @@ internal class RelationshipType30Should : CoreObjectShould<RelationshipTypeDTO>(
             relationshipType.fromConstraint()!!.trackedEntityType()!!.uid(),
         ).isEqualTo("nEenWmSyUEp")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.attributes()!![0],
+            relationshipType.fromConstraint()!!.trackerDataView()!!.attributes()[0],
         ).isEqualTo("b0vcadVrn08")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.attributes()!![1],
+            relationshipType.fromConstraint()!!.trackerDataView()!!.attributes()[1],
         ).isEqualTo("qXS2NDUEAOS")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()!![0],
+            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()[0],
         ).isEqualTo("ciWE5jde1ax")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()!![1],
+            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()[1],
         ).isEqualTo("hB9F8vKFmlk")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()!![2],
+            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()[2],
         ).isEqualTo("uFAQYm3UgBL")
         assertThat(relationshipType.toConstraint()).isNotNull()
         assertThat(
@@ -84,10 +84,10 @@ internal class RelationshipType30Should : CoreObjectShould<RelationshipTypeDTO>(
         assertThat(relationshipType.toConstraint()!!.program()!!.uid())
             .isEqualTo("WSGAb5XwJ3Y")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.attributes()!![0],
+            relationshipType.toConstraint()!!.trackerDataView()!!.attributes()[0],
         ).isEqualTo("b0vcadVrn08")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()!!.isEmpty(),
+            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements().isEmpty(),
         ).isTrue()
         assertThat(relationshipType.bidirectional()).isFalse()
         assertThat(relationshipType.access().data().read()).isTrue()

--- a/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType32Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/relationship/RelationshipType32Should.kt
@@ -62,10 +62,10 @@ internal class RelationshipType32Should : CoreObjectShould<RelationshipTypeDTO>(
             relationshipType.fromConstraint()!!.trackedEntityType()!!.uid(),
         ).isEqualTo("nEenWmSyUEp")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.attributes()!![0],
+            relationshipType.fromConstraint()!!.trackerDataView()!!.attributes()[0],
         ).isEqualTo("b0vcadVrn08")
         assertThat(
-            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements()!!.isEmpty(),
+            relationshipType.fromConstraint()!!.trackerDataView()!!.dataElements().isEmpty(),
         ).isTrue()
         assertThat(relationshipType.toConstraint()).isNotNull()
         assertThat(
@@ -74,19 +74,19 @@ internal class RelationshipType32Should : CoreObjectShould<RelationshipTypeDTO>(
         assertThat(relationshipType.toConstraint()!!.program()!!.uid())
             .isEqualTo("WSGAb5XwJ3Y")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.attributes()!![0],
+            relationshipType.toConstraint()!!.trackerDataView()!!.attributes()[0],
         ).isEqualTo("b0vcadVrn08")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.attributes()!![1],
+            relationshipType.toConstraint()!!.trackerDataView()!!.attributes()[1],
         ).isEqualTo("qXS2NDUEAOS")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()!![0],
+            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()[0],
         ).isEqualTo("ciWE5jde1ax")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()!![1],
+            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()[1],
         ).isEqualTo("hB9F8vKFmlk")
         assertThat(
-            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()!![2],
+            relationshipType.toConstraint()!!.trackerDataView()!!.dataElements()[2],
         ).isEqualTo("uFAQYm3UgBL")
         assertThat(relationshipType.bidirectional()).isTrue()
         assertThat(relationshipType.access().data().read()).isTrue()

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/CustomIntentsShould.kt
@@ -43,8 +43,8 @@ internal class CustomIntentsShould : CoreObjectShould<CustomIntentsDTO>(
         val customIntentsDTO = deserialize()
         val customIntents = customIntentsDTO.toDomain()
 
-        assertThat(customIntents.customIntents()?.size).isEqualTo(2)
-        val firstCustomIntent = customIntents.customIntents()?.get(0)!!
+        assertThat(customIntents.customIntents().size).isEqualTo(2)
+        val firstCustomIntent = customIntents.customIntents()[0]
 
         assertThat(firstCustomIntent.uid()).isEqualTo("intent1id")
         assertThat(firstCustomIntent.name()).isEqualTo("Face recognition")

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/ProgramSettingsShould.kt
@@ -45,7 +45,7 @@ internal class ProgramSettingsShould : CoreObjectShould<ProgramSettingsDTO>(
         val programSettings = programSettingsDTO.toDomain()
 
         val global = programSettings.globalSettings()
-        assertThat(global!!.uid()).isNull()
+        assertThat(global.uid()).isNull()
         assertThat(global.name()).isNull()
         assertThat(global.lastUpdated())
             .isEqualTo(BaseIdentifiableObject.parseDate("2020-02-01T20:02:46.145Z"))

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/SynchronizationSettingsShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/SynchronizationSettingsShould.kt
@@ -62,10 +62,10 @@ internal class SynchronizationSettingsShould : CoreObjectShould<SynchronizationS
         assertThat(syncSettings.programSettings()).isNotNull()
         assertThat(syncSettings.programSettings()!!.globalSettings()).isNotNull()
         assertThat(
-            syncSettings.programSettings()!!.globalSettings()!!.teiDownload(),
+            syncSettings.programSettings()!!.globalSettings().teiDownload(),
         ).isEqualTo(500)
         assertThat(
-            syncSettings.programSettings()!!.globalSettings()!!.settingDownload(),
+            syncSettings.programSettings()!!.globalSettings().settingDownload(),
         ).isEqualTo(LimitScope.ALL_ORG_UNITS)
         assertThat(syncSettings.programSettings()!!.specificSettings()).isNotNull()
         assertThat(

--- a/core/src/test/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataHandlerShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/settings/internal/AnalyticsTeiWHONutritionDataHandlerShould.kt
@@ -60,7 +60,7 @@ class AnalyticsTeiWHONutritionDataHandlerShould {
 
     @Test
     fun call_data_handlers() = runTest {
-        analyticsTeiSettingHandler.handleMany(whoData.teiSetting()!!, listOf(whoData))
+        analyticsTeiSettingHandler.handleMany(whoData.teiSetting(), listOf(whoData))
 
         verify(teiDataElementHandler).handleMany(any(), any())
         verify(teiIndicatorHandler).handleMany(any(), any())

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should.kt
@@ -42,8 +42,8 @@ internal class NewTrackerImporterTrackedEntityPayloadGreaterEqualV41Should : Cor
         val trackedEntityPayloadDTO = deserialize()
         val trackedEntityPayload = trackedEntityPayloadDTO
 
-        assertThat(trackedEntityPayload.pager()?.page).isEqualTo(1)
-        assertThat(trackedEntityPayload.pager()?.pageSize).isEqualTo(50)
+        assertThat(trackedEntityPayload.pager().page).isEqualTo(1)
+        assertThat(trackedEntityPayload.pager().pageSize).isEqualTo(50)
         assertThat(trackedEntityPayload.items().size).isEqualTo(2)
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcherShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/internal/UserAccountDisabledErrorCatcherShould.kt
@@ -43,7 +43,7 @@ import org.mockito.kotlin.verify
 class UserAccountDisabledErrorCatcherShould {
     private lateinit var catcher: UserAccountDisabledErrorCatcher
     private lateinit var response: D2HttpResponse
-    private var accountManager: AccountManagerImpl = mock()
+    private val accountManager: AccountManagerImpl = mock()
 
     @Before
     fun setUp() {

--- a/core/src/test/java/org/hisp/dhis/android/core/visualization/VisualizationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/visualization/VisualizationShould.kt
@@ -59,8 +59,8 @@ internal class VisualizationShould : CoreObjectShould<VisualizationDTO>(
         assertThat(visualization.rows()!!.size).isEqualTo(1)
         assertThat(visualization.rows()!![0].id()).isEqualTo("pe")
         assertThat(visualization.rows()!![0].items()?.size).isEqualTo(4)
-        assertThat(visualization.rows()!![0].items()!![0]?.dimensionItem()).isEqualTo("202102")
-        assertThat(visualization.rows()!![0].items()!![0]?.dimensionItemType()).isEqualTo("PERIOD")
+        assertThat(visualization.rows()!![0].items()!![0].dimensionItem()).isEqualTo("202102")
+        assertThat(visualization.rows()!![0].items()!![0].dimensionItemType()).isEqualTo("PERIOD")
 
         assertThat(visualization.filters()!!.size).isEqualTo(1)
         assertThat(visualization.filters()!![0].id()).isEqualTo("ou")


### PR DESCRIPTION
Cleans up leftovers from the migration of the Java models to Kotlin data classes. Guard clauses in the DTO mappers are normalized so that a single nullable check uses `?.let` instead of an `if/else null` block, and every non-null assertion that the compiler proves redundant is removed across main, unit test and instrumented test sources. Removing an assertion or a safe call changes the type of the surrounding expression, so the pass was repeated until no warnings were left; the dead code this exposed (pointless `let` wrappers, unreachable elvis branches and a redundant `== true`) is cleaned up as well. A few `var` declarations that are never reassigned, also inherited from the Java conversion, become `val`.

Assertions that are still needed are untouched, and there is no behavior change: all of these are no-ops the compiler already optimizes away. Note that `apiCheck` currently fails on `develop` as well, unrelated to this branch, because the Koin compiler plugin emits `org.koin.plugin.hints.*` classes that are missing from the committed API dump; that drift is left for a separate ticket rather than folded in here.

Related task: [ANDROSDK-2341](https://dhis2.atlassian.net/browse/ANDROSDK-2341)

[ANDROSDK-2341]: https://dhis2.atlassian.net/browse/ANDROSDK-2341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ