### PR TITLE
fix: [ANDROSDK-2383] send the right category option combo params when downloading data value files

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
@@ -126,7 +126,7 @@ internal class FileResourceDownloadCall(
                 values = dataValues,
                 maxContentLength = params.maxContentLength,
                 download = fileResourceNetworkHandlder::getFileFromDataValue,
-                getUid = { v -> v.value() },
+                getUid = { v -> v.value.value() },
             )
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelper.kt
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.android.core.fileresource.internal
 
+import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboCategoryOptionLinkStore
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
 import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
 import org.hisp.dhis.android.core.dataset.internal.DataSetElementStore
-import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.datavalue.internal.DataValueStore
 import org.hisp.dhis.android.core.enrollment.internal.EnrollmentStore
 import org.hisp.dhis.android.core.event.internal.EventStore
@@ -72,6 +74,8 @@ internal class FileResourceDownloadCallHelper(
     private val dataSetElementStore: DataSetElementStore,
     private val dataValueStore: DataValueStore,
     private val customIconStore: CustomIconStore,
+    private val categoryOptionComboStore: CategoryOptionComboStore,
+    private val categoryOptionComboCategoryOptionLinkStore: CategoryOptionComboCategoryOptionLinkStore,
     private val dhisVersionManager: DHISVersionManagerImpl,
 ) {
 
@@ -225,7 +229,7 @@ internal class FileResourceDownloadCallHelper(
     suspend fun getMissingAggregatedDataValues(
         params: FileResourceDownloadParams,
         existingFileResources: List<String>,
-    ): List<DataValue> {
+    ): List<MissingAggregatedDataValue> {
         val dataElementUidsWhereClause = WhereClauseBuilder()
             .appendInKeyEnumValues(DataElementTableInfo.Columns.VALUE_TYPE, params.valueTypes.map { it.valueType })
             .appendKeyStringValue(DataElementTableInfo.Columns.DOMAIN_TYPE, "AGGREGATE")
@@ -250,7 +254,28 @@ internal class FileResourceDownloadCallHelper(
             .appendNotInKeyStringValues(DataValueTableInfo.Columns.VALUE, existingFileResources)
             .build()
 
-        return dataValueStore.selectWhere(dataValuesWhereClause)
+        val dataValues = dataValueStore.selectWhere(dataValuesWhereClause)
+        val attributeOptionCombos = dataValues
+            .map { it.attributeOptionCombo() }
+            .distinct()
+            .associateWith { getAttributeOptionComboParams(it) }
+
+        return dataValues.map { dataValue ->
+            val (categoryCombo, categoryOptions) = attributeOptionCombos.getValue(dataValue.attributeOptionCombo())
+            MissingAggregatedDataValue(dataValue, categoryCombo, categoryOptions)
+        }
+    }
+
+    private suspend fun getAttributeOptionComboParams(attributeOptionCombo: String): Pair<String?, String?> {
+        val categoryCombo = categoryOptionComboStore.selectByUid(attributeOptionCombo)?.categoryCombo()?.uid()
+
+        val categoryOptions = categoryOptionComboCategoryOptionLinkStore
+            .selectLinksForMasterUid(attributeOptionCombo)
+            .map { it.categoryOption() }
+            .takeIf { it.isNotEmpty() }
+            ?.let { CollectionsHelper.semicolonSeparatedCollectionValues(it) }
+
+        return categoryCombo to categoryOptions
     }
 
     suspend fun getMissingCustomIcons(

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/MissingAggregatedDataValue.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/MissingAggregatedDataValue.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2004-2025, University of Oslo
+ *  Copyright (c) 2004-2023, University of Oslo
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,44 +28,10 @@
 
 package org.hisp.dhis.android.core.fileresource.internal
 
-import io.ktor.client.request.forms.MultiPartFormDataContent
-import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
-import org.hisp.dhis.android.core.arch.call.queries.internal.UidsQuery
-import org.hisp.dhis.android.core.fileresource.FileResource
-import org.hisp.dhis.android.core.icon.CustomIcon
-import org.hisp.dhis.android.core.trackedentity.TrackedEntityDataValue
+import org.hisp.dhis.android.core.datavalue.DataValue
 
-internal interface FileResourceNetworkHandler {
-
-    suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResource
-
-    suspend fun getFileResource(fileResource: String): FileResource
-
-    suspend fun getFileResources(
-        query: UidsQuery,
-    ): Payload<FileResource>
-
-    suspend fun getImageFromTrackedEntityAttribute(
-        v: MissingTrackerAttributeValue,
-        dimension: String,
-    ): ByteArray
-
-    suspend fun getFileFromTrackedEntityAttribute(
-        v: MissingTrackerAttributeValue,
-    ): ByteArray
-
-    suspend fun getImageFromEventValue(
-        v: TrackedEntityDataValue,
-        dimension: String,
-    ): ByteArray
-
-    suspend fun getFileFromEventValue(
-        v: TrackedEntityDataValue,
-    ): ByteArray
-
-    suspend fun getCustomIcon(
-        v: CustomIcon,
-    ): ByteArray
-
-    suspend fun getFileFromDataValue(v: MissingAggregatedDataValue, dimension: String): ByteArray
-}
+internal data class MissingAggregatedDataValue(
+    val value: DataValue,
+    val attributeCategoryCombo: String?,
+    val attributeCategoryOptions: String?,
+)

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -32,7 +32,10 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.call.queries.internal.UidsQuery
+import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper
 import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper.DimensionSize
+import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUids
+import org.hisp.dhis.android.core.category.CategoryOptionComboCollectionRepository
 import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceNetworkHandler
@@ -47,6 +50,7 @@ import org.koin.core.annotation.Singleton
 internal class FileResourceNetworkHandlerImpl(
     httpServiceClient: HttpServiceClient,
     private val dhis2VersionManager: DHISVersionManager,
+    private val categoryOptionComboCollectionRepository: CategoryOptionComboCollectionRepository,
 ) : FileResourceNetworkHandler {
     private val service = FileResourceService(httpServiceClient)
     override suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResource {
@@ -147,11 +151,21 @@ internal class FileResourceNetworkHandlerImpl(
     }
 
     override suspend fun getFileFromDataValue(v: DataValue, dimension: String): ByteArray {
+        val attributeOptionCombo = categoryOptionComboCollectionRepository
+            .withCategoryOptions()
+            .uid(v.attributeOptionCombo())
+            .suspendGet()
+
         return service.getFileFromDataValue(
+            v.sourceDataSet(),
             v.dataElement(),
             v.period(),
             v.organisationUnit(),
-            v.attributeOptionCombo(),
+            v.categoryOptionCombo(),
+            attributeOptionCombo?.categoryCombo()?.uid(),
+            attributeOptionCombo?.categoryOptions()?.let {
+                CollectionsHelper.semicolonSeparatedCollectionValues(getUids(it))
+            },
             dimension,
         )
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceNetworkHandlerImpl.kt
@@ -32,13 +32,10 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import org.hisp.dhis.android.core.arch.api.HttpServiceClient
 import org.hisp.dhis.android.core.arch.api.payload.internal.Payload
 import org.hisp.dhis.android.core.arch.call.queries.internal.UidsQuery
-import org.hisp.dhis.android.core.arch.helpers.CollectionsHelper
 import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper.DimensionSize
-import org.hisp.dhis.android.core.arch.helpers.UidsHelper.getUids
-import org.hisp.dhis.android.core.category.CategoryOptionComboCollectionRepository
-import org.hisp.dhis.android.core.datavalue.DataValue
 import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.internal.FileResourceNetworkHandler
+import org.hisp.dhis.android.core.fileresource.internal.MissingAggregatedDataValue
 import org.hisp.dhis.android.core.fileresource.internal.MissingTrackerAttributeValue
 import org.hisp.dhis.android.core.icon.CustomIcon
 import org.hisp.dhis.android.core.systeminfo.DHISVersion
@@ -50,7 +47,6 @@ import org.koin.core.annotation.Singleton
 internal class FileResourceNetworkHandlerImpl(
     httpServiceClient: HttpServiceClient,
     private val dhis2VersionManager: DHISVersionManager,
-    private val categoryOptionComboCollectionRepository: CategoryOptionComboCollectionRepository,
 ) : FileResourceNetworkHandler {
     private val service = FileResourceService(httpServiceClient)
     override suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResource {
@@ -150,22 +146,15 @@ internal class FileResourceNetworkHandlerImpl(
         return service.getCustomIcon(v.href())
     }
 
-    override suspend fun getFileFromDataValue(v: DataValue, dimension: String): ByteArray {
-        val attributeOptionCombo = categoryOptionComboCollectionRepository
-            .withCategoryOptions()
-            .uid(v.attributeOptionCombo())
-            .suspendGet()
-
+    override suspend fun getFileFromDataValue(v: MissingAggregatedDataValue, dimension: String): ByteArray {
         return service.getFileFromDataValue(
-            v.sourceDataSet(),
-            v.dataElement(),
-            v.period(),
-            v.organisationUnit(),
-            v.categoryOptionCombo(),
-            attributeOptionCombo?.categoryCombo()?.uid(),
-            attributeOptionCombo?.categoryOptions()?.let {
-                CollectionsHelper.semicolonSeparatedCollectionValues(getUids(it))
-            },
+            v.value.sourceDataSet(),
+            v.value.dataElement(),
+            v.value.period(),
+            v.value.organisationUnit(),
+            v.value.categoryOptionCombo(),
+            v.attributeCategoryCombo,
+            v.attributeCategoryOptions,
             dimension,
         )
     }

--- a/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/network/fileresource/FileResourceService.kt
@@ -34,7 +34,7 @@ import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.network.common.fields.Fields
 import org.hisp.dhis.android.network.common.filters.Filter
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 internal class FileResourceService(private val client: HttpServiceClient) {
 
     suspend fun uploadFile(filePart: MultiPartFormDataContent): FileResourceResponseDTO {
@@ -161,19 +161,25 @@ internal class FileResourceService(private val client: HttpServiceClient) {
     }
 
     suspend fun getFileFromDataValue(
+        dataSet: String?,
         dataElement: String,
         period: String,
         organisationUnit: String,
         categoryOptionCombo: String,
+        attributeCategoryCombo: String?,
+        attributeCategoryOptions: String?,
         dimension: String,
     ): ByteArray {
         return client.get {
             url("$DATA_VALUES/files")
             parameters {
+                attribute("ds", dataSet)
                 attribute("de", dataElement)
                 attribute("pe", period)
                 attribute("ou", organisationUnit)
                 attribute("co", categoryOptionCombo)
+                attribute("cc", attributeCategoryCombo)
+                attribute("cp", attributeCategoryOptions)
                 dimension.takeIf { it != DimensionSize.ORIGINAL_NAME }?.let { attribute("dimension", dimension) }
             }
         }

--- a/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
+++ b/core/src/test/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCallHelperShould.kt
@@ -29,6 +29,8 @@ package org.hisp.dhis.android.core.fileresource.internal
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboCategoryOptionLinkStore
+import org.hisp.dhis.android.core.category.internal.CategoryOptionComboStore
 import org.hisp.dhis.android.core.common.ObjectWithUid
 import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.dataelement.internal.DataElementStore
@@ -70,6 +72,8 @@ internal class FileResourceDownloadCallHelperShould {
     private val dataSetElementStore: DataSetElementStore = mock()
     private val dataValueStore: DataValueStore = mock()
     private val customIconStore: CustomIconStore = mock()
+    private val categoryOptionComboStore: CategoryOptionComboStore = mock()
+    private val categoryOptionComboCategoryOptionLinkStore: CategoryOptionComboCategoryOptionLinkStore = mock()
     private val dhisVersionManager: DHISVersionManagerImpl = mock()
 
     private lateinit var helper: FileResourceDownloadCallHelper
@@ -93,6 +97,8 @@ internal class FileResourceDownloadCallHelperShould {
             dataSetElementStore,
             dataValueStore,
             customIconStore,
+            categoryOptionComboStore,
+            categoryOptionComboCategoryOptionLinkStore,
             dhisVersionManager,
         )
     }


### PR DESCRIPTION
File resources attached to aggregate data values were never downloaded when the data set had an attribute category combo. The request to `/api/dataValues/files` was passing the data value's attribute option combo in the `co` parameter, which the API interprets as the category option combo, and it never sent the `cc` and `cp` parameters that identify the attribute option combo. The server answered `409 Data value does not exist`, and the error was swallowed by the download call, so the file was silently missing. It only worked by accident when both combos were the default one, since they share the same uid.

The fix sends `co` with the data value's own category option combo and resolves the attribute option combo locally into `cc` (its category combo) and `cp` (its semicolon-separated category options), mirroring what `DataSetCompleteRegistrationNetworkHandlerImpl` already does. The bug has been present since the aggregate file downloader was introduced in 1.7.0, so this is not a regression.

Related task: [ANDROSDK-2383](https://dhis2.atlassian.net/browse/ANDROSDK-2383)

[ANDROSDK-2383]: https://dhis2.atlassian.net/browse/ANDROSDK-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ