### PR TITLE
chore: [ANDROSDK-2378] remove scope from device enrollment body

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/server/internal/LoginConfigCall.kt
@@ -36,7 +36,6 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.hisp.dhis.android.core.server.OauthConfig
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
-import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
 import org.hisp.dhis.android.core.systeminfo.internal.PingNetworkHandler
 import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
@@ -49,7 +48,6 @@ internal class LoginConfigCall(
     private val coroutineAPICallExecutor: CoroutineAPICallExecutor,
     private val networkHandler: LoginConfigNetworkHandler,
     private val oAuth2SecureStore: OAuth2SecureStore,
-    private val dhisVersionManager: DHISVersionManagerImpl,
 ) {
     suspend fun checkServerUrl(serverUrl: String): Result<LoginConfig, D2Error> {
         try {
@@ -69,7 +67,8 @@ internal class LoginConfigCall(
     }
 
     private suspend fun withOauthConfig(serverUrl: String, loginConfig: LoginConfig): LoginConfig {
-        val oauthConfig = tryFetchOauthConfig(serverUrl)?.takeIf { it.supportsRequiredFunctions() }
+        val oauthConfig = tryFetchOauthConfig(serverUrl, loginConfig.apiVersion)
+            ?.takeIf { it.supportsRequiredFunctions() }
         return if (oauthConfig != null) {
             oAuth2SecureStore.setEndpoints(oauthConfig)
             loginConfig.apply { isOauthEnabled = true }
@@ -79,8 +78,9 @@ internal class LoginConfigCall(
         }
     }
 
-    private suspend fun tryFetchOauthConfig(serverUrl: String): OauthConfig? {
-        if (!dhisVersionManager.isGreaterOrEqualThanInternal(MIN_OAUTH_VERSION)) {
+    private suspend fun tryFetchOauthConfig(serverUrl: String, apiVersion: String?): OauthConfig? {
+        val serverVersion = apiVersion?.let { DHISVersion.getValue(it) }
+        if (serverVersion == null || serverVersion < MIN_OAUTH_VERSION) {
             return null
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/DCRNetworkHandler.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/DCRNetworkHandler.kt
@@ -41,7 +41,6 @@ internal interface DCRNetworkHandler {
         iat: String,
         clientName: String,
         redirectUri: String,
-        scope: String,
         jwks: String,
     ): Result<String, D2Error>
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImpl.kt
@@ -89,7 +89,6 @@ internal class OAuth2HandlerImpl(
             iat = iat,
             clientName = clientName,
             redirectUri = OAuth2Config.DEFAULT_REDIRECT_URI,
-            scope = OAuth2Config.DEFAULT_SCOPE,
             jwks = jwks,
         )
 

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/ClientRegistrationRequestDTO.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/ClientRegistrationRequestDTO.kt
@@ -51,9 +51,6 @@ internal data class ClientRegistrationRequestDTO(
     @SerialName("token_endpoint_auth_signing_alg")
     val tokenEndpointAuthSigningAlg: String,
 
-    @SerialName("scope")
-    val scope: String,
-
     @SerialName("jwks_uri")
     val jwksUri: String,
 

--- a/core/src/main/java/org/hisp/dhis/android/network/oauth2/DCRNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/oauth2/DCRNetworkHandlerImpl.kt
@@ -70,7 +70,6 @@ internal class DCRNetworkHandlerImpl(
         iat: String,
         clientName: String,
         redirectUri: String,
-        scope: String,
         jwks: String,
     ): Result<String, D2Error> {
         val jwksUri = oAuth2SecureStore.jwksUri
@@ -83,7 +82,6 @@ internal class DCRNetworkHandlerImpl(
                 responseTypes = listOf("code"),
                 tokenEndpointAuthMethod = "private_key_jwt",
                 tokenEndpointAuthSigningAlg = "RS256",
-                scope = scope,
                 jwksUri = jwksUri,
                 jwks = json.parseToJsonElement(jwks),
             )

--- a/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/server/internal/LoginConfigCallShould.kt
@@ -37,8 +37,6 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.server.LoginConfig
 import org.hisp.dhis.android.core.server.OauthConfig
-import org.hisp.dhis.android.core.systeminfo.DHISVersion
-import org.hisp.dhis.android.core.systeminfo.internal.DHISVersionManagerImpl
 import org.hisp.dhis.android.core.systeminfo.internal.PingNetworkHandler
 import org.hisp.dhis.android.core.user.internal.LogInExceptions
 import org.hisp.dhis.android.core.user.oauth2.internal.OAuth2SecureStore
@@ -53,7 +51,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verifyBlocking
-import org.mockito.kotlin.whenever
 
 @RunWith(JUnit4::class)
 class LoginConfigCallShould {
@@ -62,22 +59,18 @@ class LoginConfigCallShould {
     private val loginExceptions: LogInExceptions = mock()
     private val networkHandler: LoginConfigNetworkHandler = mock()
     private val oauth2SecureStore = OAuth2SecureStore(InMemorySecureStore())
-    private val dhisVersionManager: DHISVersionManagerImpl = mock()
     private val executor = CoroutineAPICallExecutorMock()
 
     private lateinit var call: LoginConfigCall
 
     @Before
-    fun setUp() = runTest {
-        whenever(dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_43)).doReturn(true)
-
+    fun setUp() {
         call = LoginConfigCall(
             pingNetworkHandler,
             loginExceptions,
             executor,
             networkHandler,
             oauth2SecureStore,
-            dhisVersionManager,
         )
     }
 
@@ -136,6 +129,41 @@ class LoginConfigCallShould {
     }
 
     @Test
+    fun marks_oauth_disabled_without_fetching_config_when_server_version_is_lower_than_2_43() = runTest {
+        oauth2SecureStore.authorizationEndpoint = "stale-auth"
+        oauth2SecureStore.jwksUri = "stale-jwks"
+
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample(apiVersion = "2.42.1")
+            onBlocking { oauthConfigFor(any(), any()) } doReturn oauthConfigSample()
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
+        assertThat(loginConfig.isOauthEnabled).isFalse()
+        verifyBlocking(networkHandler, never()) { oauthConfigFor(any(), any()) }
+        assertThat(oauth2SecureStore.authorizationEndpoint).isNull()
+        assertThat(oauth2SecureStore.jwksUri).isNull()
+    }
+
+    @Test
+    fun marks_oauth_disabled_without_fetching_config_when_server_version_is_unknown() = runTest {
+        networkHandler.stub {
+            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample(apiVersion = null)
+            onBlocking { oauthConfigFor(any(), any()) } doReturn oauthConfigSample()
+        }
+
+        val result = call.checkServerUrl(NORMALIZED_URL)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
+        assertThat(loginConfig.isOauthEnabled).isFalse()
+        verifyBlocking(networkHandler, never()) { oauthConfigFor(any(), any()) }
+    }
+
+    @Test
     fun falls_back_to_ping_without_touching_oauth_store_when_login_config_fails() = runTest {
         oauth2SecureStore.authorizationEndpoint = "kept-auth"
         oauth2SecureStore.jwksUri = "kept-jwks"
@@ -157,29 +185,8 @@ class LoginConfigCallShould {
         assertThat(oauth2SecureStore.jwksUri).isEqualTo("kept-jwks")
     }
 
-    @Test
-    fun marks_oauth_disabled_without_fetching_config_when_server_version_is_lower_than_2_43() = runTest {
-        oauth2SecureStore.authorizationEndpoint = "stale-auth"
-        oauth2SecureStore.jwksUri = "stale-jwks"
-
-        whenever(dhisVersionManager.isGreaterOrEqualThanInternal(DHISVersion.V2_43)).doReturn(false)
-        networkHandler.stub {
-            onBlocking { loginConfigFor(NORMALIZED_URL) } doReturn loginConfigSample()
-            onBlocking { oauthConfigFor(any(), any()) } doReturn oauthConfigSample()
-        }
-
-        val result = call.checkServerUrl(NORMALIZED_URL)
-
-        assertThat(result).isInstanceOf(Result.Success::class.java)
-        val loginConfig = (result as Result.Success<LoginConfig, D2Error>).value
-        assertThat(loginConfig.isOauthEnabled).isFalse()
-        verifyBlocking(networkHandler, never()) { oauthConfigFor(any(), any()) }
-        assertThat(oauth2SecureStore.authorizationEndpoint).isNull()
-        assertThat(oauth2SecureStore.jwksUri).isNull()
-    }
-
-    private fun loginConfigSample(): LoginConfig =
-        LoginConfig(applicationTitle = "Demo")
+    private fun loginConfigSample(apiVersion: String? = SUPPORTED_OAUTH_VERSION): LoginConfig =
+        LoginConfig(applicationTitle = "Demo", apiVersion = apiVersion)
 
     private fun oauthConfigSample(): OauthConfig =
         OauthConfig(
@@ -208,6 +215,7 @@ class LoginConfigCallShould {
 
     companion object {
         private const val NORMALIZED_URL = "https://server.com"
+        private const val SUPPORTED_OAUTH_VERSION = "2.43.0"
         private const val AUTHORIZATION_ENDPOINT = "https://server.com/oauth2/authorize"
         private const val JWKS_URI = "https://server.com/.well-known/jwks.json"
     }

--- a/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/user/oauth2/internal/OAuth2HandlerImplShould.kt
@@ -134,7 +134,7 @@ class OAuth2HandlerImplShould {
     fun blockingHandleEnrollmentResponse_persists_registration_and_clears_temp_on_success() {
         seedRegistrationFlowMocks()
         dcrNetworkHandler.stub {
-            onBlocking { registerClient(any(), any(), any(), any(), any(), any()) }
+            onBlocking { registerClient(any(), any(), any(), any(), any()) }
                 .doReturn(Result.Success(CLIENT_ID))
         }
         oauth2SecureStore.tempState = STATE
@@ -154,7 +154,7 @@ class OAuth2HandlerImplShould {
     fun blockingHandleEnrollmentResponse_deletes_keypair_and_throws_on_failure() {
         seedRegistrationFlowMocks()
         dcrNetworkHandler.stub {
-            onBlocking { registerClient(any(), any(), any(), any(), any(), any()) }
+            onBlocking { registerClient(any(), any(), any(), any(), any()) }
                 .doReturn(Result.Failure(serverError()))
         }
         oauth2SecureStore.tempState = STATE
@@ -171,7 +171,7 @@ class OAuth2HandlerImplShould {
     fun blockingHandleEnrollmentResponse_deletes_the_previous_key_when_enrolling_again() {
         seedRegistrationFlowMocks()
         dcrNetworkHandler.stub {
-            onBlocking { registerClient(any(), any(), any(), any(), any(), any()) }
+            onBlocking { registerClient(any(), any(), any(), any(), any()) }
                 .doReturn(Result.Success(CLIENT_ID))
         }
         // The device was already enrolled with an older key pair.


### PR DESCRIPTION
Spring Authorization Server 7 rejects any client-supplied scope on the dynamic client registration request with `invalid_scope`, so the `scope` field is no longer sent in the `POST /connect/register` body. DHIS2 assigns the defaults itself (`openid profile username`) when the field is omitted, and the authorization request still sends the scope explicitly, so behaviour is unchanged on servers that accepted it before.

This also fixes the version check that gates OAuth2 login. It was relying on `DHISVersionManager`, which reads the version from the database — not yet created at the point where the server URL is checked. The server version is now resolved from the `apiVersion` returned by the login config endpoint via `DHISVersion.getValue` and compared against the minimum supported version using the enum ordering.

Related task: [ANDROSDK-2378](https://dhis2.atlassian.net/browse/ANDROSDK-2378)

[ANDROSDK-2378]: https://dhis2.atlassian.net/browse/ANDROSDK-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ