### PR TITLE
chore: [CYCLONE-UPDATE] Update cyclonedx to 3.4.1 (Gradle 9 compatible)

### DIFF
--- a/.github/workflows/generate-and-upload-bom.yml
+++ b/.github/workflows/generate-and-upload-bom.yml
@@ -34,4 +34,4 @@ jobs:
               -H "Content-Type: multipart/form-data" \
               -H "X-Api-Key: ${{ secrets.DEPENDENCYTRACK_APIKEY }}" \
               -F "project=189ca834-ad84-4d54-ac98-c3d0526f56cc" \
-              -F "bom=@build/reports/bom.json"
+              -F "bom=@build/reports/cyclonedx/bom.json"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ sonarqube = "7.4.0.8496"
 detekt = "1.23.8"
 dokka = "2.2.0"
 nexusPublish = "2.0.0"
-cyclonedx = "2.1.0"
+cyclonedx = "3.4.1"
 
 targetSdkVersion = "37"
 minSdkVersion = "23"


### PR DESCRIPTION
The Dependency Tracker [job](https://github.com/dhis2/dhis2-android-capture-app/actions/runs/33453596742) was failing every night because the CycloneDX plugin was not compatible with Gradle 9.

This PR updates the CycloneDX plugin to the latest version and changes the Dependency Track workflow to use the new output path.