### PR TITLE
chore: [ANDROSDK-2375-2] Update expression-parser and some core libraries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Uses **Koin** with KSP code generation (Koin Annotations). Each feature has a `*
 
 `core/api/core.api` is the binary API dump. The `api-compatibility` plugin checks for breaking changes on every build.
 
-**Never edit `core/api/core.api` by hand.** It is an auto-generated artifact and the only supported way to update it is by running `./gradlew :core:apiDump` after intentional public API changes. Manual edits will drift from what the plugin actually generates and break the build. Commit the regenerated dump alongside the API change.
+**Never edit `core/api/core.api` by hand.** It is an auto-generated artifact and the only supported way to update it is by running `./gradlew :core:releaseApiDump` after intentional public API changes. Manual edits will drift from what the plugin actually generates and break the build. Commit the regenerated dump alongside the API change.
 
 ### DHIS2 Version Compatibility
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -322,7 +322,7 @@ tasks.register("testAll") {
         "ktlintFormat",
         "detekt",
         "lintDebug",
-        "apiDump",
+        "releaseApiDump",
         "testDebugUnitTest",
         "connectedDebugAndroidTest",
     )
@@ -330,7 +330,7 @@ tasks.register("testAll") {
     tasks.findByName("ktlintFormat")?.mustRunAfter("clean")
     tasks.findByName("detekt")?.mustRunAfter("ktlintFormat")
     tasks.findByName("lintDebug")?.mustRunAfter("detekt")
-    tasks.findByName("apiDump")?.mustRunAfter("lintDebug")
-    tasks.findByName("testDebugUnitTest")?.mustRunAfter("apiDump")
+    tasks.findByName("releaseApiDump")?.mustRunAfter("lintDebug")
+    tasks.findByName("testDebugUnitTest")?.mustRunAfter("releaseApiDump")
     tasks.findByName("connectedDebugAndroidTest")?.mustRunAfter("testDebugUnitTest")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,8 @@ minSdkVersion = "23"
 libraryDesugaring = "2.1.5"
 
 # android
-annotation = "1.9.1"
-androidx-core = "1.13.1"
+annotation = "1.10.0"
+androidx-core = "1.19.0"
 paging = "3.3.6"
 androidx-room = "2.8.4"
 
@@ -31,17 +31,17 @@ rxJava = "2.2.21"
 rxAndroid = "2.1.1"
 sqlCipher = "4.9.0"
 sqLite = "2.5.2"
-zip4j = "2.11.5"
+zip4j = "2.11.6"
 smsCompression = "0.2.0"
 antlrExpressionParser = "1.0.39"
-pegExpressionParser = "1.3.1"
+pegExpressionParser = "1.4.3"
 
 # Kotlin
 kotlinxDatetime = "0.7.1"
-coroutines = "1.10.2"
+coroutines = "1.11.0"
 koin = "4.2.2"
 koinPlugin = "1.0.1"
-kotlinxSerializationJson = "1.10.0"
+kotlinxSerializationJson = "1.11.0"
 
 # test dependencies
 coreTesting = "2.2.0"


### PR DESCRIPTION
Update the `expression-parser` library to the most updated version. This was not an issue when running the SDK as part of the Android app because the Android app already explicitly declared the most recent version of the library, but it is better to have it here as well.

Additionally, other core libraries has been updated to other minor versions.