### PR TITLE
feature: [POC] scope D2 to a granted subset of the data

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -36,6 +36,7 @@ public final class org/hisp/dhis/android/core/D2 {
 	public final fun periodModule ()Lorg/hisp/dhis/android/core/period/PeriodModule;
 	public final fun programModule ()Lorg/hisp/dhis/android/core/program/ProgramModule;
 	public final fun relationshipModule ()Lorg/hisp/dhis/android/core/relationship/RelationshipModule;
+	public final fun scopedTo (Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope;)Lorg/hisp/dhis/android/core/scopedaccess/ScopedD2;
 	public final fun serverModule ()Lorg/hisp/dhis/android/core/server/ServerModule;
 	public final fun settingModule ()Lorg/hisp/dhis/android/core/settings/SettingModule;
 	public final fun smsModule ()Lorg/hisp/dhis/android/core/sms/SmsModule;
@@ -11338,6 +11339,7 @@ public final class org/hisp/dhis/android/core/maintenance/D2ErrorCode : java/lan
 	public static final field OWNERSHIP_ACCESS_DENIED Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field PROGRAM_ACCESS_CLOSED Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field RELATIONSHIPS_CANT_BE_UPDATED Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
+	public static final field SCOPE_VIOLATION Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field SEARCH_GRID_PARSE Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field SERVER_CONNECTION_ERROR Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
 	public static final field SERVER_URL_MALFORMED Lorg/hisp/dhis/android/core/maintenance/D2ErrorCode;
@@ -16725,6 +16727,218 @@ public final class org/hisp/dhis/android/core/resource/internal/OrgHispDhisAndro
 	public static final fun module (Lorg/hisp/dhis/android/core/resource/internal/ResourceDIModule;)Lorg/koin/core/module/Module;
 }
 
+public final class org/hisp/dhis/android/core/scopedaccess/D2Capability : java/lang/Enum {
+	public static final field READ_DATA_VALUE Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field READ_ENROLLMENT Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field READ_EVENT Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field READ_FILE_RESOURCE Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field READ_METADATA Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field READ_RELATIONSHIP Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field READ_TRACKED_ENTITY Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field SEARCH_TRACKED_ENTITY Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field WRITE_DATA_VALUE Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field WRITE_ENROLLMENT Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field WRITE_EVENT Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static final field WRITE_TRACKED_ENTITY Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isWrite ()Z
+	public static fun valueOf (Ljava/lang/String;)Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+	public static fun values ()[Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/D2DataScope {
+	public static final field Companion Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope$Companion;
+	public static final field NONE Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope;
+	public fun <init> ()V
+	public fun <init> (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;Ljava/util/Set;)V
+	public synthetic fun <init> (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun component2 ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun component3 ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun component4 ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun component5 ()Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public final fun component6 ()Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;
+	public final fun component7 ()Ljava/util/Set;
+	public final fun copy (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;Ljava/util/Set;)Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;Ljava/util/Set;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapabilities ()Ljava/util/Set;
+	public final fun getDataElements ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun getDataSets ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun getOrgUnits ()Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public final fun getPrograms ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun getTrackedEntityTypes ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun getWritable ()Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;
+	public final fun has (Lorg/hisp/dhis/android/core/scopedaccess/D2Capability;)Z
+	public final fun hasAnyWrite ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writableDataSets ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun writablePrograms ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/D2DataScope$Companion {
+}
+
+public abstract interface class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope {
+	public static final field Companion Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Companion;
+	public fun isEmpty ()Z
+	public static fun of (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public static fun of (Ljava/util/Collection;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope$All : org/hisp/dhis/android/core/scopedaccess/OrgUnitScope {
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$All;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Capture : org/hisp/dhis/android/core/scopedaccess/OrgUnitScope {
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Capture;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Companion {
+	public final fun of (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public final fun of (Ljava/util/Collection;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public static synthetic fun of$default (Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Companion;Ljava/util/Collection;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope$DefaultImpls {
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;)Z
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope$None : org/hisp/dhis/android/core/scopedaccess/OrgUnitScope {
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Only : org/hisp/dhis/android/core/scopedaccess/OrgUnitScope {
+	public fun <init> (Ljava/util/Set;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;)V
+	public synthetic fun <init> (Ljava/util/Set;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;
+	public final fun copy (Ljava/util/Set;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Only;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Only;Ljava/util/Set;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope$Only;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMode ()Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;
+	public final fun getUids ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/ScopedD2 {
+	public final fun categoryCombos ()Lorg/hisp/dhis/android/core/category/CategoryComboCollectionRepository;
+	public final fun categoryOptionCombos ()Lorg/hisp/dhis/android/core/category/CategoryOptionComboCollectionRepository;
+	public final fun dataElements ()Lorg/hisp/dhis/android/core/dataelement/DataElementCollectionRepository;
+	public final fun dataSets ()Lorg/hisp/dhis/android/core/dataset/DataSetCollectionRepository;
+	public final fun dataValues ()Lorg/hisp/dhis/android/core/datavalue/DataValueCollectionRepository;
+	public final fun enrollments ()Lorg/hisp/dhis/android/core/enrollment/EnrollmentCollectionRepository;
+	public final fun events ()Lorg/hisp/dhis/android/core/event/EventCollectionRepository;
+	public final fun getScope ()Lorg/hisp/dhis/android/core/scopedaccess/D2DataScope;
+	public final fun optionSets ()Lorg/hisp/dhis/android/core/option/OptionSetCollectionRepository;
+	public final fun options ()Lorg/hisp/dhis/android/core/option/OptionCollectionRepository;
+	public final fun organisationUnits ()Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitCollectionRepository;
+	public final fun programStages ()Lorg/hisp/dhis/android/core/program/ProgramStageCollectionRepository;
+	public final fun programs ()Lorg/hisp/dhis/android/core/program/ProgramCollectionRepository;
+	public final fun trackedEntityAttributeValues ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeValueCollectionRepository;
+	public final fun trackedEntityAttributes ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityAttributeCollectionRepository;
+	public final fun trackedEntityDataValues ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityDataValueCollectionRepository;
+	public final fun trackedEntityInstances ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityInstanceCollectionRepository;
+	public final fun trackedEntitySearch ()Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository;
+	public final fun trackedEntityTypes ()Lorg/hisp/dhis/android/core/trackedentity/TrackedEntityTypeCollectionRepository;
+}
+
+public abstract interface class org/hisp/dhis/android/core/scopedaccess/UidScope {
+	public static final field Companion Lorg/hisp/dhis/android/core/scopedaccess/UidScope$Companion;
+	public fun allows (Ljava/lang/String;)Z
+	public fun intersect (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public fun isEmpty ()Z
+	public static fun of (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public static fun of ([Ljava/lang/String;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public fun uidsOrNull ()Ljava/util/Set;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/UidScope$All : org/hisp/dhis/android/core/scopedaccess/UidScope {
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/scopedaccess/UidScope$All;
+	public fun allows (Ljava/lang/String;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun intersect (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun uidsOrNull ()Ljava/util/Set;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/UidScope$Companion {
+	public final fun of (Ljava/util/Collection;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun of ([Ljava/lang/String;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/UidScope$DefaultImpls {
+	public static fun allows (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Ljava/lang/String;)Z
+	public static fun intersect (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public static fun isEmpty (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Z
+	public static fun uidsOrNull (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Ljava/util/Set;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/UidScope$None : org/hisp/dhis/android/core/scopedaccess/UidScope {
+	public static final field INSTANCE Lorg/hisp/dhis/android/core/scopedaccess/UidScope$None;
+	public fun allows (Ljava/lang/String;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun intersect (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun uidsOrNull ()Ljava/util/Set;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/UidScope$Only : org/hisp/dhis/android/core/scopedaccess/UidScope {
+	public fun <init> (Ljava/util/Set;)V
+	public fun allows (Ljava/lang/String;)Z
+	public final fun component1 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/Set;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope$Only;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/scopedaccess/UidScope$Only;Ljava/util/Set;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope$Only;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUids ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun intersect (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;)Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun uidsOrNull ()Ljava/util/Set;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/WritableScope {
+	public static final field Companion Lorg/hisp/dhis/android/core/scopedaccess/WritableScope$Companion;
+	public static final field NONE Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;
+	public fun <init> ()V
+	public fun <init> (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;)V
+	public synthetic fun <init> (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun component2 ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun component3 ()Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public final fun copy (Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;)Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/UidScope;Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/scopedaccess/WritableScope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataSets ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public final fun getOrgUnits ()Lorg/hisp/dhis/android/core/scopedaccess/OrgUnitScope;
+	public final fun getPrograms ()Lorg/hisp/dhis/android/core/scopedaccess/UidScope;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/hisp/dhis/android/core/scopedaccess/WritableScope$Companion {
+}
+
 public final class org/hisp/dhis/android/core/server/LoginConfig {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/server/LoginPageLayout;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ZZZZZLjava/util/List;)V
@@ -22019,7 +22233,8 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 
 public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope : org/hisp/dhis/android/core/arch/repositories/scope/BaseScope {
 	public static final field Companion Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope$Companion;
-	public fun <init> (Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;)V
+	public fun <init> (Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant;)V
+	public synthetic fun <init> (Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun allowOnlineCache ()Z
 	public final fun assignedUserMode ()Lorg/hisp/dhis/android/core/common/AssignedUserMode;
 	public final fun attribute ()Ljava/util/List;
@@ -22050,8 +22265,8 @@ public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntity
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Lorg/hisp/dhis/android/core/common/DateFilterPeriod;
-	public final fun copy (Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;
-	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;
+	public final fun copy (Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;
+	public static synthetic fun copy$default (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryMode;Ljava/util/List;Lorg/hisp/dhis/android/core/organisationunit/OrganisationUnitMode;Ljava/lang/String;Ljava/lang/String;Lorg/hisp/dhis/android/core/arch/repositories/scope/internal/RepositoryScopeFilterItem;Ljava/util/List;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;Lorg/hisp/dhis/android/core/common/AssignedUserMode;Ljava/lang/String;ZLjava/util/List;Ljava/lang/Boolean;Ljava/util/List;Lorg/hisp/dhis/android/core/common/DateFilterPeriod;Ljava/util/List;ZLjava/util/Set;Ljava/util/List;Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant;ILjava/lang/Object;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;
 	public final fun dataValue ()Ljava/util/List;
 	public final fun dueDate ()Lorg/hisp/dhis/android/core/common/DateFilterPeriod;
 	public static final fun empty ()Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope;
@@ -22351,6 +22566,10 @@ public class org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstan
 
 public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryScopeOrderColumnBuilder$Companion {
 	public final fun from (Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryScopeOrderColumn;)Lorg/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryScopeOrderColumn$Builder;
+}
+
+public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant {
+	public static final field NO_MATCH Ljava/lang/String;
 }
 
 public final class org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchCollectionRepository : org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators, org/hisp/dhis/android/core/arch/repositories/collection/ReadOnlyWithUidCollectionRepository {

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/scopedaccess/ScopedD2MockIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/scopedaccess/ScopedD2MockIntegrationShould.kt
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.utils.integration.mock.BaseMockIntegrationTestFullDispatcher
+import org.junit.Test
+
+/**
+ * [ScopedD2] against a real, populated database.
+ *
+ * The unit tests prove the scope *algebra* — that filters accumulate, that a guard survives a
+ * builder chain. They cannot prove that the resulting SQL parses, runs, and returns the right rows,
+ * and two things here are only knowable by executing them: the hand-written sub-selects for tables
+ * with no program column, and an empty grant rendering as `IN ()`, which relies on SQLite accepting
+ * an empty list and evaluating it false.
+ *
+ * The assertions are written against whatever the fixture happens to contain rather than hardcoded
+ * UIDs, so they keep meaning if the fixture changes.
+ */
+class ScopedD2MockIntegrationShould : BaseMockIntegrationTestFullDispatcher() {
+
+    private val readEverything = setOf(
+        D2Capability.READ_METADATA,
+        D2Capability.READ_TRACKED_ENTITY,
+        D2Capability.READ_ENROLLMENT,
+        D2Capability.READ_EVENT,
+        D2Capability.READ_DATA_VALUE,
+    )
+
+    private fun scopedTo(programs: UidScope, orgUnits: OrgUnitScope = OrgUnitScope.All) =
+        d2.scopedTo(
+            D2DataScope(
+                programs = programs,
+                orgUnits = orgUnits,
+                capabilities = readEverything,
+            ),
+        )
+
+    private fun allProgramUids() = d2.programModule().programs().blockingGetUids()
+
+    // ── Reads ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun expose_only_the_granted_program() {
+        val granted = allProgramUids().first()
+
+        val visible = scopedTo(UidScope.of(granted)).programs().blockingGetUids()
+
+        assertThat(visible).containsExactly(granted)
+    }
+
+    @Test
+    fun return_nothing_when_asked_for_a_program_outside_the_grant() {
+        val all = allProgramUids()
+        // Needs at least two programs for this to mean anything.
+        assertThat(all.size).isAtLeast(2)
+        val granted = all[0]
+        val other = all[1]
+
+        val sdk = scopedTo(UidScope.of(granted))
+
+        // The grant and the caller's filter are AND-ed, so this is empty rather than `other`.
+        assertThat(sdk.programs().byUid().eq(other).blockingGetUids()).isEmpty()
+        assertThat(sdk.events().byProgramUid().eq(other).blockingGet()).isEmpty()
+        assertThat(sdk.enrollments().byProgram().eq(other).blockingGet()).isEmpty()
+    }
+
+    @Test
+    fun never_return_more_events_than_the_unscoped_sdk_would_for_that_program() {
+        val granted = allProgramUids().first()
+
+        val scoped = scopedTo(UidScope.of(granted)).events().blockingGet().map { it.uid() }
+        val expected = d2.eventModule().events()
+            .byProgramUid().eq(granted)
+            .blockingGet()
+            .map { it.uid() }
+
+        assertThat(scoped).containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun see_nothing_at_all_when_the_grant_is_empty() {
+        // Exercises `.in(emptyList())` → `column IN ()`. SQLite accepts an empty IN list and
+        // evaluates it false; most engines reject it outright, so this is worth executing rather
+        // than reasoning about.
+        val sdk = scopedTo(UidScope.None)
+
+        assertThat(sdk.programs().blockingGet()).isEmpty()
+        assertThat(sdk.events().blockingGet()).isEmpty()
+        assertThat(sdk.enrollments().blockingGet()).isEmpty()
+        assertThat(sdk.trackedEntityInstances().blockingGet()).isEmpty()
+    }
+
+    @Test
+    fun run_the_attribute_value_subquery_for_a_table_with_no_program_column() {
+        // TrackedEntityAttributeValue only references its tracked entity, so the grant becomes a
+        // hand-written sub-select through the enrollment table. This asserts that SQL is valid and
+        // bounded — a syntax error here would surface as an exception, not an empty list.
+        val granted = allProgramUids().first()
+        val sdk = scopedTo(UidScope.of(granted))
+
+        val inScopeTeis = sdk.trackedEntityInstances().blockingGetUids().toSet()
+        val values = sdk.trackedEntityAttributeValues().blockingGet()
+
+        assertThat(inScopeTeis).containsAtLeastElementsIn(values.map { it.trackedEntityInstance() }.toSet())
+    }
+
+    @Test
+    fun bound_attribute_values_to_the_grant_rather_than_returning_every_row() {
+        val granted = allProgramUids().first()
+
+        val scoped = scopedTo(UidScope.of(granted)).trackedEntityAttributeValues().blockingGet().size
+        val unscoped = d2.trackedEntityModule().trackedEntityAttributeValues().blockingGet().size
+
+        // Only meaningful if the fixture has data outside the granted program; if it does not, this
+        // still guards against the sub-select being dropped entirely.
+        assertThat(scoped).isAtMost(unscoped)
+    }
+
+    @Test
+    fun run_the_event_data_value_subquery() {
+        val granted = allProgramUids().first()
+        val sdk = scopedTo(UidScope.of(granted))
+
+        val inScopeEvents = sdk.events().blockingGetUids().toSet()
+        val values = sdk.trackedEntityDataValues().blockingGet()
+
+        assertThat(inScopeEvents).containsAtLeastElementsIn(values.map { it.event() }.toSet())
+    }
+
+    @Test
+    fun expand_org_unit_descendants_from_a_root() {
+        val root = d2.organisationUnitModule().organisationUnits().blockingGetUids().first()
+
+        val visible = d2.scopedTo(
+            D2DataScope(
+                orgUnits = OrgUnitScope.of(listOf(root)),
+                capabilities = setOf(D2Capability.READ_METADATA),
+            ),
+        ).organisationUnits().blockingGetUids()
+
+        // The root itself is always in scope; descendants come from the path LIKE match.
+        assertThat(visible).contains(root)
+    }
+
+    // ── Capabilities ─────────────────────────────────────────────────────────
+
+    @Test
+    fun refuse_an_accessor_whose_capability_was_not_granted() {
+        val sdk = d2.scopedTo(
+            D2DataScope(
+                programs = UidScope.All,
+                capabilities = setOf(D2Capability.READ_METADATA),
+            ),
+        )
+
+        // Metadata is granted…
+        assertThat(sdk.programs().blockingGet()).isNotEmpty()
+
+        // …tracker data is not.
+        val error = runCatching { sdk.trackedEntityInstances() }.exceptionOrNull()
+        assertThat(error).isInstanceOf(D2Error::class.java)
+        assertThat((error as D2Error).errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    // ── Writes ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun refuse_a_data_value_write_outside_the_grant() {
+        val sdk = d2.scopedTo(
+            D2DataScope(
+                dataSets = UidScope.None,
+                capabilities = setOf(D2Capability.READ_DATA_VALUE, D2Capability.WRITE_DATA_VALUE),
+            ),
+        )
+
+        val existing = d2.dataValueModule().dataValues().blockingGet().firstOrNull()
+        assertThat(existing).isNotNull()
+
+        val error = runCatching {
+            sdk.dataValues().value(
+                period = existing!!.period(),
+                organisationUnit = existing.organisationUnit(),
+                dataElement = existing.dataElement(),
+                categoryOptionCombo = existing.categoryOptionCombo(),
+                attributeOptionCombo = existing.attributeOptionCombo(),
+                sourceDataSet = "anyDataSet",
+            ).blockingSet("999")
+        }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(D2Error::class.java)
+        assertThat((error as D2Error).errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun leave_the_unscoped_sdk_completely_alone() {
+        // Everything above installs guards and filters on scopes. None of it may leak into the
+        // repositories the rest of the app gets from D2 directly.
+        val granted = allProgramUids().first()
+        scopedTo(UidScope.of(granted)).events().blockingGet()
+
+        assertThat(d2.programModule().programs().blockingGetUids())
+            .containsExactlyElementsIn(allProgramUids())
+        assertThat(d2.eventModule().events().blockingGet().size)
+            .isEqualTo(d2.eventModule().events().blockingCount())
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/D2.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/D2.kt
@@ -60,6 +60,8 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitModule
 import org.hisp.dhis.android.core.period.PeriodModule
 import org.hisp.dhis.android.core.program.ProgramModule
 import org.hisp.dhis.android.core.relationship.RelationshipModule
+import org.hisp.dhis.android.core.scopedaccess.D2DataScope
+import org.hisp.dhis.android.core.scopedaccess.ScopedD2
 import org.hisp.dhis.android.core.server.ServerModule
 import org.hisp.dhis.android.core.settings.SettingModule
 import org.hisp.dhis.android.core.sms.SmsModule
@@ -240,6 +242,22 @@ class D2 internal constructor(internal val d2DIComponent: D2DIComponent) {
 
     fun smsModule(): SmsModule {
         return modules.sms
+    }
+
+    /**
+     * Returns a view of this [D2] restricted to [scope].
+     *
+     * Use it wherever code should not reach the whole database — a third-party extension, an
+     * embedded feature, a component that must be provably confined to a few programs. The returned
+     * [ScopedD2] hands out ordinary SDK repositories that already carry the grant's filters, so
+     * callers keep the full fluent API and can only ever narrow further. See [ScopedD2] for what is
+     * exposed, what is withheld, and why the grant cannot be widened.
+     *
+     * This is an API boundary, not a sandbox: it constrains code that goes through it, and says
+     * nothing about code that can reach [D2Manager] or the database directly.
+     */
+    fun scopedTo(scope: D2DataScope): ScopedD2 {
+        return ScopedD2(this, scope)
     }
 
     internal fun context(): Context {

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/collection/internal/ReadWriteWithUidCollectionRepositoryImpl.kt
@@ -67,6 +67,10 @@ abstract class ReadWriteWithUidCollectionRepositoryImpl<M, P, R : ReadOnlyCollec
     @Suppress("TooGenericExceptionCaught")
     override suspend fun suspendAdd(o: P): String {
         val obj = transformer.transform(o)
+        // Deliberately outside the try: a scope violation must surface as SCOPE_VIOLATION rather
+        // than be rewritten as OBJECT_CANT_BE_INSERTED. The projection carries its own org unit and
+        // program, so the transformed object — not the query — is what has to be checked.
+        scope.accessGuard()?.checkWrite(obj)
         return try {
             store.insert(obj)
             propagateState(obj, HandleAction.Insert)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/FilterConnectorFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/filters/internal/FilterConnectorFactory.kt
@@ -87,6 +87,14 @@ class FilterConnectorFactory<R : BaseRepository> internal constructor(
         return SubQueryFilterConnector(repositoryFactory, scope, key)
     }
 
+    /**
+     * Rebuilds the repository with [updatedScope]. Backs
+     * [BaseRepositoryImpl.withScope][
+     * org.hisp.dhis.android.core.arch.repositories.collection.internal.BaseRepositoryImpl.withScope];
+     * every other caller should go through a filter connector instead.
+     */
+    internal fun updated(updatedScope: RepositoryScope): R = repositoryFactory.updated(updatedScope)
+
     @SuppressWarnings("LongParameterList")
     fun valueSubQuery(
         key: String,

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidDataObjectRepositoryImpl.kt
@@ -66,6 +66,7 @@ abstract class ReadWriteWithUidDataObjectRepositoryImpl<M, R : ReadOnlyObjectRep
                 .errorDescription("Tried to delete non existing object")
                 .build()
         } else {
+            scope.accessGuard()?.checkWrite(obj)
             deleteObject(obj)
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithUidObjectRepositoryImpl.kt
@@ -53,6 +53,7 @@ open class ReadWriteWithUidObjectRepositoryImpl<M, R : ReadOnlyObjectRepository<
     @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
     protected open suspend fun updateObject(m: M): Unit {
+        scope.accessGuard()?.checkWrite(m)
         return try {
             store.update(m)
             Unit()

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/object/internal/ReadWriteWithValueObjectRepositoryImpl.kt
@@ -73,6 +73,7 @@ internal constructor(
     @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
     protected open suspend fun suspendDelete(m: M) {
+        scope.accessGuard()?.checkWrite(m)
         try {
             store.deleteWhere(m)
             propagateState(m)
@@ -90,6 +91,7 @@ internal constructor(
     @Throws(D2Error::class)
     @Suppress("TooGenericExceptionCaught")
     protected suspend fun setObject(m: M) {
+        scope.accessGuard()?.checkWrite(m)
         try {
             store.updateOrInsertWhere(m)
             propagateState(m)

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/RepositoryScope.kt
@@ -29,6 +29,7 @@ package org.hisp.dhis.android.core.arch.repositories.scope
 
 import org.hisp.dhis.android.annotations.ModelBuilder
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenSelection
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.AccessGuard
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeComplexFilterItem
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeOrderByItem
@@ -40,6 +41,15 @@ data class RepositoryScope internal constructor(
     val complexFilters: List<RepositoryScopeComplexFilterItem>,
     internal val orderBy: List<RepositoryScopeOrderByItem>,
     internal val children: ChildrenSelection,
+    /**
+     * Vetoes out-of-scope writes, or null for an unrestricted scope (the default, and the case for
+     * every repository obtained straight from [D2][org.hisp.dhis.android.core.D2]).
+     *
+     * Set only by [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2]. The generated
+     * builder setter is `internal` and copy-on-write carries the guard through every filter call,
+     * so restricted code can neither install nor remove one.
+     */
+    internal val accessGuard: AccessGuard? = null,
 ) {
     enum class OrderByDirection(val api: String) {
         ASC("asc"),
@@ -50,6 +60,7 @@ data class RepositoryScope internal constructor(
     fun complexFilters(): List<RepositoryScopeComplexFilterItem> = complexFilters
     internal fun orderBy(): List<RepositoryScopeOrderByItem> = orderBy
     internal fun children(): ChildrenSelection = children
+    internal fun accessGuard(): AccessGuard? = accessGuard
 
     fun hasFilters(): Boolean = filters.isNotEmpty() || complexFilters.isNotEmpty()
 

--- a/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/AccessGuard.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/arch/repositories/scope/internal/AccessGuard.kt
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.repositories.scope.internal
+
+import org.hisp.dhis.android.core.maintenance.D2Error
+
+/**
+ * Vetoes writes that fall outside the scope a repository was created with.
+ *
+ * Read access is enforced by the filters in [RepositoryScope][
+ * org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope]: those are append-only, so a
+ * pre-narrowed repository can only ever be narrowed further. Writes have no such protection — the
+ * write entry points hand a fully-formed object straight to the store, and the object carries its
+ * own organisation unit, program or data element regardless of what the query said. This interface
+ * is the missing check.
+ *
+ * A guard is carried *on the scope*, not on the repository, which is what makes it unforgeable:
+ * `RepositoryScope` is copied field-by-field on every builder call, its generated setter for this
+ * field is `internal`, and no API removes it. So the guard survives every `by*()`, `orderBy*()`,
+ * `withChild()` and `uid()` in a fluent chain, and cannot be cleared by the code being restricted.
+ *
+ * Implementations live in `org.hisp.dhis.android.core.scopedaccess.internal`.
+ */
+internal interface AccessGuard {
+
+    /**
+     * Verifies that [target] may be written.
+     *
+     * @param target the object about to be inserted, updated or deleted.
+     * @throws D2Error with [D2ErrorCode.SCOPE_VIOLATION][
+     *     org.hisp.dhis.android.core.maintenance.D2ErrorCode.SCOPE_VIOLATION] if it may not.
+     */
+    @Throws(D2Error::class)
+    suspend fun checkWrite(target: Any?)
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2ErrorCode.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/maintenance/D2ErrorCode.kt
@@ -109,4 +109,12 @@ enum class D2ErrorCode {
     SSL_ERROR,
     SMS_NOT_SUPPORTED,
     INVALID_CHARACTERS,
+
+    /**
+     * A read or write was attempted outside the bounds of the
+     * [D2DataScope][org.hisp.dhis.android.core.scopedaccess.D2DataScope] the repository was
+     * obtained with. Raised only by repositories reached through
+     * [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2].
+     */
+    SCOPE_VIOLATION,
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/D2Capability.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/D2Capability.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2023, University of Oslo
+ *  Copyright (c) 2004-2025, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -25,26 +25,54 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.android.core.arch.repositories.collection.internal
+package org.hisp.dhis.android.core.scopedaccess
 
-import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
-import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConnectorFactory
-import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+/**
+ * A feature area a [D2DataScope] may unlock.
+ *
+ * Capabilities are opt-in: a scope with an empty capability set exposes nothing, no matter which
+ * UIDs it grants. This keeps the default surface closed, so widening it is always an explicit act by
+ * whoever authors the scope.
+ */
+enum class D2Capability {
 
-open class BaseRepositoryImpl<R : BaseRepository>(
-    @JvmField protected val scope: RepositoryScope,
-    @JvmField protected val cf: FilterConnectorFactory<R>,
-) : BaseRepository {
+    /** Read metadata: programs, data sets, org units, data elements, attributes, option sets. */
+    READ_METADATA,
 
-    /**
-     * Rebuilds this repository with a transformed scope.
-     *
-     * The public `by*()` filters cover almost everything a caller needs, but two things are only
-     * reachable from inside the SDK: installing an
-     * [AccessGuard][org.hisp.dhis.android.core.arch.repositories.scope.internal.AccessGuard], and
-     * adding a complex (sub-select) filter for a table with no column to filter on. Both are needed
-     * by [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2], which sits outside the
-     * repository classes and so cannot reach the `protected` [cf].
-     */
-    internal fun withScope(transform: (RepositoryScope) -> RepositoryScope): R = cf.updated(transform(scope))
+    /** Read tracked entity instances and their attribute values. */
+    READ_TRACKED_ENTITY,
+
+    /** Read enrollments. */
+    READ_ENROLLMENT,
+
+    /** Read events and their data values. */
+    READ_EVENT,
+
+    /** Read aggregated data values and complete registrations. */
+    READ_DATA_VALUE,
+
+    /** Use the tracked entity search API. Always resolved against the local database. */
+    SEARCH_TRACKED_ENTITY,
+
+    /** Read relationships between tracked entities and events. */
+    READ_RELATIONSHIP,
+
+    /** Read file resources. */
+    READ_FILE_RESOURCE,
+
+    /** Create and update tracked entity instances. */
+    WRITE_TRACKED_ENTITY,
+
+    /** Create and update enrollments. */
+    WRITE_ENROLLMENT,
+
+    /** Create and update events and their data values. */
+    WRITE_EVENT,
+
+    /** Create, update and delete aggregated data values. */
+    WRITE_DATA_VALUE,
+    ;
+
+    /** True if this capability grants write access of any kind. */
+    fun isWrite(): Boolean = name.startsWith("WRITE_")
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/D2DataScope.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/D2DataScope.kt
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+/**
+ * The subset of the local database a [ScopedD2] may reach.
+ *
+ * A scope is a *grant*: it is authored by whoever owns the trust decision — a server administrator,
+ * a host application — and handed to the code being restricted, which cannot widen it. Every
+ * dimension defaults to the closed value, so an empty `D2DataScope()` grants nothing.
+ *
+ * Read and write access are separate. [writable] never widens the read scope; a UID must be in both
+ * to be writable, so the common "read this program, write nothing" case is the default.
+ *
+ * ```kotlin
+ * val scope = D2DataScope(
+ *     programs = UidScope.of("IpHINAT79UW"),
+ *     orgUnits = OrgUnitScope.of(listOf("O6uvpzGd5pu")),
+ *     capabilities = setOf(D2Capability.READ_METADATA, D2Capability.READ_TRACKED_ENTITY),
+ * )
+ * val sdk = d2.scopedTo(scope)
+ * ```
+ */
+data class D2DataScope(
+    /** Programs whose tracked entities, enrollments and events are readable. */
+    val programs: UidScope = UidScope.None,
+    /** Data sets whose data values are readable. */
+    val dataSets: UidScope = UidScope.None,
+    /** Tracked entity types that are readable. Defaults to [UidScope.All]: [programs] already bounds
+     *  the tracker data, and narrowing types further is rarely needed. */
+    val trackedEntityTypes: UidScope = UidScope.All,
+    /** Data elements that are readable, within the bound already set by [programs] and [dataSets]. */
+    val dataElements: UidScope = UidScope.All,
+    /** Organisation units whose data is readable. */
+    val orgUnits: OrgUnitScope = OrgUnitScope.None,
+    /** The subset of the above that may also be written. Always intersected with the read scope. */
+    val writable: WritableScope = WritableScope.NONE,
+    /** Feature areas this scope unlocks. Empty means nothing is exposed. */
+    val capabilities: Set<D2Capability> = emptySet(),
+) {
+
+    /** True if [capability] is granted. */
+    fun has(capability: D2Capability): Boolean = capability in capabilities
+
+    /** True if any write capability is granted and something is actually writable. */
+    fun hasAnyWrite(): Boolean =
+        capabilities.any { it.isWrite() } && !(writable.programs.isEmpty() && writable.dataSets.isEmpty())
+
+    /** Programs that may be written: the read grant intersected with [WritableScope.programs]. */
+    fun writablePrograms(): UidScope = programs.intersect(writable.programs)
+
+    /** Data sets that may be written: the read grant intersected with [WritableScope.dataSets]. */
+    fun writableDataSets(): UidScope = dataSets.intersect(writable.dataSets)
+
+    companion object {
+        /** A scope that grants nothing. */
+        @JvmField
+        val NONE: D2DataScope = D2DataScope()
+    }
+}
+
+/**
+ * The writable subset of a [D2DataScope].
+ *
+ * Every field is intersected with the corresponding read field, so this can only ever restrict.
+ * Listing a UID here that the read scope does not grant has no effect.
+ */
+data class WritableScope(
+    val programs: UidScope = UidScope.None,
+    val dataSets: UidScope = UidScope.None,
+    val orgUnits: OrgUnitScope = OrgUnitScope.None,
+) {
+    companion object {
+        /** Read-only: nothing may be written. */
+        @JvmField
+        val NONE: WritableScope = WritableScope()
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/OrgUnitScope.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/OrgUnitScope.kt
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
+
+/**
+ * The organisation unit restriction of a [D2DataScope].
+ *
+ * Unlike [UidScope] this needs a hierarchy mode, because granting an org unit almost always means
+ * granting the sub-tree below it. [Only] with [OrganisationUnitMode.DESCENDANTS] is the usual
+ * choice; resolution of the sub-tree is done by the SDK, not by the caller.
+ */
+sealed interface OrgUnitScope {
+
+    /** No restriction — every organisation unit on the device is in scope. */
+    data object All : OrgUnitScope
+
+    /** No organisation unit is in scope. The default. */
+    data object None : OrgUnitScope
+
+    /** The organisation units the logged-in user can capture data in, and their descendants. */
+    data object Capture : OrgUnitScope
+
+    /**
+     * Only [uids] are in scope, interpreted according to [mode].
+     *
+     * [OrganisationUnitMode.SELECTED] means exactly those units;
+     * [OrganisationUnitMode.DESCENDANTS] (the default) means those units and everything beneath
+     * them; [OrganisationUnitMode.CHILDREN] means those units and their immediate children.
+     */
+    data class Only(
+        val uids: Set<String>,
+        val mode: OrganisationUnitMode = OrganisationUnitMode.DESCENDANTS,
+    ) : OrgUnitScope
+
+    /** True if this scope permits nothing. */
+    fun isEmpty(): Boolean = when (this) {
+        is All, is Capture -> false
+        is None -> true
+        is Only -> uids.isEmpty()
+    }
+
+    companion object {
+        /** [Only] over [uids] with the given [mode], or [None] when empty. */
+        @JvmStatic
+        @JvmOverloads
+        fun of(
+            uids: Collection<String>,
+            mode: OrganisationUnitMode = OrganisationUnitMode.DESCENDANTS,
+        ): OrgUnitScope = if (uids.isEmpty()) None else Only(uids.toSet(), mode)
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/ScopedD2.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/ScopedD2.kt
@@ -1,0 +1,350 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.collection.BaseRepository
+import org.hisp.dhis.android.core.arch.repositories.collection.internal.BaseRepositoryImpl
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.AccessGuard
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeComplexFilterItem
+import org.hisp.dhis.android.core.category.CategoryComboCollectionRepository
+import org.hisp.dhis.android.core.category.CategoryOptionComboCollectionRepository
+import org.hisp.dhis.android.core.common.IdentifiableColumns
+import org.hisp.dhis.android.core.dataelement.DataElementCollectionRepository
+import org.hisp.dhis.android.core.dataset.DataSetCollectionRepository
+import org.hisp.dhis.android.core.datavalue.DataValueCollectionRepository
+import org.hisp.dhis.android.core.enrollment.EnrollmentCollectionRepository
+import org.hisp.dhis.android.core.event.EventCollectionRepository
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.option.OptionCollectionRepository
+import org.hisp.dhis.android.core.option.OptionSetCollectionRepository
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitCollectionRepository
+import org.hisp.dhis.android.core.program.ProgramCollectionRepository
+import org.hisp.dhis.android.core.program.ProgramStageCollectionRepository
+import org.hisp.dhis.android.core.scopedaccess.internal.ScopeResolver
+import org.hisp.dhis.android.core.scopedaccess.internal.ScopedAccessGuard
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeCollectionRepository
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValueCollectionRepository
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValueCollectionRepository
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceCollectionRepository
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityTypeCollectionRepository
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityQueryGrant
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntitySearchCollectionRepository
+import org.hisp.dhis.android.persistence.enrollment.EnrollmentTableInfo
+import org.hisp.dhis.android.persistence.event.EventTableInfo
+import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityAttributeValueTableInfo
+import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityDataValueTableInfo
+
+/**
+ * [D2] narrowed to a [D2DataScope].
+ *
+ * Every accessor returns a **real SDK repository**, already carrying the filters that express the
+ * grant. Callers get the full fluent API — `by*()`, `orderBy*()`, `withChild()`, `uid()`, paging,
+ * `blockingGet()` — at full granularity and with no wrapper indirection.
+ *
+ * ### Why the grant cannot be widened
+ *
+ * [RepositoryScope][org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope] filters are
+ * append-only and copy-on-write: every `by*()` call routes through `RepositoryScopeHelper`, which
+ * only ever does `filters + item`, and the scope itself is `protected`. No API removes, replaces or
+ * resets a filter. So a caller holding a pre-narrowed repository can only narrow it further —
+ * asking for a program outside the grant yields an empty result, not a wider one.
+ *
+ * Writes get no such protection from filters, because a create projection or value object carries
+ * its own organisation unit and program regardless of the query. They are covered instead by an
+ * [AccessGuard] carried on the same scope, checked at every write entry point.
+ *
+ * ### What is deliberately absent
+ *
+ * [D2] members with no safe restriction are not exposed at all, and this is a decision rather than
+ * an oversight:
+ *
+ *  - `databaseAdapter()`, `httpServiceClient()` — raw database and network access;
+ *  - `wipeModule()`, `maintenanceModule()` — destructive;
+ *  - `dataStoreModule()` — privilege escalation, since host applications keep their own
+ *    configuration there, including the configuration that authors scopes;
+ *  - `userModule()` — credentials and account management;
+ *  - `importModule()`, `metadataModule()`, `smsModule()`, `settingModule()` — sync and transport;
+ *  - `analyticsModule()`, `relationshipModule()` — a free-form dimension DSL and object-graph
+ *    traversal that can both reach outside a grant; deferred until they get their own design pass.
+ *
+ * Metadata *definitions* (option sets, category combos, attribute definitions) are exposed
+ * unrestricted under [D2Capability.READ_METADATA]. The line drawn here is between metadata, which
+ * describes the shape of the data, and the data itself, which is what the grant bounds.
+ *
+ * Obtain one with [D2.scopedTo]:
+ *
+ * ```kotlin
+ * val sdk = d2.scopedTo(
+ *     D2DataScope(
+ *         programs = UidScope.of("IpHINAT79UW"),
+ *         orgUnits = OrgUnitScope.of(listOf("O6uvpzGd5pu")),
+ *         capabilities = setOf(D2Capability.READ_METADATA, D2Capability.READ_EVENT),
+ *     ),
+ * )
+ * val recent = sdk.events()
+ *     .byEventDate().after(lastWeek)
+ *     .orderByEventDate(RepositoryScope.OrderByDirection.DESC)
+ *     .blockingGet()
+ * ```
+ *
+ * Derived parts of a grant (org unit descendants, the data elements of a data set) are resolved once
+ * and cached for this instance's lifetime. Obtain a fresh `ScopedD2` after a metadata sync.
+ */
+@Suppress("TooManyFunctions")
+class ScopedD2 internal constructor(
+    private val d2: D2,
+    /** The grant this instance enforces. Read-only; nothing here can widen it. */
+    val scope: D2DataScope,
+) {
+
+    private val resolver = ScopeResolver(d2, scope)
+    private val guard: AccessGuard = ScopedAccessGuard(scope, resolver)
+
+    // ── Metadata ─────────────────────────────────────────────────────────────
+
+    /** Programs in the grant. */
+    fun programs(): ProgramCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        var repo = d2.programModule().programs()
+        scope.programs.uidsOrNull()?.let { repo = repo.byUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Program stages belonging to programs in the grant. */
+    fun programStages(): ProgramStageCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        var repo = d2.programModule().programStages()
+        scope.programs.uidsOrNull()?.let { repo = repo.byProgramUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Data sets in the grant. */
+    fun dataSets(): DataSetCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        var repo = d2.dataSetModule().dataSets()
+        scope.dataSets.uidsOrNull()?.let { repo = repo.byUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Data elements reachable through the granted data sets, or all of them if unrestricted. */
+    fun dataElements(): DataElementCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        var repo = d2.dataElementModule().dataElements()
+        resolver.readableDataElements()?.let { repo = repo.byUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Tracked entity types in the grant. */
+    fun trackedEntityTypes(): TrackedEntityTypeCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        var repo = d2.trackedEntityModule().trackedEntityTypes()
+        scope.trackedEntityTypes.uidsOrNull()?.let { repo = repo.byUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Organisation units in the grant, with any hierarchy mode already expanded. */
+    fun organisationUnits(): OrganisationUnitCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        var repo = d2.organisationUnitModule().organisationUnits()
+        resolver.readableOrgUnits()?.let { repo = repo.byUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Tracked entity attribute *definitions*. Their values are scoped by [trackedEntityAttributeValues]. */
+    fun trackedEntityAttributes(): TrackedEntityAttributeCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        return d2.trackedEntityModule().trackedEntityAttributes().guarded()
+    }
+
+    /** Option sets. Metadata, unrestricted under [D2Capability.READ_METADATA]. */
+    fun optionSets(): OptionSetCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        return d2.optionModule().optionSets().guarded()
+    }
+
+    /** Options. Metadata, unrestricted under [D2Capability.READ_METADATA]. */
+    fun options(): OptionCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        return d2.optionModule().options().guarded()
+    }
+
+    /** Category combos. Metadata, unrestricted under [D2Capability.READ_METADATA]. */
+    fun categoryCombos(): CategoryComboCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        return d2.categoryModule().categoryCombos().guarded()
+    }
+
+    /** Category option combos. Metadata, unrestricted under [D2Capability.READ_METADATA]. */
+    fun categoryOptionCombos(): CategoryOptionComboCollectionRepository {
+        requireCapability(D2Capability.READ_METADATA)
+        return d2.categoryModule().categoryOptionCombos().guarded()
+    }
+
+    // ── Tracker data ─────────────────────────────────────────────────────────
+
+    /**
+     * Tracked entity instances enrolled in a granted program and held in a granted organisation
+     * unit.
+     *
+     * The program restriction is a sub-select through the enrollment table — a TEI has no program
+     * column of its own — using the SDK's own `byProgramUids`.
+     */
+    fun trackedEntityInstances(): TrackedEntityInstanceCollectionRepository {
+        requireCapability(D2Capability.READ_TRACKED_ENTITY)
+        var repo = d2.trackedEntityModule().trackedEntityInstances()
+        scope.programs.uidsOrNull()?.let { repo = repo.byProgramUids(it.toList()) }
+        resolver.readableOrgUnits()?.let { repo = repo.byOrganisationUnitUid().`in`(it.toList()) }
+        scope.trackedEntityTypes.uidsOrNull()?.let { repo = repo.byTrackedEntityType().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /**
+     * Attribute values of tracked entities inside the grant.
+     *
+     * This table has no program or organisation unit column, only a tracked entity reference, so the
+     * restriction has to be a sub-select through the enrollment table. Without it a caller could
+     * read the attribute values of any tracked entity on the device by UID.
+     */
+    fun trackedEntityAttributeValues(): TrackedEntityAttributeValueCollectionRepository {
+        requireCapability(D2Capability.READ_TRACKED_ENTITY)
+        val repo = d2.trackedEntityModule().trackedEntityAttributeValues()
+        val programs = scope.programs.uidsOrNull() ?: return repo.guarded()
+        return repo.guardedWith(enrolledInProgramsClause(programs))
+    }
+
+    /** Enrollments into granted programs, in granted organisation units. */
+    fun enrollments(): EnrollmentCollectionRepository {
+        requireCapability(D2Capability.READ_ENROLLMENT)
+        var repo = d2.enrollmentModule().enrollments()
+        scope.programs.uidsOrNull()?.let { repo = repo.byProgram().`in`(it.toList()) }
+        resolver.readableOrgUnits()?.let { repo = repo.byOrganisationUnit().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /** Events of granted programs, in granted organisation units. */
+    fun events(): EventCollectionRepository {
+        requireCapability(D2Capability.READ_EVENT)
+        var repo = d2.eventModule().events()
+        scope.programs.uidsOrNull()?.let { repo = repo.byProgramUid().`in`(it.toList()) }
+        resolver.readableOrgUnits()?.let { repo = repo.byOrganisationUnitUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    /**
+     * Data values of events inside the grant.
+     *
+     * Like attribute values this table only references its parent, so the program restriction is a
+     * sub-select through the event table.
+     */
+    fun trackedEntityDataValues(): TrackedEntityDataValueCollectionRepository {
+        requireCapability(D2Capability.READ_EVENT)
+        val repo = d2.trackedEntityModule().trackedEntityDataValues()
+        val programs = scope.programs.uidsOrNull() ?: return repo.guarded()
+        return repo.guardedWith(eventInProgramsClause(programs))
+    }
+
+    /**
+     * Tracked entity search, restricted to the grant and answered from the local database.
+     *
+     * Unlike the repositories above, this one's scope is a record of fields that `by*()` calls
+     * replace rather than append to, so the grant is re-applied on every repository the fluent API
+     * produces — see [TrackedEntityQueryGrant]. `onlineOnly()` and `onlineFirst()` are forced back
+     * to offline: a server-side search is answered where none of these restrictions exist.
+     */
+    fun trackedEntitySearch(): TrackedEntitySearchCollectionRepository {
+        requireCapability(D2Capability.SEARCH_TRACKED_ENTITY)
+        return d2.trackedEntityModule().trackedEntitySearch().withGrant(
+            TrackedEntityQueryGrant(
+                programs = scope.programs.uidsOrNull(),
+                orgUnits = resolver.readableOrgUnits(),
+                trackedEntityTypes = scope.trackedEntityTypes.uidsOrNull(),
+            ),
+        )
+    }
+
+    // ── Aggregate data ───────────────────────────────────────────────────────
+
+    /**
+     * Data values for data elements of the granted data sets, in granted organisation units.
+     *
+     * `DataValue` has no data-set column, so the grant is resolved to the data elements those data
+     * sets contain.
+     */
+    fun dataValues(): DataValueCollectionRepository {
+        requireCapability(D2Capability.READ_DATA_VALUE)
+        var repo = d2.dataValueModule().dataValues()
+        resolver.readableDataElements()?.let { repo = repo.byDataElementUid().`in`(it.toList()) }
+        resolver.readableOrgUnits()?.let { repo = repo.byOrganisationUnitUid().`in`(it.toList()) }
+        return repo.guarded()
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    private fun requireCapability(capability: D2Capability) {
+        if (!scope.has(capability)) {
+            throw D2Error
+                .builder()
+                .errorComponent(D2ErrorComponent.SDK)
+                .errorCode(D2ErrorCode.SCOPE_VIOLATION)
+                .errorDescription("This D2DataScope does not grant the $capability capability")
+                .build()
+        }
+    }
+
+    /** Installs the write guard, leaving the read filters exactly as the caller built them. */
+    private fun <R : BaseRepository> BaseRepositoryImpl<R>.guarded(): R =
+        withScope { it.toBuilder().accessGuard(guard).build() }
+
+    /** Installs the write guard and one mandatory sub-select the public filters cannot express. */
+    private fun <R : BaseRepository> BaseRepositoryImpl<R>.guardedWith(whereClause: String): R =
+        withScope { current ->
+            current.toBuilder()
+                .complexFilters(current.complexFilters() + RepositoryScopeComplexFilterItem(whereClause))
+                .accessGuard(guard)
+                .build()
+        }
+
+    private fun enrolledInProgramsClause(programs: Set<String>): String =
+        "${TrackedEntityAttributeValueTableInfo.Columns.TRACKED_ENTITY_INSTANCE} IN (" +
+            "SELECT ${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE} " +
+            "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
+            "WHERE ${EnrollmentTableInfo.Columns.PROGRAM} IN ${sqlList(programs)})"
+
+    private fun eventInProgramsClause(programs: Set<String>): String =
+        "${TrackedEntityDataValueTableInfo.Columns.EVENT} IN (" +
+            "SELECT ${IdentifiableColumns.UID} " +
+            "FROM ${EventTableInfo.TABLE_INFO.name()} " +
+            "WHERE ${EventTableInfo.Columns.PROGRAM} IN ${sqlList(programs)})"
+
+    /** DHIS2 UIDs are alphanumeric, but quotes are escaped anyway rather than trusted. */
+    private fun sqlList(uids: Set<String>): String =
+        uids.joinToString(prefix = "(", postfix = ")") { "'${it.replace("'", "''")}'" }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/UidScope.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/UidScope.kt
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+/**
+ * A restriction over a set of metadata UIDs, used to build a [D2DataScope].
+ *
+ * The three cases are deliberately distinct: [None] and `Only(emptySet())` both permit nothing,
+ * while [All] applies no restriction at all. [uidsOrNull] returns `null` precisely for [All], which
+ * is how callers know that no filter needs to be applied.
+ */
+sealed interface UidScope {
+
+    /** No restriction — every UID of the relevant type is in scope. */
+    data object All : UidScope
+
+    /** Nothing is in scope. This is the default for every dimension of a [D2DataScope]. */
+    data object None : UidScope
+
+    /** Only the listed [uids] are in scope. */
+    data class Only(val uids: Set<String>) : UidScope
+
+    /** True if [uid] falls inside this scope. A null [uid] is never in scope. */
+    fun allows(uid: String?): Boolean = when (this) {
+        is All -> uid != null
+        is None -> false
+        is Only -> uid != null && uid in uids
+    }
+
+    /** True if this scope permits nothing, either because it is [None] or an empty [Only]. */
+    fun isEmpty(): Boolean = when (this) {
+        is All -> false
+        is None -> true
+        is Only -> uids.isEmpty()
+    }
+
+    /**
+     * The explicit UID set this scope narrows to, or null when it does not narrow ([All]) and no
+     * filter is therefore required.
+     */
+    fun uidsOrNull(): Set<String>? = when (this) {
+        is All -> null
+        is None -> emptySet()
+        is Only -> uids
+    }
+
+    /**
+     * The intersection of this scope with [other]. Intersection is how a grant is combined with a
+     * caller-supplied narrowing: it can only ever shrink.
+     */
+    fun intersect(other: UidScope): UidScope = when {
+        this is All -> other
+        other is All -> this
+        this is None || other is None -> None
+        else -> Only((this as Only).uids intersect (other as Only).uids)
+    }
+
+    companion object {
+        /** [Only] over [uids], or [None] when empty. */
+        @JvmStatic
+        fun of(uids: Collection<String>): UidScope = if (uids.isEmpty()) None else Only(uids.toSet())
+
+        /** [Only] over [uids], or [None] when empty. */
+        @JvmStatic
+        fun of(vararg uids: String): UidScope = of(uids.toList())
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/internal/ScopeResolver.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/internal/ScopeResolver.kt
@@ -1,0 +1,202 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess.internal
+
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
+import org.hisp.dhis.android.core.scopedaccess.D2DataScope
+import org.hisp.dhis.android.core.scopedaccess.OrgUnitScope
+import org.hisp.dhis.android.core.scopedaccess.UidScope
+
+/**
+ * Turns the declarative parts of a [D2DataScope] into the concrete UID sets the repository filters
+ * need.
+ *
+ * Three of the grant's dimensions cannot be expressed as a filter directly:
+ *
+ *  - [OrgUnitScope.Only] with `DESCENDANTS`/`CHILDREN` names roots, but `byOrganisationUnitUid()`
+ *    wants leaves;
+ *  - [OrgUnitScope.Capture] names no UIDs at all;
+ *  - a data set grant has to become the set of data elements belonging to those data sets, because
+ *    `DataValue` has no data-set column.
+ *
+ * Each answer is computed once and cached for the life of the resolver, which is the life of the
+ * [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2] that owns it. Callers that need to
+ * pick up a metadata sync should obtain a fresh `ScopedD2`.
+ */
+@Suppress("TooManyFunctions")
+internal class ScopeResolver(
+    private val d2: D2,
+    private val scope: D2DataScope,
+) {
+
+    private var readOrgUnitsResolved = false
+    private var readOrgUnits: Set<String>? = null
+
+    private var writeOrgUnitsResolved = false
+    private var writeOrgUnits: Set<String>? = null
+
+    private var readDataElementsResolved = false
+    private var readDataElements: Set<String>? = null
+
+    private var writeDataElementsResolved = false
+    private var writeDataElements: Set<String>? = null
+
+    /**
+     * The organisation units readable under this grant, or null when unrestricted and no filter is
+     * needed.
+     */
+    fun readableOrgUnits(): Set<String>? {
+        if (!readOrgUnitsResolved) {
+            readOrgUnits = resolveOrgUnits(scope.orgUnits)
+            readOrgUnitsResolved = true
+        }
+        return readOrgUnits
+    }
+
+    /** The organisation units writable under this grant, or null when unrestricted. */
+    fun writableOrgUnits(): Set<String>? {
+        if (!writeOrgUnitsResolved) {
+            val read = readableOrgUnits()
+            val write = resolveOrgUnits(scope.writable.orgUnits)
+            writeOrgUnits = intersect(read, write)
+            writeOrgUnitsResolved = true
+        }
+        return writeOrgUnits
+    }
+
+    /**
+     * The data elements readable under this grant, or null when unrestricted.
+     *
+     * Derived from [D2DataScope.dataSets] and then narrowed by an explicit
+     * [D2DataScope.dataElements] if one was given.
+     */
+    fun readableDataElements(): Set<String>? {
+        if (!readDataElementsResolved) {
+            readDataElements = intersect(
+                dataElementsOf(scope.dataSets),
+                scope.dataElements.uidsOrNull(),
+            )
+            readDataElementsResolved = true
+        }
+        return readDataElements
+    }
+
+    /** The data elements writable under this grant, or null when unrestricted. */
+    fun writableDataElements(): Set<String>? {
+        if (!writeDataElementsResolved) {
+            writeDataElements = intersect(
+                readableDataElements(),
+                dataElementsOf(scope.writableDataSets()),
+            )
+            writeDataElementsResolved = true
+        }
+        return writeDataElements
+    }
+
+    /** The programs an enrollment of [teiUid] belongs to. Used to place a TEI inside the grant. */
+    fun programsOfTrackedEntity(teiUid: String): Set<String> =
+        d2.enrollmentModule().enrollments()
+            .byTrackedEntityInstance().eq(teiUid)
+            .blockingGet()
+            .mapNotNull { it.program() }
+            .toSet()
+
+    /** The program an event belongs to, or null if the event is unknown locally. */
+    fun programOfEvent(eventUid: String): String? =
+        d2.eventModule().events().uid(eventUid).blockingGet()?.program()
+
+    /** The organisation unit an event belongs to, or null if the event is unknown locally. */
+    fun orgUnitOfEvent(eventUid: String): String? =
+        d2.eventModule().events().uid(eventUid).blockingGet()?.organisationUnit()
+
+    private fun resolveOrgUnits(orgUnitScope: OrgUnitScope): Set<String>? = when (orgUnitScope) {
+        is OrgUnitScope.All -> null
+        is OrgUnitScope.None -> emptySet()
+        is OrgUnitScope.Capture -> d2.organisationUnitModule().organisationUnits()
+            .byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE)
+            .blockingGetUids()
+            .toSet()
+
+        is OrgUnitScope.Only -> when (orgUnitScope.mode) {
+            OrganisationUnitMode.SELECTED -> orgUnitScope.uids
+            else -> expandHierarchy(orgUnitScope.uids, orgUnitScope.mode)
+        }
+    }
+
+    /**
+     * Expands org unit roots to the units beneath them.
+     *
+     * `path` on an organisation unit is the slash-separated chain of ancestor UIDs ending in its
+     * own, so a `LIKE %uid%` over `path` finds the whole sub-tree in one query. For
+     * [OrganisationUnitMode.CHILDREN] the result is trimmed back to the roots and their immediate
+     * children.
+     */
+    private fun expandHierarchy(roots: Set<String>, mode: OrganisationUnitMode): Set<String> {
+        if (roots.isEmpty()) return emptySet()
+
+        val descendants = roots.flatMapTo(mutableSetOf()) { root ->
+            d2.organisationUnitModule().organisationUnits()
+                .byPath().like(root)
+                .blockingGetUids()
+        }
+
+        return if (mode == OrganisationUnitMode.CHILDREN) {
+            val children = d2.organisationUnitModule().organisationUnits()
+                .byParentUid().`in`(roots.toList())
+                .blockingGetUids()
+            roots + children
+        } else {
+            descendants + roots
+        }
+    }
+
+    private fun dataElementsOf(dataSets: UidScope): Set<String>? {
+        val uids = dataSets.uidsOrNull() ?: return null
+
+        return if (uids.isEmpty()) {
+            emptySet()
+        } else {
+            d2.dataSetModule().dataSets()
+                .withDataSetElements()
+                .byUid().`in`(uids.toList())
+                .blockingGet()
+                .flatMap { dataSet -> dataSet.dataSetElements().orEmpty() }
+                .map { it.dataElement().uid() }
+                .toSet()
+        }
+    }
+
+    /** Null means "no restriction", so it is the identity of this intersection, not the zero. */
+    private fun intersect(a: Set<String>?, b: Set<String>?): Set<String>? = when {
+        a == null -> b
+        b == null -> a
+        else -> a intersect b
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/internal/ScopedAccessGuard.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/scopedaccess/internal/ScopedAccessGuard.kt
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess.internal
+
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.AccessGuard
+import org.hisp.dhis.android.core.datavalue.DataValue
+import org.hisp.dhis.android.core.enrollment.Enrollment
+import org.hisp.dhis.android.core.event.Event
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
+import org.hisp.dhis.android.core.scopedaccess.D2Capability
+import org.hisp.dhis.android.core.scopedaccess.D2DataScope
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+
+/**
+ * The [AccessGuard] installed on every repository handed out by
+ * [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2].
+ *
+ * Validates the *object being written*, not the query that produced it — a create projection or a
+ * value object carries its own organisation unit, program and data element, none of which the read
+ * filters constrain.
+ *
+ * Unknown types are denied. That is deliberate: a model type this guard has not been taught about
+ * must not become silently writable when the SDK grows, and every writable type reachable through
+ * `ScopedD2` is listed here.
+ */
+@Suppress("TooManyFunctions")
+internal class ScopedAccessGuard(
+    private val scope: D2DataScope,
+    private val resolver: ScopeResolver,
+) : AccessGuard {
+
+    override suspend fun checkWrite(target: Any?) {
+        when (target) {
+            null -> deny("a null object")
+            is TrackedEntityInstance -> checkTrackedEntityInstance(target)
+            is Enrollment -> checkEnrollment(target)
+            is Event -> checkEvent(target)
+            is DataValue -> checkDataValue(target)
+            is TrackedEntityDataValue -> checkTrackedEntityDataValue(target)
+            is TrackedEntityAttributeValue -> checkTrackedEntityAttributeValue(target)
+            else -> deny("${target.javaClass.simpleName}, which no scoped repository may write")
+        }
+    }
+
+    private fun checkTrackedEntityInstance(tei: TrackedEntityInstance) {
+        require(D2Capability.WRITE_TRACKED_ENTITY)
+        requireOrgUnit(tei.organisationUnit(), "tracked entity instance ${tei.uid()}")
+        if (!scope.trackedEntityTypes.allows(tei.trackedEntityType())) {
+            deny("tracked entity type '${tei.trackedEntityType()}'")
+        }
+    }
+
+    private fun checkEnrollment(enrollment: Enrollment) {
+        require(D2Capability.WRITE_ENROLLMENT)
+        requireProgram(enrollment.program(), "enrollment ${enrollment.uid()}")
+        requireOrgUnit(enrollment.organisationUnit(), "enrollment ${enrollment.uid()}")
+    }
+
+    private fun checkEvent(event: Event) {
+        require(D2Capability.WRITE_EVENT)
+        requireProgram(event.program(), "event ${event.uid()}")
+        requireOrgUnit(event.organisationUnit(), "event ${event.uid()}")
+    }
+
+    private fun checkDataValue(dataValue: DataValue) {
+        require(D2Capability.WRITE_DATA_VALUE)
+        val writable = resolver.writableDataElements()
+        if (!allowed(writable, dataValue.dataElement())) {
+            deny("data element '${dataValue.dataElement()}'")
+        }
+        requireOrgUnit(dataValue.organisationUnit(), "data value for '${dataValue.dataElement()}'")
+    }
+
+    private fun checkTrackedEntityDataValue(value: TrackedEntityDataValue) {
+        require(D2Capability.WRITE_EVENT)
+        val program = resolver.programOfEvent(value.event())
+            ?: deny("a data value for unknown event '${value.event()}'")
+        requireProgram(program, "event ${value.event()}")
+        requireOrgUnit(resolver.orgUnitOfEvent(value.event()), "event ${value.event()}")
+    }
+
+    private fun checkTrackedEntityAttributeValue(value: TrackedEntityAttributeValue) {
+        require(D2Capability.WRITE_TRACKED_ENTITY)
+        val writablePrograms = scope.writablePrograms().uidsOrNull()
+        if (writablePrograms != null) {
+            val teiPrograms = resolver.programsOfTrackedEntity(value.trackedEntityInstance())
+            if (teiPrograms.none { it in writablePrograms }) {
+                deny(
+                    "attribute value for tracked entity '${value.trackedEntityInstance()}', " +
+                        "which is not enrolled in any writable program",
+                )
+            }
+        }
+    }
+
+    private fun require(capability: D2Capability) {
+        if (!scope.has(capability)) {
+            deny("an operation requiring the $capability capability")
+        }
+    }
+
+    private fun requireProgram(programUid: String?, what: String) {
+        if (!scope.writablePrograms().allows(programUid)) {
+            deny("$what in program '$programUid'")
+        }
+    }
+
+    private fun requireOrgUnit(orgUnitUid: String?, what: String) {
+        if (!allowed(resolver.writableOrgUnits(), orgUnitUid)) {
+            deny("$what in organisation unit '$orgUnitUid'")
+        }
+    }
+
+    /** A null [permitted] set means no restriction, so only a null [uid] fails. */
+    private fun allowed(permitted: Set<String>?, uid: String?): Boolean =
+        uid != null && (permitted == null || uid in permitted)
+
+    private fun deny(what: String): Nothing = throw D2Error
+        .builder()
+        .errorComponent(D2ErrorComponent.SDK)
+        .errorCode(D2ErrorCode.SCOPE_VIOLATION)
+        .errorDescription("Write refused: this D2DataScope does not permit writing $what")
+        .build()
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -169,6 +169,8 @@ internal class TrackedEntityInstanceLocalQueryHelper(
             )
         }
 
+        appendGrantWhere(where, scope)
+
         scope.states()?.let {
             where.appendInKeyEnumValues(dot(teiAlias, DataColumns.AGGREGATED_SYNC_STATE), it)
         } ?: run {
@@ -196,6 +198,25 @@ internal class TrackedEntityInstanceLocalQueryHelper(
         }
 
         return queryStr
+    }
+
+    /**
+     * Applies the program half of a [TrackedEntityQueryGrant].
+     *
+     * The scope carries a single `program` value and so cannot express "one of these", which is the
+     * normal shape of a grant. A sub-select on the tracked entity UID says the same thing, needs no
+     * join — the enrollment join only exists when the caller picked a program — and ANDs with
+     * whatever else the caller filtered on.
+     */
+    private fun appendGrantWhere(where: WhereClauseBuilder, scope: TrackedEntityInstanceQueryRepositoryScope) {
+        val grantedPrograms = scope.mandatory?.programs ?: return
+        val programList = grantedPrograms.joinToString(",") { "'${escapeQuotes(it)}'" }
+        where.appendInSubQuery(
+            dot(teiAlias, IdentifiableColumns.UID),
+            "SELECT ${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE} " +
+                "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
+                "WHERE $program IN ($programList)",
+        )
     }
 
     private fun hasProgram(scope: TrackedEntityInstanceQueryRepositoryScope): Boolean {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt
@@ -201,23 +201,49 @@ internal class TrackedEntityInstanceLocalQueryHelper(
     }
 
     /**
-     * Applies the program half of a [TrackedEntityQueryGrant].
+     * Applies the dimensions of a [TrackedEntityQueryGrant] that the scope's own fields cannot.
      *
-     * The scope carries a single `program` value and so cannot express "one of these", which is the
-     * normal shape of a grant. A sub-select on the tracked entity UID says the same thing, needs no
-     * join — the enrollment join only exists when the caller picked a program — and ANDs with
-     * whatever else the caller filtered on.
+     * `program` and `trackedEntityType` are single-valued on the scope, so neither can express "one
+     * of these" — the normal shape of a grant — and
+     * [applyGrant][TrackedEntityQueryGrant.applyGrant] can only correct a value the *caller* named.
+     * A caller who names nothing would otherwise be unrestricted, so these clauses are what bound an
+     * unfiltered search. They AND with whatever else the caller filtered on.
+     *
+     * Org units are not here: the scope holds a list, so `applyGrant` can substitute the granted set
+     * directly.
      */
     private fun appendGrantWhere(where: WhereClauseBuilder, scope: TrackedEntityInstanceQueryRepositoryScope) {
-        val grantedPrograms = scope.mandatory?.programs ?: return
-        val programList = grantedPrograms.joinToString(",") { "'${escapeQuotes(it)}'" }
-        where.appendInSubQuery(
-            dot(teiAlias, IdentifiableColumns.UID),
-            "SELECT ${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE} " +
-                "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
-                "WHERE $program IN ($programList)",
-        )
+        val grant = scope.mandatory ?: return
+
+        // A sub-select on the tracked entity UID rather than a join: the enrollment join only exists
+        // when the caller picked a program.
+        grant.programs?.let { granted ->
+            val programList = granted.orNoMatch().joinToString(",") { "'${escapeQuotes(it)}'" }
+            where.appendInSubQuery(
+                dot(teiAlias, IdentifiableColumns.UID),
+                "SELECT ${EnrollmentTableInfo.Columns.TRACKED_ENTITY_INSTANCE} " +
+                    "FROM ${EnrollmentTableInfo.TABLE_INFO.name()} " +
+                    "WHERE $program IN ($programList)",
+            )
+        }
+
+        grant.trackedEntityTypes?.let { granted ->
+            where.appendInKeyStringValues(
+                dot(teiAlias, TrackedEntityInstanceTableInfo.Columns.TRACKED_ENTITY_TYPE),
+                granted.orNoMatch(),
+            )
+        }
     }
+
+    /**
+     * A grant of nothing has to match nothing.
+     *
+     * An empty set would render as `IN ()`, which is not valid SQL — so a scope that grants none of a
+     * dimension is expressed with the same sentinel [applyGrant][TrackedEntityQueryGrant.applyGrant]
+     * uses, which no UID can equal.
+     */
+    private fun Set<String>.orNoMatch(): List<String> =
+        if (isEmpty()) listOf(TrackedEntityQueryGrant.NO_MATCH) else toList()
 
     private fun hasProgram(scope: TrackedEntityInstanceQueryRepositoryScope): Boolean {
         return scope.program() != null

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -47,22 +47,34 @@ internal class TrackedEntityInstanceQueryDataFetcher(
     private val scope: TrackedEntityInstanceQueryRepositoryScope,
     private val childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance>,
     private val onlineCache: TrackedEntityInstanceOnlineCache,
-    onlineHelper: TrackedEntityInstanceQueryOnlineHelper,
+    private val onlineHelper: TrackedEntityInstanceQueryOnlineHelper,
     private val localQueryHelper: TrackedEntityInstanceLocalQueryHelper,
 ) {
-    private val baseOnlineQueries: List<TrackedEntityInstanceQueryOnline> = onlineHelper.fromScope(scope)
-    private val onlineQueryStatusMap: MutableMap<TrackedEntityInstanceQueryOnline, OnlineQueryStatus> = HashMap()
+    /**
+     * The server-side queries this scope translates to, resolved on first use.
+     *
+     * Lazy rather than eager, and that is load-bearing. [TrackedEntityInstanceQueryOnlineHelper
+     * .fromScope] refuses outright a scope carrying a
+     * [TrackedEntityQueryGrant][org.hisp.dhis.android.core.trackedentity.search.TrackedEntityQueryGrant],
+     * because an online search is answered by the server where none of the grant's local
+     * restrictions apply. Computing it in the constructor made that refusal fire for *every* scoped
+     * search including offline ones — so a granted caller could not search at all, which is the
+     * opposite of what the guard is for. Nothing on the offline path reads this or
+     * [onlineQueryStatusMap], so a scoped offline search now never reaches the guard, while an
+     * online one still does.
+     */
+    private val baseOnlineQueries: List<TrackedEntityInstanceQueryOnline> by lazy {
+        onlineHelper.fromScope(scope)
+    }
+
+    private val onlineQueryStatusMap: MutableMap<TrackedEntityInstanceQueryOnline, OnlineQueryStatus> by lazy {
+        baseOnlineQueries.associateWithTo(HashMap()) { OnlineQueryStatus() }
+    }
 
     private var returnedUidsOffline: MutableSet<String> = scope.excludedUids()?.toMutableSet() ?: HashSet()
     private var returnedUidsOnline: MutableSet<String> = HashSet()
     private var returnedErrorCodes: MutableSet<D2ErrorCode> = HashSet()
     private var isExhaustedOffline = false
-
-    init {
-        for (onlineQuery in baseOnlineQueries) {
-            onlineQueryStatusMap[onlineQuery] = OnlineQueryStatus()
-        }
-    }
 
     fun refresh() {
         returnedUidsOffline = scope.excludedUids()?.toMutableSet() ?: HashSet()

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -33,6 +33,9 @@ import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositorySco
 import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
 import org.hisp.dhis.android.core.common.FilterOperatorsHelper
 import org.hisp.dhis.android.core.event.EventStatus
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.tracker.TrackerExporterVersion
 import org.koin.core.annotation.Singleton
 import java.util.Date
@@ -44,6 +47,19 @@ internal class TrackedEntityInstanceQueryOnlineHelper(
 
     @Suppress("ComplexMethod")
     fun fromScope(scope: TrackedEntityInstanceQueryRepositoryScope): List<TrackedEntityInstanceQueryOnline> {
+        // Defence in depth. `applyGrant` already forces a granted scope to OFFLINE_ONLY, so reaching
+        // here with a grant would mean that invariant was bypassed rather than that the caller asked
+        // for something unreasonable — and an online query is answered by the server, where none of
+        // the local restrictions apply.
+        if (scope.mandatory != null) {
+            throw D2Error
+                .builder()
+                .errorComponent(D2ErrorComponent.SDK)
+                .errorCode(D2ErrorCode.SCOPE_VIOLATION)
+                .errorDescription("A scoped tracked entity search cannot be answered by the server")
+                .build()
+        }
+
         val queries = if (scope.eventFilters().isEmpty()) {
             listOf(getBaseQuery(scope))
         } else {

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryRepositoryScope.kt
@@ -68,6 +68,14 @@ data class TrackedEntityInstanceQueryRepositoryScope(
     val allowOnlineCache: Boolean,
     val excludedUids: Set<String>?,
     val uids: List<String>?,
+    /**
+     * A restriction that survives every `by*()` call, or null for an unrestricted scope.
+     *
+     * Set only by [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2]. The generated
+     * builder setter is `internal`, and [applyGrant] re-applies it on every repository
+     * construction, so restricted code can neither install nor drop one.
+     */
+    internal val mandatory: TrackedEntityQueryGrant? = null,
 ) : BaseScope {
 
     fun mode(): RepositoryMode = mode

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrant.kt
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.trackedentity.search
+
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMode
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
+
+/**
+ * A mandatory restriction carried by a [TrackedEntityInstanceQueryRepositoryScope].
+ *
+ * Tracker search uses a different scope mechanism from the rest of the SDK: its scope is a record of
+ * *fields*, and `by*()` calls **replace** them rather than appending, so the append-only guarantee
+ * that protects
+ * [RepositoryScope][org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope] does not
+ * hold here. A grant closes that gap by being re-applied on every repository construction — and
+ * every `by*()` builds a new repository — so a caller's own narrowing can never outlive it.
+ *
+ * Instances come only from [ScopedD2][org.hisp.dhis.android.core.scopedaccess.ScopedD2].
+ */
+class TrackedEntityQueryGrant internal constructor(
+    internal val programs: Set<String>?,
+    internal val orgUnits: Set<String>?,
+    internal val trackedEntityTypes: Set<String>?,
+) {
+    internal companion object {
+        /**
+         * A UID that cannot match any row, used to reduce an out-of-grant equality filter to an
+         * empty result. DHIS2 UIDs are 11 alphanumeric characters starting with a letter, so this
+         * is not a valid UID and cannot collide.
+         */
+        const val NO_MATCH = "__scope_denied__"
+    }
+}
+
+/**
+ * Re-applies the mandatory restriction to this scope, returning the scope that may actually be run.
+ *
+ * Called from the [TrackedEntitySearchOperators] constructor, so it runs on every repository the
+ * fluent API produces. Program is handled separately, in
+ * [TrackedEntityInstanceLocalQueryHelper]: the scope holds a single program value and cannot express
+ * "one of these", so a multi-program grant becomes a sub-select at query time instead.
+ */
+internal fun TrackedEntityInstanceQueryRepositoryScope.applyGrant(): TrackedEntityInstanceQueryRepositoryScope {
+    val grant = mandatory ?: return this
+
+    val builder = toBuilder()
+        // A scoped search is answered from the local database. The online modes query the server
+        // directly with the user's credentials, which no local filter can bound.
+        .mode(RepositoryMode.OFFLINE_ONLY)
+
+    grant.programs?.let { granted ->
+        if (program != null && program !in granted) {
+            builder.program(TrackedEntityQueryGrant.NO_MATCH)
+        }
+    }
+
+    grant.trackedEntityTypes?.let { granted ->
+        if (trackedEntityType != null && trackedEntityType !in granted) {
+            builder.trackedEntityType(TrackedEntityQueryGrant.NO_MATCH)
+        }
+    }
+
+    grant.orgUnits?.let { granted ->
+        val requested = orgUnits
+        val effective = if (requested.isEmpty()) granted.toList() else requested.filter { it in granted }
+        builder
+            // `granted` is already expanded to leaves by the caller's scope resolver, so SELECTED is
+            // exact. Leaving the caller's mode would let DESCENDANTS or ACCESSIBLE widen it again.
+            .orgUnitMode(OrganisationUnitMode.SELECTED)
+            .orgUnits(effective.ifEmpty { listOf(TrackedEntityQueryGrant.NO_MATCH) })
+    }
+
+    return builder.build()
+}

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntitySearchOperators.kt
@@ -54,13 +54,27 @@ import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstanceFilterColle
 
 @Suppress("TooManyFunctions")
 abstract class TrackedEntitySearchOperators<R : BaseRepository> internal constructor(
-    val scope: TrackedEntityInstanceQueryRepositoryScope,
+    requestedScope: TrackedEntityInstanceQueryRepositoryScope,
     private val scopeHelper: TrackedEntityInstanceQueryRepositoryScopeHelper,
     private val versionManager: DHISVersionManager,
     private val filtersRepository: TrackedEntityInstanceFilterCollectionRepository,
     private val workingListRepository: ProgramStageWorkingListCollectionRepository,
 ) {
+    /**
+     * The scope this repository will actually run.
+     *
+     * Any [TrackedEntityQueryGrant] on [requestedScope] is re-applied here rather than trusted from
+     * the caller. This is the single place that has to happen: every `by*()` rebuilds the repository
+     * through this constructor, so a narrowing the caller asked for can never survive past the grant
+     * — including `onlineOnly()`, which would otherwise reach the server unfiltered.
+     */
+    val scope: TrackedEntityInstanceQueryRepositoryScope = requestedScope.applyGrant()
+
     internal abstract val connectorFactory: ScopedFilterConnectorFactory<R, TrackedEntityInstanceQueryRepositoryScope>
+
+    /** Installs [grant] on this repository. Only [ScopedD2] calls this. */
+    internal fun withGrant(grant: TrackedEntityQueryGrant): R =
+        connectorFactory.eqConnector<Any> { scope.toBuilder().mandatory(grant).build() }.eq(null)
 
     /**
      * Only TrackedEntityInstances coming from the server are shown in the list.

--- a/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/AccessGuardPropagationShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/arch/repositories/scope/AccessGuardPropagationShould.kt
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.arch.repositories.scope
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.AccessGuard
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOperator
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeComplexFilterItem
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeHelper
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeOrderByItem
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.mock
+
+/**
+ * The invariants that make [org.hisp.dhis.android.core.scopedaccess.ScopedD2] safe.
+ *
+ * A pre-narrowed repository is only unforgeable because a scope cannot be widened once built. These
+ * tests pin that property down directly, rather than through a repository, so a regression shows up
+ * here as the cause rather than somewhere downstream as a symptom.
+ */
+@RunWith(JUnit4::class)
+class AccessGuardPropagationShould {
+
+    private val guard: AccessGuard = mock()
+
+    private val mandatoryFilter = RepositoryScopeFilterItem.builder()
+        .key("program").operator(FilterItemOperator.IN).value("('granted')").build()
+
+    private val callerFilter = RepositoryScopeFilterItem.builder()
+        .key("program").operator(FilterItemOperator.EQ).value("'other'").build()
+
+    private val guardedScope = RepositoryScope.empty().toBuilder().accessGuard(guard).build()
+
+    @Test
+    fun keep_the_guard_when_a_filter_is_added() {
+        val narrowed = RepositoryScopeHelper.withFilterItem(guardedScope, callerFilter)
+
+        assertThat(narrowed.accessGuard()).isSameInstanceAs(guard)
+    }
+
+    @Test
+    fun keep_the_guard_through_a_long_chain_of_filters() {
+        val narrowed = (1..10).fold(guardedScope) { scope, index ->
+            RepositoryScopeHelper.withFilterItem(
+                scope,
+                RepositoryScopeFilterItem.builder()
+                    .key("k$index").operator(FilterItemOperator.EQ).value("'v$index'").build(),
+            )
+        }
+
+        assertThat(narrowed.accessGuard()).isSameInstanceAs(guard)
+        assertThat(narrowed.filters()).hasSize(10)
+    }
+
+    @Test
+    fun keep_the_guard_when_a_complex_filter_is_added() {
+        val narrowed = RepositoryScopeHelper.withComplexFilterItem(
+            guardedScope,
+            RepositoryScopeComplexFilterItem("uid IN (SELECT uid FROM Whatever)"),
+        )
+
+        assertThat(narrowed.accessGuard()).isSameInstanceAs(guard)
+    }
+
+    @Test
+    fun keep_the_guard_when_ordering_changes() {
+        val narrowed = RepositoryScopeHelper.withOrderBy(
+            guardedScope,
+            RepositoryScopeOrderByItem.builder()
+                .column("name").direction(RepositoryScope.OrderByDirection.ASC).build(),
+        )
+
+        assertThat(narrowed.accessGuard()).isSameInstanceAs(guard)
+    }
+
+    @Test
+    fun accumulate_filters_rather_than_replace_them() {
+        // The property the whole design rests on: a caller filtering the same column the grant
+        // already filtered gets the intersection, never a replacement.
+        val granted = RepositoryScopeHelper.withFilterItem(guardedScope, mandatoryFilter)
+        val narrowed = RepositoryScopeHelper.withFilterItem(granted, callerFilter)
+
+        assertThat(narrowed.filters()).hasSize(2)
+        assertThat(narrowed.filters()).containsExactly(mandatoryFilter, callerFilter).inOrder()
+    }
+
+    @Test
+    fun have_no_guard_on_an_ordinary_scope() {
+        // Repositories obtained straight from D2 must be unaffected by any of this.
+        assertThat(RepositoryScope.empty().accessGuard()).isNull()
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/ScopeResolverShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/ScopeResolverShould.kt
@@ -1,0 +1,211 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnit
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitCollectionRepository
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitModule
+import org.hisp.dhis.android.core.scopedaccess.internal.ScopeResolver
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Resolution of a [D2DataScope] into the concrete UID sets the scoped repositories filter on.
+ *
+ * This is where a grant stops being a declaration and becomes a set of rows, so the org unit
+ * hierarchy modes matter: an administrator picks `SELECTED`, `CHILDREN` or `DESCENDANTS` expecting
+ * three different answers, and a mode that resolves wider than intended is exactly the failure the
+ * closed-by-default model is meant to prevent — and exactly the one that would not announce itself.
+ */
+@RunWith(JUnit4::class)
+class ScopeResolverShould {
+
+    private val root = "ImspTQPwCqd"
+    private val child = "O6uvpzGd5pu"
+    private val grandchild = "DiszpKrYNg8"
+
+    private val descendantsRepo: OrganisationUnitCollectionRepository = mock {
+        // `byPath().like(root)` is a LIKE over the slash-separated ancestor chain, so it returns the
+        // whole subtree beneath the root.
+        on { blockingGetUids() } doReturn listOf(child, grandchild)
+    }
+
+    private val childrenRepo: OrganisationUnitCollectionRepository = mock {
+        on { blockingGetUids() } doReturn listOf(child)
+    }
+
+    private val captureRepo: OrganisationUnitCollectionRepository = mock {
+        on { blockingGetUids() } doReturn listOf(grandchild)
+    }
+
+    private val pathConnector: StringFilterConnector<OrganisationUnitCollectionRepository> = mock {
+        on { like(any()) } doReturn descendantsRepo
+    }
+
+    private val parentConnector: StringFilterConnector<OrganisationUnitCollectionRepository> = mock {
+        on { `in`(any<List<String>>()) } doReturn childrenRepo
+    }
+
+    private val orgUnitRepo: OrganisationUnitCollectionRepository = mock {
+        on { byPath() } doReturn pathConnector
+        on { byParentUid() } doReturn parentConnector
+        on { byOrganisationUnitScope(OrganisationUnit.Scope.SCOPE_DATA_CAPTURE) } doReturn captureRepo
+    }
+
+    private val orgUnitModule: OrganisationUnitModule = mock {
+        on { organisationUnits() } doReturn orgUnitRepo
+    }
+
+    private val d2: D2 = mock {
+        on { organisationUnitModule() } doReturn orgUnitModule
+    }
+
+    private fun resolverFor(orgUnits: OrgUnitScope) =
+        ScopeResolver(d2, D2DataScope(orgUnits = orgUnits))
+
+    // ── Org unit hierarchy modes ─────────────────────────────────────────────
+
+    @Test
+    fun `resolve SELECTED to the named units and nothing beneath them`() {
+        val resolved = resolverFor(OrgUnitScope.Only(setOf(root), OrganisationUnitMode.SELECTED))
+            .readableOrgUnits()
+
+        assertThat(resolved).containsExactly(root)
+    }
+
+    @Test
+    fun `answer SELECTED without querying the database at all`() {
+        // The units are already named, so touching the database would be pure cost — and worse, it
+        // would make the answer depend on what happens to be synced.
+        resolverFor(OrgUnitScope.Only(setOf(root), OrganisationUnitMode.SELECTED)).readableOrgUnits()
+
+        verify(orgUnitRepo, never()).byPath()
+        verify(orgUnitRepo, never()).byParentUid()
+    }
+
+    @Test
+    fun `resolve DESCENDANTS to the whole subtree including the root itself`() {
+        // The root is added back explicitly: it may not be stored on this device even though units
+        // beneath it are, which is the normal shape of a partial sync.
+        val resolved = resolverFor(OrgUnitScope.Only(setOf(root), OrganisationUnitMode.DESCENDANTS))
+            .readableOrgUnits()
+
+        assertThat(resolved).containsExactly(root, child, grandchild)
+    }
+
+    @Test
+    fun `resolve CHILDREN to one level only, not the whole subtree`() {
+        // The distinction that matters: `grandchild` is a descendant but not a child, so a CHILDREN
+        // grant must not reach it even though the descendants query returned it.
+        val resolved = resolverFor(OrgUnitScope.Only(setOf(root), OrganisationUnitMode.CHILDREN))
+            .readableOrgUnits()
+
+        assertThat(resolved).containsExactly(root, child)
+        assertThat(resolved).doesNotContain(grandchild)
+    }
+
+    // ── The other org unit grants ────────────────────────────────────────────
+
+    @Test
+    fun `treat All as no restriction rather than as every uid`() {
+        // Null and "every uid currently on the device" are different: null keeps the filter off
+        // entirely, so nothing depends on what happens to be synced.
+        assertThat(resolverFor(OrgUnitScope.All).readableOrgUnits()).isNull()
+    }
+
+    @Test
+    fun `resolve None to a set that can match nothing`() {
+        assertThat(resolverFor(OrgUnitScope.None).readableOrgUnits()).isEmpty()
+    }
+
+    @Test
+    fun `resolve Capture to the user's own capture units`() {
+        assertThat(resolverFor(OrgUnitScope.Capture).readableOrgUnits()).containsExactly(grandchild)
+    }
+
+    @Test
+    fun `resolve an empty root set to nothing rather than to everything`() {
+        val resolved = resolverFor(OrgUnitScope.Only(emptySet(), OrganisationUnitMode.DESCENDANTS))
+            .readableOrgUnits()
+
+        assertThat(resolved).isEmpty()
+    }
+
+    // ── Caching ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolve the hierarchy once however often it is asked for`() {
+        // A scoped repository consults this per query, so re-expanding the hierarchy every time
+        // would put a LIKE scan on a hot path.
+        val resolver = resolverFor(OrgUnitScope.Only(setOf(root), OrganisationUnitMode.DESCENDANTS))
+
+        repeat(3) { resolver.readableOrgUnits() }
+
+        verify(orgUnitRepo, org.mockito.kotlin.times(1)).byPath()
+    }
+
+    // ── Writable is an intersection ──────────────────────────────────────────
+
+    @Test
+    fun `intersect writable org units with the readable ones`() {
+        val resolver = ScopeResolver(
+            d2,
+            D2DataScope(
+                orgUnits = OrgUnitScope.Only(setOf(root), OrganisationUnitMode.SELECTED),
+                writable = WritableScope(
+                    orgUnits = OrgUnitScope.Only(setOf(root, "somewhereElse"), OrganisationUnitMode.SELECTED),
+                ),
+            ),
+        )
+
+        // "somewhereElse" was named writable but never readable, so it grants nothing.
+        assertThat(resolver.writableOrgUnits()).containsExactly(root)
+    }
+
+    @Test
+    fun `grant no writable org units when none were declared`() {
+        val resolver = ScopeResolver(
+            d2,
+            D2DataScope(orgUnits = OrgUnitScope.Only(setOf(root), OrganisationUnitMode.SELECTED)),
+        )
+
+        // Closed by default: readable does not imply writable.
+        assertThat(resolver.writableOrgUnits()).isEmpty()
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/ScopedAccessGuardShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/ScopedAccessGuardShould.kt
@@ -30,16 +30,21 @@ package org.hisp.dhis.android.core.scopedaccess
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.hisp.dhis.android.core.datavalue.DataValue
+import org.hisp.dhis.android.core.enrollment.Enrollment
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.scopedaccess.internal.ScopeResolver
 import org.hisp.dhis.android.core.scopedaccess.internal.ScopedAccessGuard
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityAttributeValue
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 /**
  * Read filters cannot bound a write: a create projection or value object carries its own
@@ -61,9 +66,12 @@ class ScopedAccessGuardShould {
             programs = UidScope.of("grantedProgram"),
             dataSets = UidScope.of("grantedDataSet"),
         ),
+        trackedEntityTypes = UidScope.of("grantedType"),
         capabilities = setOf(
             D2Capability.WRITE_EVENT,
             D2Capability.WRITE_DATA_VALUE,
+            D2Capability.WRITE_TRACKED_ENTITY,
+            D2Capability.WRITE_ENROLLMENT,
         ),
     )
 
@@ -88,6 +96,26 @@ class ScopedAccessGuardShould {
             error
         }
     } ?: throw AssertionError("Expected the write to be refused")
+
+    private fun trackedEntity(orgUnit: String, type: String): TrackedEntityInstance = mock {
+        on { uid() } doReturn "teiUid"
+        on { organisationUnit() } doReturn orgUnit
+        on { trackedEntityType() } doReturn type
+    }
+
+    private fun enrollment(program: String, orgUnit: String): Enrollment = mock {
+        on { uid() } doReturn "enrollmentUid"
+        on { program() } doReturn program
+        on { organisationUnit() } doReturn orgUnit
+    }
+
+    private fun eventDataValue(event: String): TrackedEntityDataValue = mock {
+        on { event() } doReturn event
+    }
+
+    private fun attributeValue(tei: String): TrackedEntityAttributeValue = mock {
+        on { trackedEntityInstance() } doReturn tei
+    }
 
     @Test
     fun allow_a_write_fully_inside_the_grant() = runBlocking {
@@ -138,6 +166,135 @@ class ScopedAccessGuardShould {
     @Test
     fun refuse_a_null_target() {
         val error = denialFor { guard.checkWrite(null) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    // ── Tracked entity instances ─────────────────────────────────────────────
+
+    @Test
+    fun allow_a_tracked_entity_inside_the_grant() = runBlocking {
+        guard.checkWrite(trackedEntity("grantedOu", "grantedType"))
+    }
+
+    @Test
+    fun refuse_a_tracked_entity_in_an_organisation_unit_outside_the_grant() {
+        val error = denialFor { guard.checkWrite(trackedEntity("otherOu", "grantedType")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_a_tracked_entity_of_a_type_outside_the_grant() {
+        // The type dimension is checked on writes as well as reads; a grant of one entity type must
+        // not let another be created in an otherwise granted org unit.
+        val error = denialFor { guard.checkWrite(trackedEntity("grantedOu", "otherType")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_a_tracked_entity_when_its_capability_was_not_granted() {
+        val withoutTeiWrite = ScopedAccessGuard(
+            scope.copy(capabilities = setOf(D2Capability.WRITE_EVENT)),
+            resolver,
+        )
+
+        val error = denialFor { withoutTeiWrite.checkWrite(trackedEntity("grantedOu", "grantedType")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    // ── Enrollments ──────────────────────────────────────────────────────────
+
+    @Test
+    fun allow_an_enrollment_inside_the_grant() = runBlocking {
+        guard.checkWrite(enrollment("grantedProgram", "grantedOu"))
+    }
+
+    @Test
+    fun refuse_an_enrollment_in_a_program_outside_the_grant() {
+        val error = denialFor { guard.checkWrite(enrollment("otherProgram", "grantedOu")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_an_enrollment_in_an_organisation_unit_outside_the_grant() {
+        val error = denialFor { guard.checkWrite(enrollment("grantedProgram", "otherOu")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_an_enrollment_when_its_capability_was_not_granted() {
+        val withoutEnrollmentWrite = ScopedAccessGuard(
+            scope.copy(capabilities = setOf(D2Capability.WRITE_EVENT)),
+            resolver,
+        )
+
+        val error = denialFor {
+            withoutEnrollmentWrite.checkWrite(enrollment("grantedProgram", "grantedOu"))
+        }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    // ── Event data values, checked through their parent event ────────────────
+
+    @Test
+    fun allow_an_event_data_value_whose_event_is_inside_the_grant() = runBlocking {
+        whenever(resolver.programOfEvent("grantedEvent")) doReturn "grantedProgram"
+        whenever(resolver.orgUnitOfEvent("grantedEvent")) doReturn "grantedOu"
+
+        guard.checkWrite(eventDataValue("grantedEvent"))
+    }
+
+    @Test
+    fun refuse_an_event_data_value_whose_event_is_in_an_ungranted_program() {
+        // This row carries no program of its own, so the guard has to go and look the event up.
+        whenever(resolver.programOfEvent("foreignEvent")) doReturn "otherProgram"
+        whenever(resolver.orgUnitOfEvent("foreignEvent")) doReturn "grantedOu"
+
+        val error = denialFor { guard.checkWrite(eventDataValue("foreignEvent")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_an_event_data_value_for_an_event_it_cannot_find() {
+        // An unknown parent means the guard cannot prove the write is in scope, so it must refuse
+        // rather than assume.
+        whenever(resolver.programOfEvent("ghostEvent")) doReturn null
+
+        val error = denialFor { guard.checkWrite(eventDataValue("ghostEvent")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    // ── Attribute values, checked through the entity's enrollments ───────────
+
+    @Test
+    fun allow_an_attribute_value_for_an_entity_enrolled_in_a_writable_program() = runBlocking {
+        whenever(resolver.programsOfTrackedEntity("grantedTei")) doReturn setOf("grantedProgram")
+
+        guard.checkWrite(attributeValue("grantedTei"))
+    }
+
+    @Test
+    fun refuse_an_attribute_value_for_an_entity_in_no_writable_program() {
+        whenever(resolver.programsOfTrackedEntity("foreignTei")) doReturn setOf("otherProgram")
+
+        val error = denialFor { guard.checkWrite(attributeValue("foreignTei")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_an_attribute_value_for_an_entity_with_no_enrollments_at_all() {
+        whenever(resolver.programsOfTrackedEntity("orphanTei")) doReturn emptySet()
+
+        val error = denialFor { guard.checkWrite(attributeValue("orphanTei")) }
 
         assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/ScopedAccessGuardShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/ScopedAccessGuardShould.kt
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.hisp.dhis.android.core.datavalue.DataValue
+import org.hisp.dhis.android.core.event.Event
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.scopedaccess.internal.ScopeResolver
+import org.hisp.dhis.android.core.scopedaccess.internal.ScopedAccessGuard
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * Read filters cannot bound a write: a create projection or value object carries its own
+ * organisation unit, program and data element regardless of the query that produced the repository.
+ * This is the check that closes that gap.
+ */
+@RunWith(JUnit4::class)
+class ScopedAccessGuardShould {
+
+    private val resolver: ScopeResolver = mock {
+        on { writableOrgUnits() } doReturn setOf("grantedOu")
+        on { writableDataElements() } doReturn setOf("grantedDe")
+    }
+
+    private val scope = D2DataScope(
+        programs = UidScope.of("grantedProgram"),
+        dataSets = UidScope.of("grantedDataSet"),
+        writable = WritableScope(
+            programs = UidScope.of("grantedProgram"),
+            dataSets = UidScope.of("grantedDataSet"),
+        ),
+        capabilities = setOf(
+            D2Capability.WRITE_EVENT,
+            D2Capability.WRITE_DATA_VALUE,
+        ),
+    )
+
+    private val guard = ScopedAccessGuard(scope, resolver)
+
+    private fun event(program: String, orgUnit: String): Event = mock {
+        on { uid() } doReturn "eventUid"
+        on { program() } doReturn program
+        on { organisationUnit() } doReturn orgUnit
+    }
+
+    private fun dataValue(dataElement: String, orgUnit: String): DataValue = mock {
+        on { dataElement() } doReturn dataElement
+        on { organisationUnit() } doReturn orgUnit
+    }
+
+    private fun denialFor(block: suspend () -> Unit): D2Error = runBlocking {
+        try {
+            block()
+            null
+        } catch (error: D2Error) {
+            error
+        }
+    } ?: throw AssertionError("Expected the write to be refused")
+
+    @Test
+    fun allow_a_write_fully_inside_the_grant() = runBlocking {
+        guard.checkWrite(event("grantedProgram", "grantedOu"))
+        guard.checkWrite(dataValue("grantedDe", "grantedOu"))
+    }
+
+    @Test
+    fun refuse_an_event_in_a_program_outside_the_grant() {
+        val error = denialFor { guard.checkWrite(event("otherProgram", "grantedOu")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_an_event_in_an_organisation_unit_outside_the_grant() {
+        val error = denialFor { guard.checkWrite(event("grantedProgram", "otherOu")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_a_data_value_for_a_data_element_outside_the_granted_data_sets() {
+        // The bug this replaces: validating the data set argument while writing whichever data
+        // element the caller supplied.
+        val error = denialFor { guard.checkWrite(dataValue("otherDe", "grantedOu")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_a_write_whose_capability_was_not_granted() {
+        val readOnly = ScopedAccessGuard(scope.copy(capabilities = emptySet()), resolver)
+
+        val error = denialFor { readOnly.checkWrite(event("grantedProgram", "grantedOu")) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_a_model_type_it_does_not_know() {
+        // Deny by default, so a model type added to the SDK later cannot become silently writable.
+        val error = denialFor { guard.checkWrite("an unexpected object") }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+
+    @Test
+    fun refuse_a_null_target() {
+        val error = denialFor { guard.checkWrite(null) }
+
+        assertThat(error.errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/UidScopeShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/scopedaccess/UidScopeShould.kt
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.scopedaccess
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOperator
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * The grant algebra, and the one piece of SQL behaviour it leans on.
+ *
+ * The distinction that matters throughout: `null` from [UidScope.uidsOrNull] means "apply no
+ * filter", and an empty set means "apply a filter that matches nothing". Conflating the two would
+ * turn a grant of nothing into a grant of everything, which is the worst possible direction for this
+ * mistake to go.
+ */
+@RunWith(JUnit4::class)
+class UidScopeShould {
+
+    @Test
+    fun `distinguish no restriction from an empty restriction`() {
+        assertThat(UidScope.All.uidsOrNull()).isNull()
+        assertThat(UidScope.None.uidsOrNull()).isEmpty()
+        assertThat(UidScope.Only(setOf("a")).uidsOrNull()).containsExactly("a")
+    }
+
+    @Test
+    fun `render an empty grant as a filter that cannot match`() {
+        // ScopedD2 turns an empty grant into `.in(emptyList())`. SQLite — unlike most engines —
+        // accepts an empty IN list and evaluates it to false, which is what makes "granted nothing"
+        // mean "sees nothing" rather than being a syntax error or, worse, no filter at all.
+        val condition = FilterItemOperator.IN.getSqlCondition("dataElement", "()")
+
+        assertThat(condition).contains("IN")
+        assertThat(condition).contains("()")
+    }
+
+    @Test
+    fun `treat a program as in scope only when it was granted`() {
+        val scope = UidScope.of("granted")
+
+        assertThat(scope.allows("granted")).isTrue()
+        assertThat(scope.allows("other")).isFalse()
+        assertThat(scope.allows(null)).isFalse()
+    }
+
+    @Test
+    fun `let All allow anything except null`() {
+        assertThat(UidScope.All.allows("anything")).isTrue()
+        assertThat(UidScope.All.allows(null)).isFalse()
+    }
+
+    @Test
+    fun `let None allow nothing`() {
+        assertThat(UidScope.None.allows("anything")).isFalse()
+    }
+
+    @Test
+    fun `collapse an empty collection to None rather than an empty Only`() {
+        assertThat(UidScope.of(emptyList())).isEqualTo(UidScope.None)
+        assertThat(UidScope.of(listOf("a"))).isEqualTo(UidScope.Only(setOf("a")))
+    }
+
+    @Test
+    fun `intersect so a grant can only ever shrink`() {
+        val granted = UidScope.of("a", "b")
+
+        assertThat(granted.intersect(UidScope.All)).isEqualTo(granted)
+        assertThat(UidScope.All.intersect(granted)).isEqualTo(granted)
+        assertThat(granted.intersect(UidScope.of("b", "c"))).isEqualTo(UidScope.Only(setOf("b")))
+        assertThat(granted.intersect(UidScope.of("c"))).isEqualTo(UidScope.Only(emptySet()))
+        assertThat(granted.intersect(UidScope.None)).isEqualTo(UidScope.None)
+    }
+
+    @Test
+    fun `report emptiness for both None and an empty Only`() {
+        assertThat(UidScope.None.isEmpty()).isTrue()
+        assertThat(UidScope.Only(emptySet()).isEmpty()).isTrue()
+        assertThat(UidScope.Only(setOf("a")).isEmpty()).isFalse()
+        assertThat(UidScope.All.isEmpty()).isFalse()
+    }
+
+    @Test
+    fun `grant nothing by default`() {
+        // A D2DataScope() built with no arguments must not be a back door.
+        val scope = D2DataScope()
+
+        assertThat(scope.programs).isEqualTo(UidScope.None)
+        assertThat(scope.dataSets).isEqualTo(UidScope.None)
+        assertThat(scope.orgUnits).isEqualTo(OrgUnitScope.None)
+        assertThat(scope.capabilities).isEmpty()
+        assertThat(scope.hasAnyWrite()).isFalse()
+        assertThat(scope.writablePrograms().isEmpty()).isTrue()
+    }
+
+    @Test
+    fun `never make something writable that is not readable`() {
+        val scope = D2DataScope(
+            programs = UidScope.of("readable"),
+            writable = WritableScope(programs = UidScope.of("readable", "sneaky")),
+        )
+
+        assertThat(scope.writablePrograms()).isEqualTo(UidScope.Only(setOf("readable")))
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/ScopedSearchDataFetcherShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/ScopedSearchDataFetcherShould.kt
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.trackedentity.search
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppenderGetter
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMode
+import org.hisp.dhis.android.core.common.DateFilterPeriodHelper
+import org.hisp.dhis.android.core.maintenance.D2Error
+import org.hisp.dhis.android.core.maintenance.D2ErrorCode
+import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
+import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
+import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
+import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
+import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceStore
+import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression tests for the interaction between a search grant and the online query resolution.
+ *
+ * A scoped search is forced offline, and `TrackedEntityInstanceQueryOnlineHelper.fromScope` refuses a
+ * granted scope outright — an online search is answered by the server, where none of the grant's
+ * local restrictions apply. Those two facts only compose if the online queries are resolved lazily:
+ * resolving them in the constructor made the refusal fire for *every* scoped search, so a granted
+ * caller could not search at all and the guard rejected precisely the case it was meant to allow.
+ */
+@RunWith(JUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class ScopedSearchDataFetcherShould {
+
+    private val store: TrackedEntityInstanceStore = mock()
+    private val trackerParentCallFactory: TrackerParentCallFactory = mock()
+    private val childrenAppenders: ChildrenAppenderGetter<TrackedEntityInstance> = mock()
+
+    private val clockProvider = ClockProviderFactory.clockProvider
+    private val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, RelativePeriodHelperMock()))
+    private val onlineHelper = TrackedEntityInstanceQueryOnlineHelper(periodHelper)
+    private val localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
+    private val onlineCache = TrackedEntityInstanceOnlineCache(TimeUnit.MINUTES.toMillis(5))
+
+    private val grantedScope = TrackedEntityInstanceQueryRepositoryScope.empty()
+        .toBuilder()
+        .mandatory(
+            TrackedEntityQueryGrant(
+                programs = setOf("IpHINAT79UW"),
+                orgUnits = null,
+                trackedEntityTypes = null,
+            ),
+        )
+        .build()
+        .applyGrant()
+
+    private fun fetcher(scope: TrackedEntityInstanceQueryRepositoryScope) =
+        TrackedEntityInstanceQueryDataFetcher(
+            store,
+            trackerParentCallFactory,
+            scope,
+            childrenAppenders,
+            onlineCache,
+            onlineHelper,
+            localQueryHelper,
+        )
+
+    @Test
+    fun `force a granted scope offline`() {
+        assertThat(grantedScope.mode()).isEqualTo(RepositoryMode.OFFLINE_ONLY)
+    }
+
+    @Test
+    fun `answer an offline search on a granted scope without consulting the online helper`() = runTest {
+        store.stub { onBlocking { selectRawQuery(any()) } doReturn emptyList() }
+
+        // Constructing and querying must both stay clear of fromScope. Before this was lazy, merely
+        // building the fetcher threw SCOPE_VIOLATION and no scoped search could run at all.
+        val result = fetcher(grantedScope).queryAllOffline()
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `refuse an online search on a granted scope`() = runTest {
+        // The guard is still reachable, just no longer on the offline path: getting here means the
+        // OFFLINE_ONLY invariant was bypassed rather than that the caller asked for something odd.
+        val onlineScope = grantedScope.toBuilder().mode(RepositoryMode.ONLINE_ONLY).build()
+
+        val error = runCatching { fetcher(onlineScope).queryAllOnline() }.exceptionOrNull()
+
+        assertThat(error).isInstanceOf(D2Error::class.java)
+        assertThat((error as D2Error).errorCode()).isEqualTo(D2ErrorCode.SCOPE_VIOLATION)
+    }
+}

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould.kt
@@ -36,6 +36,7 @@ import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
 import org.hisp.dhis.android.core.period.clock.internal.ClockProviderFactory
 import org.hisp.dhis.android.core.period.internal.ParentPeriodGeneratorImpl.Companion.create
 import org.hisp.dhis.android.core.period.internal.RelativePeriodHelperMock
+import org.hisp.dhis.android.persistence.trackedentity.TrackedEntityInstanceTableInfo
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -57,6 +58,41 @@ class TrackedEntityInstanceLocalQueryHelperShould {
         val relativePeriodHelper = RelativePeriodHelperMock()
         val periodHelper = DateFilterPeriodHelper(clockProvider, create(clockProvider, relativePeriodHelper))
         localQueryHelper = TrackedEntityInstanceLocalQueryHelper(periodHelper)
+    }
+
+    @Test
+    fun bound_tracked_entity_types_to_the_grant_when_the_caller_named_none() {
+        // Reproduces a leak found on a device: a grant of Person only returned 32 Malaria Entity
+        // records through trackedEntitySearch(). applyGrant only corrects a type the *caller* asked
+        // for, and this clause is the only thing that can bound the caller-asked-for-nothing case —
+        // exactly as the program half already does. The sibling accessor
+        // ScopedD2.trackedEntityInstances() has always applied this restriction, so without it the
+        // same grant meant two different things depending on which accessor you used.
+        val scope = queryBuilder
+            .mandatory(
+                TrackedEntityQueryGrant(
+                    programs = null,
+                    orgUnits = null,
+                    trackedEntityTypes = setOf("nEenWmSyUEp", "We9I19a3vO1"),
+                ),
+            )
+            .build()
+
+        val sqlQuery = localQueryHelper.getSqlQuery(scope, emptySet(), 50)
+
+        assertThat(sqlQuery).contains("nEenWmSyUEp")
+        assertThat(sqlQuery).contains("We9I19a3vO1")
+    }
+
+    @Test
+    fun leave_tracked_entity_types_alone_when_the_grant_does_not_restrict_them() {
+        val scope = queryBuilder
+            .mandatory(TrackedEntityQueryGrant(programs = null, orgUnits = null, trackedEntityTypes = null))
+            .build()
+
+        val sqlQuery = localQueryHelper.getSqlQuery(scope, emptySet(), 50)
+
+        assertThat(sqlQuery).doesNotContain(TrackedEntityInstanceTableInfo.Columns.TRACKED_ENTITY_TYPE + " IN")
     }
 
     @Test

--- a/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrantShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityQueryGrantShould.kt
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2004-2025, University of Oslo
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  Neither the name of the HISP project nor the names of its contributors may
+ *  be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.android.core.trackedentity.search
+
+import com.google.common.truth.Truth.assertThat
+import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryMode
+import org.hisp.dhis.android.core.organisationunit.OrganisationUnitMode
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Tracker search does not get the append-only guarantee the rest of the SDK has — its scope fields
+ * are replaced by `by*()` rather than accumulated — so the grant has to be re-applied on every
+ * repository construction. These tests cover what that re-application must do.
+ */
+@RunWith(JUnit4::class)
+class TrackedEntityQueryGrantShould {
+
+    private val grant = TrackedEntityQueryGrant(
+        programs = setOf("granted1", "granted2"),
+        orgUnits = setOf("ouA", "ouB"),
+        trackedEntityTypes = setOf("teType"),
+    )
+
+    private fun granted(
+        block: TrackedEntityInstanceQueryRepositoryScope.Builder.() -> Unit = {},
+    ): TrackedEntityInstanceQueryRepositoryScope =
+        TrackedEntityInstanceQueryRepositoryScope.builder()
+            .apply { block() }
+            .mandatory(grant)
+            .build()
+            .applyGrant()
+
+    @Test
+    fun leave_an_ungranted_scope_untouched() {
+        val scope = TrackedEntityInstanceQueryRepositoryScope.builder()
+            .mode(RepositoryMode.ONLINE_ONLY)
+            .program("anything")
+            .build()
+
+        assertThat(scope.applyGrant()).isSameInstanceAs(scope)
+    }
+
+    @Test
+    fun force_offline_mode_so_the_server_is_never_asked() {
+        // The online modes are answered by the server, where none of these restrictions exist.
+        for (mode in listOf(RepositoryMode.ONLINE_ONLY, RepositoryMode.ONLINE_FIRST, RepositoryMode.OFFLINE_FIRST)) {
+            assertThat(granted { mode(mode) }.mode()).isEqualTo(RepositoryMode.OFFLINE_ONLY)
+        }
+    }
+
+    @Test
+    fun keep_a_program_that_is_inside_the_grant() {
+        assertThat(granted { program("granted1") }.program()).isEqualTo("granted1")
+    }
+
+    @Test
+    fun reduce_a_program_outside_the_grant_to_no_match() {
+        assertThat(granted { program("other") }.program()).isEqualTo(TrackedEntityQueryGrant.NO_MATCH)
+    }
+
+    @Test
+    fun leave_an_unset_program_for_the_query_layer_to_bound() {
+        // A single `program` field cannot express "one of these", so a null program stays null here
+        // and the local query helper adds the sub-select instead.
+        assertThat(granted().program()).isNull()
+    }
+
+    @Test
+    fun reduce_a_tracked_entity_type_outside_the_grant_to_no_match() {
+        assertThat(granted { trackedEntityType("other") }.trackedEntityType())
+            .isEqualTo(TrackedEntityQueryGrant.NO_MATCH)
+        assertThat(granted { trackedEntityType("teType") }.trackedEntityType()).isEqualTo("teType")
+    }
+
+    @Test
+    fun fall_back_to_the_granted_org_units_when_none_were_requested() {
+        val scope = granted()
+
+        assertThat(scope.orgUnits()).containsExactly("ouA", "ouB")
+        assertThat(scope.orgUnitMode()).isEqualTo(OrganisationUnitMode.SELECTED)
+    }
+
+    @Test
+    fun intersect_requested_org_units_with_the_grant() {
+        val scope = granted { orgUnits(listOf("ouA", "ouOutside")) }
+
+        assertThat(scope.orgUnits()).containsExactly("ouA")
+    }
+
+    @Test
+    fun reduce_org_units_entirely_outside_the_grant_to_no_match() {
+        // An empty list would read as "no filter" downstream, which would leak the whole database.
+        assertThat(granted { orgUnits(listOf("ouOutside")) }.orgUnits())
+            .containsExactly(TrackedEntityQueryGrant.NO_MATCH)
+    }
+
+    @Test
+    fun pin_org_unit_mode_so_a_hierarchy_mode_cannot_widen_the_grant() {
+        // The granted set is already expanded to leaves, so DESCENDANTS or ACCESSIBLE could only
+        // reach further than intended.
+        val scope = granted { orgUnitMode(OrganisationUnitMode.ACCESSIBLE) }
+
+        assertThat(scope.orgUnitMode()).isEqualTo(OrganisationUnitMode.SELECTED)
+    }
+
+    @Test
+    fun survive_a_rebuild_through_to_builder() {
+        // Every by*() call rebuilds the scope this way; the grant has to come along.
+        val rebuilt = granted().toBuilder().program("other").build()
+
+        assertThat(rebuilt.mandatory).isSameInstanceAs(grant)
+        assertThat(rebuilt.applyGrant().program()).isEqualTo(TrackedEntityQueryGrant.NO_MATCH)
+    }
+}

--- a/docs/content/developer/scoped-access.md
+++ b/docs/content/developer/scoped-access.md
@@ -1,0 +1,331 @@
+# Scoped access { #android_sdk_scoped_access }
+
+```kotlin
+val scopedD2: ScopedD2 = d2.scopedTo(scope)
+```
+
+`ScopedD2` is the DHIS2 SDK narrowed to a subset of the data on the device. Code holding one can
+read and write only what the scope grants, and cannot widen it.
+
+It exists so that a host application can hand SDK access to code it does not fully trust — the
+Capture App's plugin system is the first caller — without handing over `D2`. It is a general SDK
+feature, not a plugin feature.
+
+The important thing to understand first: **`ScopedD2` hands back ordinary SDK repositories.** There
+is no wrapper API to learn. `scopedD2.events()` returns the same `EventCollectionRepository` you
+would get from `d2.eventModule().events()`, already narrowed, so the whole fluent API — filters,
+ordering, paging, `blockingGet()` — works unchanged.
+
+```kotlin
+val overdue = scopedD2.events()
+    .byStatus().eq(EventStatus.OVERDUE)
+    .byOrganisationUnitUid().eq(clinicUid)
+    .orderByDueDate(RepositoryScope.OrderByDirection.ASC)
+    .blockingGet()
+```
+
+## Describing a scope { #android_sdk_scoped_access_scope }
+
+A scope is a `D2DataScope`: what may be read, what may be written, and which feature areas are
+enabled at all.
+
+```kotlin
+val scope = D2DataScope(
+    programs = UidScope.of("IpHINAT79UW"),
+    dataSets = UidScope.None,
+    trackedEntityTypes = UidScope.All,
+    dataElements = UidScope.All,
+    orgUnits = OrgUnitScope.of(setOf("ImspTQPwCqd"), OrganisationUnitMode.DESCENDANTS),
+    writable = WritableScope(programs = UidScope.of("IpHINAT79UW")),
+    capabilities = setOf(
+        D2Capability.READ_METADATA,
+        D2Capability.READ_TRACKED_ENTITY,
+        D2Capability.WRITE_EVENT,
+    ),
+)
+```
+
+Three building blocks:
+
+| Type | Values | Notes |
+|---|---|---|
+| `UidScope` | `All`, `None`, `Only(uids)` | `uidsOrNull()` returns `null` for unrestricted and an **empty set** for `None` — those mean opposite things |
+| `OrgUnitScope` | `All`, `None`, `Capture`, `Only(uids, mode)` | `mode` is `SELECTED`, `CHILDREN` or `DESCENDANTS`; the roots are expanded on the device |
+| `WritableScope` | `programs`, `dataSets`, `orgUnits` | **Always intersected with the read grant** |
+
+Two rules worth internalising:
+
+- **Closed by default.** Every dimension defaults to nothing. An empty scope grants nothing, not
+  everything.
+- **Writable is a subset, never an extension.** `writablePrograms()` is
+  `programs.intersect(writable.programs)`, so naming a program in `writable` that is not readable
+  grants nothing at all. The same holds for data sets and org units.
+
+### Capabilities { #android_sdk_scoped_access_capabilities }
+
+Capabilities gate whole feature areas, independently of which UIDs are granted. An empty capability
+set exposes nothing however generous the UID grants are.
+
+`READ_METADATA`, `READ_TRACKED_ENTITY`, `READ_ENROLLMENT`, `READ_EVENT`, `READ_DATA_VALUE`,
+`SEARCH_TRACKED_ENTITY`, `READ_RELATIONSHIP`, `READ_FILE_RESOURCE`, and the four writes
+`WRITE_TRACKED_ENTITY`, `WRITE_ENROLLMENT`, `WRITE_EVENT`, `WRITE_DATA_VALUE`.
+
+Every accessor calls `requireCapability` before returning anything, so a missing capability throws
+`D2Error(SCOPE_VIOLATION)` rather than returning an empty result. That distinction is deliberate:
+"you may not look here" and "there is nothing here" are different answers and callers need to tell
+them apart.
+
+| Accessor | Capability |
+|---|---|
+| `programs()`, `programStages()`, `dataSets()`, `dataElements()`, `trackedEntityTypes()`, `organisationUnits()`, `trackedEntityAttributes()`, `optionSets()`, `options()`, `categoryCombos()`, `categoryOptionCombos()` | `READ_METADATA` |
+| `trackedEntityInstances()`, `trackedEntityAttributeValues()` | `READ_TRACKED_ENTITY` |
+| `enrollments()` | `READ_ENROLLMENT` |
+| `events()`, `trackedEntityDataValues()` | `READ_EVENT` |
+| `trackedEntitySearch()` | `SEARCH_TRACKED_ENTITY` |
+| `dataValues()` | `READ_DATA_VALUE` |
+
+## How it is enforced { #android_sdk_scoped_access_enforcement }
+
+There are **four** distinct mechanisms. Knowing which one applies to a given accessor is the key to
+working on this code safely.
+
+```
+                    ┌──────────────────────────────────────────────┐
+  reads             │ 1. Append-only filters on RepositoryScope    │
+  (most accessors)  │    by*() calls can only narrow further       │
+                    └──────────────────────────────────────────────┘
+  reads on tables   ┌──────────────────────────────────────────────┐
+  with no program   │ 2. Mandatory SQL sub-select (guardedWith)    │
+  column            └──────────────────────────────────────────────┘
+                    ┌──────────────────────────────────────────────┐
+  writes            │ 3. AccessGuard on the scope, checks the      │
+                    │    object being written                      │
+                    └──────────────────────────────────────────────┘
+  tracker search    ┌──────────────────────────────────────────────┐
+                    │ 4. TrackedEntityQueryGrant, re-applied on    │
+                    │    every repository the fluent API builds    │
+                    └──────────────────────────────────────────────┘
+```
+
+### 1. Reads: append-only filters { #android_sdk_scoped_access_reads }
+
+`ScopedD2` pre-applies the grant with ordinary `by*()` calls before handing the repository over:
+
+```kotlin
+fun events(): EventCollectionRepository {
+    requireCapability(D2Capability.READ_EVENT)
+    var repo = d2.eventModule().events()
+    scope.programs.uidsOrNull()?.let { repo = repo.byProgramUid().`in`(it.toList()) }
+    resolver.readableOrgUnits()?.let { repo = repo.byOrganisationUnitUid().`in`(it.toList()) }
+    return repo.guarded()
+}
+```
+
+This cannot be undone, and that is a property of `RepositoryScope` rather than a check: every
+`by*()` routes through `RepositoryScopeHelper`, which only ever does `filters + item`; the scope
+field is `protected`; and no API removes, replaces or resets a filter. A caller's own filters are
+AND-ed on top, so asking for something outside the grant returns **empty**, never wider results.
+
+That is why an out-of-scope read is silent. Callers who need to know what they were granted should
+read the scope rather than infer it from an empty list.
+
+### 2. Reads via sub-select { #android_sdk_scoped_access_subselect }
+
+`TrackedEntityAttributeValue` and `TrackedEntityDataValue` rows reference only their parent — there
+is no program or org unit column to filter on. Restricting them needs SQL:
+
+```kotlin
+fun trackedEntityAttributeValues(): TrackedEntityAttributeValueCollectionRepository {
+    requireCapability(D2Capability.READ_TRACKED_ENTITY)
+    val repo = d2.trackedEntityModule().trackedEntityAttributeValues()
+    val programs = scope.programs.uidsOrNull() ?: return repo.guarded()
+    return repo.guardedWith(enrolledInProgramsClause(programs))
+}
+```
+
+Without that clause a caller could read the attribute values of any tracked entity on the device by
+UID. `guardedWith` adds the clause as a `RepositoryScopeComplexFilterItem`, which is as
+unremovable as a filter.
+
+### 3. Writes: a guard on the object { #android_sdk_scoped_access_writes }
+
+Filters cannot protect writes. A create projection or value object carries its own org unit,
+program and data element regardless of what the query said — so the object being written is what
+gets checked, not the query that found it.
+
+`ScopedAccessGuard` (implementing the internal `AccessGuard`) travels **on the `RepositoryScope`**,
+which is what makes it unforgeable: the scope is copied field-by-field on every builder call, the
+generated setter for `accessGuard` is `internal`, and nothing clears it. It therefore survives every
+`by*()`, `orderBy*()`, `withChild()` and `uid()` in a fluent chain and cannot be removed by the code
+being restricted.
+
+It is consulted at every write entry point — `add()`, `set()`, `delete()`,
+`dataValues().value(…)` — *before* the store is touched, so a refusal is whole rather than a
+half-completed write:
+
+```kotlin
+override suspend fun suspendAdd(o: P): String {
+    val obj = transformer.transform(o)
+    // Deliberately outside the try: a scope violation must surface as SCOPE_VIOLATION rather than
+    // be rewritten as OBJECT_CANT_BE_INSERTED.
+    scope.accessGuard()?.checkWrite(obj)
+    ...
+}
+```
+
+One branch per writable type, and **unknown types are denied**:
+
+| Object | Capability | Also checked |
+|---|---|---|
+| `TrackedEntityInstance` | `WRITE_TRACKED_ENTITY` | org unit, tracked entity type |
+| `Enrollment` | `WRITE_ENROLLMENT` | writable program, org unit |
+| `Event` | `WRITE_EVENT` | writable program, org unit |
+| `DataValue` | `WRITE_DATA_VALUE` | writable data element, org unit |
+| `TrackedEntityDataValue` | `WRITE_EVENT` | program and org unit of the parent event |
+| `TrackedEntityAttributeValue` | `WRITE_TRACKED_ENTITY` | the entity is enrolled in a writable program |
+| anything else | — | refused |
+
+Denying by default matters: a model type added to the SDK later cannot become silently writable.
+
+### 4. Tracker search: a re-applied grant { #android_sdk_scoped_access_search }
+
+`trackedEntitySearch()` cannot use mechanism 1, and this is the subtlest part of the system.
+
+Tracker search uses `TrackedEntityInstanceQueryRepositoryScope`, whose fields are **single-valued
+and replaced** by `by*()` rather than appended: `program`, `trackedEntityType`, `orgUnits`,
+`orgUnitMode`, and the online/offline mode. A caller could otherwise overwrite the grant simply by
+asking for something else.
+
+Two things close that:
+
+- `TrackedEntitySearchOperators.scope` calls `requestedScope.applyGrant()`. Every `by*()` rebuilds
+  the repository through that constructor, so a widening never survives the call that requested it.
+- `applyGrant()` forces `RepositoryMode.OFFLINE_ONLY`. An online search is answered by the server,
+  where none of these local restrictions exist, so a granted search is always local.
+  `TrackedEntityInstanceQueryOnlineHelper.fromScope` refuses a granted scope outright as defence in
+  depth.
+
+Because the scope fields are single-valued, they cannot express "one of these" — the normal shape of
+a grant. So the dimensions are enforced in two places:
+
+| Dimension | Where | How |
+|---|---|---|
+| `orgUnits` | `applyGrant()` | the scope holds a *list*, so the granted set is substituted directly and the mode pinned to `SELECTED` |
+| `programs` | `appendGrantWhere()` | sub-select on the enrollment table |
+| `trackedEntityTypes` | `appendGrantWhere()` | `IN` clause on the tracked entity type column |
+
+`applyGrant()` additionally rewrites a *caller-specified* program or type that falls outside the
+grant to the sentinel `__scope_denied__`, which no UID can equal.
+
+## Working on this code { #android_sdk_scoped_access_maintaining }
+
+Rules to preserve. Each one has already been broken once.
+
+1. **A new scope dimension needs a clause in both read paths.** Mechanism 1 (the `by*()` filter in
+   `ScopedD2`) and mechanism 4 (`appendGrantWhere` / `applyGrant`) are separate. Adding a dimension
+   to one and not the other means the same grant means different things depending on which accessor
+   the caller used.
+2. **A new writable type needs a branch in `ScopedAccessGuard.checkWrite`.** Without one it is
+   refused — which is safe, but it will look like a bug, so add the branch deliberately.
+3. **A new accessor calls `requireCapability` first**, and `guarded()` (or `guardedWith`) on the way
+   out. `guarded()` is what installs the write guard; forgetting it makes the repository readable but
+   unguarded for writes.
+4. **Never render an empty grant as `IN ()`.** That is not valid SQL. Empty sets go through the
+   `__scope_denied__` sentinel.
+5. **Resolve grants lazily.** `ScopeResolver` caches org unit and data element resolution because
+   both hit the database, and a scoped accessor may be called per row.
+6. **Do not evaluate a refusal eagerly.** A guard that throws must be reached only on the path it
+   guards — see the cautionary tale below.
+
+### Two bugs, and what they teach { #android_sdk_scoped_access_bugs }
+
+Both were found by exercising a real grant on a device, not by reading the code.
+
+**Every scoped search threw.** `TrackedEntityInstanceQueryDataFetcher` resolved
+`baseOnlineQueries = onlineHelper.fromScope(scope)` in a property initializer, and an `init` block
+iterated it. Both ran whenever the fetcher was constructed — which happens for *every* query
+regardless of mode. Since `fromScope` refuses a granted scope, the online guard fired on offline
+searches too, and `trackedEntitySearch()` was unusable for any caller holding a grant. The guard
+rejected exactly the case it exists to permit. Both properties are now `by lazy`.
+
+*Lesson: a check that refuses must sit on the path it guards, not in a constructor.*
+
+**The type grant was ignored.** `applyGrant()` only corrected a `trackedEntityType` the caller had
+*named*, and `appendGrantWhere` bounded programs only. A caller who filtered by nothing got no type
+restriction at all — a grant of one tracked entity type returned records of another. Meanwhile
+`trackedEntityInstances()` had always applied the filter, so one grant meant two different things.
+
+*Lesson: a grant has to be enforced for the caller who asks for nothing, not just the caller who
+asks for the wrong thing.*
+
+## What is deliberately withheld { #android_sdk_scoped_access_withheld }
+
+`ScopedD2` exposes no accessor for these, by design:
+
+- `databaseAdapter()` and `httpServiceClient()` — raw SQL and raw HTTP bypass every mechanism above.
+- `wipeModule()` — destructive and outside any scope.
+- `dataStoreModule()` — in the plugin use case it holds the configuration that defines the scope,
+  so exposing it would let a caller widen its own grant.
+- `userModule()` — credentials and account management.
+- The sync and transport modules.
+- Analytics and relationships. Both can reach outside a grant — a free-form dimension DSL, and
+  object-graph traversal to tracked entities in other programs — and need their own design pass.
+
+## Known limitations { #android_sdk_scoped_access_limitations }
+
+Be honest about these when reasoning about the guarantee.
+
+- **Same-process.** A scoped caller runs in the host process. Reflection, `internal` visibility
+  (public in JVM bytecode), and the class loader of any object it legitimately holds are all
+  available to it. Scoping makes the sanctioned path fully capable and every other path deliberate;
+  it is not a sandbox. Real containment needs a separate process, which is why the grant and its
+  enforcement live in the SDK — an IPC layer can sit in front of the same `ScopedD2`.
+- `TrackedEntityInstanceQueryRepositoryScope` still has a **public constructor**, so a grant
+  installed through the builder can in principle be bypassed by constructing a scope directly.
+  Making it `internal` is a public-API break and needs a deprecation cycle.
+- Capabilities are checked when a repository is **obtained**, not per operation. A caller holding a
+  repository across a scope change would keep using it.
+- `checkTrackedEntityAttributeValue` verifies the entity is enrolled in a writable program but does
+  **not** check its org unit, unlike `checkEvent`. An unrestricted writable program grant therefore
+  permits attribute writes outside the org unit grant.
+- In the aggregate path the *guard* is covered (`refuse_a_data_value_for_a_data_element_outside_the_granted_data_sets`),
+  but the resolution behind it is not: `ScopeResolver.readableDataElements()` turning granted data
+  sets into data elements has no test, and it is the step that decides what `dataValues()` can see.
+
+## Source map { #android_sdk_scoped_access_sources }
+
+`core/src/main/java/org/hisp/dhis/android/core/`
+
+| File | Role |
+|---|---|
+| `D2.kt` → `scopedTo()` | entry point |
+| `scopedaccess/ScopedD2.kt` | every accessor, capability checks, read filters |
+| `scopedaccess/D2DataScope.kt` | the scope model, `writablePrograms()`, `writableDataSets()` |
+| `scopedaccess/UidScope.kt`, `OrgUnitScope.kt` | grant primitives |
+| `scopedaccess/D2Capability.kt` | capability enum |
+| `scopedaccess/internal/ScopeResolver.kt` | org unit hierarchy expansion, data element resolution, caching |
+| `scopedaccess/internal/ScopedAccessGuard.kt` | the write guard, one branch per type |
+| `arch/repositories/scope/internal/AccessGuard.kt` | the guard interface, carried on `RepositoryScope` |
+| `trackedentity/search/TrackedEntityQueryGrant.kt` | the search grant and `applyGrant()` |
+| `trackedentity/search/TrackedEntityInstanceLocalQueryHelper.kt` | `appendGrantWhere()` — programs and types |
+| `trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt` | online refusal |
+
+### Tests { #android_sdk_scoped_access_tests }
+
+| Test | Covers |
+|---|---|
+| `scopedaccess/UidScopeShould` | grant primitives, `intersect`, and that writable can never exceed readable |
+| `scopedaccess/ScopeResolverShould` | the three org unit hierarchy modes, `All`/`None`/`Capture`, caching, and the writable intersection |
+| `scopedaccess/ScopedAccessGuardShould` | the write guard — all six model branches, all four write capabilities, unknown type, null |
+| `arch/repositories/scope/AccessGuardPropagationShould` | the guard survives filters, ordering and long fluent chains |
+| `trackedentity/search/TrackedEntityQueryGrantShould` | `applyGrant()` — offline pinning, org unit substitution, `__scope_denied__` |
+| `trackedentity/search/TrackedEntityInstanceLocalQueryHelperShould` | `appendGrantWhere()` — the program sub-select and the type clause |
+| `trackedentity/search/ScopedSearchDataFetcherShould` | the online guard stays off the offline path |
+| `androidTest .../ScopedD2MockIntegrationShould` | accessors end to end against a mock server — **device required**, so it does not run with the JVM unit tests |
+
+**Gaps worth knowing before you rely on something.** `ScopeResolver.readableDataElements()` — the
+step that turns granted data *sets* into the data *elements* `dataValues()` filters on — has no unit
+test; only the org unit half of the resolver is covered. `OrgUnitScope` has no dedicated test, though
+`ScopeResolverShould` exercises every one of its cases indirectly. And the accessor-level filtering in
+`ScopedD2` itself is covered only by `ScopedD2MockIntegrationShould`, which needs a device — so a
+plain JVM unit run verifies the *pieces* of the read path without ever assembling them.

--- a/docs/dhis2_android_sdk_developer_guide_INDEX.yml
+++ b/docs/dhis2_android_sdk_developer_guide_INDEX.yml
@@ -4,6 +4,7 @@
 - Modules and repositories: "@github(dhis2/dhis2-android-sdk, docs/content/developer/modules-and-repositories.md, master)"
 - Database: "@github(dhis2/dhis2-android-sdk, docs/content/developer/database.md, master)"
 - Data Store: "@github(dhis2/dhis2-android-sdk, docs/content/developer/data-store.md, master)"
+- Scoped access: "@github(dhis2/dhis2-android-sdk, docs/content/developer/scoped-access.md, master)"
 - Workflow: "@github(dhis2/dhis2-android-sdk, docs/content/developer/workflow.md, master)"
 - Analytics: "@github(dhis2/dhis2-android-sdk, docs/content/developer/analytics.md, master)"
 - Settings: "@github(dhis2/dhis2-android-sdk, docs/content/developer/settings.md, master)"


### PR DESCRIPTION
Adds `ScopedD2`, the DHIS2 SDK narrowed to a subset of the data on the device. Code holding one can read and write only what the scope grants and cannot widen it, so a host application can hand SDK access to code it does not fully trust — the Capture App plugin system is the first caller — without handing over `D2`. It is a general SDK feature, not a plugin one.

The important property is that it hands back **ordinary SDK repositories**, not a facade. There is no second API to learn or maintain: `scopedD2.events()` returns the same `EventCollectionRepository`, already narrowed, so filters, ordering, paging and `blockingGet()` all work unchanged.

```
  D2DataScope                     ScopedD2                    caller
  ───────────────                 ────────────                ──────
  programs / dataSets      ──►    programs()          ──►     .byProgramUid().eq(…)
  orgUnits (+ mode)               events()                    .orderByDueDate(…)
  trackedEntityTypes              enrollments()               .blockingGet()
  dataElements                    dataValues()
  writable ⊆ readable             trackedEntitySearch()       a caller's own filters
  capabilities                    …                           can only narrow further
```

Four enforcement mechanisms, one per shape of the problem. Most reads are pre-narrowed with append-only `RepositoryScope` filters, which have no removal API — so an out-of-scope query returns empty rather than something wider, enforced by construction rather than by check. Tables with no program column of their own (`trackedEntityAttributeValues`, `trackedEntityDataValues`) get a mandatory SQL sub-select instead. Writes are covered by an `AccessGuard` carried *on the scope*, which validates the object being written rather than the query that found it — a create projection carries its own org unit and program regardless of what was queried. Tracker search needs its own mechanism because its scope fields are single-valued and *replaced* by `by*()` rather than accumulated, so the grant is re-applied on every repository the fluent API produces and the online modes are forced offline.

Two bugs found by running a real grant on a device are fixed here, each with a regression test. Every scoped search threw, because the online-refusal was evaluated in a property initializer rather than on the path it guards — the guard rejected exactly the case it exists to permit. And the tracked-entity-type grant was ignored for a caller who filtered by nothing, so a grant of one entity type returned records of another; the type clause now sits beside the program sub-select, which is the only place that can bound a caller who asks for nothing.

Also included: `ScopeResolverShould` covering the three org unit hierarchy modes and the caching, and `ScopedAccessGuardShould` extended from two of the guard's six model branches to all six, with all four write capabilities exercised.

The system is documented in `docs/content/developer/scoped-access.md`, registered in the developer guide index beside Data Store. It covers the four mechanisms, six maintenance rules, a test-coverage table with the remaining gaps named, and the honest limitations — a scoped caller runs in the host process, so this is a guardrail that makes the sanctioned path fully capable and every other path deliberate, not a sandbox.

Draft, and a proof of concept: analytics and relationships are deliberately not exposed yet, since both can reach outside a grant and need their own design pass.