### PR TITLE
chore: [ANDROSDK-2381] update sdk version and code

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-dhis2AndroidSdkVersion = "1.15.0-SNAPSHOT"
-dhis2AndroidSdkCode = "306"
+dhis2AndroidSdkVersion = "1.15.1-SNAPSHOT"
+dhis2AndroidSdkCode = "307"
 
 gradle = "9.3.1"
 kotlin = "2.4.10"


### PR DESCRIPTION
Update the SDK to continue working on develop with 1.15.1 patch tasks until 1.16.0 targeted tasks are started to be taken.