### PR TITLE
chore: [ANDROSDK-2374] allow OAuth2 login only from version 2.43

### DIFF
--- a/core/src/androidTest/java/org/hisp/dhis/android/core/server/ServerCheckCallMockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/server/ServerCheckCallMockIntegrationShould.kt
@@ -29,7 +29,6 @@
 package org.hisp.dhis.android.core.server
 
 import com.google.common.truth.Truth.assertThat
-import io.ktor.http.HttpStatusCode
 import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTest
 import org.hisp.dhis.android.core.utils.integration.mock.MockIntegrationTestDatabaseContent
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
@@ -43,7 +42,6 @@ class ServerCheckCallMockIntegrationShould : BaseMockIntegrationTest() {
     fun setUp() {
         setUpClass(MockIntegrationTestDatabaseContent.EmptyEnqueable)
         dhis2MockServer.enqueueMockResponse(LOGIN_CONFIG_JSON)
-        dhis2MockServer.enqueueMockResponse(HttpStatusCode.NotFound.value)
     }
 
     @Test
@@ -73,6 +71,7 @@ class ServerCheckCallMockIntegrationShould : BaseMockIntegrationTest() {
         assertThat(loginConfig.selfRegistrationNoRecaptcha).isFalse()
         assertThat(loginConfig.allowAccountRecovery).isTrue()
         assertThat(loginConfig.useCustomLogoFront).isFalse()
+        assertThat(loginConfig.isOauthEnabled).isFalse()
 
         val oidcProviders = loginConfig.oidcProviders
         assertThat(oidcProviders).hasSize(2)

--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
@@ -35,6 +35,8 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.hisp.dhis.android.core.server.OauthConfig
+import org.hisp.dhis.android.core.systeminfo.DHISVersion
+import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
 import org.hisp.dhis.android.core.systeminfo.internal.PingNetworkHandler
 import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
@@ -47,6 +49,7 @@ internal class LoginConfigCall(
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     private val networkHandler: LoginConfigNetworkHandler,
     private val oAuth2SecureStore: OAuth2SecureStore,
+    private val dhisVersionManager: DHISVersionManagerImpl,
 ) {
     suspend fun checkServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
         try {
@@ -66,8 +69,8 @@ internal class LoginConfigCall(
     }
 
     private suspend fun withOauthConfig(serverUrl: String, loginConfig: LoginConfig): LoginConfig {
-        val oauthConfig = tryFetchOauthConfig(serverUrl)
-        return if (oauthConfig != null && oauthConfig.supportsRequiredFunctions()) {
+        val oauthConfig = tryFetchOauthConfig(serverUrl)?.takeIf { it.supportsRequiredFunctions() }
+        return if (oauthConfig != null) {
             oAuth2SecureStore.setEndpoints(oauthConfig)
             loginConfig.apply { isOauthEnabled = true }
         } else {
@@ -77,6 +80,10 @@ internal class LoginConfigCall(
     }
 
     private suspend fun tryFetchOauthConfig(serverUrl: String): OauthConfig? {
+        if (!dhisVersionManager.isGreaterOrEqualThanInternal(MIN_OAUTH_VERSION)) {
+            return null
+        }
+
         return coroutineAPICallExecutor.wrap(storeError = false) {
             networkHandler.oauthConfigFor(serverUrl)
         }.getOrNull()
@@ -109,5 +116,9 @@ internal class LoginConfigCall(
                     d2Error
                 }
             }
+    }
+
+    companion object {
+        private val MIN_OAUTH_VERSION = DHISVersion.V2_43
     }
 }

--- a/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
@@ -37,6 +37,8 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.hisp.dhis.android.core.server.OauthConfig
+import org.hisp.dhis.android.core.systeminfo.DHISVersion
+import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
 import org.hisp.dhis.android.core.systeminfo.internal.PingNetworkHandler
 import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
@@ -51,6 +53,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
 
 @RunWith(JUnit4::class)
 class LoginConfigCallShould {
@@ -59,18 +62,22 @@ class LoginConfigCallShould {
     private val loginExceptions: LogInExceptions = mock()
     private val networkHandler: LoginConfigNetworkHandler = mock()
     private val oauth2SecureStore = OAuth2SecureStore(InMemorySecureStore())
+    private val dhisVersionManager: DHISVersionManagerImpl = mock()
     private val executor = CoroutineAPICallExecutorMock()
 
     private lateinit var call: LoginConfigCall
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
+        whenever(dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_43)).doReturn(true)
+
         call = LoginConfigCall(
             pingNetworkHandler,
             loginExceptions,
             executor,
             networkHandler,
             oauth2SecureStore,
+            dhisVersionManager,
         )
     }
 
@@ -148,6 +155,27 @@ class LoginConfigCallShould {
         // along the loginConfig-success branch.
         assertThat(oauth2SecureStore.authorizationEndpoint).isEqualTo("kept-auth")
         assertThat(oauth2SecureStore.jwksUri).isEqualTo("kept-jwks")
+    }
+
+    @Test
+    fun marks_oauth_disabled_without_fetching_config_when_server_version_is_lower_than_2_43() = runTest {
+        oauth2SecureStore.authorizationEndpoint = "stale-auth"
+        oauth2SecureStore.jwksUri = "stale-jwks"
+
+        whenever(dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_43)).doReturn(false)
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample()
+            onBlocking { oauthConfigFor(any(), any()) } doReturn oauthConfigSample()
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
+        assertThat(loginConfig.isOauthEnabled).isFalse()
+        verifyBlocking(networkHandler, never()) { oauthConfigFor(any(), any()) }
+        assertThat(oauth2SecureStore.authorizationEndpoint).isNull()
+        assertThat(oauth2SecureStore.jwksUri).isNull()
     }
 
     private fun loginConfigSample(): LoginConfig =


### PR DESCRIPTION
OAuth2 was backported to 2.42.5, but the backend does not return a proper redirection URL to enroll the device, so OAuth2 login does not actually work against v42 servers. The server check now only offers OAuth2 login for servers with a version equal to or greater than 2.43, resolving the version through `DHISVersionManager`. Below that version the `.well-known/oauth-authorization-server` endpoint is not requested at all and the stored OAuth2 endpoints are cleared, so `LoginConfig.isOauthEnabled` stays false.

`ServerCheckCallMockIntegrationShould` no longer enqueues a response for the OAuth2 config request, since it is not performed for the 2.41 version reported by the mock server. Leaving it enqueued desynchronised the mock server FIFO queue, which is shared by every test class using the same database content, and made several unrelated tests fail when the whole instrumented suite ran.

Related task: [ANDROSDK-2374](https://dhis2.atlassian.net/browse/ANDROSDK-2374)

[ANDROSDK-2374]: https://dhis2.atlassian.net/browse/ANDROSDK-2374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ