### PR TITLE
chore: [ANDROSDK-2379] revert discarding online failures in OFFLINE_FIRST

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -81,7 +81,7 @@ internal class TrackedEntityInstanceQueryDataFetcher(
             }
             if (result.size < requestedLoadSize && scope.mode() == RepositoryMode.OFFLINE_FIRST) {
                 val onlineInstances = queryOnline(requestedLoadSize)
-                result.addAll(onlineInstances.filter { it.succeeded })
+                result.addAll(onlineInstances)
             }
         } else {
             val instances = queryOnline(requestedLoadSize)


### PR DESCRIPTION
Reverts the filtering of failed online results in `TrackedEntityInstanceQueryDataFetcher` so that online errors are surfaced again when querying in `OFFLINE_FIRST` mode.

Related task: [ANDROSDK-2379](https://dhis2.atlassian.net/browse/ANDROSDK-2379)

[ANDROSDK-2379]: https://dhis2.atlassian.net/browse/ANDROSDK-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ